### PR TITLE
Load project snippet into agent prompts

### DIFF
--- a/src/agents/developer/dev-action.ts
+++ b/src/agents/developer/dev-action.ts
@@ -18,7 +18,7 @@ import {
 import { createAnthropicAgentLoop } from '../../lib/llm/agent-loop/anthropic.js';
 import type { AgentLoop } from '../../lib/llm/agent-loop/types.js';
 import { loadFerryConfig } from '../../lib/config.js';
-import { resolvePromptPath } from '../../lib/prompts/resolve.js';
+import { resolvePromptPath, loadProjectSnippet } from '../../lib/prompts/resolve.js';
 
 const REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 
@@ -122,7 +122,11 @@ async function main(): Promise<void> {
     'When you have finished implementing, call the `done` tool.',
   ].join('\n');
 
-  const system = readFileSync(resolvePromptPath('dev', REPO_ROOT), 'utf8');
+  const systemBase = readFileSync(resolvePromptPath('dev', REPO_ROOT), 'utf8');
+  const projectSnippet = loadProjectSnippet(REPO_ROOT);
+  const system = projectSnippet
+    ? `${systemBase}\n\n## Project conventions\n\n${projectSnippet}`
+    : systemBase;
   const ferryCfg = loadFerryConfig(REPO_ROOT);
   const model = ferryCfg.models.dev.model;
 

--- a/src/agents/iterator/iterate-action.ts
+++ b/src/agents/iterator/iterate-action.ts
@@ -13,7 +13,7 @@ import { checkIterationCap } from './cap.js';
 import { decideIteratorTransition } from './transition.js';
 import { formatCommitMessage } from './prompt.js';
 import { loadFerryConfig } from '../../lib/config.js';
-import { resolvePromptPath } from '../../lib/prompts/resolve.js';
+import { resolvePromptPath, loadProjectSnippet } from '../../lib/prompts/resolve.js';
 
 const REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 
@@ -112,7 +112,11 @@ async function main(): Promise<void> {
     return;
   }
 
-  const system = readFileSync(resolvePromptPath('iterate', REPO_ROOT), 'utf8');
+  const systemBase = readFileSync(resolvePromptPath('iterate', REPO_ROOT), 'utf8');
+  const projectSnippet = loadProjectSnippet(REPO_ROOT);
+  const system = projectSnippet
+    ? `${systemBase}\n\n## Project conventions\n\n${projectSnippet}`
+    : systemBase;
 
   execSync('git config user.name "ferry-bot"', { cwd: REPO_ROOT });
   execSync('git config user.email "ferry-bot@users.noreply.github.com"', { cwd: REPO_ROOT });

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -9,7 +9,7 @@ import { FerryError } from '../../lib/errors/index.js';
 import { GitHubActionsRunner } from '../../lib/dispatch/runner/github-actions/index.js';
 import { detectMergeConflicts, buildFileList, runReviewLoop } from './review-loop.js';
 import { loadFerryConfig } from '../../lib/config.js';
-import { resolvePromptPath } from '../../lib/prompts/resolve.js';
+import { resolvePromptPath, loadProjectSnippet } from '../../lib/prompts/resolve.js';
 
 const REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 
@@ -161,7 +161,13 @@ async function main(): Promise<void> {
   } catch {
     /* optional */
   }
-  const system = commentTemplate ? `${systemBase}\n\n---\n\n${commentTemplate}` : systemBase;
+  const projectSnippet = loadProjectSnippet(REPO_ROOT);
+  const systemParts = [
+    systemBase,
+    commentTemplate || null,
+    projectSnippet ? `## Project conventions\n\n${projectSnippet}` : null,
+  ].filter(Boolean) as string[];
+  const system = systemParts.join('\n\n---\n\n');
   const anthropic = new Anthropic({ apiKey: anthropicApiKey });
 
   const {

--- a/src/lib/prompts/resolve.test.ts
+++ b/src/lib/prompts/resolve.test.ts
@@ -62,10 +62,7 @@ describe('loadProjectSnippet', () => {
     const readSpy = vi.fn(() => 'ferry default content');
     const result = loadProjectSnippet(REPO_ROOT, check, readSpy);
     expect(result).toBe('ferry default content');
-    expect(readSpy).toHaveBeenCalledWith(
-      '/workspace/repo/.ferry/prompts/_project.md',
-      'utf8',
-    );
+    expect(readSpy).toHaveBeenCalledWith('/workspace/repo/.ferry/prompts/_project.md', 'utf8');
   });
 
   it('prefers prompts/_project.md over .ferry/prompts/_project.md', () => {

--- a/src/lib/prompts/resolve.test.ts
+++ b/src/lib/prompts/resolve.test.ts
@@ -44,7 +44,7 @@ describe('resolvePromptPath', () => {
 });
 
 describe('loadProjectSnippet', () => {
-  const read = (_p: string, _enc: BufferEncoding) => 'project conventions content';
+  const read = () => 'project conventions content';
 
   it('returns null when _project.md is absent from both locations', () => {
     const check = () => false;
@@ -59,7 +59,7 @@ describe('loadProjectSnippet', () => {
 
   it('loads from .ferry/prompts/_project.md when prompts/_project.md absent', () => {
     const check = (p: string) => p === '/workspace/repo/.ferry/prompts/_project.md';
-    const readSpy = vi.fn((_p: string, _enc: BufferEncoding) => 'ferry default content');
+    const readSpy = vi.fn(() => 'ferry default content');
     const result = loadProjectSnippet(REPO_ROOT, check, readSpy);
     expect(result).toBe('ferry default content');
     expect(readSpy).toHaveBeenCalledWith(
@@ -70,7 +70,7 @@ describe('loadProjectSnippet', () => {
 
   it('prefers prompts/_project.md over .ferry/prompts/_project.md', () => {
     const check = () => true;
-    const readSpy = vi.fn((_p: string, _enc: BufferEncoding) => 'content');
+    const readSpy = vi.fn(() => 'content');
     loadProjectSnippet(REPO_ROOT, check, readSpy);
     expect(readSpy).toHaveBeenCalledWith('/workspace/repo/prompts/_project.md', 'utf8');
     expect(readSpy).toHaveBeenCalledTimes(1);
@@ -78,7 +78,7 @@ describe('loadProjectSnippet', () => {
 
   it('truncates content exceeding 2048 bytes', () => {
     const big = 'x'.repeat(3000);
-    const readBig = (_p: string, _enc: BufferEncoding) => big;
+    const readBig = () => big;
     const check = (p: string) => p === '/workspace/repo/prompts/_project.md';
     const result = loadProjectSnippet(REPO_ROOT, check, readBig);
     expect(result).toHaveLength(2048);
@@ -88,7 +88,7 @@ describe('loadProjectSnippet', () => {
   it('respects FERRY_PROMPTS_DIR for the first candidate', () => {
     vi.stubEnv('FERRY_PROMPTS_DIR', '/custom/prompts');
     const check = (p: string) => p === '/custom/prompts/_project.md';
-    const readSpy = vi.fn((_p: string, _enc: BufferEncoding) => 'custom content');
+    const readSpy = vi.fn(() => 'custom content');
     const result = loadProjectSnippet(REPO_ROOT, check, readSpy);
     expect(result).toBe('custom content');
     expect(readSpy).toHaveBeenCalledWith('/custom/prompts/_project.md', 'utf8');

--- a/src/lib/prompts/resolve.test.ts
+++ b/src/lib/prompts/resolve.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { resolvePromptPath } from './resolve.js';
+import { resolvePromptPath, loadProjectSnippet } from './resolve.js';
 
 const REPO_ROOT = '/workspace/repo';
 
@@ -40,5 +40,57 @@ describe('resolvePromptPath', () => {
     const iterResult = resolvePromptPath('iterate', REPO_ROOT, check);
     expect(devResult).toBe('/workspace/repo/.ferry/prompts/dev.md');
     expect(iterResult).toBe('/workspace/repo/prompts/iterate.md');
+  });
+});
+
+describe('loadProjectSnippet', () => {
+  const read = (_p: string, _enc: BufferEncoding) => 'project conventions content';
+
+  it('returns null when _project.md is absent from both locations', () => {
+    const check = () => false;
+    expect(loadProjectSnippet(REPO_ROOT, check, read)).toBeNull();
+  });
+
+  it('loads from prompts/_project.md when present', () => {
+    const check = (p: string) => p === '/workspace/repo/prompts/_project.md';
+    const result = loadProjectSnippet(REPO_ROOT, check, read);
+    expect(result).toBe('project conventions content');
+  });
+
+  it('loads from .ferry/prompts/_project.md when prompts/_project.md absent', () => {
+    const check = (p: string) => p === '/workspace/repo/.ferry/prompts/_project.md';
+    const readSpy = vi.fn((_p: string, _enc: BufferEncoding) => 'ferry default content');
+    const result = loadProjectSnippet(REPO_ROOT, check, readSpy);
+    expect(result).toBe('ferry default content');
+    expect(readSpy).toHaveBeenCalledWith(
+      '/workspace/repo/.ferry/prompts/_project.md',
+      'utf8',
+    );
+  });
+
+  it('prefers prompts/_project.md over .ferry/prompts/_project.md', () => {
+    const check = () => true;
+    const readSpy = vi.fn((_p: string, _enc: BufferEncoding) => 'content');
+    loadProjectSnippet(REPO_ROOT, check, readSpy);
+    expect(readSpy).toHaveBeenCalledWith('/workspace/repo/prompts/_project.md', 'utf8');
+    expect(readSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('truncates content exceeding 2048 bytes', () => {
+    const big = 'x'.repeat(3000);
+    const readBig = (_p: string, _enc: BufferEncoding) => big;
+    const check = (p: string) => p === '/workspace/repo/prompts/_project.md';
+    const result = loadProjectSnippet(REPO_ROOT, check, readBig);
+    expect(result).toHaveLength(2048);
+    expect(result).toBe('x'.repeat(2048));
+  });
+
+  it('respects FERRY_PROMPTS_DIR for the first candidate', () => {
+    vi.stubEnv('FERRY_PROMPTS_DIR', '/custom/prompts');
+    const check = (p: string) => p === '/custom/prompts/_project.md';
+    const readSpy = vi.fn((_p: string, _enc: BufferEncoding) => 'custom content');
+    const result = loadProjectSnippet(REPO_ROOT, check, readSpy);
+    expect(result).toBe('custom content');
+    expect(readSpy).toHaveBeenCalledWith('/custom/prompts/_project.md', 'utf8');
   });
 });

--- a/src/lib/prompts/resolve.ts
+++ b/src/lib/prompts/resolve.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import * as path from 'node:path';
 
 export function resolvePromptPath(
@@ -14,4 +14,32 @@ export function resolvePromptPath(
   const defaultPath = path.join(repoRoot, '.ferry', 'prompts', `${name}.md`);
   console.error(`[ferry:prompts] ${name}: consumer override not found, using shipped default`);
   return defaultPath;
+}
+
+const PROJECT_SNIPPET_MAX_BYTES = 2048;
+
+export function loadProjectSnippet(
+  repoRoot: string,
+  _checkExists: (p: string) => boolean = existsSync,
+  _readFile: (p: string, enc: BufferEncoding) => string = (p, enc) => readFileSync(p, enc),
+): string | null {
+  const overridesDir = process.env.FERRY_PROMPTS_DIR ?? path.join(repoRoot, 'prompts');
+  const candidates = [
+    path.join(overridesDir, '_project.md'),
+    path.join(repoRoot, '.ferry', 'prompts', '_project.md'),
+  ];
+  for (const candidate of candidates) {
+    if (_checkExists(candidate)) {
+      const raw = _readFile(candidate, 'utf8');
+      if (raw.length > PROJECT_SNIPPET_MAX_BYTES) {
+        console.error(
+          `[ferry:prompts] _project.md exceeds ${PROJECT_SNIPPET_MAX_BYTES}B — truncating`,
+        );
+        return raw.slice(0, PROJECT_SNIPPET_MAX_BYTES);
+      }
+      console.error(`[ferry:prompts] loaded _project.md from ${candidate}`);
+      return raw;
+    }
+  }
+  return null;
 }


### PR DESCRIPTION
Add loadProjectSnippet to prompts/resolve.ts and include project-specific conventions into agent system prompts.

- Implement loadProjectSnippet(repoRoot) to look for _project.md in FERRY_PROMPTS_DIR or prompts/_project.md and fall back to .ferry/prompts/_project.md; logs source and truncates files over 2048 bytes.
- Update developer, iterator, and reviewer actions to load the project snippet and append it to the resolved system prompt when present.
- Add unit tests for loadProjectSnippet covering candidate selection, FERRY_PROMPTS_DIR usage, truncation behavior, and read/check interactions.

close https://github.com/big-emotion/ferry/issues/25