### PR TITLE
feat(developer): richer PR title + body template

### DIFF
--- a/src/agents/developer/dev-action.ts
+++ b/src/agents/developer/dev-action.ts
@@ -289,7 +289,10 @@ async function main(): Promise<void> {
       ticketKey,
       jiraBaseUrl,
       runId: eventId,
-      tldr: done.summary,
+      summary: done.summary,
+      subtasks,
+      validation: done.validation ?? [],
+      notes: done.notes ?? [],
     });
 
     const prUrl = await runner.createPR(owner, repo, branchName, 'main', prTitle, prBody);

--- a/src/agents/developer/pr.test.ts
+++ b/src/agents/developer/pr.test.ts
@@ -7,33 +7,86 @@ import {
 } from './pr.js';
 
 describe('formatPullRequestTitle (Story 4-4 FR16)', () => {
-  it('prefixes the ticket key in brackets', () => {
+  it('prefixes with the ticket key (no brackets)', () => {
     expect(formatPullRequestTitle({ ticketKey: 'CHAN-27', summary: 'Add login button' })).toBe(
-      '[CHAN-27] Add login button',
+      'CHAN-27 Add login button',
     );
   });
 });
 
 describe('formatPullRequestBody (Story 4-4)', () => {
-  it('includes Jira link, run id, and TLDR', () => {
-    const body = formatPullRequestBody({
-      ticketKey: 'CHAN-27',
-      jiraBaseUrl: 'https://example.atlassian.net',
-      runId: '01HXYZ',
-      tldr: 'Adds a login button to the home page.',
-    });
+  const base = {
+    ticketKey: 'CHAN-27',
+    jiraBaseUrl: 'https://example.atlassian.net',
+    runId: '01HXYZ',
+    summary: 'Adds a login button to the home page.',
+    subtasks: ['- [CHAN-28] Design button', '- [CHAN-29] Wire click handler'],
+    validation: [
+      { command: 'npm test', outcome: '42 tests passed' },
+      { command: 'npm run typecheck', outcome: 'no errors' },
+    ],
+    notes: ['Removed unused auth helper', 'Follow-up: add tooltip in CHAN-30'],
+  };
+
+  it('contains the four required sections in order', () => {
+    const body = formatPullRequestBody(base);
+    const summaryIdx = body.indexOf('## Summary');
+    const subtasksIdx = body.indexOf('## Included subtasks');
+    const validationIdx = body.indexOf('## Validation');
+    const notesIdx = body.indexOf('## Notes');
+    expect(summaryIdx).toBeGreaterThan(-1);
+    expect(subtasksIdx).toBeGreaterThan(summaryIdx);
+    expect(validationIdx).toBeGreaterThan(subtasksIdx);
+    expect(notesIdx).toBeGreaterThan(validationIdx);
+  });
+
+  it('includes Jira link and idempotency prefix in footer', () => {
+    const body = formatPullRequestBody(base);
     expect(body).toContain('https://example.atlassian.net/browse/CHAN-27');
-    expect(body).toContain('01HXYZ');
-    expect(body).toContain('Adds a login button to the home page.');
+    expect(body).toContain('[ferry:dev:01HXYZ]');
+  });
+
+  it('renders subtasks list', () => {
+    const body = formatPullRequestBody(base);
+    expect(body).toContain('[CHAN-28] Design button');
+    expect(body).toContain('[CHAN-29] Wire click handler');
+  });
+
+  it('renders validation entries with command and outcome', () => {
+    const body = formatPullRequestBody(base);
+    expect(body).toContain('`npm test` — 42 tests passed');
+    expect(body).toContain('`npm run typecheck` — no errors');
+  });
+
+  it('renders notes list', () => {
+    const body = formatPullRequestBody(base);
+    expect(body).toContain('Removed unused auth helper');
+    expect(body).toContain('Follow-up: add tooltip in CHAN-30');
+  });
+
+  it('renders _None_ for empty subtasks', () => {
+    const body = formatPullRequestBody({ ...base, subtasks: [] });
+    expect(body).toContain('## Included subtasks\n_None_');
+  });
+
+  it('renders _None_ for empty validation', () => {
+    const body = formatPullRequestBody({ ...base, validation: [] });
+    expect(body).toContain('## Validation\n_None_');
+  });
+
+  it('renders _None_ for empty notes', () => {
+    const body = formatPullRequestBody({ ...base, notes: [] });
+    expect(body).toContain('## Notes\n_None_');
+  });
+
+  it('strips trailing slash from jiraBaseUrl', () => {
+    const body = formatPullRequestBody({ ...base, jiraBaseUrl: 'https://example.atlassian.net/' });
+    expect(body).toContain('https://example.atlassian.net/browse/CHAN-27');
+    expect(body).not.toContain('//browse');
   });
 
   it('keeps the body trim-able (no trailing spaces, ends with newline)', () => {
-    const body = formatPullRequestBody({
-      ticketKey: 'CHAN-1',
-      jiraBaseUrl: 'https://j',
-      runId: 'r1',
-      tldr: 't',
-    });
+    const body = formatPullRequestBody(base);
     expect(body).not.toMatch(/ +\n/);
     expect(body.endsWith('\n')).toBe(true);
   });

--- a/src/agents/developer/pr.ts
+++ b/src/agents/developer/pr.ts
@@ -30,8 +30,7 @@ export interface PrBodyInput {
 export function formatPullRequestBody(input: PrBodyInput): string {
   const ticketUrl = `${input.jiraBaseUrl.replace(/\/+$/, '')}/browse/${input.ticketKey}`;
 
-  const subtaskLines =
-    input.subtasks.length > 0 ? input.subtasks.join('\n') : '_None_';
+  const subtaskLines = input.subtasks.length > 0 ? input.subtasks.join('\n') : '_None_';
 
   const validationLines =
     input.validation.length > 0

--- a/src/agents/developer/pr.ts
+++ b/src/agents/developer/pr.ts
@@ -2,6 +2,10 @@
  * Story 4-4: PR title + body formatters and state transition (FR16 / FR18).
  */
 
+import type { ValidationEntry } from '../../lib/llm/agent-loop/types.js';
+
+export { ValidationEntry };
+
 export const DRAFT_PR_OPTS = { draft: true } as const;
 
 export interface PrTitleInput {
@@ -10,27 +14,48 @@ export interface PrTitleInput {
 }
 
 export function formatPullRequestTitle(input: PrTitleInput): string {
-  return `[${input.ticketKey}] ${input.summary}`;
+  return `${input.ticketKey} ${input.summary}`;
 }
 
 export interface PrBodyInput {
   ticketKey: string;
   jiraBaseUrl: string;
   runId: string;
-  tldr: string;
+  summary: string;
+  subtasks: string[];
+  validation: ValidationEntry[];
+  notes: string[];
 }
 
 export function formatPullRequestBody(input: PrBodyInput): string {
   const ticketUrl = `${input.jiraBaseUrl.replace(/\/+$/, '')}/browse/${input.ticketKey}`;
+
+  const subtaskLines =
+    input.subtasks.length > 0 ? input.subtasks.join('\n') : '_None_';
+
+  const validationLines =
+    input.validation.length > 0
+      ? input.validation.map((v) => `- \`${v.command}\` — ${v.outcome}`).join('\n')
+      : '_None_';
+
+  const notesLines =
+    input.notes.length > 0 ? input.notes.map((n) => `- ${n}`).join('\n') : '_None_';
+
   return [
-    `## TL;DR`,
-    input.tldr,
+    `## Summary`,
+    input.summary,
     ``,
-    `## Ticket`,
-    `[${input.ticketKey}](${ticketUrl})`,
+    `## Included subtasks`,
+    subtaskLines,
     ``,
-    `## Run`,
-    `Ferry run id: ${input.runId}`,
+    `## Validation`,
+    validationLines,
+    ``,
+    `## Notes`,
+    notesLines,
+    ``,
+    `---`,
+    `[${input.ticketKey}](${ticketUrl}) · \`[ferry:dev:${input.runId}]\``,
     ``,
   ].join('\n');
 }

--- a/src/agents/developer/tools.ts
+++ b/src/agents/developer/tools.ts
@@ -150,19 +150,24 @@ export const TOOL_SCHEMAS: AgentTool[] = [
         },
         validation: {
           type: 'array',
-          description: 'Validation commands run during this session and their outcomes (used in the PR body).',
+          description:
+            'Validation commands run during this session and their outcomes (used in the PR body).',
           items: {
             type: 'object',
             properties: {
               command: { type: 'string', description: 'Command run, e.g. "npm test".' },
-              outcome: { type: 'string', description: 'Result, e.g. "74 files / 371 tests passed".' },
+              outcome: {
+                type: 'string',
+                description: 'Result, e.g. "74 files / 371 tests passed".',
+              },
             },
             required: ['command', 'outcome'],
           },
         },
         notes: {
           type: 'array',
-          description: 'Noteworthy side-effects, follow-ups, deprecated paths, or config changes (used in the PR body).',
+          description:
+            'Noteworthy side-effects, follow-ups, deprecated paths, or config changes (used in the PR body).',
           items: { type: 'string' },
         },
       },

--- a/src/agents/developer/tools.ts
+++ b/src/agents/developer/tools.ts
@@ -148,6 +148,23 @@ export const TOOL_SCHEMAS: AgentTool[] = [
           type: 'string',
           description: 'Reason the ticket cannot be implemented (required when actionable: false).',
         },
+        validation: {
+          type: 'array',
+          description: 'Validation commands run during this session and their outcomes (used in the PR body).',
+          items: {
+            type: 'object',
+            properties: {
+              command: { type: 'string', description: 'Command run, e.g. "npm test".' },
+              outcome: { type: 'string', description: 'Result, e.g. "74 files / 371 tests passed".' },
+            },
+            required: ['command', 'outcome'],
+          },
+        },
+        notes: {
+          type: 'array',
+          description: 'Noteworthy side-effects, follow-ups, deprecated paths, or config changes (used in the PR body).',
+          items: { type: 'string' },
+        },
       },
       required: ['actionable', 'summary'],
     },

--- a/src/lib/llm/agent-loop/types.ts
+++ b/src/lib/llm/agent-loop/types.ts
@@ -17,11 +17,18 @@ export interface McpServerConfig {
   denied_tools?: string[];
 }
 
+export interface ValidationEntry {
+  command: string;
+  outcome: string;
+}
+
 export interface DonePayload {
   actionable: boolean;
   summary: string;
   commit_message?: string;
   reason_if_not_actionable?: string;
+  validation?: ValidationEntry[];
+  notes?: string[];
 }
 
 export interface AgentLoopUsage {


### PR DESCRIPTION
Closes #33

## Summary

- Replace minimal TL;DR/Ticket/Run PR body with a four-section template: Summary, Included subtasks, Validation, Notes
- Title format changed from `[TICKET-KEY] summary` to `TICKET-KEY summary` (no brackets)
- Preserves Jira link and `[ferry:dev:runId]` idempotency prefix in footer
- Wires Jira subtasks, LLM-reported validation results, and notes into the formatter

## Test plan

- [x] Updated `pr.test.ts` with section-order, empty-tolerance, and footer content checks
- [ ] `npm test` in CI
- [ ] `npm run typecheck` in CI
- [ ] `npm run lint` in CI

Generated with [Claude Code](https://claude.ai/code)