### PR TITLE
feat(1-5): wire ferry-emit-audit composite action into dispatch workflows

### DIFF
--- a/.github/actions/ferry-emit-audit/action.yml
+++ b/.github/actions/ferry-emit-audit/action.yml
@@ -1,0 +1,73 @@
+name: Ferry — Emit Audit Line
+description: Posts exactly one JSON audit comment to the ferry-audit GitHub Issue. Idempotent via [ferry:audit:<run_id>] marker.
+inputs:
+  ticket:
+    description: Jira ticket key (e.g. CHAN-27)
+    required: true
+  phase:
+    description: Workflow phase — one of refine, dev, review, iterate, reconcile
+    required: true
+  run_id:
+    description: ULID event_id from the envelope (used as idempotency marker)
+    required: true
+  model:
+    description: Model identifier (e.g. gemini-2.5-flash) or "none" for no-LLM runs
+    required: true
+  outcome:
+    description: Run outcome (success, transient, spend-cap, state-invariant, oscillation, unknown, ...)
+    required: true
+  input_tokens:
+    description: Input tokens consumed by the LLM call (0 if no call)
+    required: false
+    default: '0'
+  output_tokens:
+    description: Output tokens produced by the LLM call (0 if no call)
+    required: false
+    default: '0'
+  cost_eur:
+    description: Cost in EUR (0 if no LLM call)
+    required: false
+    default: '0'
+  start_ms:
+    description: Epoch milliseconds when the agent began (used for duration_ms)
+    required: true
+  audit_issue:
+    description: GitHub Issue number that serves as the canonical ferry-audit issue
+    required: true
+  owner:
+    description: GitHub repository owner
+    required: true
+  repo:
+    description: GitHub repository name
+    required: true
+  github_token:
+    description: GITHUB_TOKEN with issues:write on the audit repository
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+      with:
+        node-version: '20'
+        cache: npm
+    - name: Install dependencies
+      shell: bash
+      run: npm ci --prefer-offline
+    - name: Emit audit line
+      shell: bash
+      run: npx tsx src/lib/audit/emit-audit-action.ts
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        FERRY_AUDIT_ISSUE: ${{ inputs.audit_issue }}
+        FERRY_OWNER: ${{ inputs.owner }}
+        FERRY_REPO: ${{ inputs.repo }}
+        FERRY_RUN_ID: ${{ inputs.run_id }}
+        FERRY_TICKET: ${{ inputs.ticket }}
+        FERRY_PHASE: ${{ inputs.phase }}
+        FERRY_MODEL: ${{ inputs.model }}
+        FERRY_OUTCOME: ${{ inputs.outcome }}
+        FERRY_INPUT_TOKENS: ${{ inputs.input_tokens }}
+        FERRY_OUTPUT_TOKENS: ${{ inputs.output_tokens }}
+        FERRY_COST_EUR: ${{ inputs.cost_eur }}
+        FERRY_START_MS: ${{ inputs.start_ms }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -36,8 +36,25 @@ jobs:
   emit-audit:
     name: Emit audit line
     needs: [run-agent]
-    if: always()
+    if: needs.run-agent.result != 'skipped'
     runs-on: ubuntu-latest
     steps:
-      - name: Placeholder — audit emission (Story 1.5)
-        run: echo "Audit placeholder"
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Emit audit line
+        uses: ./.github/actions/ferry-emit-audit
+        with:
+          ticket: ${{ github.event.client_payload.ticket_key }}
+          phase: dev
+          run_id: ${{ github.event.client_payload.event_id }}
+          model: placeholder
+          outcome: ${{ needs.run-agent.result }}
+          input_tokens: '0'
+          output_tokens: '0'
+          cost_eur: '0'
+          start_ms: ${{ github.run_id }}
+          audit_issue: ${{ vars.FERRY_AUDIT_ISSUE }}
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/iterate.yml
+++ b/.github/workflows/iterate.yml
@@ -36,8 +36,25 @@ jobs:
   emit-audit:
     name: Emit audit line
     needs: [run-agent]
-    if: always()
+    if: needs.run-agent.result != 'skipped'
     runs-on: ubuntu-latest
     steps:
-      - name: Placeholder — audit emission (Story 1.5)
-        run: echo "Audit placeholder"
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Emit audit line
+        uses: ./.github/actions/ferry-emit-audit
+        with:
+          ticket: ${{ github.event.client_payload.ticket_key }}
+          phase: iterate
+          run_id: ${{ github.event.client_payload.event_id }}
+          model: placeholder
+          outcome: ${{ needs.run-agent.result }}
+          input_tokens: '0'
+          output_tokens: '0'
+          cost_eur: '0'
+          start_ms: ${{ github.run_id }}
+          audit_issue: ${{ vars.FERRY_AUDIT_ISSUE }}
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/refine.yml
+++ b/.github/workflows/refine.yml
@@ -36,8 +36,25 @@ jobs:
   emit-audit:
     name: Emit audit line
     needs: [run-agent]
-    if: always()
+    if: needs.run-agent.result != 'skipped'
     runs-on: ubuntu-latest
     steps:
-      - name: Placeholder — audit emission (Story 1.5)
-        run: echo "Audit placeholder"
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Emit audit line
+        uses: ./.github/actions/ferry-emit-audit
+        with:
+          ticket: ${{ github.event.client_payload.ticket_key }}
+          phase: refine
+          run_id: ${{ github.event.client_payload.event_id }}
+          model: placeholder
+          outcome: ${{ needs.run-agent.result }}
+          input_tokens: '0'
+          output_tokens: '0'
+          cost_eur: '0'
+          start_ms: ${{ github.run_id }}
+          audit_issue: ${{ vars.FERRY_AUDIT_ISSUE }}
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -36,8 +36,25 @@ jobs:
   emit-audit:
     name: Emit audit line
     needs: [run-agent]
-    if: always()
+    if: needs.run-agent.result != 'skipped'
     runs-on: ubuntu-latest
     steps:
-      - name: Placeholder — audit emission (Story 1.5)
-        run: echo "Audit placeholder"
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Emit audit line
+        uses: ./.github/actions/ferry-emit-audit
+        with:
+          ticket: ${{ github.event.client_payload.ticket_key }}
+          phase: review
+          run_id: ${{ github.event.client_payload.event_id }}
+          model: placeholder
+          outcome: ${{ needs.run-agent.result }}
+          input_tokens: '0'
+          output_tokens: '0'
+          cost_eur: '0'
+          start_ms: ${{ github.run_id }}
+          audit_issue: ${{ vars.FERRY_AUDIT_ISSUE }}
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/_bmad-output/implementation-artifacts/1-5-error-taxonomy-audit-writer-and-labels-allowlist.md
+++ b/_bmad-output/implementation-artifacts/1-5-error-taxonomy-audit-writer-and-labels-allowlist.md
@@ -1,6 +1,6 @@
 # Story 1.5: Error Taxonomy, Audit Writer & Labels Allowlist
 
-Status: ready-for-dev
+Status: review
 
 ## Story
 
@@ -351,20 +351,48 @@ src/
 
 ### Agent Model Used
 
-_to be filled_
+claude-sonnet-4-6 (DS continuation + CR self-loop on 2026-04-28).
 
 ### Debug Log References
 
-_to be filled_
+- Initial baseline (commit `cfc5228`): `npm test` 92/92 green; `npm run typecheck` failed with 5x TS2352 in `src/lib/audit/audit.test.ts` due to stricter Octokit method overload typing; `npm run lint` failed with 2x unused-import errors in `src/lib/ulid/ulid.test.ts`; `npm run format:check` green.
+- After fixes: all four gates green; 92/92 tests pass.
 
 ### Completion Notes List
 
-_to be filled_
+- Tasks 1–6 were already implemented in commit `cfc5228` (error-taxonomy module, audit writer, labels allowlist + tests). This continuation completes Tasks 7–11.
+- **Task 7** — `src/lib/audit/emit-audit-action.ts` thin GHA entrypoint added. Required env vars validated up-front; numeric env vars parsed defensively; Octokit instantiated only at the entrypoint boundary (library code stays testable).
+- **Task 8** — `.github/actions/ferry-emit-audit/action.yml` composite action added, mirroring `ferry-envelope-validate/action.yml` (same `actions/setup-node` SHA `39370e3970a6d050c480ffad4ff0ed4d3fdee5af`, `cache: npm`, `npm ci --prefer-offline`, `npx tsx`). Resolved an internal spec inconsistency: Task 7 lists `FERRY_OWNER`/`FERRY_REPO` as required env vars, but Task 8 omits `owner`/`repo` from action inputs. Action now exposes both, sourced from `github.repository_owner` and `github.event.repository.name` in workflow callers.
+- **Task 9** — `refine.yml`, `dev.yml`, `review.yml`, `iterate.yml` updated: placeholder `emit-audit` jobs replaced with real action call, `if: always()` → `if: needs.run-agent.result != 'skipped'` (resolves W1 from 1.4). `outcome` is sourced from `needs.run-agent.result` (success/failure/cancelled) rather than `job.status` because audit job's own status would always be `success` at the point the expression evaluates. `reconciler.yml` is intentionally NOT updated: it has no placeholder emit-audit job (cron runs are per-sweep, not per-ticket), and Story 8.3 will wire its per-ticket audit emissions. This deviation from the story's "5 workflows" wording is documented; the spec's intent (every dispatch workflow emits one audit line) is satisfied.
+- **Task 10** — `validateEnvelope` error code remains `state-invariant`. Per D11 taxonomy, a malformed envelope = state invariant violation → `status:stale` label → human re-dispatches. `mapError('state-invariant')` returns `{ labels: ['status:stale'], outcome: 'state-invariant', ... }`, which is the correct action. No code change needed.
+- **Task 11** — `npm run typecheck`, `npm run lint`, `npm run format:check`, `npm test` all green. Two pre-existing baseline failures fixed inline as part of finishing Story 1.5 because they were introduced by the same commit (`cfc5228`):
+  - `src/lib/audit/audit.test.ts`: changed `as ReturnType<typeof vi.fn>` casts to `as unknown as ReturnType<typeof vi.fn>` to satisfy TS strict type-overlap rule for Octokit method signatures.
+  - `src/lib/ulid/ulid.test.ts`: removed unused `beforeEach`, `afterEach` imports.
+- **CI infrastructure note** — `package-lock.json` is gitignored by project convention. `ferry-ci.yml` and the new `ferry-emit-audit` composite action both invoke `npm ci`, which requires a committed lockfile. The two most recent CI runs on `main` (commits `cfc5228`, `087ce3e`) failed for this reason. This is out of scope for Story 1-5 — logged as deferred-work W4 for resolution in Story 1-6 (CI/IO wrappers) or 1-1 hardening.
 
 ### File List
 
-_to be filled_
+**Added:**
+- `src/lib/audit/emit-audit-action.ts`
+- `.github/actions/ferry-emit-audit/action.yml`
+
+**Modified:**
+- `src/lib/audit/audit.test.ts` (typecheck fix)
+- `src/lib/ulid/ulid.test.ts` (lint fix)
+- `.github/workflows/refine.yml`
+- `.github/workflows/dev.yml`
+- `.github/workflows/review.yml`
+- `.github/workflows/iterate.yml`
+- `_bmad-output/implementation-artifacts/sprint-status.yaml`
+- `_bmad-output/implementation-artifacts/deferred-work.md`
 
 ### Review Findings
 
-_to be filled_
+Self-review (CR phase) on 2026-04-28:
+
+- **(info) Reconciler workflow not updated** — Story spec says "5 workflows"; only 4 dispatch workflows have placeholder `emit-audit` jobs to replace. Reconciler emits its audit per-ticket inside Story 8.3 logic. This is the correct call. Documented above.
+- **(info) `outcome` source** — Story spec example uses `outcome: ${{ job.status }}`. I used `${{ needs.run-agent.result }}` instead because at the time `emit-audit`'s steps execute, `job.status` refers to the `emit-audit` job (always `success` so far) — not the agent run outcome the audit is supposed to record. Using `needs.run-agent.result` correctly captures the upstream agent's outcome.
+- **(info) `start_ms` placeholder** — Story acknowledges this; `github.run_id` is a workflow run ID, not epoch ms, so `duration_ms` will be nonsensical until Stories 3.1+ pass real values from agent entrypoint outputs. No bug, just placeholder.
+- **(W) `audit_issue` requires repo variable** — Workflow uses `${{ vars.FERRY_AUDIT_ISSUE }}` (GitHub Actions repo-level variable). When this is unset, the entrypoint will throw a clear error at install time. Recommendation: add a setup step in Story 1.8 (README / first-time setup docs) covering the required vars: `FERRY_AUDIT_ISSUE`. Logged below in deferred-work.
+- **No security findings** — `GITHUB_TOKEN` flows only through composite action input → entrypoint env; no payload values are echoed; failures only log sanitized messages.
+- **All ACs pass** — 1, 2, 3, 4 verified by tests + manual workflow inspection.

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,5 +1,12 @@
 # Deferred Work
 
+## Deferred from: code review of 1-5-error-taxonomy-audit-writer-and-labels-allowlist (2026-04-28)
+
+- W1: `audit_issue` is sourced from `${{ vars.FERRY_AUDIT_ISSUE }}` (GitHub repo-level variable). The first-time setup docs in Story 1.8 must document this variable plus `FERRY_OWNER`/`FERRY_REPO` defaults so operators can configure the audit issue before any dispatch workflow runs.
+- W2: `start_ms` workflow input uses `${{ github.run_id }}` as a placeholder — produces nonsensical `duration_ms` values until Stories 3.1, 4.1, 5.1, 6.1 pass real agent-entry epoch ms via job outputs.
+- W3: Reconciler workflow does not yet emit audit lines. Story 8.3 must wire per-ticket `emit-audit` invocations inside the reconciler sweep (cron runs are per-sweep, but each reconciled ticket should produce its own audit line keyed by the original `event_id`).
+- W4: **CI on `main` is failing.** `ferry-ci.yml` and the new `ferry-emit-audit` composite action both call `npm ci`, but `package-lock.json` is gitignored. The two most recent CI runs on `main` (commits `cfc5228`, `087ce3e`) failed at the install step. Resolution: either commit the lockfile (remove the `.gitignore` entry) or switch CI/composite-action installs to `npm install --no-audit --no-fund`. Recommend lockfile route for reproducibility. Should be tackled in Story 1-6 (I/O wrappers) or as a hotfix before any Story 1-5 dispatch workflow runs in production.
+
 ## Deferred from: code review of 1-4-cross-workflow-concurrency-action-and-freshness-check (2026-04-27)
 
 - W1: `emit-audit` job runs on `gate-envelope` failure due to `if: always()` — produces misleading audit records for rejected envelopes. Placeholder jobs in `.github/workflows/*.yml`; Story 1.5 implements proper audit logic with correct condition guards.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: "2026-04-27T00:00:00Z"
-last_updated: "2026-04-27T00:00:00Z"  # updated by code-review (story 1.4)
+last_updated: "2026-04-28T00:00:00Z"  # updated by code-review (story 1.5)
 project: ferry
 project_key: NOKEY
 tracking_system: file-system
@@ -51,7 +51,7 @@ development_status:
   1-2-state-schema-json-validation-and-preflight-invariants: done
   1-3-event-envelope-schema-ulid-generation-and-deduplication: done
   1-4-cross-workflow-concurrency-action-and-freshness-check: done
-  1-5-error-taxonomy-audit-writer-and-labels-allowlist: backlog
+  1-5-error-taxonomy-audit-writer-and-labels-allowlist: review
   1-6-secret-scanning-codeowners-path-filter-and-io-wrappers: backlog
   1-7-llm-harness-model-routing-and-configuration-loading: backlog
   1-8-readme-examples-and-first-time-setup-documentation: backlog

--- a/src/lib/audit/audit.test.ts
+++ b/src/lib/audit/audit.test.ts
@@ -44,7 +44,8 @@ describe('emitAudit', () => {
   it('comment body is valid JSON with all required fields', async () => {
     const octokit = makeMockOctokit();
     await emitAudit(PAYLOAD, { ...OPTS, octokit });
-    const call = (octokit.rest.issues.createComment as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const call = (octokit.rest.issues.createComment as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
     const lines = call.body.split('\n');
     const json = JSON.parse(lines[1]);
     expect(json).toMatchObject({
@@ -64,14 +65,16 @@ describe('emitAudit', () => {
   it('comment body starts with idempotency marker on first line', async () => {
     const octokit = makeMockOctokit();
     await emitAudit(PAYLOAD, { ...OPTS, octokit });
-    const call = (octokit.rest.issues.createComment as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const call = (octokit.rest.issues.createComment as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
     expect(call.body).toMatch(new RegExp(`^\\[ferry:audit:${RUN_ID}\\]\\n`));
   });
 
   it('duration_ms is a non-negative integer', async () => {
     const octokit = makeMockOctokit();
     await emitAudit(PAYLOAD, { ...OPTS, octokit });
-    const call = (octokit.rest.issues.createComment as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const call = (octokit.rest.issues.createComment as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
     const json = JSON.parse(call.body.split('\n')[1]);
     expect(json.duration_ms).toBeGreaterThanOrEqual(0);
     expect(Number.isInteger(json.duration_ms)).toBe(true);
@@ -80,7 +83,8 @@ describe('emitAudit', () => {
   it('timestamp is a valid ISO-8601 string', async () => {
     const octokit = makeMockOctokit();
     await emitAudit(PAYLOAD, { ...OPTS, octokit });
-    const call = (octokit.rest.issues.createComment as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const call = (octokit.rest.issues.createComment as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
     const json = JSON.parse(call.body.split('\n')[1]);
     expect(() => new Date(json.timestamp).toISOString()).not.toThrow();
     expect(json.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
@@ -96,7 +100,8 @@ describe('emitAudit', () => {
   it('defaults tokens and cost to 0 when usage is null', async () => {
     const octokit = makeMockOctokit();
     await emitAudit({ ...PAYLOAD, usage: null }, { ...OPTS, octokit });
-    const call = (octokit.rest.issues.createComment as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const call = (octokit.rest.issues.createComment as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
     const json = JSON.parse(call.body.split('\n')[1]);
     expect(json.input_tokens).toBe(0);
     expect(json.output_tokens).toBe(0);

--- a/src/lib/audit/emit-audit-action.ts
+++ b/src/lib/audit/emit-audit-action.ts
@@ -1,0 +1,84 @@
+import { Octokit } from '@octokit/rest';
+import { emitAudit, type AuditPayload, type AuditOpts, type AuditUsage } from './index.js';
+
+const REQUIRED_ENV = [
+  'GITHUB_TOKEN',
+  'FERRY_AUDIT_ISSUE',
+  'FERRY_OWNER',
+  'FERRY_REPO',
+  'FERRY_RUN_ID',
+  'FERRY_TICKET',
+  'FERRY_PHASE',
+  'FERRY_MODEL',
+  'FERRY_OUTCOME',
+  'FERRY_START_MS',
+] as const;
+
+function readEnv(name: string): string {
+  const value = process.env[name];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`[ferry:audit] Missing required env var: ${name}`);
+  }
+  return value;
+}
+
+function readNumberEnv(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return defaultValue;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`[ferry:audit] Env var ${name} is not a valid number: ${raw}`);
+  }
+  return parsed;
+}
+
+async function main(): Promise<void> {
+  for (const name of REQUIRED_ENV) {
+    readEnv(name);
+  }
+
+  const auditIssueRaw = readEnv('FERRY_AUDIT_ISSUE');
+  const auditIssue = Number.parseInt(auditIssueRaw, 10);
+  if (!Number.isInteger(auditIssue) || auditIssue <= 0) {
+    throw new Error(`[ferry:audit] FERRY_AUDIT_ISSUE is not a positive integer: ${auditIssueRaw}`);
+  }
+
+  const startMsRaw = readEnv('FERRY_START_MS');
+  const startMs = Number.parseInt(startMsRaw, 10);
+  if (!Number.isInteger(startMs) || startMs < 0) {
+    throw new Error(`[ferry:audit] FERRY_START_MS is not a non-negative integer: ${startMsRaw}`);
+  }
+
+  const usage: AuditUsage = {
+    inputTokens: readNumberEnv('FERRY_INPUT_TOKENS', 0),
+    outputTokens: readNumberEnv('FERRY_OUTPUT_TOKENS', 0),
+    costEur: readNumberEnv('FERRY_COST_EUR', 0),
+  };
+
+  const payload: AuditPayload = {
+    ticket: readEnv('FERRY_TICKET'),
+    phase: readEnv('FERRY_PHASE'),
+    runId: readEnv('FERRY_RUN_ID'),
+    model: readEnv('FERRY_MODEL'),
+    outcome: readEnv('FERRY_OUTCOME'),
+    usage,
+    start: startMs,
+  };
+
+  const octokit = new Octokit({ auth: readEnv('GITHUB_TOKEN') });
+
+  const opts: AuditOpts = {
+    octokit,
+    owner: readEnv('FERRY_OWNER'),
+    repo: readEnv('FERRY_REPO'),
+    auditIssue,
+  };
+
+  await emitAudit(payload, opts);
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`[ferry:audit] Failed to emit audit line: ${message}`);
+  process.exit(1);
+});

--- a/src/lib/ulid/ulid.test.ts
+++ b/src/lib/ulid/ulid.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { generateULID } from './index.js';
 
 const ULID_PATTERN = /^[0-9A-HJKMNP-TV-Z]{26}$/;


### PR DESCRIPTION
## Story 1-5 — Tasks 7–11

Closes the Story 1-5 implementation by wiring the `ferry-emit-audit` composite action into the four dispatch workflows.

### Changes

**Added**
- `src/lib/audit/emit-audit-action.ts` — thin GHA entrypoint. Validates required env vars up-front, parses numeric env vars defensively, instantiates Octokit only at the entrypoint boundary so library code stays test-pure.
- `.github/actions/ferry-emit-audit/action.yml` — composite action mirroring `ferry-envelope-validate` (same `actions/setup-node` SHA `39370e3970a6d050c480ffad4ff0ed4d3fdee5af`, `cache: npm`, `npm ci --prefer-offline`, `npx tsx`). Exposes `ticket`, `phase`, `run_id`, `model`, `outcome`, `input_tokens`, `output_tokens`, `cost_eur`, `start_ms`, `audit_issue`, `owner`, `repo`, `github_token` as inputs.

**Modified**
- `refine.yml`, `dev.yml`, `review.yml`, `iterate.yml` — placeholder `emit-audit` jobs replaced with the real composite action call. Condition changed from `if: always()` to `if: needs.run-agent.result != 'skipped'` (resolves W1 from code review of 1-4: avoid misleading audit records when `gate-envelope` rejects). `outcome` sourced from `needs.run-agent.result` instead of `job.status` so the audit reflects the upstream agent's outcome rather than the audit job's own status.
- `src/lib/audit/audit.test.ts` — `as ReturnType<typeof vi.fn>` casts changed to `as unknown as ReturnType<typeof vi.fn>` to satisfy stricter TS overlap rules for Octokit method signatures.
- `src/lib/ulid/ulid.test.ts` — drop unused `beforeEach`, `afterEach` imports.
- `_bmad-output/implementation-artifacts/sprint-status.yaml` — `1-5` set to `review`.
- `_bmad-output/implementation-artifacts/deferred-work.md` — append CR findings W1–W4.
- Story file Dev Agent Record + Review Findings filled in.

### Reconciler intentionally not updated

The story spec mentions "all 5 workflows" but `reconciler.yml` has no placeholder `emit-audit` job to replace — it's a per-sweep cron, not per-ticket. Story 8.3 will wire its per-ticket audit emissions inside the sweep logic. Logged in completion notes.

### Validation

```
npm run typecheck   ✅
npm run lint        ✅
npm run format:check ✅
npm test            ✅ (92/92)
```

### Pre-existing CI break flagged separately

`ferry-ci.yml` and the new composite action both call `npm ci`, but `package-lock.json` is gitignored. Last 2 CI runs on `main` (`cfc5228`, `087ce3e`) fail at install. Logged as deferred-work W4 — out of scope for 1-5 but blocks every PR. Recommend committing the lockfile (remove the gitignore entry) so CI can pass.

### Acceptance criteria

- [x] AC1 — `mapError` covers all 5 classes (verified by 7 unit tests)
- [x] AC2 — `emitAudit` posts exactly one comment with all required fields, idempotency marker, and per-run dedupe (verified by 7 unit tests)
- [x] AC3 — `labels-allowlist.test.ts` scans `src/lib` and `src/agents` (passes)
- [x] AC4 — `.github/actions/ferry-emit-audit/action.yml` wraps `emitAudit` and is wired into all 4 dispatch workflows