### PR TITLE
fix(tsconfig): pin types: [node] for TS 6; reconcile sprint-status

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: "2026-04-27T00:00:00Z"
-last_updated: "2026-04-28T12:53:00Z"  # rebased onto main after PR #17 merged; bulk session: epics 2-9 all stories review
+last_updated: "2026-04-28T13:24:00Z"  # Epics 1-9 all stories done
 project: ferry
 project_key: NOKEY
 tracking_system: file-system
@@ -46,7 +46,7 @@ development_status:
   # ─────────────────────────────────────────────────────────────
   # Epic 1: Foundation — Scaffold, Core Infrastructure & Setup
   # ─────────────────────────────────────────────────────────────
-  epic-1: in-progress
+  epic-1: done
   1-1-project-scaffold-typescript-config-and-ci-pipeline: done
   1-2-state-schema-json-validation-and-preflight-invariants: done
   1-3-event-envelope-schema-ulid-generation-and-deduplication: done
@@ -54,7 +54,7 @@ development_status:
   1-5-error-taxonomy-audit-writer-and-labels-allowlist: done
   1-6-secret-scanning-codeowners-path-filter-and-io-wrappers: done
   1-6b-gitleaks-secret-scan-integration: done
-  1-6c-gitleaks-harness-runtime-scanning: review
+  1-6c-gitleaks-harness-runtime-scanning: done
   1-7-llm-harness-model-routing-and-configuration-loading: done
   1-8-readme-examples-and-first-time-setup-documentation: done
   epic-1-retrospective: optional
@@ -62,77 +62,77 @@ development_status:
   # ─────────────────────────────────────────────────────────────
   # Epic 2: Event Routing — Ticket Ingestion & Dispatch
   # ─────────────────────────────────────────────────────────────
-  epic-2: in-progress
-  2-1-column-transition-dispatch-and-workflow-routing: review
-  2-2-label-based-and-mention-re-trigger-dispatch: review
-  2-3-per-ticket-daily-trigger-cap: review
-  2-4-phase-labels-jira-phase-comments-and-ferry-audit-emission: review
+  epic-2: done
+  2-1-column-transition-dispatch-and-workflow-routing: done
+  2-2-label-based-and-mention-re-trigger-dispatch: done
+  2-3-per-ticket-daily-trigger-cap: done
+  2-4-phase-labels-jira-phase-comments-and-ferry-audit-emission: done
   epic-2-retrospective: optional
 
   # ─────────────────────────────────────────────────────────────
   # Epic 3: Refiner Agent — Automated Planning
   # ─────────────────────────────────────────────────────────────
-  epic-3: in-progress
-  3-1-refiner-reads-ticket-and-produces-sub-task-plan: review
-  3-2-atomic-batch-sub-task-creation-with-cap: review
-  3-3-idempotent-re-run-and-empty-ticket-escalation: review
+  epic-3: done
+  3-1-refiner-reads-ticket-and-produces-sub-task-plan: done
+  3-2-atomic-batch-sub-task-creation-with-cap: done
+  3-3-idempotent-re-run-and-empty-ticket-escalation: done
   epic-3-retrospective: optional
 
   # ─────────────────────────────────────────────────────────────
   # Epic 4: Developer Agent — Automated Implementation
   # ─────────────────────────────────────────────────────────────
-  epic-4: in-progress
-  4-1-developer-reads-ticket-and-builds-file-context: review
-  4-2-branch-creation-code-generation-and-scope-enforced-diff-application: review
-  4-3-critical-model-routing-on-critical-label: review
-  4-4-draft-pr-open-and-auto-transition-to-in-review: review
+  epic-4: done
+  4-1-developer-reads-ticket-and-builds-file-context: done
+  4-2-branch-creation-code-generation-and-scope-enforced-diff-application: done
+  4-3-critical-model-routing-on-critical-label: done
+  4-4-draft-pr-open-and-auto-transition-to-in-review: done
   epic-4-retrospective: optional
 
   # ─────────────────────────────────────────────────────────────
   # Epic 5: Reviewer Agent — Quality Gate
   # ─────────────────────────────────────────────────────────────
-  epic-5: in-progress
-  5-1-ci-status-gate-green-proceeds-red-produces-synthetic-finding: review
-  5-2-code-review-with-fingerprinted-findings-and-rule-taxonomy: review
-  5-3-structured-reviewer-summary-and-verdict: review
-  5-4-auto-transition-based-on-review-outcome: review
+  epic-5: done
+  5-1-ci-status-gate-green-proceeds-red-produces-synthetic-finding: done
+  5-2-code-review-with-fingerprinted-findings-and-rule-taxonomy: done
+  5-3-structured-reviewer-summary-and-verdict: done
+  5-4-auto-transition-based-on-review-outcome: done
   epic-5-retrospective: optional
 
   # ─────────────────────────────────────────────────────────────
   # Epic 6: Iterator Agent — Closed-Loop Delivery
   # ─────────────────────────────────────────────────────────────
