### PR TITLE
feat(dispatch): add phase routing + Task skip scaffold

### DIFF
--- a/.github/workflows/refine.yml
+++ b/.github/workflows/refine.yml
@@ -30,6 +30,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Set up Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # v4.1.0
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        shell: bash
+        run: npm ci --prefer-offline
+
+      - name: Skip Task tickets (FR6)
+        shell: bash
+        run: npx tsx src/lib/dispatch/skip-task-type-action.ts
+        env:
+          FERRY_ENVELOPE_PAYLOAD: ${{ toJson(github.event.client_payload) }}
+
       - name: Placeholder — Refiner agent (Story 3.1)
         run: echo "Refiner placeholder"
 

--- a/_bmad-output/implementation-artifacts/2-1-column-transition-dispatch-and-workflow-routing.md
+++ b/_bmad-output/implementation-artifacts/2-1-column-transition-dispatch-and-workflow-routing.md
@@ -1,0 +1,41 @@
+# Story 2-1 — Column-Transition Dispatch & Workflow Routing
+
+## Status
+- **Story**: 2-1-column-transition-dispatch-and-workflow-routing
+- **Epic**: Epic 2 — Event Routing — Ticket Ingestion & Dispatch
+- **Status**: ready-for-dev
+
+## Context
+Ferry is triggered via `repository_dispatch` events emitted by Jira Automation when a ticket moves to a configured Ferry column (e.g., “Refinement”).
+
+This story adds:
+- A pure routing/contract helper for phase→workflow and Task-type skip semantics.
+- Support for `issue_type` in the event envelope schema to enable Task skipping.
+- A workflow step (before `run-agent`) that skips Task tickets by posting a Jira comment via the existing scaffold (`src/lib/io/jira.ts`) and exits 0.
+
+## User Story
+As a Ferry operator,
+I want moving a Jira ticket to a Ferry column to automatically trigger the correct GitHub Actions workflow on the target repo,
+So that Ferry starts working the moment I drag a ticket on the board — no manual intervention needed.
+
+## Acceptance Criteria
+1) **Phase routes to workflow (contract test)**
+- Given a Jira Automation rule sends `repository_dispatch` payload `{ phase: "refine", ticket_key: "CHAN-27", ... }` with type `ferry-refine`
+- When the dispatch is received by the target repo
+- Then `refine.yml` triggers (and only `refine.yml`) — satisfied by per-workflow `repository_dispatch` types; additionally enforced via unit tests for the static mapping.
+
+2) **Unknown phase is rejected**
+- Given `validateEnvelope(payload)` enforces allowed phases
+- When an unknown `phase` value is dispatched
+- Then it is rejected before any side-effect runs.
+
+3) **Task type is skipped**
+- Given a ticket of type `Task` (not `Story`) triggers a dispatch
+- When the workflow starts
+- Then it posts a Jira comment `[ferry:refiner:<run_id>] Skipped — ticket type Task is not processed by Ferry` and exits 0 without creating sub-tasks or writing state (FR6)
+
+4) **Dry-run E2E fixture coverage**
+- And all four phase-to-workflow mappings are covered by a unit/fixture test.
+
+## Open Questions
+- None.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -62,8 +62,8 @@ development_status:
   # ─────────────────────────────────────────────────────────────
   # Epic 2: Event Routing — Ticket Ingestion & Dispatch
   # ─────────────────────────────────────────────────────────────
-  epic-2: backlog
-  2-1-column-transition-dispatch-and-workflow-routing: backlog
+  epic-2: in-progress
+  2-1-column-transition-dispatch-and-workflow-routing: review
   2-2-label-based-and-mention-re-trigger-dispatch: backlog
   2-3-per-ticket-daily-trigger-cap: backlog
   2-4-phase-labels-jira-phase-comments-and-ferry-audit-emission: backlog

--- a/src/lib/dispatch/route.test.ts
+++ b/src/lib/dispatch/route.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { validateEnvelope } from '../envelope/validate.js';
+import { buildTaskSkipComment, phaseToWorkflow, shouldSkipForTaskType } from './route.js';
+
+describe('dispatch routing helpers', () => {
+  it('maps phases to workflow filenames', () => {
+    expect(phaseToWorkflow('refine')).toBe('refine.yml');
+    expect(phaseToWorkflow('dev')).toBe('dev.yml');
+    expect(phaseToWorkflow('review')).toBe('review.yml');
+    expect(phaseToWorkflow('iterate')).toBe('iterate.yml');
+  });
+
+  it('throws for unknown phases', () => {
+    // validateEnvelope enforces allowed phases, but route should still be defensive.
+    expect(() => phaseToWorkflow('nope' as never)).toThrow(/Unknown phase/);
+  });
+
+  it('skips Task issue types', () => {
+    expect(shouldSkipForTaskType('Task')).toEqual({
+      skip: true,
+      reason: 'ticket type Task is not processed by Ferry',
+    });
+  });
+
+  it('does not skip Story issue types', () => {
+    expect(shouldSkipForTaskType('Story')).toEqual({ skip: false });
+  });
+
+  it('builds the Task skip comment in the required format', () => {
+    expect(buildTaskSkipComment('refiner', '01ARZ3NDEKTSV4RRFFQ69G5FAV')).toBe(
+      '[ferry:refiner:01ARZ3NDEKTSV4RRFFQ69G5FAV] Skipped — ticket type Task is not processed by Ferry',
+    );
+  });
+
+  it('accepts envelope with issue_type', () => {
+    const env = validateEnvelope({
+      version: 'v1',
+      event_id: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+      ticket_key: 'CHAN-27',
+      phase: 'refine',
+      source: 'jira-column',
+      ts: '2026-01-01T00:00:00Z',
+      issue_type: 'Task',
+    });
+    expect(env.issue_type).toBe('Task');
+  });
+});

