### PR TITLE
chore(sprint): mark 1-6 as done after PR #10 merge

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -52,7 +52,7 @@ development_status:
   1-3-event-envelope-schema-ulid-generation-and-deduplication: done
   1-4-cross-workflow-concurrency-action-and-freshness-check: done
   1-5-error-taxonomy-audit-writer-and-labels-allowlist: done
-  1-6-secret-scanning-codeowners-path-filter-and-io-wrappers: review
+  1-6-secret-scanning-codeowners-path-filter-and-io-wrappers: done
   1-6b-gitleaks-secret-scan-integration: backlog
   1-7-llm-harness-model-routing-and-configuration-loading: backlog
   1-8-readme-examples-and-first-time-setup-documentation: backlog


### PR DESCRIPTION
Cron didn't update sprint-status after PR #10 merged. Marking 1-6 done so the next builder run picks 1-6b (gitleaks) or 1-7 (LLM harness) as the next backlog story.