### PR TITLE
refactor(dispatch): extract CIRunner interface to decouple agents from GitHub Actions

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,7 +25,7 @@ export default [
       '@typescript-eslint/no-explicit-any': 'error',
     },
   },
-  // Agent code must never import Octokit directly — must go through src/lib/io/github.ts
+  // Agent code must never import Octokit directly — must go through the CIRunner interface
   {
     files: ['src/agents/**/*.ts'],
     languageOptions: {
@@ -39,7 +39,7 @@ export default [
           patterns: [
             {
               group: ['@octokit/rest'],
-              message: 'Import Octokit only through src/lib/io/github.ts',
+              message: 'Import Octokit only through src/lib/dispatch/runner/github-actions/',
             },
             {
               group: ['src/lib/io/github.js', 'src/lib/io/jira.js', 'src/lib/io/github.ts', 'src/lib/io/jira.ts'],

--- a/src/agents/developer/dev-action.ts
+++ b/src/agents/developer/dev-action.ts
@@ -8,6 +8,7 @@ import { createJiraRestClientFromEnv } from '../../lib/io/jira-rest.js';
 import { adfToText } from '../../lib/io/jira-adf.js';
 import { scanWithGitleaks } from '../../lib/secret-scan/scan.js';
 import { FerryError } from '../../lib/error.js';
+import { GitHubActionsRunner } from '../../lib/dispatch/runner/github-actions/index.js';
 import { formatDeveloperCommit } from './commit.js';
 import { formatPullRequestTitle, formatPullRequestBody } from './pr.js';
 import { runAgentLoop } from './loop.js';
@@ -74,9 +75,16 @@ async function main(): Promise<void> {
 
   const anthropicApiKey = requireEnv('ANTHROPIC_API_KEY');
   const reviewTransitionId = requireEnv('FERRY_REVIEW_TRANSITION_ID');
+  const githubToken = requireEnv('GITHUB_TOKEN');
   const githubRepo = requireEnv('GITHUB_REPO');
   const jiraBaseUrl = requireEnv('FERRY_JIRA_BASE_URL');
 
+  const [owner, repo] = githubRepo.split('/');
+  if (!owner || !repo) {
+    throw new FerryError('state-invariant', { reason: 'invalid-github-repo', githubRepo });
+  }
+
+  const runner = new GitHubActionsRunner(githubToken, owner, repo);
   const jira = createJiraRestClientFromEnv();
   const issue = await jira.getIssue(ticketKey);
   const description = adfToText(issue.fields.description);
@@ -210,21 +218,7 @@ async function main(): Promise<void> {
     tldr: done.summary,
   });
 
-  let prUrl: string;
-  try {
-    const result = execFileSync(
-      'gh',
-      ['pr', 'create', '--title', prTitle, '--body', prBody, '--base', 'main', '--head', branchName],
-      { cwd: REPO_ROOT, encoding: 'utf8' },
-    );
-    prUrl = result.trim();
-  } catch {
-    prUrl = execFileSync(
-      'gh',
-      ['pr', 'view', branchName, '--json', 'url', '-q', '.url'],
-      { cwd: REPO_ROOT, encoding: 'utf8' },
-    ).trim();
-  }
+  const prUrl = await runner.createPR(owner, repo, branchName, 'main', prTitle, prBody);
 
   // Jira transition
   await fetch(

--- a/src/agents/iterator/iterate-action.ts
+++ b/src/agents/iterator/iterate-action.ts
@@ -2,7 +2,6 @@ import { appendFileSync, readFileSync } from 'node:fs';
 import { execFileSync, execSync } from 'node:child_process';
 import * as path from 'node:path';
 import Anthropic from '@anthropic-ai/sdk';
-import { Octokit } from '@octokit/rest';
 import { validateEnvelope } from '../../lib/envelope/validate.js';
 import { delimitUntrusted } from '../../lib/sanitization/delimit-untrusted.js';
 import { createJiraRestClientFromEnv } from '../../lib/io/jira-rest.js';
@@ -10,6 +9,7 @@ import { adfToText, textToAdf } from '../../lib/io/jira-adf.js';
 import { checkIdempotencyMarker } from '../../lib/io/idempotency.js';
 import { scanWithGitleaks } from '../../lib/secret-scan/scan.js';
 import { FerryError } from '../../lib/error.js';
+import { GitHubActionsRunner } from '../../lib/dispatch/runner/github-actions/index.js';
 import { checkIterationCap } from './cap.js';
 import { decideIteratorTransition } from './transition.js';
 import { formatCommitMessage } from './prompt.js';
@@ -40,7 +40,7 @@ async function main(): Promise<void> {
     throw new FerryError('state-invariant', { reason: 'invalid-github-repo', githubRepo });
   }
 
-  const octokit = new Octokit({ auth: githubToken });
+  const runner = new GitHubActionsRunner(githubToken, owner, repo);
   const jira = createJiraRestClientFromEnv();
 
   const issue = await jira.getIssue(ticketKey);
@@ -52,15 +52,9 @@ async function main(): Promise<void> {
   checkIterationCap({ iteration: priorIterations, hasFindings: true });
 
   const branchName = `ferry/${ticketKey}`;
-  const { data: pulls } = await octokit.pulls.list({
-    owner,
-    repo,
-    state: 'open',
-    head: `${owner}:${branchName}`,
-    per_page: 1,
-  });
+  const prs = await runner.listPRsForBranch(owner, repo, branchName);
 
-  if (pulls.length === 0) {
+  if (prs.length === 0) {
     // Review ID not yet known — use event_id to prevent duplicate error comments
     const eventMarker = `[ferry:iterator:${eventId}]`;
     const { skipped } = checkIdempotencyMarker(eventMarker, existingComments);
@@ -74,17 +68,10 @@ async function main(): Promise<void> {
     return;
   }
 
-  const prNumber = pulls[0].number;
+  const prNumber = prs[0].number;
 
-  const { data: recentComments } = await octokit.issues.listComments({
-    owner,
-    repo,
-    issue_number: prNumber,
-    sort: 'created',
-    direction: 'desc',
-    per_page: 30,
-  });
-  const reviewComments = recentComments.filter((c) => c.body?.includes('[ferry:reviewer:'));
+  const recentComments = await runner.listPRComments({ owner, repo, prNumber }, 30);
+  const reviewComments = recentComments.filter((c) => c.body.includes('[ferry:reviewer:'));
   if (reviewComments.length === 0) {
     const eventMarker = `[ferry:iterator:${eventId}]`;
     const { skipped } = checkIdempotencyMarker(eventMarker, existingComments);
@@ -110,7 +97,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const reviewComment = latestReview.body ?? '';
+  const reviewComment = latestReview.body;
   if (/\*\*Verdict\*\*:\s*Approved\b/.test(reviewComment)) {
     await jira.postComment(
       ticketKey,

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -1,7 +1,6 @@
 import { appendFileSync, readFileSync } from 'node:fs';
 import * as path from 'node:path';
 import Anthropic from '@anthropic-ai/sdk';
-import { Octokit } from '@octokit/rest';
 import { validateEnvelope } from '../../lib/envelope/validate.js';
 import { delimitUntrusted } from '../../lib/sanitization/delimit-untrusted.js';
 import { createJiraRestClientFromEnv } from '../../lib/io/jira-rest.js';
@@ -9,9 +8,8 @@ import { adfToText, textToAdf } from '../../lib/io/jira-adf.js';
 import { checkIdempotencyMarker } from '../../lib/io/idempotency.js';
 import { gateCi } from './ci-gate.js';
 import { FerryError } from '../../lib/error.js';
+import { GitHubActionsRunner } from '../../lib/dispatch/runner/github-actions/index.js';
 import {
-  resolveCiStatus,
-  fetchAllPrFiles,
   detectMergeConflicts,
   buildFileList,
   runReviewLoop,
@@ -45,7 +43,7 @@ async function main(): Promise<void> {
   if (!owner || !repo) {
     throw new FerryError('state-invariant', { reason: 'invalid-github-repo', githubRepo });
   }
-  const octokit = new Octokit({ auth: githubToken });
+  const runner = new GitHubActionsRunner(githubToken, owner, repo);
   const jira = createJiraRestClientFromEnv();
 
   const issue = await jira.getIssue(ticketKey);
@@ -53,15 +51,9 @@ async function main(): Promise<void> {
 
   // Find PR for this ticket's branch
   const branchName = `ferry/${ticketKey}`;
-  const { data: pulls } = await octokit.pulls.list({
-    owner,
-    repo,
-    state: 'open',
-    head: `${owner}:${branchName}`,
-    per_page: 1,
-  });
+  const prs = await runner.listPRsForBranch(owner, repo, branchName);
 
-  if (pulls.length === 0) {
+  if (prs.length === 0) {
     const errorMarker = `[ferry:reviewer:${eventId}]`;
     const { skipped } = checkIdempotencyMarker(errorMarker, existingComments);
     if (!skipped) {
@@ -74,10 +66,10 @@ async function main(): Promise<void> {
     return;
   }
 
-  const prNumber = pulls[0].number;
+  const prNumber = prs[0].number;
   // Fetch the full PR to get the `mergeable` field (not available in list response)
-  const { data: pr } = await octokit.pulls.get({ owner, repo, pull_number: prNumber });
-  const headSha = pr.head.sha;
+  const pr = await runner.getPR({ owner, repo, prNumber });
+  const headSha = pr.headSha;
   const mergeable = pr.mergeable;
 
   // Idempotency keyed on head SHA — a new push always produces a new SHA,
@@ -91,7 +83,7 @@ async function main(): Promise<void> {
   }
 
   // CI gate
-  const ciStatus = await resolveCiStatus(octokit, owner, repo, headSha);
+  const ciStatus = await runner.getCommitStatus(owner, repo, headSha);
   const ciOutcome = gateCi({ status: ciStatus });
 
   if (!ciOutcome.proceed) {
@@ -111,19 +103,17 @@ async function main(): Promise<void> {
       ticketKey,
       textToAdf(`${idempotencyMarker} CI checks failed. Moved to Dev Iteration.`),
     );
-    await octokit.issues.createComment({
-      owner,
-      repo,
-      issue_number: prNumber,
-      body: `${idempotencyMarker}\n\n**CI failed:** ${ciMessage}`,
-    });
+    await runner.commentOnPR(
+      { owner, repo, prNumber },
+      `${idempotencyMarker}\n\n**CI failed:** ${ciMessage}`,
+    );
     await jira.postTransition(ticketKey, iterTransitionId);
     appendOutput({ input_tokens: 0, output_tokens: 0, model });
     return;
   }
 
   // Fetch ALL PR files (paginated)
-  const files = await fetchAllPrFiles(octokit, owner, repo, prNumber);
+  const files = await runner.listPRFiles({ owner, repo, prNumber });
   const fileMap = new Map<string, string | undefined>(files.map((f) => [f.filename, f.patch]));
 
   // Detect merge conflicts in patches
@@ -131,11 +121,9 @@ async function main(): Promise<void> {
   const hasMergeConflicts = mergeable === false || conflictedFiles.length > 0;
 
   // Fetch commits for context
-  const { data: commits } = await octokit.pulls.listCommits({
-    owner, repo, pull_number: prNumber, per_page: 50,
-  });
+  const commits = await runner.listPRCommits({ owner, repo, prNumber });
   const commitLog = commits
-    .map((c) => `${c.sha.slice(0, 7)} ${c.commit.message.split('\n')[0]}`)
+    .map((c) => `${c.sha.slice(0, 7)} ${c.message.split('\n')[0]}`)
     .join('\n');
 
   // Build ticket context
@@ -157,7 +145,7 @@ async function main(): Promise<void> {
     '',
     '## PR Metadata',
     `PR #${prNumber}: ${pr.title}`,
-    `Base: ${pr.base.ref} ← Head: ${branchName} (${headSha.slice(0, 7)})`,
+    `Base: ${pr.baseRef} ← Head: ${branchName} (${headSha.slice(0, 7)})`,
     `Files changed: ${files.length}  Commits: ${commits.length}`,
     mergeConflictWarning,
     '',
@@ -185,7 +173,7 @@ async function main(): Promise<void> {
     system,
     initialPrompt,
     fileMap,
-    octokit,
+    runner,
     owner,
     repo,
     headSha,
@@ -200,21 +188,13 @@ async function main(): Promise<void> {
       ticketKey,
       textToAdf(`${idempotencyMarker} Approved. PR#${prNumber} is ready to merge.`),
     );
-    await octokit.issues.addLabels({
-      owner, repo, issue_number: prNumber, labels: ['ferry:approved'],
-    });
-    await octokit.issues.removeLabel({
-      owner, repo, issue_number: prNumber, name: 'ferry:reviewing',
-    }).catch(() => {});
-    await octokit.issues.createComment({
-      owner, repo, issue_number: prNumber, body: review.comment,
-    });
+    await runner.addLabelsToPR({ owner, repo, prNumber }, ['ferry:approved']);
+    await runner.removeLabelFromPR({ owner, repo, prNumber }, 'ferry:reviewing').catch(() => {});
+    await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
   } else {
     const hasIteratorMarker = existingComments.some((c) => c.includes('[ferry:iterator:'));
 
-    await octokit.issues.createComment({
-      owner, repo, issue_number: prNumber, body: review.comment,
-    });
+    await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
 
     if (!hasIteratorMarker) {
       await jira.postComment(

--- a/src/agents/reviewer/review-loop.ts
+++ b/src/agents/reviewer/review-loop.ts
@@ -1,6 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk';
 import type { MessageParam, ToolResultBlockParam, ContentBlock } from '@anthropic-ai/sdk/resources/messages.js';
-import { Octokit } from '@octokit/rest';
+import type { CIRunner, PRFile } from '../../lib/dispatch/runner/types.js';
 import { FerryError } from '../../lib/error.js';
 import type { CiStatus } from './ci-gate.js';
 
@@ -8,7 +8,7 @@ export const MAX_PATCH_CHARS = 20_000;
 export const MAX_CONTENT_CHARS = 40_000;
 const MAX_ITERATIONS = 40;
 
-export { CiStatus };
+export type { CiStatus, PRFile as PrFile };
 
 export const REVIEW_TOOLS: Anthropic.Tool[] = [
   {
@@ -57,48 +57,12 @@ export const REVIEW_TOOLS: Anthropic.Tool[] = [
   },
 ];
 
-export type PrFile = { filename: string; status: string; additions: number; deletions: number; patch?: string };
-
 export interface ReviewResult {
   approved: boolean;
   comment: string;
 }
 
-export async function resolveCiStatus(
-  octokit: Octokit,
-  owner: string,
-  repo: string,
-  sha: string,
-): Promise<CiStatus> {
-  const { data } = await octokit.checks.listForRef({ owner, repo, ref: sha, per_page: 100 });
-  const runs = data.check_runs;
-  if (runs.some((r) => r.status !== 'completed')) return 'pending';
-  if (runs.some((r) => r.conclusion === 'failure' || r.conclusion === 'timed_out')) return 'red';
-  return 'green';
-}
-
-export async function fetchAllPrFiles(
-  octokit: Octokit,
-  owner: string,
-  repo: string,
-  prNumber: number,
-): Promise<PrFile[]> {
-  const files = await octokit.paginate(octokit.pulls.listFiles, {
-    owner,
-    repo,
-    pull_number: prNumber,
-    per_page: 100,
-  });
-  return files.map((f) => ({
-    filename: f.filename,
-    status: f.status,
-    additions: f.additions,
-    deletions: f.deletions,
-    patch: f.patch,
-  }));
-}
-
-export function detectMergeConflicts(files: PrFile[]): string[] {
+export function detectMergeConflicts(files: PRFile[]): string[] {
   const conflicted: string[] = [];
   for (const f of files) {
     if (f.patch && /^[+].*<{7}|^[+].*={7}|^[+].*>{7}/m.test(f.patch)) {
@@ -108,31 +72,10 @@ export function detectMergeConflicts(files: PrFile[]): string[] {
   return conflicted;
 }
 
-export function buildFileList(files: PrFile[]): string {
+export function buildFileList(files: PRFile[]): string {
   return files
     .map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`)
     .join('\n');
-}
-
-export async function getFileContent(
-  octokit: Octokit,
-  owner: string,
-  repo: string,
-  filename: string,
-  ref: string,
-): Promise<string> {
-  try {
-    const { data } = await octokit.repos.getContent({ owner, repo, path: filename, ref });
-    if ('content' in data && typeof data.content === 'string') {
-      const decoded = Buffer.from(data.content, 'base64').toString('utf8');
-      return decoded.length > MAX_CONTENT_CHARS
-        ? decoded.slice(0, MAX_CONTENT_CHARS) + '\n... (truncated)'
-        : decoded;
-    }
-    return '(binary file or directory — cannot display)';
-  } catch (e) {
-    return `(error fetching content: ${(e as Error).message})`;
-  }
 }
 
 export async function runReviewLoop(opts: {
@@ -141,12 +84,12 @@ export async function runReviewLoop(opts: {
   system: string;
   initialPrompt: string;
   fileMap: Map<string, string | undefined>;
-  octokit: Octokit;
+  runner: CIRunner;
   owner: string;
   repo: string;
   headSha: string;
 }): Promise<{ result: ReviewResult; inputTokens: number; outputTokens: number }> {
-  const { anthropic, model, system, initialPrompt, fileMap, octokit, owner, repo, headSha } = opts;
+  const { anthropic, model, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
 
   const tools = REVIEW_TOOLS.map((t, i) =>
     i === REVIEW_TOOLS.length - 1
@@ -223,7 +166,7 @@ export async function runReviewLoop(opts: {
       if (block.name === 'get_file_content') {
         const filename = input.filename as string;
         console.error(`[ferry:review-tool] iter=${iter + 1} get_file_content ${filename}`);
-        const content = await getFileContent(octokit, owner, repo, filename, headSha);
+        const content = await runner.getFileContent(owner, repo, filename, headSha);
         toolResults.push({ type: 'tool_result', tool_use_id: block.id, content });
         continue;
       }

--- a/src/lib/dispatch/runner/github-actions/index.test.ts
+++ b/src/lib/dispatch/runner/github-actions/index.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Octokit } from '@octokit/rest';
+import { GitHubActionsRunner } from './index.js';
+
+type MockOctokit = {
+  pulls: {
+    list: ReturnType<typeof vi.fn>;
+    get: ReturnType<typeof vi.fn>;
+    listFiles: ReturnType<typeof vi.fn>;
+    listCommits: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
+  issues: {
+    createComment: ReturnType<typeof vi.fn>;
+    addLabels: ReturnType<typeof vi.fn>;
+    removeLabel: ReturnType<typeof vi.fn>;
+    listComments: ReturnType<typeof vi.fn>;
+  };
+  checks: {
+    listForRef: ReturnType<typeof vi.fn>;
+  };
+  repos: {
+    getContent: ReturnType<typeof vi.fn>;
+    createDispatchEvent: ReturnType<typeof vi.fn>;
+  };
+  paginate: ReturnType<typeof vi.fn>;
+};
+
+function makeMockOctokit(): MockOctokit {
+  return {
+    pulls: {
+      list: vi.fn(),
+      get: vi.fn(),
+      listFiles: vi.fn(),
+      listCommits: vi.fn(),
+      create: vi.fn(),
+    },
+    issues: {
+      createComment: vi.fn(),
+      addLabels: vi.fn(),
+      removeLabel: vi.fn(),
+      listComments: vi.fn(),
+    },
+    checks: {
+      listForRef: vi.fn(),
+    },
+    repos: {
+      getContent: vi.fn(),
+      createDispatchEvent: vi.fn(),
+    },
+    paginate: vi.fn(),
+  };
+}
+
+const OWNER = 'acme';
+const REPO = 'ferry';
+const PR_REF = { owner: OWNER, repo: REPO, prNumber: 42 };
+
+describe('GitHubActionsRunner', () => {
+  let mock: MockOctokit;
+  let runner: GitHubActionsRunner;
+
+  beforeEach(() => {
+    mock = makeMockOctokit();
+    runner = new GitHubActionsRunner(mock as unknown as Octokit, OWNER, REPO);
+  });
+
+  describe('getCommitStatus', () => {
+    it('returns green when all checks completed without failure', async () => {
+      mock.checks.listForRef.mockResolvedValue({
+        data: {
+          check_runs: [
+            { status: 'completed', conclusion: 'success' },
+            { status: 'completed', conclusion: 'neutral' },
+          ],
+        },
+      });
+      expect(await runner.getCommitStatus(OWNER, REPO, 'abc123')).toBe('green');
+    });
+
+    it('returns pending when any check is not completed', async () => {
+      mock.checks.listForRef.mockResolvedValue({
+        data: {
+          check_runs: [
+            { status: 'completed', conclusion: 'success' },
+            { status: 'in_progress', conclusion: null },
+          ],
+        },
+      });
+      expect(await runner.getCommitStatus(OWNER, REPO, 'abc123')).toBe('pending');
+    });
+
+    it('returns red when any check has failed', async () => {
+      mock.checks.listForRef.mockResolvedValue({
+        data: {
+          check_runs: [
+            { status: 'completed', conclusion: 'success' },
+            { status: 'completed', conclusion: 'failure' },
+          ],
+        },
+      });
+      expect(await runner.getCommitStatus(OWNER, REPO, 'abc123')).toBe('red');
+    });
+
+    it('returns red when any check timed out', async () => {
+      mock.checks.listForRef.mockResolvedValue({
+        data: {
+          check_runs: [{ status: 'completed', conclusion: 'timed_out' }],
+        },
+      });
+      expect(await runner.getCommitStatus(OWNER, REPO, 'abc123')).toBe('red');
+    });
+  });
+
+  describe('createPR', () => {
+    it('returns html_url when PR creation succeeds', async () => {
+      mock.pulls.create.mockResolvedValue({
+        data: { html_url: 'https://github.com/acme/ferry/pull/99' },
+      });
+      const url = await runner.createPR(OWNER, REPO, 'feature-branch', 'main', 'title', 'body');
+      expect(url).toBe('https://github.com/acme/ferry/pull/99');
+    });
+
+    it('returns existing PR url when creation fails (PR already exists)', async () => {
+      mock.pulls.create.mockRejectedValue(new Error('Validation Failed'));
+      mock.pulls.list.mockResolvedValue({
+        data: [{ html_url: 'https://github.com/acme/ferry/pull/42', number: 42 }],
+      });
+      const url = await runner.createPR(OWNER, REPO, 'feature-branch', 'main', 'title', 'body');
+      expect(url).toBe('https://github.com/acme/ferry/pull/42');
+    });
+
+    it('throws when creation fails and no existing PR is found', async () => {
+      mock.pulls.create.mockRejectedValue(new Error('Validation Failed'));
+      mock.pulls.list.mockResolvedValue({ data: [] });
+      await expect(
+        runner.createPR(OWNER, REPO, 'feature-branch', 'main', 'title', 'body'),
+      ).rejects.toThrow('Failed to create or find PR');
+    });
+  });
+
+  describe('listPRsForBranch', () => {
+    it('returns mapped PR list', async () => {
+      mock.pulls.list.mockResolvedValue({
+        data: [
+          {
+            number: 7,
+            title: 'My PR',
+            base: { ref: 'main' },
+            head: { ref: 'feature', sha: 'deadbeef' },
+          },
+        ],
+      });
+      const prs = await runner.listPRsForBranch(OWNER, REPO, 'feature');
+      expect(prs).toHaveLength(1);
+      expect(prs[0]).toMatchObject({
+        number: 7,
+        title: 'My PR',
+        baseRef: 'main',
+        headRef: 'feature',
+        headSha: 'deadbeef',
+        mergeable: null,
+      });
+    });
+  });
+
+  describe('getPR', () => {
+    it('returns PR with mergeable field', async () => {
+      mock.pulls.get.mockResolvedValue({
+        data: {
+          number: 42,
+          title: 'Fix: something',
+          base: { ref: 'main' },
+          head: { ref: 'ferry/CHAN-1', sha: 'cafebabe' },
+          mergeable: true,
+        },
+      });
+      const pr = await runner.getPR(PR_REF);
+      expect(pr).toMatchObject({
+        number: 42,
+        headSha: 'cafebabe',
+        mergeable: true,
+      });
+    });
+
+    it('maps null mergeable from Octokit to null', async () => {
+      mock.pulls.get.mockResolvedValue({
+        data: {
+          number: 42,
+          title: 'Fix',
+          base: { ref: 'main' },
+          head: { ref: 'ferry/CHAN-1', sha: 'cafebabe' },
+          mergeable: null,
+        },
+      });
+      const pr = await runner.getPR(PR_REF);
+      expect(pr.mergeable).toBeNull();
+    });
+  });
+
+  describe('listPRFiles', () => {
+    it('paginates and maps file list', async () => {
+      mock.paginate.mockResolvedValue([
+        { filename: 'src/foo.ts', status: 'modified', additions: 5, deletions: 2, patch: '@@ ...' },
+        { filename: 'src/bar.ts', status: 'added', additions: 10, deletions: 0, patch: undefined },
+      ]);
+      const files = await runner.listPRFiles(PR_REF);
+      expect(files).toHaveLength(2);
+      expect(files[0].filename).toBe('src/foo.ts');
+      expect(files[1].patch).toBeUndefined();
+    });
+  });
+
+  describe('listPRCommits', () => {
+    it('returns sha and message for each commit', async () => {
+      mock.pulls.listCommits.mockResolvedValue({
+        data: [
+          { sha: 'abc1234', commit: { message: 'feat: add feature\n\ndetails' } },
+          { sha: 'def5678', commit: { message: 'fix: a bug' } },
+        ],
+      });
+      const commits = await runner.listPRCommits(PR_REF);
+      expect(commits).toEqual([
+        { sha: 'abc1234', message: 'feat: add feature\n\ndetails' },
+        { sha: 'def5678', message: 'fix: a bug' },
+      ]);
+    });
+  });
+
+  describe('commentOnPR', () => {
+    it('calls createComment with correct params', async () => {
+      mock.issues.createComment.mockResolvedValue({ data: { id: 1 } });
+      await runner.commentOnPR(PR_REF, 'hello world');
+      expect(mock.issues.createComment).toHaveBeenCalledWith({
+        owner: OWNER,
+        repo: REPO,
+        issue_number: 42,
+        body: 'hello world',
+      });
+    });
+  });
+
+  describe('addLabelsToPR', () => {
+    it('calls addLabels with correct params', async () => {
+      mock.issues.addLabels.mockResolvedValue({ data: [] });
+      await runner.addLabelsToPR(PR_REF, ['ferry:approved']);
+      expect(mock.issues.addLabels).toHaveBeenCalledWith({
+        owner: OWNER,
+        repo: REPO,
+        issue_number: 42,
+        labels: ['ferry:approved'],
+      });
+    });
+  });
+
+  describe('removeLabelFromPR', () => {
+    it('calls removeLabel with correct params', async () => {
+      mock.issues.removeLabel.mockResolvedValue({ data: {} });
+      await runner.removeLabelFromPR(PR_REF, 'ferry:reviewing');
+      expect(mock.issues.removeLabel).toHaveBeenCalledWith({
+        owner: OWNER,
+        repo: REPO,
+        issue_number: 42,
+        name: 'ferry:reviewing',
+      });
+    });
+  });
+
+  describe('listPRComments', () => {
+    it('returns id and body for each comment', async () => {
+      mock.issues.listComments.mockResolvedValue({
+        data: [
+          { id: 1001, body: '[ferry:reviewer:abc] LGTM' },
+          { id: 1002, body: null },
+        ],
+      });
+      const comments = await runner.listPRComments(PR_REF, 30);
+      expect(comments).toEqual([
+        { id: 1001, body: '[ferry:reviewer:abc] LGTM' },
+        { id: 1002, body: '' },
+      ]);
+    });
+  });
+
+  describe('dispatch', () => {
+    it('sends createDispatchEvent for a known phase', async () => {
+      mock.repos.createDispatchEvent.mockResolvedValue({ data: {} });
+      const payload = {
+        version: 'v1' as const,
+        event_id: 'evt-1',
+        ticket_key: 'CHAN-1',
+        phase: 'dev' as const,
+        source: 'jira-column' as const,
+        ts: '2026-01-01T00:00:00Z',
+      };
+      await runner.dispatch('dev', payload);
+      expect(mock.repos.createDispatchEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: OWNER,
+          repo: REPO,
+          event_type: 'ferry-dev',
+          client_payload: payload,
+        }),
+      );
+    });
+
+    it('throws for an unknown phase', async () => {
+      await expect(
+        runner.dispatch('unknown-phase', {} as never),
+      ).rejects.toThrow('Unknown phase for dispatch: unknown-phase');
+    });
+  });
+
+  describe('getFileContent', () => {
+    it('decodes base64 file content', async () => {
+      const content = 'hello world';
+      mock.repos.getContent.mockResolvedValue({
+        data: { content: Buffer.from(content).toString('base64') },
+      });
+      const result = await runner.getFileContent(OWNER, REPO, 'src/foo.ts', 'main');
+      expect(result).toBe(content);
+    });
+
+    it('returns fallback message for binary files', async () => {
+      mock.repos.getContent.mockResolvedValue({ data: { type: 'file' } });
+      const result = await runner.getFileContent(OWNER, REPO, 'image.png', 'main');
+      expect(result).toBe('(binary file or directory — cannot display)');
+    });
+
+    it('returns error message when API throws', async () => {
+      mock.repos.getContent.mockRejectedValue(new Error('Not Found'));
+      const result = await runner.getFileContent(OWNER, REPO, 'missing.ts', 'main');
+      expect(result).toContain('error fetching content');
+    });
+  });
+});

--- a/src/lib/dispatch/runner/github-actions/index.ts
+++ b/src/lib/dispatch/runner/github-actions/index.ts
@@ -1,0 +1,178 @@
+import { Octokit } from '@octokit/rest';
+import { PHASE_TO_WORKFLOW } from '../../routing.js';
+import type { CIRunner, PR, PRRef, PRFile, PRComment, CommitStatus, DispatchPayload } from '../types.js';
+
+const MAX_CONTENT_CHARS = 40_000;
+
+export class GitHubActionsRunner implements CIRunner {
+  private readonly octokit: Octokit;
+  private readonly defaultOwner: string;
+  private readonly defaultRepo: string;
+
+  constructor(tokenOrOctokit: string | Octokit, owner: string, repo: string) {
+    this.octokit =
+      typeof tokenOrOctokit === 'string'
+        ? new Octokit({ auth: tokenOrOctokit })
+        : tokenOrOctokit;
+    this.defaultOwner = owner;
+    this.defaultRepo = repo;
+  }
+
+  async dispatch(phase: string, payload: DispatchPayload): Promise<void> {
+    const route = (PHASE_TO_WORKFLOW as Record<string, { dispatchType: string } | undefined>)[phase];
+    if (!route) throw new Error(`Unknown phase for dispatch: ${phase}`);
+    await this.octokit.repos.createDispatchEvent({
+      owner: this.defaultOwner,
+      repo: this.defaultRepo,
+      event_type: route.dispatchType,
+      client_payload: payload as Record<string, unknown>,
+    });
+  }
+
+  async listPRsForBranch(owner: string, repo: string, branch: string): Promise<PR[]> {
+    const { data } = await this.octokit.pulls.list({
+      owner,
+      repo,
+      state: 'open',
+      head: `${owner}:${branch}`,
+      per_page: 1,
+    });
+    return data.map((p) => ({
+      number: p.number,
+      title: p.title,
+      baseRef: p.base.ref,
+      headRef: p.head.ref,
+      headSha: p.head.sha,
+      mergeable: null,
+    }));
+  }
+
+  async getPR(prRef: PRRef): Promise<PR> {
+    const { data } = await this.octokit.pulls.get({
+      owner: prRef.owner,
+      repo: prRef.repo,
+      pull_number: prRef.prNumber,
+    });
+    return {
+      number: data.number,
+      title: data.title,
+      baseRef: data.base.ref,
+      headRef: data.head.ref,
+      headSha: data.head.sha,
+      mergeable: data.mergeable ?? null,
+    };
+  }
+
+  async listPRFiles(prRef: PRRef): Promise<PRFile[]> {
+    const files = await this.octokit.paginate(this.octokit.pulls.listFiles, {
+      owner: prRef.owner,
+      repo: prRef.repo,
+      pull_number: prRef.prNumber,
+      per_page: 100,
+    });
+    return files.map((f) => ({
+      filename: f.filename,
+      status: f.status,
+      additions: f.additions,
+      deletions: f.deletions,
+      patch: f.patch,
+    }));
+  }
+
+  async listPRCommits(prRef: PRRef): Promise<Array<{ sha: string; message: string }>> {
+    const { data } = await this.octokit.pulls.listCommits({
+      owner: prRef.owner,
+      repo: prRef.repo,
+      pull_number: prRef.prNumber,
+      per_page: 50,
+    });
+    return data.map((c) => ({ sha: c.sha, message: c.commit.message }));
+  }
+
+  async getCommitStatus(owner: string, repo: string, sha: string): Promise<CommitStatus> {
+    const { data } = await this.octokit.checks.listForRef({ owner, repo, ref: sha, per_page: 100 });
+    const runs = data.check_runs;
+    if (runs.some((r) => r.status !== 'completed')) return 'pending';
+    if (runs.some((r) => r.conclusion === 'failure' || r.conclusion === 'timed_out')) return 'red';
+    return 'green';
+  }
+
+  async getFileContent(owner: string, repo: string, path: string, ref: string): Promise<string> {
+    try {
+      const { data } = await this.octokit.repos.getContent({ owner, repo, path, ref });
+      if ('content' in data && typeof data.content === 'string') {
+        const decoded = Buffer.from(data.content, 'base64').toString('utf8');
+        return decoded.length > MAX_CONTENT_CHARS
+          ? decoded.slice(0, MAX_CONTENT_CHARS) + '\n... (truncated)'
+          : decoded;
+      }
+      return '(binary file or directory — cannot display)';
+    } catch (e) {
+      return `(error fetching content: ${(e as Error).message})`;
+    }
+  }
+
+  async createPR(
+    owner: string,
+    repo: string,
+    head: string,
+    base: string,
+    title: string,
+    body: string,
+  ): Promise<string> {
+    try {
+      const { data } = await this.octokit.pulls.create({ owner, repo, head, base, title, body });
+      return data.html_url;
+    } catch {
+      // PR may already exist — find and return its URL
+      const { data: existing } = await this.octokit.pulls.list({
+        owner,
+        repo,
+        state: 'open',
+        head: `${owner}:${head}`,
+        per_page: 1,
+      });
+      if (existing.length > 0) return existing[0].html_url;
+      throw new Error(`Failed to create or find PR for head branch ${head}`);
+    }
+  }
+
+  async commentOnPR(prRef: PRRef, body: string): Promise<void> {
+    await this.octokit.issues.createComment({
+      owner: prRef.owner,
+      repo: prRef.repo,
+      issue_number: prRef.prNumber,
+      body,
+    });
+  }
+
+  async addLabelsToPR(prRef: PRRef, labels: string[]): Promise<void> {
+    await this.octokit.issues.addLabels({
+      owner: prRef.owner,
+      repo: prRef.repo,
+      issue_number: prRef.prNumber,
+      labels,
+    });
+  }
+
+  async removeLabelFromPR(prRef: PRRef, label: string): Promise<void> {
+    await this.octokit.issues.removeLabel({
+      owner: prRef.owner,
+      repo: prRef.repo,
+      issue_number: prRef.prNumber,
+      name: label,
+    });
+  }
+
+  async listPRComments(prRef: PRRef, count: number): Promise<PRComment[]> {
+    const { data } = await this.octokit.issues.listComments({
+      owner: prRef.owner,
+      repo: prRef.repo,
+      issue_number: prRef.prNumber,
+      sort: 'created',
+      direction: 'desc',
+      per_page: count,
+    });
+    return data.map((c) => ({ id: c.id, body: c.body ?? '' }));
+  }
+}

--- a/src/lib/dispatch/runner/types.ts
+++ b/src/lib/dispatch/runner/types.ts
@@ -1,0 +1,57 @@
+import type { EventEnvelopeV1 } from '../../envelope/types.js';
+
+export interface PRRef {
+  owner: string;
+  repo: string;
+  prNumber: number;
+}
+
+export interface PR {
+  number: number;
+  title: string;
+  baseRef: string;
+  headRef: string;
+  headSha: string;
+  mergeable: boolean | null;
+}
+
+export interface PRFile {
+  filename: string;
+  status: string;
+  additions: number;
+  deletions: number;
+  patch?: string;
+}
+
+export interface PRComment {
+  id: number;
+  body: string;
+}
+
+export type CommitStatus = 'green' | 'red' | 'pending';
+
+export type DispatchPayload = EventEnvelopeV1;
+
+export interface CIRunner {
+  dispatch(phase: string, payload: DispatchPayload): Promise<void>;
+
+  listPRsForBranch(owner: string, repo: string, branch: string): Promise<PR[]>;
+  getPR(prRef: PRRef): Promise<PR>;
+  listPRFiles(prRef: PRRef): Promise<PRFile[]>;
+  listPRCommits(prRef: PRRef): Promise<Array<{ sha: string; message: string }>>;
+  getCommitStatus(owner: string, repo: string, sha: string): Promise<CommitStatus>;
+  getFileContent(owner: string, repo: string, path: string, ref: string): Promise<string>;
+
+  createPR(
+    owner: string,
+    repo: string,
+    head: string,
+    base: string,
+    title: string,
+    body: string,
+  ): Promise<string>;
+  commentOnPR(prRef: PRRef, body: string): Promise<void>;
+  addLabelsToPR(prRef: PRRef, labels: string[]): Promise<void>;
+  removeLabelFromPR(prRef: PRRef, label: string): Promise<void>;
+  listPRComments(prRef: PRRef, count: number): Promise<PRComment[]>;
+}


### PR DESCRIPTION
Closes #37

## Summary

- Defines `CIRunner` interface in `src/lib/dispatch/runner/types.ts` with provider-neutral types
- Implements `GitHubActionsRunner` in `src/lib/dispatch/runner/github-actions/` wrapping Octokit
- Refactors all three agent action files and review-loop to use the interface

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm test` passes (new runner unit tests + all existing tests)
- [ ] `npm run lint` passes
- [ ] Existing GHA workflows still trigger correctly end-to-end

Generated with [Claude Code](https://claude.ai/code)