### PR TITLE
chore(sprint): mark 1-6b as done after PR #13 merge

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: "2026-04-27T00:00:00Z"
-last_updated: "2026-04-28T09:10:00Z"  # updated by cron run (story 1-6b progressed; 1-6c added)
+last_updated: "2026-04-28T09:52:00Z"  # 1-6b merged via PR #13
 project: ferry
 project_key: NOKEY
 tracking_system: file-system
@@ -53,7 +53,7 @@ development_status:
   1-4-cross-workflow-concurrency-action-and-freshness-check: done
   1-5-error-taxonomy-audit-writer-and-labels-allowlist: done
   1-6-secret-scanning-codeowners-path-filter-and-io-wrappers: done
-  1-6b-gitleaks-secret-scan-integration: review
+  1-6b-gitleaks-secret-scan-integration: done
   1-6c-gitleaks-harness-runtime-scanning: backlog
   1-7-llm-harness-model-routing-and-configuration-loading: backlog
   1-8-readme-examples-and-first-time-setup-documentation: backlog


### PR DESCRIPTION
Mark story `1-6b-gitleaks-secret-scan-integration` as `done` in sprint-status.yaml — PR #13 was merged (commit `089077a`) but the status field was still `review` because the merge happened outside the cron's dev-story flow.

No code changes — yaml-only.

## Why
- PR #13 implemented Story 1-6b and was merged manually
- Sprint status didn't get the `review → done` transition the cron usually performs at end of dev-story
- Without this fix, the next builder cron run would re-evaluate 1-6b instead of moving on to 1-7

## Files
- `_bmad-output/implementation-artifacts/sprint-status.yaml` — `1-6b: review → done`, bump `last_updated`

## Gates
N/a — yaml metadata only, no code paths affected. Local typecheck/lint/format/test all green on prior commit.