--- a/src/lib/dispatch/route.ts
+++ b/src/lib/dispatch/route.ts
@@ -1,0 +1,30 @@
+import { FerryError } from '../error.js';
+import type { EventEnvelopeV1 } from '../envelope/types.js';
+
+export type EventPhase = EventEnvelopeV1['phase'];
+
+export function phaseToWorkflow(phase: EventPhase): string {
+  switch (phase) {
+    case 'refine':
+      return 'refine.yml';
+    case 'dev':
+      return 'dev.yml';
+    case 'review':
+      return 'review.yml';
+    case 'iterate':
+      return 'iterate.yml';
+    default:
+      throw new FerryError('state-invariant', { message: `Unknown phase '${phase as string}'` });
+  }
+}
+
+export function shouldSkipForTaskType(issueType: string): { skip: boolean; reason?: string } {
+  if (issueType === 'Task') {
+    return { skip: true, reason: 'ticket type Task is not processed by Ferry' };
+  }
+  return { skip: false };
+}
+
+export function buildTaskSkipComment(role: string, runId: string): string {
+  return `[ferry:${role}:${runId}] Skipped — ticket type Task is not processed by Ferry`;
+}

--- a/src/lib/dispatch/skip-task-type-action.ts
+++ b/src/lib/dispatch/skip-task-type-action.ts
@@ -1,0 +1,36 @@
+import { postComment } from '../io/jira.js';
+import { validateEnvelope } from '../envelope/validate.js';
+import { buildTaskSkipComment, shouldSkipForTaskType } from './route.js';
+
+const raw = process.env.FERRY_ENVELOPE_PAYLOAD;
+if (!raw) {
+  console.error('[ferry:dispatch] FERRY_ENVELOPE_PAYLOAD is not set');
+  process.exit(1);
+}
+
+let parsed: unknown;
+try {
+  parsed = JSON.parse(raw);
+} catch {
+  console.error('[ferry:dispatch] FERRY_ENVELOPE_PAYLOAD is not valid JSON');
+  process.exit(1);
+}
+
+const envelope = validateEnvelope(parsed);
+const issueType = envelope.issue_type;
+if (!issueType) process.exit(0);
+
+const skip = shouldSkipForTaskType(issueType);
+if (!skip.skip) process.exit(0);
+
+const role = 'refiner';
+const body = buildTaskSkipComment(role, envelope.event_id);
+
+await postComment({
+  ticketKey: envelope.ticket_key,
+  body,
+  idempotencyMarker: `[ferry:${role}:${envelope.event_id}]`,
+  recentComments: [],
+});
+
+process.exit(0);

--- a/src/lib/envelope/types.ts
+++ b/src/lib/envelope/types.ts
@@ -10,4 +10,5 @@ export interface EventEnvelopeV1 {
   source: EventSource;
   ts: string;
   instructions?: string;
+  issue_type?: string;
 }

--- a/src/schemas/event.v1.schema.json
+++ b/src/schemas/event.v1.schema.json
@@ -12,6 +12,7 @@
       "enum": ["jira-column", "jira-label", "jira-mention", "reconciler"]
     },
     "instructions": { "type": "string" },
+    "issue_type": { "type": "string" },
     "ts": { "type": "string", "format": "date-time" }
   },
   "additionalProperties": false


### PR DESCRIPTION
## TL;DR
Implements Story 2-1 scaffolding: adds a pure phase→workflow routing helper with unit tests, extends the event envelope schema to accept `issue_type`, and wires `refine.yml` to skip Task tickets by posting the required Jira comment via the existing deferred-REST `postComment()` wrapper.

## What changed
- `src/lib/dispatch/route.ts`: phase→workflow mapping + Task skip helpers
- `src/lib/dispatch/route.test.ts`: contract tests for mappings, unknown phase, Task skip, comment format, and envelope `issue_type`
- `src/schemas/event.v1.schema.json` + `src/lib/envelope/types.ts`: add optional `issue_type`
- `src/lib/dispatch/skip-task-type-action.ts` + `refine.yml`: early step to skip Task tickets and post the Jira comment (scaffold)

## Notes
- No new dependencies; Jira writes remain scaffold-only per existing repo convention.
- Only `refine.yml` is wired for Task skipping in this PR; dev/review/iterate can follow the same step if desired.

## Gates
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test`