-  epic-6: in-progress
-  6-1-iterator-reads-review-history-and-applies-findings: review
-  6-2-resurgent-finding-detection-and-immediate-escalation: review
-  6-3-3-iteration-cap-with-needs-human-escalation: review
-  6-4-escalation-summary-block-on-pr-body: review
-  6-5-auto-transition-to-in-review-after-iterator-commit: review
+  epic-6: done
+  6-1-iterator-reads-review-history-and-applies-findings: done
+  6-2-resurgent-finding-detection-and-immediate-escalation: done
+  6-3-3-iteration-cap-with-needs-human-escalation: done
+  6-4-escalation-summary-block-on-pr-body: done
+  6-5-auto-transition-to-in-review-after-iterator-commit: done
   epic-6-retrospective: optional
 
   # ─────────────────────────────────────────────────────────────
   # Epic 7: Human Control & Override
   # ─────────────────────────────────────────────────────────────
-  epic-7: in-progress
-  7-1-manual-cancel-via-github-actions-ui: review
-  7-2-label-re-trigger-and-mention-re-trigger-with-context: review
-  7-3-pause-and-needs-human-label-handling: review
-  7-4-human-only-merge-and-column-transition-invariants: review
+  epic-7: done
+  7-1-manual-cancel-via-github-actions-ui: done
+  7-2-label-re-trigger-and-mention-re-trigger-with-context: done
+  7-3-pause-and-needs-human-label-handling: done
+  7-4-human-only-merge-and-column-transition-invariants: done
   epic-7-retrospective: optional
 
   # ─────────────────────────────────────────────────────────────
   # Epic 8: Observability, Cost Governance & Webhook Resilience
   # ─────────────────────────────────────────────────────────────
-  epic-8: in-progress
-  8-1-daily-provider-spend-check-and-50-soft-alert: review
-  8-2-http-429-402-auto-pause-on-provider-rate-limits: review
-  8-3-15-minute-reconciler-cron-with-ulid-dedupe: review
-  8-4-comment-volume-ceiling-via-in-place-editing: review
+  epic-8: done
+  8-1-daily-provider-spend-check-and-50-soft-alert: done
+  8-2-http-429-402-auto-pause-on-provider-rate-limits: done
+  8-3-15-minute-reconciler-cron-with-ulid-dedupe: done
+  8-4-comment-volume-ceiling-via-in-place-editing: done
   epic-8-retrospective: optional
 
   # ─────────────────────────────────────────────────────────────
   # Epic 9: Human-Reader Experience
   # ─────────────────────────────────────────────────────────────
-  epic-9: in-progress
-  9-1-mandated-tldr-block-in-pr-body: review
-  9-2-ci-check-for-tldr-format-and-length: review
+  epic-9: done
+  9-1-mandated-tldr-block-in-pr-body: done
+  9-2-ci-check-for-tldr-format-and-length: done
   epic-9-retrospective: optional

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
+    "types": ["node"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true


### PR DESCRIPTION
# Fix: typecheck red on main + reconcile sprint-status

## Why this PR exists

Two related cleanup items after PR #19 (Epics 2–9 bulk) and the dependabot toolchain bumps merged:

### 1. Typecheck regression on main

Dependabot PR #3 (typescript-toolchain group) bumped `typescript` from 5.x to 6.x and `@types/node` to 25.x. Starting with TS 6, `@types/node` is no longer auto-loaded without an explicit `types` field in `tsconfig.json` — so every node global (`Buffer`, `process`, `child_process`, `node:fs`, etc.) starts erroring with TS2591.

Visible on commit `dcf5c0c` (current HEAD of main):

```
Typecheck         - completed failure
Tests (vitest)    - completed success
Secret Scan       - completed success
Lint & Format     - completed success
```

Vitest doesn't typecheck, which is why the regression slipped through — the bulk PR #19 was reviewed and merged with a passing test suite but a broken typecheck. This PR adds `"types": ["node"]` to `tsconfig.json` to restore the autoload behavior.

### 2. Sprint-status drift

Sprint-status.yaml still listed all 22 Epics 2–9 stories as `review` and all `epic-N` as `in-progress`, even though PR #19 merged them all to main. The autonomous BMad cron then escalated correctly — it found no `backlog` stories to work on but the file didn't reflect the actual project completion.

This PR flips:
- All `review` story statuses → `done`
- All `epic-N: in-progress` → `epic-N: done`

## Changes

- `tsconfig.json` — add `"types": ["node"]`
- `_bmad-output/implementation-artifacts/sprint-status.yaml` — reconcile to actual main state

## Local gates

- ✅ `npm run typecheck` (was failing, now passes)
- ✅ `npm run lint`
- ✅ `npm run format:check`
- ✅ `npm test` — 358/358 tests pass

## Notes

- No source code changes, no behavior changes.
- The Ferry project is now functionally complete: 9 epics, 38 stories, all done on main.
- After merge: the BMad cron will exit silently on next run (no backlog), the reviewer cron will skip silently (no eligible PRs).