### PR TITLE
feat(prompts): per-phase prompt overrides via auto-discovered prompts/ dir

### DIFF
--- a/scripts/build-ferry-actions.mjs
+++ b/scripts/build-ferry-actions.mjs
@@ -3,6 +3,10 @@ import { mkdirSync, copyFileSync, writeFileSync, readFileSync } from 'fs';
 import { execSync } from 'child_process';
 
 mkdirSync('.ferry/schemas', { recursive: true });
+mkdirSync('.ferry/prompts', { recursive: true });
+for (const name of ['refiner', 'dev', 'review', 'review-comment', 'iterate']) {
+  copyFileSync(`prompts/${name}.md`, `.ferry/prompts/${name}.md`);
+}
 
 const shared = {
   bundle: true,

--- a/src/agents/developer/dev-action.ts
+++ b/src/agents/developer/dev-action.ts
@@ -18,10 +18,9 @@ import {
 import { createAnthropicAgentLoop } from '../../lib/llm/agent-loop/anthropic.js';
 import type { AgentLoop } from '../../lib/llm/agent-loop/types.js';
 import { loadFerryConfig } from '../../lib/config.js';
+import { resolvePromptPath } from '../../lib/prompts/resolve.js';
 
 const REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
-const SYSTEM_PROMPT_PATH =
-  process.env.FERRY_PROMPT_PATH ?? path.join(REPO_ROOT, 'prompts', 'dev.md');
 
 function requireEnv(key: string): string {
   const val = process.env[key];
@@ -123,7 +122,7 @@ async function main(): Promise<void> {
     'When you have finished implementing, call the `done` tool.',
   ].join('\n');
 
-  const system = readFileSync(SYSTEM_PROMPT_PATH, 'utf8');
+  const system = readFileSync(resolvePromptPath('dev', REPO_ROOT), 'utf8');
   const ferryCfg = loadFerryConfig(REPO_ROOT);
   const model = ferryCfg.models.dev.model;
 

--- a/src/agents/iterator/iterate-action.ts
+++ b/src/agents/iterator/iterate-action.ts
@@ -14,10 +14,9 @@ import { checkIterationCap } from './cap.js';
 import { decideIteratorTransition } from './transition.js';
 import { formatCommitMessage } from './prompt.js';
 import { loadFerryConfig } from '../../lib/config.js';
+import { resolvePromptPath } from '../../lib/prompts/resolve.js';
 
 const REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
-const SYSTEM_PROMPT_PATH =
-  process.env.FERRY_PROMPT_PATH ?? path.join(REPO_ROOT, 'prompts', 'iterate.md');
 
 function requireEnv(key: string): string {
   const val = process.env[key];
@@ -111,7 +110,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const system = readFileSync(SYSTEM_PROMPT_PATH, 'utf8');
+  const system = readFileSync(resolvePromptPath('iterate', REPO_ROOT), 'utf8');
 
   execSync('git config user.name "ferry-bot"', { cwd: REPO_ROOT });
   execSync('git config user.email "ferry-bot@users.noreply.github.com"', { cwd: REPO_ROOT });

--- a/src/agents/iterator/iterate-action.ts
+++ b/src/agents/iterator/iterate-action.ts
@@ -49,7 +49,10 @@ async function main(): Promise<void> {
   const priorIterations = existingComments.filter(
     (c) => c.includes('[ferry:iterator:') && c.includes('complete. Pushed fixes to PR#'),
   ).length;
-  checkIterationCap({ iteration: priorIterations, hasFindings: true }, ferryCfg.limits.max_iterations);
+  checkIterationCap(
+    { iteration: priorIterations, hasFindings: true },
+    ferryCfg.limits.max_iterations,
+  );
 
   const branchName = `ferry/${ticketKey}`;
   const prs = await runner.listPRsForBranch(owner, repo, branchName);

--- a/src/agents/iterator/iterate-action.ts
+++ b/src/agents/iterator/iterate-action.ts
@@ -1,6 +1,5 @@
 import { appendFileSync, readFileSync } from 'node:fs';
 import { execFileSync, execSync } from 'node:child_process';
-import * as path from 'node:path';
 import { validateEnvelope } from '../../lib/envelope/validate.js';
 import { delimitUntrusted } from '../../lib/llm/delimit-untrusted.js';
 import { createTrackerFromEnv } from '../../lib/io/tracker/factory.js';

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -1,5 +1,4 @@
 import { appendFileSync, readFileSync } from 'node:fs';
-import * as path from 'node:path';
 import Anthropic from '@anthropic-ai/sdk';
 import { validateEnvelope } from '../../lib/envelope/validate.js';
 import { delimitUntrusted } from '../../lib/llm/delimit-untrusted.js';

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -10,12 +10,9 @@ import { FerryError } from '../../lib/errors/index.js';
 import { GitHubActionsRunner } from '../../lib/dispatch/runner/github-actions/index.js';
 import { detectMergeConflicts, buildFileList, runReviewLoop } from './review-loop.js';
 import { loadFerryConfig } from '../../lib/config.js';
+import { resolvePromptPath } from '../../lib/prompts/resolve.js';
 
 const REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
-const SYSTEM_PROMPT_PATH =
-  process.env.FERRY_PROMPT_PATH ?? path.join(REPO_ROOT, 'prompts', 'review.md');
-const COMMENT_TEMPLATE_PATH =
-  process.env.FERRY_REVIEW_TEMPLATE_PATH ?? path.join(REPO_ROOT, 'prompts', 'review-comment.md');
 
 function requireEnv(key: string): string {
   const val = process.env[key];
@@ -158,10 +155,10 @@ async function main(): Promise<void> {
     .filter((l) => l !== null)
     .join('\n');
 
-  const systemBase = readFileSync(SYSTEM_PROMPT_PATH, 'utf8');
+  const systemBase = readFileSync(resolvePromptPath('review', REPO_ROOT), 'utf8');
   let commentTemplate = '';
   try {
-    commentTemplate = readFileSync(COMMENT_TEMPLATE_PATH, 'utf8');
+    commentTemplate = readFileSync(resolvePromptPath('review-comment', REPO_ROOT), 'utf8');
   } catch {
     /* optional */
   }

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -89,7 +89,9 @@ describe('loadFerryConfig', () => {
       const cfg = loadFerryConfig('/repo');
       expect(cfg.limits.max_iterations).toBe(5);
       expect(cfg.limits.max_tokens_per_run).toBe(200000);
-      expect(cfg.limits.max_agent_iterations).toBe(DEFAULT_FERRY_CONFIG.limits.max_agent_iterations);
+      expect(cfg.limits.max_agent_iterations).toBe(
+        DEFAULT_FERRY_CONFIG.limits.max_agent_iterations,
+      );
     });
 
     it('loads ticket_types allowlists from JSON config', () => {
@@ -132,10 +134,7 @@ describe('loadFerryConfig', () => {
     });
 
     it('throws with field path in error for invalid limit type', () => {
-      mockConfigFile(
-        'ferry.config.json',
-        JSON.stringify({ limits: { max_iterations: -1 } }),
-      );
+      mockConfigFile('ferry.config.json', JSON.stringify({ limits: { max_iterations: -1 } }));
       let thrown: FerryError | null = null;
       try {
         loadFerryConfig('/repo');
@@ -212,7 +211,9 @@ describe('loadFerryConfig', () => {
       mockNoConfigFile();
       vi.stubEnv('FERRY_DEV_MAX_ITERATIONS', 'not-a-number');
       const cfg = loadFerryConfig('/repo');
-      expect(cfg.limits.max_agent_iterations).toBe(DEFAULT_FERRY_CONFIG.limits.max_agent_iterations);
+      expect(cfg.limits.max_agent_iterations).toBe(
+        DEFAULT_FERRY_CONFIG.limits.max_agent_iterations,
+      );
     });
   });
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -121,11 +121,16 @@ function validateConfigShape(raw: unknown): ValidationError[] {
       errs.push('limits: must be an object');
     } else {
       const l = c.limits as Record<string, unknown>;
-      if (l.max_iterations !== undefined) errs.push(...validatePosInt(l.max_iterations, 'limits.max_iterations'));
-      if (l.max_agent_iterations !== undefined) errs.push(...validatePosInt(l.max_agent_iterations, 'limits.max_agent_iterations'));
-      if (l.max_tokens_per_run !== undefined) errs.push(...validatePosInt(l.max_tokens_per_run, 'limits.max_tokens_per_run'));
-      if (l.max_tokens_per_message !== undefined) errs.push(...validatePosInt(l.max_tokens_per_message, 'limits.max_tokens_per_message'));
-      if (l.max_cost_eur_per_run !== undefined) errs.push(...validatePosNumber(l.max_cost_eur_per_run, 'limits.max_cost_eur_per_run'));
+      if (l.max_iterations !== undefined)
+        errs.push(...validatePosInt(l.max_iterations, 'limits.max_iterations'));
+      if (l.max_agent_iterations !== undefined)
+        errs.push(...validatePosInt(l.max_agent_iterations, 'limits.max_agent_iterations'));
+      if (l.max_tokens_per_run !== undefined)
+        errs.push(...validatePosInt(l.max_tokens_per_run, 'limits.max_tokens_per_run'));
+      if (l.max_tokens_per_message !== undefined)
+        errs.push(...validatePosInt(l.max_tokens_per_message, 'limits.max_tokens_per_message'));
+      if (l.max_cost_eur_per_run !== undefined)
+        errs.push(...validatePosNumber(l.max_cost_eur_per_run, 'limits.max_cost_eur_per_run'));
     }
   }
 
@@ -134,8 +139,10 @@ function validateConfigShape(raw: unknown): ValidationError[] {
       errs.push('ticket_types: must be an object');
     } else {
       const t = c.ticket_types as Record<string, unknown>;
-      if (t.refine_allowlist !== undefined) errs.push(...validateStringArray(t.refine_allowlist, 'ticket_types.refine_allowlist'));
-      if (t.dev_allowlist !== undefined) errs.push(...validateStringArray(t.dev_allowlist, 'ticket_types.dev_allowlist'));
+      if (t.refine_allowlist !== undefined)
+        errs.push(...validateStringArray(t.refine_allowlist, 'ticket_types.refine_allowlist'));
+      if (t.dev_allowlist !== undefined)
+        errs.push(...validateStringArray(t.dev_allowlist, 'ticket_types.dev_allowlist'));
     }
   }
 
@@ -215,8 +222,7 @@ function mergeWithDefaults(raw: RawConfig): FerryConfig {
     };
   };
 
-  const num = (val: unknown, def: number): number =>
-    typeof val === 'number' ? val : def;
+  const num = (val: unknown, def: number): number => (typeof val === 'number' ? val : def);
   const strArr = (val: unknown, def: string[]): string[] =>
     Array.isArray(val) ? (val as string[]) : def;
 
@@ -229,13 +235,25 @@ function mergeWithDefaults(raw: RawConfig): FerryConfig {
     },
     limits: {
       max_iterations: num(l.max_iterations, DEFAULT_FERRY_CONFIG.limits.max_iterations),
-      max_agent_iterations: num(l.max_agent_iterations, DEFAULT_FERRY_CONFIG.limits.max_agent_iterations),
+      max_agent_iterations: num(
+        l.max_agent_iterations,
+        DEFAULT_FERRY_CONFIG.limits.max_agent_iterations,
+      ),
       max_tokens_per_run: num(l.max_tokens_per_run, DEFAULT_FERRY_CONFIG.limits.max_tokens_per_run),
-      max_tokens_per_message: num(l.max_tokens_per_message, DEFAULT_FERRY_CONFIG.limits.max_tokens_per_message),
-      max_cost_eur_per_run: num(l.max_cost_eur_per_run, DEFAULT_FERRY_CONFIG.limits.max_cost_eur_per_run),
+      max_tokens_per_message: num(
+        l.max_tokens_per_message,
+        DEFAULT_FERRY_CONFIG.limits.max_tokens_per_message,
+      ),
+      max_cost_eur_per_run: num(
+        l.max_cost_eur_per_run,
+        DEFAULT_FERRY_CONFIG.limits.max_cost_eur_per_run,
+      ),
     },
     ticket_types: {
-      refine_allowlist: strArr(t.refine_allowlist, DEFAULT_FERRY_CONFIG.ticket_types.refine_allowlist),
+      refine_allowlist: strArr(
+        t.refine_allowlist,
+        DEFAULT_FERRY_CONFIG.ticket_types.refine_allowlist,
+      ),
       dev_allowlist: strArr(t.dev_allowlist, DEFAULT_FERRY_CONFIG.ticket_types.dev_allowlist),
     },
   };

--- a/src/lib/dispatch/routing.ts
+++ b/src/lib/dispatch/routing.ts
@@ -49,7 +49,11 @@ export function phaseToDispatchType(phase: keyof RoutingTable): DispatchType {
  */
 export type TicketType = 'Story' | 'Task' | 'Bug' | 'Spike';
 
-const DEFAULT_PROCESSED_TICKET_TYPES: ReadonlySet<string> = new Set<TicketType>(['Story', 'Bug', 'Spike']);
+const DEFAULT_PROCESSED_TICKET_TYPES: ReadonlySet<string> = new Set<TicketType>([
+  'Story',
+  'Bug',
+  'Spike',
+]);
 
 export function shouldProcessTicketType(
   ticketType: TicketType | undefined,

--- a/src/lib/llm/agent-loop/anthropic.ts
+++ b/src/lib/llm/agent-loop/anthropic.ts
@@ -55,8 +55,10 @@ export function createAnthropicAgentLoop(opts: {
       throw new FerryError('state-invariant', { reason: 'mcp-not-implemented' });
     }
     const { system, initialPrompt, tools, repoRoot, branchName, secretScan, depth = 0 } = input;
-    const maxIterations = opts.maxIterations ?? parseInt(process.env.FERRY_DEV_MAX_ITERATIONS ?? '200', 10);
-    const maxInputTokens = opts.maxInputTokens ?? parseInt(process.env.FERRY_DEV_MAX_INPUT_TOKENS ?? '500000', 10);
+    const maxIterations =
+      opts.maxIterations ?? parseInt(process.env.FERRY_DEV_MAX_ITERATIONS ?? '200', 10);
+    const maxInputTokens =
+      opts.maxInputTokens ?? parseInt(process.env.FERRY_DEV_MAX_INPUT_TOKENS ?? '500000', 10);
     const maxTokens = opts.maxTokens ?? parseInt(process.env.FERRY_DEV_MAX_TOKENS ?? '16384', 10);
 
     // Cached system prompt + tools — static across the run, marked once.

--- a/src/lib/prompts/resolve.test.ts
+++ b/src/lib/prompts/resolve.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { resolvePromptPath } from './resolve.js';
+
+const REPO_ROOT = '/workspace/repo';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('resolvePromptPath', () => {
+  it('returns consumer override path when file exists', () => {
+    const check = (p: string) => p === '/workspace/repo/prompts/dev.md';
+    const result = resolvePromptPath('dev', REPO_ROOT, check);
+    expect(result).toBe('/workspace/repo/prompts/dev.md');
+  });
+
+  it('falls back to .ferry default when consumer override is absent', () => {
+    const check = () => false;
+    const result = resolvePromptPath('dev', REPO_ROOT, check);
+    expect(result).toBe('/workspace/repo/.ferry/prompts/dev.md');
+  });
+
+  it('uses FERRY_PROMPTS_DIR as override directory when set', () => {
+    vi.stubEnv('FERRY_PROMPTS_DIR', '/custom/prompts');
+    const check = (p: string) => p === '/custom/prompts/review.md';
+    const result = resolvePromptPath('review', REPO_ROOT, check);
+    expect(result).toBe('/custom/prompts/review.md');
+  });
+
+  it('falls back to default when FERRY_PROMPTS_DIR file is absent', () => {
+    vi.stubEnv('FERRY_PROMPTS_DIR', '/custom/prompts');
+    const check = () => false;
+    const result = resolvePromptPath('review', REPO_ROOT, check);
+    expect(result).toBe('/workspace/repo/.ferry/prompts/review.md');
+  });
+
+  it('only the named phase falls back; other phases unaffected', () => {
+    const check = (p: string) => p === '/workspace/repo/prompts/iterate.md';
+    const devResult = resolvePromptPath('dev', REPO_ROOT, check);
+    const iterResult = resolvePromptPath('iterate', REPO_ROOT, check);
+    expect(devResult).toBe('/workspace/repo/.ferry/prompts/dev.md');
+    expect(iterResult).toBe('/workspace/repo/prompts/iterate.md');
+  });
+});

--- a/src/lib/prompts/resolve.ts
+++ b/src/lib/prompts/resolve.ts
@@ -1,0 +1,17 @@
+import { existsSync } from 'node:fs';
+import * as path from 'node:path';
+
+export function resolvePromptPath(
+  name: string,
+  repoRoot: string,
+  _checkExists: (p: string) => boolean = existsSync,
+): string {
+  const overridesDir = process.env.FERRY_PROMPTS_DIR ?? path.join(repoRoot, 'prompts');
+  const overridePath = path.join(overridesDir, `${name}.md`);
+  if (_checkExists(overridePath)) {
+    return overridePath;
+  }
+  const defaultPath = path.join(repoRoot, '.ferry', 'prompts', `${name}.md`);
+  console.error(`[ferry:prompts] ${name}: consumer override not found, using shipped default`);
+  return defaultPath;
+}


### PR DESCRIPTION
Closes #24

## Summary

- Adds `src/lib/prompts/resolve.ts` — `resolvePromptPath(name, repoRoot)` checks `<consumer-repo>/prompts/<name>.md` first (or `FERRY_PROMPTS_DIR/<name>.md` when the env var is set), then falls back to `<repo-root>/.ferry/prompts/<name>.md` with a debug log
- Drops the single `FERRY_PROMPT_PATH` env var (and `FERRY_REVIEW_TEMPLATE_PATH`) from all three action files; each phase now resolves its own prompt independently
- Updates `scripts/build-ferry-actions.mjs` to copy `prompts/*.md` → `.ferry/prompts/` so shipped defaults are available at runtime

## Behaviour

- A consumer can override only `dev.md`; `review.md` and `iterate.md` continue using shipped defaults — no error, just a debug log
- `FERRY_PROMPTS_DIR` provides a directory-level override for all phases at once
- `review-comment.md` follows the same lookup; the existing try/catch in `review-action.ts` is kept as a safety net

## Test plan

- [ ] `npm test` — 533 tests pass (5 new tests in `src/lib/prompts/resolve.test.ts`)
- [ ] `npm run typecheck` — clean
- [ ] Override present → override path returned
- [ ] Override absent → `.ferry/prompts/<name>.md` returned
- [ ] `FERRY_PROMPTS_DIR` set → custom dir used
- [ ] Partial override (only `dev.md` present) → other phases fall back transparently