### PR TITLE
feat(llm): support CLAUDE_CODE_OAUTH_TOKEN + LOG_VERBOSITY=debug structured logs

### DIFF
--- a/src/agents/developer/dev-action.ts
+++ b/src/agents/developer/dev-action.ts
@@ -20,6 +20,7 @@ import type { AgentLoop, McpServerConfig } from '../../lib/llm/agent-loop/types.
 import { loadFerryConfig } from '../../lib/config.js';
 import { resolvePromptPath, loadProjectSnippet } from '../../lib/prompts/resolve.js';
 import { resolveCapabilities, filterMcpServers } from '../../lib/labels/capabilities.js';
+import { resolveAnthropicAuth } from '../../lib/llm/anthropic-auth.js';
 
 const REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 
@@ -96,7 +97,7 @@ async function main(): Promise<void> {
   const envelope = validateEnvelope(JSON.parse(rawPayload));
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
 
-  const anthropicApiKey = requireEnv('ANTHROPIC_API_KEY');
+  const anthropicAuth = resolveAnthropicAuth({ apiKeyEnv: 'ANTHROPIC_API_KEY' });
   const reviewTransitionId = requireEnv('FERRY_REVIEW_TRANSITION_ID');
   const githubToken = requireEnv('GITHUB_TOKEN');
   const githubRepo = requireEnv('GITHUB_REPO');
@@ -213,7 +214,7 @@ async function main(): Promise<void> {
 
   let loop!: AgentLoop;
   loop = createAnthropicAgentLoop({
-    apiKey: anthropicApiKey,
+    ...anthropicAuth,
     model,
     maxIterations: ferryCfg.limits.max_agent_iterations,
     maxInputTokens: ferryCfg.limits.max_tokens_per_run,

--- a/src/agents/iterator/iterate-action.ts
+++ b/src/agents/iterator/iterate-action.ts
@@ -16,6 +16,7 @@ import { formatCommitMessage } from './prompt.js';
 import { loadFerryConfig } from '../../lib/config.js';
 import { resolvePromptPath, loadProjectSnippet } from '../../lib/prompts/resolve.js';
 import { resolveCapabilities, filterMcpServers } from '../../lib/labels/capabilities.js';
+import { resolveAnthropicAuth } from '../../lib/llm/anthropic-auth.js';
 
 const REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 
@@ -48,7 +49,7 @@ async function main(): Promise<void> {
   const envelope = validateEnvelope(JSON.parse(rawPayload));
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
 
-  const anthropicApiKey = requireEnv('ANTHROPIC_API_KEY');
+  const anthropicAuth = resolveAnthropicAuth({ apiKeyEnv: 'ANTHROPIC_API_KEY' });
   const reviewTransitionId = requireEnv('FERRY_REVIEW_TRANSITION_ID');
   const githubToken = requireEnv('GITHUB_TOKEN');
   const githubRepo = requireEnv('GITHUB_REPO');
@@ -234,7 +235,7 @@ async function main(): Promise<void> {
   };
 
   const loop = createAnthropicAgentLoop({
-    apiKey: anthropicApiKey,
+    ...anthropicAuth,
     model,
     maxIterations: ferryCfg.limits.max_agent_iterations,
     maxInputTokens: ferryCfg.limits.max_tokens_per_run,

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -11,6 +11,7 @@ import { detectMergeConflicts, buildFileList, runReviewLoop } from './review-loo
 import { loadFerryConfig } from '../../lib/config.js';
 import { resolvePromptPath, loadProjectSnippet } from '../../lib/prompts/resolve.js';
 import { resolveCapabilities } from '../../lib/labels/capabilities.js';
+import { resolveAnthropicAuth } from '../../lib/llm/anthropic-auth.js';
 
 const REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 
@@ -25,7 +26,6 @@ async function main(): Promise<void> {
   const envelope = validateEnvelope(JSON.parse(rawPayload));
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
 
-  const anthropicApiKey = requireEnv('ANTHROPIC_API_KEY');
   const githubToken = requireEnv('GITHUB_TOKEN');
   const iterTransitionId = requireEnv('FERRY_ITER_TRANSITION_ID');
   const githubRepo = requireEnv('GITHUB_REPO');
@@ -181,7 +181,7 @@ async function main(): Promise<void> {
     projectSnippet ? `## Project conventions\n\n${projectSnippet}` : null,
   ].filter(Boolean) as string[];
   const system = systemParts.join('\n\n---\n\n');
-  const anthropic = new Anthropic({ apiKey: anthropicApiKey });
+  const anthropic = new Anthropic(resolveAnthropicAuth({ apiKeyEnv: 'ANTHROPIC_API_KEY' }));
 
   const {
     result: review,

--- a/src/agents/reviewer/review-loop.test.ts
+++ b/src/agents/reviewer/review-loop.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import Anthropic from '@anthropic-ai/sdk';
+import { runReviewLoop } from './review-loop.js';
+import type { CIRunner } from '../../lib/dispatch/runner/types.js';
+import { FerryError } from '../../lib/errors/index.js';
+
+type FakeMessage = {
+  stop_reason: string;
+  content: Array<{ type: string; id?: string; name?: string; input?: unknown; text?: string }>;
+  usage: { input_tokens: number; output_tokens: number };
+};
+
+function makeAnthropicMock(responses: FakeMessage[]) {
+  let idx = 0;
+  const create = vi.fn().mockImplementation(async () => {
+    const r = responses[idx++];
+    return {
+      stop_reason: r.stop_reason,
+      content: r.content,
+      usage: r.usage,
+    };
+  });
+  return {
+    messages: { create },
+    create,
+  };
+}
+
+const finishReviewResponse: FakeMessage = {
+  stop_reason: 'tool_use',
+  content: [
+    {
+      type: 'tool_use',
+      id: 'tu_finish',
+      name: 'finish_review',
+      input: { approved: true, comment: 'LGTM' },
+    },
+  ],
+  usage: { input_tokens: 100, output_tokens: 50 },
+};
+
+const baseOpts = {
+  model: 'm',
+  system: 'sys',
+  initialPrompt: 'review this',
+  fileMap: new Map<string, string | undefined>(),
+  runner: {} as unknown as CIRunner,
+  owner: 'org',
+  repo: 'repo',
+  headSha: 'abc123',
+};
+
+describe('runReviewLoop', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('completes when finish_review is called', async () => {
+    const mock = makeAnthropicMock([finishReviewResponse]);
+    const result = await runReviewLoop({
+      ...baseOpts,
+      anthropic: mock as unknown as Anthropic,
+    });
+    expect(result.result.approved).toBe(true);
+    expect(result.result.comment).toBe('LGTM');
+    expect(result.inputTokens).toBe(100);
+    expect(result.outputTokens).toBe(50);
+  });
+
+  it('throws FerryError on unexpected stop_reason', async () => {
+    const mock = makeAnthropicMock([
+      {
+        stop_reason: 'end_turn',
+        content: [{ type: 'text', text: 'done' }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+    ]);
+    await expect(
+      runReviewLoop({ ...baseOpts, anthropic: mock as unknown as Anthropic }),
+    ).rejects.toThrow(FerryError);
+  });
+
+  it('emits debug "turn" JSON event when LOG_VERBOSITY=debug', async () => {
+    vi.stubEnv('LOG_VERBOSITY', 'debug');
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const mock = makeAnthropicMock([finishReviewResponse]);
+
+    await runReviewLoop({ ...baseOpts, anthropic: mock as unknown as Anthropic });
+
+    const jsonCalls = spy.mock.calls
+      .map((c) => c[0] as string)
+      .filter((s) => typeof s === 'string' && s.startsWith('{'));
+    const turnRaw = jsonCalls.find((s) => s.includes('"type":"turn"'));
+    expect(turnRaw).toBeDefined();
+    const turnEvent = JSON.parse(turnRaw!) as Record<string, unknown>;
+    expect(turnEvent).toMatchObject({
+      type: 'turn',
+      iter: 1,
+      depth: 0,
+      stop_reason: 'tool_use',
+    });
+    expect(typeof turnEvent['elapsed_ms']).toBe('number');
+  });
+
+  it('emits debug "result" JSON event on success when LOG_VERBOSITY=debug', async () => {
+    vi.stubEnv('LOG_VERBOSITY', 'debug');
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const mock = makeAnthropicMock([finishReviewResponse]);
+
+    await runReviewLoop({ ...baseOpts, anthropic: mock as unknown as Anthropic });
+
+    const jsonCalls = spy.mock.calls
+      .map((c) => c[0] as string)
+      .filter((s) => typeof s === 'string' && s.startsWith('{'));
+    const resultRaw = jsonCalls.find((s) => s.includes('"type":"result"'));
+    expect(resultRaw).toBeDefined();
+    const resultEvent = JSON.parse(resultRaw!) as Record<string, unknown>;
+    expect(resultEvent).toMatchObject({
+      type: 'result',
+      subtype: 'success',
+      iterations: 1,
+    });
+    expect(typeof resultEvent['elapsed_ms']).toBe('number');
+  });
+
+  it('does not emit JSON events when LOG_VERBOSITY is unset', async () => {
+    vi.stubEnv('LOG_VERBOSITY', '');
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const mock = makeAnthropicMock([finishReviewResponse]);
+
+    await runReviewLoop({ ...baseOpts, anthropic: mock as unknown as Anthropic });
+
+    const jsonCalls = spy.mock.calls
+      .map((c) => c[0] as string)
+      .filter((s) => typeof s === 'string' && s.startsWith('{'));
+    expect(jsonCalls).toHaveLength(0);
+  });
+
+  it('still emits terse [ferry:review-loop] line when debug is on (additive)', async () => {
+    vi.stubEnv('LOG_VERBOSITY', 'debug');
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const mock = makeAnthropicMock([finishReviewResponse]);
+
+    await runReviewLoop({ ...baseOpts, anthropic: mock as unknown as Anthropic });
+
+    const terseCalls = spy.mock.calls
+      .map((c) => c[0] as string)
+      .filter((s) => typeof s === 'string' && s.includes('[ferry:review-loop]'));
+    expect(terseCalls.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/agents/reviewer/review-loop.ts
+++ b/src/agents/reviewer/review-loop.ts
@@ -6,6 +6,7 @@ import type {
 } from '@anthropic-ai/sdk/resources/messages.js';
 import type { CIRunner, PRFile } from '../../lib/dispatch/runner/types.js';
 import { FerryError } from '../../lib/errors/index.js';
+import { emitDebug } from '../../lib/llm/debug-log.js';
 import type { CiStatus } from './ci-gate.js';
 
 export const MAX_PATCH_CHARS = 20_000;
@@ -115,8 +116,10 @@ export async function runReviewLoop(opts: {
   let inputTokens = 0;
   let outputTokens = 0;
   let result: ReviewResult | null = null;
+  const loopStart = Date.now();
 
   for (let iter = 0; iter < maxIterations; iter++) {
+    const iterStart = Date.now();
     const response = await anthropic.messages.create({
       model,
       max_tokens: maxTokens,
@@ -129,9 +132,23 @@ export async function runReviewLoop(opts: {
     outputTokens += response.usage.output_tokens;
     messages.push({ role: 'assistant', content: response.content as ContentBlock[] });
 
+    const toolCount = response.content.filter((b) => b.type === 'tool_use').length;
     console.error(
-      `[ferry:review-loop] iter=${iter + 1} stop=${response.stop_reason} tools=${response.content.filter((b) => b.type === 'tool_use').length} in=${response.usage.input_tokens} out=${response.usage.output_tokens}`,
+      `[ferry:review-loop] iter=${iter + 1} stop=${response.stop_reason} tools=${toolCount} in=${response.usage.input_tokens} out=${response.usage.output_tokens}`,
     );
+    emitDebug({
+      type: 'turn',
+      iter: iter + 1,
+      depth: 0,
+      stop_reason: response.stop_reason,
+      tools: toolCount,
+      mcp_tools: 0,
+      in: response.usage.input_tokens,
+      cache_w: 0,
+      cache_r: 0,
+      out: response.usage.output_tokens,
+      elapsed_ms: Date.now() - iterStart,
+    });
 
     if (response.stop_reason !== 'tool_use') {
       throw new FerryError('state-invariant', {
@@ -212,7 +229,17 @@ export async function runReviewLoop(opts: {
 
     messages.push({ role: 'user', content: toolResults });
 
-    if (result) return { result, inputTokens, outputTokens };
+    if (result) {
+      emitDebug({
+        type: 'result',
+        subtype: 'success',
+        iterations: iter + 1,
+        total_in: inputTokens,
+        total_out: outputTokens,
+        elapsed_ms: Date.now() - loopStart,
+      });
+      return { result, inputTokens, outputTokens };
+    }
   }
 
   throw new FerryError('state-invariant', {

--- a/src/agents/reviewer/review-loop.ts
+++ b/src/agents/reviewer/review-loop.ts
@@ -140,7 +140,7 @@ export async function runReviewLoop(opts: {
       type: 'turn',
       iter: iter + 1,
       depth: 0,
-      stop_reason: response.stop_reason,
+      stop_reason: response.stop_reason ?? 'unknown',
       tools: toolCount,
       mcp_tools: 0,
       in: response.usage.input_tokens,

--- a/src/lib/llm/agent-loop/anthropic.test.ts
+++ b/src/lib/llm/agent-loop/anthropic.test.ts
@@ -328,7 +328,9 @@ describe('createAnthropicAgentLoop — LOG_VERBOSITY=debug structured events', (
       .map((c) => c[0] as string)
       .filter((s) => typeof s === 'string' && s.startsWith('{'));
     expect(jsonCalls.length).toBeGreaterThanOrEqual(1);
-    const turnEvent = JSON.parse(jsonCalls.find((s) => s.includes('"type":"turn"') ?? false) ?? jsonCalls[0]) as Record<string, unknown>;
+    const turnEvent = JSON.parse(
+      jsonCalls.find((s) => s.includes('"type":"turn"') ?? false) ?? jsonCalls[0],
+    ) as Record<string, unknown>;
     expect(turnEvent).toMatchObject({
       type: 'turn',
       iter: 1,

--- a/src/lib/llm/agent-loop/anthropic.test.ts
+++ b/src/lib/llm/agent-loop/anthropic.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import Anthropic from '@anthropic-ai/sdk';
 import { FerryError } from '../../errors/index.js';
 import { createAnthropicAgentLoop } from './anthropic.js';
@@ -299,5 +299,104 @@ describe('createAnthropicAgentLoop — MCP connector', () => {
 
     const server: McpServerConfig = { name: 'context7', url: 'https://mcp.context7.com/mcp' };
     await expect(loop.run({ ...baseInput, mcpServers: [server] })).rejects.toThrow(FerryError);
+  });
+});
+
+describe('createAnthropicAgentLoop — LOG_VERBOSITY=debug structured events', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('emits debug "turn" JSON event when LOG_VERBOSITY=debug', async () => {
+    vi.stubEnv('LOG_VERBOSITY', 'debug');
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const mock = makeMock([doneResponse]);
+    const loop = createAnthropicAgentLoop({
+      model: 'm',
+      client: mock as unknown as Anthropic,
+      executeTool: noopExecuteTool,
+    });
+
+    await loop.run(baseInput);
+
+    const jsonCalls = spy.mock.calls
+      .map((c) => c[0] as string)
+      .filter((s) => typeof s === 'string' && s.startsWith('{'));
+    expect(jsonCalls.length).toBeGreaterThanOrEqual(1);
+    const turnEvent = JSON.parse(jsonCalls.find((s) => s.includes('"type":"turn"') ?? false) ?? jsonCalls[0]) as Record<string, unknown>;
+    expect(turnEvent).toMatchObject({
+      type: 'turn',
+      iter: 1,
+      depth: 0,
+      stop_reason: 'tool_use',
+    });
+    expect(typeof turnEvent['elapsed_ms']).toBe('number');
+  });
+
+  it('emits debug "result" JSON event on completion when LOG_VERBOSITY=debug', async () => {
+    vi.stubEnv('LOG_VERBOSITY', 'debug');
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const mock = makeMock([doneResponse]);
+    const loop = createAnthropicAgentLoop({
+      model: 'm',
+      client: mock as unknown as Anthropic,
+      executeTool: noopExecuteTool,
+    });
+
+    await loop.run(baseInput);
+
+    const jsonCalls = spy.mock.calls
+      .map((c) => c[0] as string)
+      .filter((s) => typeof s === 'string' && s.startsWith('{'));
+    const resultRaw = jsonCalls.find((s) => s.includes('"type":"result"'));
+    expect(resultRaw).toBeDefined();
+    const resultEvent = JSON.parse(resultRaw!) as Record<string, unknown>;
+    expect(resultEvent).toMatchObject({
+      type: 'result',
+      subtype: 'success',
+      iterations: 1,
+    });
+    expect(typeof resultEvent['elapsed_ms']).toBe('number');
+  });
+
+  it('does not emit JSON events when LOG_VERBOSITY is unset', async () => {
+    vi.stubEnv('LOG_VERBOSITY', '');
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const mock = makeMock([doneResponse]);
+    const loop = createAnthropicAgentLoop({
+      model: 'm',
+      client: mock as unknown as Anthropic,
+      executeTool: noopExecuteTool,
+    });
+
+    await loop.run(baseInput);
+
+    const jsonCalls = spy.mock.calls
+      .map((c) => c[0] as string)
+      .filter((s) => typeof s === 'string' && s.startsWith('{'));
+    expect(jsonCalls).toHaveLength(0);
+  });
+
+  it('still emits terse [ferry:dev-loop] line when debug is on (additive)', async () => {
+    vi.stubEnv('LOG_VERBOSITY', 'debug');
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const mock = makeMock([doneResponse]);
+    const loop = createAnthropicAgentLoop({
+      model: 'm',
+      client: mock as unknown as Anthropic,
+      executeTool: noopExecuteTool,
+    });
+
+    await loop.run(baseInput);
+
+    const terseCalls = spy.mock.calls
+      .map((c) => c[0] as string)
+      .filter((s) => typeof s === 'string' && s.includes('[ferry:dev-loop]'));
+    expect(terseCalls.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/src/lib/llm/agent-loop/anthropic.ts
+++ b/src/lib/llm/agent-loop/anthropic.ts
@@ -91,7 +91,8 @@ export function createAnthropicAgentLoop(opts: {
   maxInputTokens?: number;
   maxTokens?: number;
 }): AgentLoop {
-  const anthropic = opts.client ?? new Anthropic({ apiKey: opts.apiKey, authToken: opts.authToken });
+  const anthropic =
+    opts.client ?? new Anthropic({ apiKey: opts.apiKey, authToken: opts.authToken });
 
   async function runLoop(input: {
     system: string;

--- a/src/lib/llm/agent-loop/anthropic.ts
+++ b/src/lib/llm/agent-loop/anthropic.ts
@@ -6,6 +6,7 @@ import type {
   Tool as AnthropicTool,
 } from '@anthropic-ai/sdk/resources/messages.js';
 import { FerryError } from '../../errors/index.js';
+import { emitDebug } from '../debug-log.js';
 import type {
   AgentTool,
   AgentLoop,
@@ -80,6 +81,7 @@ function buildMcpParams(mcpServers: McpServerConfig[]): {
 
 export function createAnthropicAgentLoop(opts: {
   apiKey?: string;
+  authToken?: string;
   model: string;
   client?: Anthropic;
   executeTool: ToolExecutor;
@@ -89,7 +91,7 @@ export function createAnthropicAgentLoop(opts: {
   maxInputTokens?: number;
   maxTokens?: number;
 }): AgentLoop {
-  const anthropic = opts.client ?? new Anthropic({ apiKey: opts.apiKey });
+  const anthropic = opts.client ?? new Anthropic({ apiKey: opts.apiKey, authToken: opts.authToken });
 
   async function runLoop(input: {
     system: string;
@@ -138,9 +140,11 @@ export function createAnthropicAgentLoop(opts: {
     };
     let done: DonePayload | null = null;
     let iter = 0;
+    const loopStart = Date.now();
 
     while (iter < maxIterations) {
       iter++;
+      const iterStart = Date.now();
 
       if (
         usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens >
@@ -181,9 +185,25 @@ export function createAnthropicAgentLoop(opts: {
       messages.push({ role: 'assistant', content: contentBlocks as unknown as ContentBlock[] });
 
       const mcpToolUseCount = contentBlocks.filter((b) => b.type === 'mcp_tool_use').length;
+      const toolUseCount = contentBlocks.filter((b) => b.type === 'tool_use').length;
+      const cacheW = response.usage.cache_creation_input_tokens ?? 0;
+      const cacheR = response.usage.cache_read_input_tokens ?? 0;
       console.error(
-        `[ferry:dev-loop] depth=${depth} iter=${iter} stop_reason=${response.stop_reason} tools=${contentBlocks.filter((b) => b.type === 'tool_use').length} mcp_tools=${mcpToolUseCount} in=${response.usage.input_tokens} cache_w=${response.usage.cache_creation_input_tokens ?? 0} cache_r=${response.usage.cache_read_input_tokens ?? 0} out=${response.usage.output_tokens}`,
+        `[ferry:dev-loop] depth=${depth} iter=${iter} stop_reason=${response.stop_reason} tools=${toolUseCount} mcp_tools=${mcpToolUseCount} in=${response.usage.input_tokens} cache_w=${cacheW} cache_r=${cacheR} out=${response.usage.output_tokens}`,
       );
+      emitDebug({
+        type: 'turn',
+        iter,
+        depth,
+        stop_reason: response.stop_reason,
+        tools: toolUseCount,
+        mcp_tools: mcpToolUseCount,
+        in: response.usage.input_tokens,
+        cache_w: cacheW,
+        cache_r: cacheR,
+        out: response.usage.output_tokens,
+        elapsed_ms: Date.now() - iterStart,
+      });
 
       for (const block of contentBlocks) {
         if (block.type === 'text' && typeof block.text === 'string' && block.text.trim()) {
@@ -319,7 +339,18 @@ export function createAnthropicAgentLoop(opts: {
 
       messages.push({ role: 'user', content: toolResults });
 
-      if (done) return { done, usage, iterations: iter };
+      if (done) {
+        emitDebug({
+          type: 'result',
+          subtype: 'success',
+          iterations: iter,
+          total_in:
+            usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens,
+          total_out: usage.output_tokens,
+          elapsed_ms: Date.now() - loopStart,
+        });
+        return { done, usage, iterations: iter };
+      }
     }
 
     throw new FerryError('state-invariant', {

--- a/src/lib/llm/anthropic-auth.test.ts
+++ b/src/lib/llm/anthropic-auth.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { resolveAnthropicAuth } from './anthropic-auth.js';
+
+describe('resolveAnthropicAuth', () => {
+  it('returns { authToken } when CLAUDE_CODE_OAUTH_TOKEN is set', () => {
+    const result = resolveAnthropicAuth({
+      apiKeyEnv: 'FERRY_ANTHROPIC_KEY',
+      env: { CLAUDE_CODE_OAUTH_TOKEN: 'oauth-tok-123' },
+    });
+    expect(result).toEqual({ authToken: 'oauth-tok-123' });
+  });
+
+  it('returns { apiKey } when only the primary key env is set', () => {
+    const result = resolveAnthropicAuth({
+      apiKeyEnv: 'FERRY_ANTHROPIC_KEY',
+      env: { FERRY_ANTHROPIC_KEY: 'sk-ant-abc' },
+    });
+    expect(result).toEqual({ apiKey: 'sk-ant-abc' });
+  });
+
+  it('prefers CLAUDE_CODE_OAUTH_TOKEN over the primary key', () => {
+    const result = resolveAnthropicAuth({
+      apiKeyEnv: 'FERRY_ANTHROPIC_KEY',
+      env: { CLAUDE_CODE_OAUTH_TOKEN: 'oauth-tok-123', FERRY_ANTHROPIC_KEY: 'sk-ant-abc' },
+    });
+    expect(result).toEqual({ authToken: 'oauth-tok-123' });
+    expect(result).not.toHaveProperty('apiKey');
+  });
+
+  it('treats empty-string CLAUDE_CODE_OAUTH_TOKEN as not set', () => {
+    const result = resolveAnthropicAuth({
+      apiKeyEnv: 'FERRY_ANTHROPIC_KEY',
+      env: { CLAUDE_CODE_OAUTH_TOKEN: '', FERRY_ANTHROPIC_KEY: 'sk-ant-abc' },
+    });
+    expect(result).toEqual({ apiKey: 'sk-ant-abc' });
+  });
+
+  it('treats empty-string primary key as not set', () => {
+    expect(() =>
+      resolveAnthropicAuth({
+        apiKeyEnv: 'FERRY_ANTHROPIC_KEY',
+        env: { FERRY_ANTHROPIC_KEY: '' },
+      }),
+    ).toThrow(expect.objectContaining({ code: 'state-invariant' }));
+  });
+
+  it('throws FerryError("state-invariant") with reason="missing-env" and the apiKeyEnv when neither is set', () => {
+    expect(() =>
+      resolveAnthropicAuth({
+        apiKeyEnv: 'FERRY_ANTHROPIC_KEY',
+        env: {},
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: 'state-invariant',
+        context: { reason: 'missing-env', key: 'FERRY_ANTHROPIC_KEY' },
+      }),
+    );
+  });
+
+  it('uses the correct key name in the error when apiKeyEnv is ANTHROPIC_API_KEY', () => {
+    expect(() =>
+      resolveAnthropicAuth({
+        apiKeyEnv: 'ANTHROPIC_API_KEY',
+        env: {},
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        context: { reason: 'missing-env', key: 'ANTHROPIC_API_KEY' },
+      }),
+    );
+  });
+
+  it('works smoke test for apiKeyEnv=FERRY_ANTHROPIC_KEY', () => {
+    const result = resolveAnthropicAuth({
+      apiKeyEnv: 'FERRY_ANTHROPIC_KEY',
+      env: { FERRY_ANTHROPIC_KEY: 'sk-ant-ferry' },
+    });
+    expect(result).toHaveProperty('apiKey', 'sk-ant-ferry');
+  });
+
+  it('works smoke test for apiKeyEnv=ANTHROPIC_API_KEY', () => {
+    const result = resolveAnthropicAuth({
+      apiKeyEnv: 'ANTHROPIC_API_KEY',
+      env: { ANTHROPIC_API_KEY: 'sk-ant-action' },
+    });
+    expect(result).toHaveProperty('apiKey', 'sk-ant-action');
+  });
+
+  it('never returns both apiKey and authToken simultaneously', () => {
+    const withOauth = resolveAnthropicAuth({
+      apiKeyEnv: 'FERRY_ANTHROPIC_KEY',
+      env: { CLAUDE_CODE_OAUTH_TOKEN: 'oauth-tok', FERRY_ANTHROPIC_KEY: 'sk-ant-abc' },
+    });
+    expect(withOauth).not.toHaveProperty('apiKey');
+    expect(withOauth).toHaveProperty('authToken');
+
+    const withKey = resolveAnthropicAuth({
+      apiKeyEnv: 'FERRY_ANTHROPIC_KEY',
+      env: { FERRY_ANTHROPIC_KEY: 'sk-ant-abc' },
+    });
+    expect(withKey).not.toHaveProperty('authToken');
+    expect(withKey).toHaveProperty('apiKey');
+  });
+});

--- a/src/lib/llm/anthropic-auth.ts
+++ b/src/lib/llm/anthropic-auth.ts
@@ -1,0 +1,33 @@
+import { FerryError } from '../errors/index.js';
+
+export interface AnthropicClientOptions {
+  apiKey?: string;
+  authToken?: string;
+}
+
+export interface ResolveAnthropicAuthInput {
+  /** Primary key env var name, e.g. 'FERRY_ANTHROPIC_KEY' or 'ANTHROPIC_API_KEY'. */
+  apiKeyEnv: string;
+  /** Process env override for testability. Defaults to process.env. */
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Resolve Anthropic SDK auth options.
+ * CLAUDE_CODE_OAUTH_TOKEN takes precedence when set (subscription auth).
+ * Falls back to the named API key env var.
+ * Throws if neither is set.
+ * Returns exactly one of { authToken } or { apiKey } — never both.
+ */
+export function resolveAnthropicAuth(input: ResolveAnthropicAuthInput): AnthropicClientOptions {
+  const env = input.env ?? process.env;
+  const oauthToken = env['CLAUDE_CODE_OAUTH_TOKEN'];
+  if (oauthToken) {
+    return { authToken: oauthToken };
+  }
+  const apiKey = env[input.apiKeyEnv];
+  if (apiKey) {
+    return { apiKey };
+  }
+  throw new FerryError('state-invariant', { reason: 'missing-env', key: input.apiKeyEnv });
+}

--- a/src/lib/llm/anthropic.ts
+++ b/src/lib/llm/anthropic.ts
@@ -2,14 +2,15 @@ import Anthropic from '@anthropic-ai/sdk';
 import { FerryError } from '../errors/index.js';
 import { computeCostEur } from './pricing.js';
 import type { LlmResult } from './call.js';
+import type { AnthropicClientOptions } from './anthropic-auth.js';
 
 export async function invokeAnthropic(opts: {
-  apiKey: string;
+  auth: AnthropicClientOptions;
   model: string;
   prompt: string;
   maxTokens: number;
 }): Promise<LlmResult> {
-  const client = new Anthropic({ apiKey: opts.apiKey });
+  const client = new Anthropic(opts.auth);
 
   try {
     const msg = await client.messages.create({

--- a/src/lib/llm/anthropic.ts
+++ b/src/lib/llm/anthropic.ts
@@ -2,18 +2,15 @@ import Anthropic from '@anthropic-ai/sdk';
 import { FerryError } from '../errors/index.js';
 import { computeCostEur } from './pricing.js';
 import type { LlmResult } from './call.js';
-import type { AnthropicClientOptions } from './anthropic-auth.js';
 
 export async function invokeAnthropic(opts: {
-  auth: AnthropicClientOptions;
+  client: Anthropic;
   model: string;
   prompt: string;
   maxTokens: number;
 }): Promise<LlmResult> {
-  const client = new Anthropic(opts.auth);
-
   try {
-    const msg = await client.messages.create({
+    const msg = await opts.client.messages.create({
       model: opts.model,
       max_tokens: opts.maxTokens,
       messages: [{ role: 'user', content: opts.prompt }],

--- a/src/lib/llm/call.test.ts
+++ b/src/lib/llm/call.test.ts
@@ -106,8 +106,12 @@ describe('createLlmCall', () => {
       vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', 'oauth-tok-xyz');
       vi.stubEnv('FERRY_ANTHROPIC_KEY', '');
       createLlmCall(route);
-      expect(Anthropic).toHaveBeenCalledWith(expect.objectContaining({ authToken: 'oauth-tok-xyz' }));
-      expect(Anthropic).not.toHaveBeenCalledWith(expect.objectContaining({ apiKey: expect.anything() }));
+      expect(Anthropic).toHaveBeenCalledWith(
+        expect.objectContaining({ authToken: 'oauth-tok-xyz' }),
+      );
+      expect(Anthropic).not.toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: expect.anything() }),
+      );
     });
 
     it('falls back to FERRY_ANTHROPIC_KEY when CLAUDE_CODE_OAUTH_TOKEN is unset', () => {
@@ -115,7 +119,9 @@ describe('createLlmCall', () => {
       vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', '');
       createLlmCall(route);
       expect(Anthropic).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'sk-ant-abc' }));
-      expect(Anthropic).not.toHaveBeenCalledWith(expect.objectContaining({ authToken: expect.anything() }));
+      expect(Anthropic).not.toHaveBeenCalledWith(
+        expect.objectContaining({ authToken: expect.anything() }),
+      );
     });
 
     it('maps RateLimitError to FerryError("spend-cap") immediately (no retry)', async () => {

--- a/src/lib/llm/call.test.ts
+++ b/src/lib/llm/call.test.ts
@@ -102,6 +102,22 @@ describe('createLlmCall', () => {
       );
     });
 
+    it('uses CLAUDE_CODE_OAUTH_TOKEN when set, initialises SDK with authToken', async () => {
+      vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', 'oauth-tok-xyz');
+      vi.stubEnv('FERRY_ANTHROPIC_KEY', '');
+      createLlmCall(route);
+      expect(Anthropic).toHaveBeenCalledWith(expect.objectContaining({ authToken: 'oauth-tok-xyz' }));
+      expect(Anthropic).not.toHaveBeenCalledWith(expect.objectContaining({ apiKey: expect.anything() }));
+    });
+
+    it('falls back to FERRY_ANTHROPIC_KEY when CLAUDE_CODE_OAUTH_TOKEN is unset', () => {
+      vi.stubEnv('FERRY_ANTHROPIC_KEY', 'sk-ant-abc');
+      vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', '');
+      createLlmCall(route);
+      expect(Anthropic).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'sk-ant-abc' }));
+      expect(Anthropic).not.toHaveBeenCalledWith(expect.objectContaining({ authToken: expect.anything() }));
+    });
+
     it('maps RateLimitError to FerryError("spend-cap") immediately (no retry)', async () => {
       vi.stubEnv('FERRY_ANTHROPIC_KEY', 'test-key');
       const RLE = Anthropic.RateLimitError as unknown as ZeroArgClass;

--- a/src/lib/llm/call.ts
+++ b/src/lib/llm/call.ts
@@ -4,6 +4,7 @@ import type { LlmRoute } from './config.js';
 import { invokeAnthropic } from './anthropic.js';
 import { invokeOpenAI } from './openai.js';
 import { invokeGoogle } from './google.js';
+import { resolveAnthropicAuth } from './anthropic-auth.js';
 
 export interface LlmUsage {
   inputTokens: number;
@@ -31,10 +32,10 @@ function requireEnv(key: string): string {
 
 export function createLlmCall(route: LlmRoute): LlmCall {
   if (route.provider === 'anthropic') {
-    const apiKey = requireEnv('FERRY_ANTHROPIC_KEY');
+    const auth = resolveAnthropicAuth({ apiKeyEnv: 'FERRY_ANTHROPIC_KEY' });
     return retry(
       (prompt: string) =>
-        invokeAnthropic({ apiKey, model: route.model, prompt, maxTokens: MAX_TOKENS }),
+        invokeAnthropic({ auth, model: route.model, prompt, maxTokens: MAX_TOKENS }),
       { baseDelayMs: 2000, maxAttempts: 3 },
     );
   }

--- a/src/lib/llm/call.ts
+++ b/src/lib/llm/call.ts
@@ -1,3 +1,4 @@
+import Anthropic from '@anthropic-ai/sdk';
 import { FerryError } from '../errors/index.js';
 import { retry } from '../io/retry.js';
 import type { LlmRoute } from './config.js';
@@ -33,9 +34,10 @@ function requireEnv(key: string): string {
 export function createLlmCall(route: LlmRoute): LlmCall {
   if (route.provider === 'anthropic') {
     const auth = resolveAnthropicAuth({ apiKeyEnv: 'FERRY_ANTHROPIC_KEY' });
+    const client = new Anthropic(auth);
     return retry(
       (prompt: string) =>
-        invokeAnthropic({ auth, model: route.model, prompt, maxTokens: MAX_TOKENS }),
+        invokeAnthropic({ client, model: route.model, prompt, maxTokens: MAX_TOKENS }),
       { baseDelayMs: 2000, maxAttempts: 3 },
     );
   }

--- a/src/lib/llm/debug-log.test.ts
+++ b/src/lib/llm/debug-log.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { isDebugEnabled, emitDebug } from './debug-log.js';
+import type { DebugEvent } from './debug-log.js';
+
+const turnEvent: DebugEvent = {
+  type: 'turn',
+  iter: 1,
+  depth: 0,
+  stop_reason: 'tool_use',
+  tools: 2,
+  mcp_tools: 0,
+  in: 100,
+  cache_w: 0,
+  cache_r: 0,
+  out: 50,
+  elapsed_ms: 123,
+};
+
+const resultEvent: DebugEvent = {
+  type: 'result',
+  subtype: 'success',
+  iterations: 6,
+  total_in: 500,
+  total_out: 300,
+  elapsed_ms: 12345,
+};
+
+describe('isDebugEnabled', () => {
+  it('true when LOG_VERBOSITY is exactly "debug"', () => {
+    expect(isDebugEnabled({ LOG_VERBOSITY: 'debug' })).toBe(true);
+  });
+
+  it('false when LOG_VERBOSITY is unset', () => {
+    expect(isDebugEnabled({})).toBe(false);
+  });
+
+  it('false when LOG_VERBOSITY is "DEBUG" (case-sensitive)', () => {
+    expect(isDebugEnabled({ LOG_VERBOSITY: 'DEBUG' })).toBe(false);
+  });
+
+  it('false when LOG_VERBOSITY is "verbose"', () => {
+    expect(isDebugEnabled({ LOG_VERBOSITY: 'verbose' })).toBe(false);
+  });
+
+  it('false when LOG_VERBOSITY is empty string', () => {
+    expect(isDebugEnabled({ LOG_VERBOSITY: '' })).toBe(false);
+  });
+});
+
+describe('emitDebug', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('writes one JSON line to stderr when debug is enabled', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    emitDebug(turnEvent, { LOG_VERBOSITY: 'debug' });
+    expect(spy).toHaveBeenCalledOnce();
+    const arg = spy.mock.calls[0][0] as string;
+    expect(() => JSON.parse(arg)).not.toThrow();
+    expect(JSON.parse(arg)).toMatchObject(turnEvent);
+  });
+
+  it('writes nothing when debug is disabled', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    emitDebug(turnEvent, {});
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('turn event has all expected keys', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    emitDebug(turnEvent, { LOG_VERBOSITY: 'debug' });
+    const parsed = JSON.parse(spy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(parsed).toHaveProperty('type', 'turn');
+    expect(parsed).toHaveProperty('iter', 1);
+    expect(parsed).toHaveProperty('depth', 0);
+    expect(parsed).toHaveProperty('stop_reason', 'tool_use');
+    expect(parsed).toHaveProperty('tools', 2);
+    expect(parsed).toHaveProperty('mcp_tools', 0);
+    expect(parsed).toHaveProperty('in', 100);
+    expect(parsed).toHaveProperty('cache_w', 0);
+    expect(parsed).toHaveProperty('cache_r', 0);
+    expect(parsed).toHaveProperty('out', 50);
+    expect(parsed).toHaveProperty('elapsed_ms', 123);
+  });
+
+  it('result event has all expected keys', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    emitDebug(resultEvent, { LOG_VERBOSITY: 'debug' });
+    const parsed = JSON.parse(spy.mock.calls[0][0] as string) as Record<string, unknown>;
+    expect(parsed).toHaveProperty('type', 'result');
+    expect(parsed).toHaveProperty('subtype', 'success');
+    expect(parsed).toHaveProperty('iterations', 6);
+    expect(parsed).toHaveProperty('total_in', 500);
+    expect(parsed).toHaveProperty('total_out', 300);
+    expect(parsed).toHaveProperty('elapsed_ms', 12345);
+  });
+
+  it('emitted JSON round-trips faithfully', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    emitDebug(resultEvent, { LOG_VERBOSITY: 'debug' });
+    const parsed = JSON.parse(spy.mock.calls[0][0] as string) as DebugEvent;
+    expect(parsed).toEqual(resultEvent);
+  });
+});

--- a/src/lib/llm/debug-log.ts
+++ b/src/lib/llm/debug-log.ts
@@ -1,0 +1,36 @@
+// Debug events contain only numeric counters and stop_reason enum — no string payloads
+// from tool inputs/outputs — so no secret-redaction is needed for these events.
+
+export type DebugEvent =
+  | {
+      type: 'turn';
+      iter: number;
+      depth: number;
+      stop_reason: string;
+      tools: number;
+      mcp_tools: number;
+      in: number;
+      cache_w: number;
+      cache_r: number;
+      out: number;
+      elapsed_ms: number;
+    }
+  | {
+      type: 'result';
+      subtype: 'success';
+      iterations: number;
+      total_in: number;
+      total_out: number;
+      elapsed_ms: number;
+    };
+
+/** True when LOG_VERBOSITY equals 'debug' (case-sensitive). */
+export function isDebugEnabled(env?: NodeJS.ProcessEnv): boolean {
+  return (env ?? process.env)['LOG_VERBOSITY'] === 'debug';
+}
+
+/** Emit one JSON line on stderr when debug is enabled; no-op otherwise. */
+export function emitDebug(event: DebugEvent, env?: NodeJS.ProcessEnv): void {
+  if (!isDebugEnabled(env)) return;
+  console.error(JSON.stringify(event));
+}


### PR DESCRIPTION
Closes #35

## Summary

- New `resolveAnthropicAuth()` in `src/lib/llm/anthropic-auth.ts`: prefers `CLAUDE_CODE_OAUTH_TOKEN` (subscription auth) over `FERRY_ANTHROPIC_KEY`/`ANTHROPIC_API_KEY`. Wired into all four agent entrypoints.
- New `emitDebug()` in `src/lib/llm/debug-log.ts`: structured JSON turn/result events on stderr when `LOG_VERBOSITY=debug`. Default terse logs unchanged.
- `createAnthropicAgentLoop` now accepts `authToken?` alongside `apiKey?`.
- 28 new tests (TDD: tests written before implementation).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`

Generated with [Claude Code](https://claude.ai/code)