### PR TITLE
feat(cli): add ferry-cost command for surfacing spend from audit log

### DIFF
--- a/scripts/ferry-cost.ts
+++ b/scripts/ferry-cost.ts
@@ -1,0 +1,143 @@
+#!/usr/bin/env tsx
+/**
+ * ferry-cost — surface daily/per-phase spend from ferry-audit.jsonl
+ *
+ * Usage: tsx scripts/ferry-cost.ts [options] [file]
+ *
+ * Reads ferry-audit.jsonl (or the file given as the last argument) and prints
+ * a spend table grouped by phase. Accepts the raw comment export format
+ * (lines starting with [ferry:audit:...] are silently skipped).
+ *
+ * Options:
+ *   --days <n>         Show last N days (default: 7)
+ *   --since <date>     ISO date lower bound (overrides --days)
+ *   --until <date>     ISO date upper bound
+ *   --by-ticket        Group by ticket instead of phase
+ *   --json             Emit machine-readable JSON instead of table
+ *   --help             Show this message
+ */
+import { readAuditFile } from '../src/cli/cost/parse.js';
+import { filterLines, groupByPhase, groupByTicket, totalStats } from '../src/cli/cost/aggregate.js';
+import { formatTable, formatJson } from '../src/cli/cost/format.js';
+
+function parseArgs(argv: string[]): {
+  file: string;
+  days: number;
+  since?: Date;
+  until?: Date;
+  byTicket: boolean;
+  json: boolean;
+  help: boolean;
+} {
+  let file = 'ferry-audit.jsonl';
+  let days = 7;
+  let since: Date | undefined;
+  let until: Date | undefined;
+  let byTicket = false;
+  let json = false;
+  let help = false;
+
+  const args = argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--help' || arg === '-h') {
+      help = true;
+    } else if (arg === '--by-ticket') {
+      byTicket = true;
+    } else if (arg === '--json') {
+      json = true;
+    } else if (arg === '--days') {
+      const raw = args[++i];
+      const n = Number(raw);
+      if (!Number.isInteger(n) || n <= 0) {
+        process.stderr.write(`error: --days must be a positive integer (got "${raw}")\n`);
+        process.exit(2);
+      }
+      days = n;
+    } else if (arg === '--since') {
+      const raw = args[++i];
+      const d = new Date(raw ?? '');
+      if (isNaN(d.getTime())) {
+        process.stderr.write(`error: --since must be an ISO date (got "${raw}")\n`);
+        process.exit(2);
+      }
+      since = d;
+    } else if (arg === '--until') {
+      const raw = args[++i];
+      const d = new Date(raw ?? '');
+      if (isNaN(d.getTime())) {
+        process.stderr.write(`error: --until must be an ISO date (got "${raw}")\n`);
+        process.exit(2);
+      }
+      until = d;
+    } else if (!arg.startsWith('--')) {
+      file = arg;
+    } else {
+      process.stderr.write(`error: unknown option "${arg}"\n`);
+      process.exit(2);
+    }
+  }
+
+  return { file, days, since, until, byTicket, json, help };
+}
+
+const USAGE = `
+Usage: tsx scripts/ferry-cost.ts [options] [file]
+
+  file              ferry-audit.jsonl path (default: ferry-audit.jsonl)
+
+Options:
+  --days <n>        Show last N days (default: 7)
+  --since <date>    ISO date lower bound, e.g. 2026-04-01 (overrides --days)
+  --until <date>    ISO date upper bound
+  --by-ticket       Group by ticket instead of phase
+  --json            Emit JSON output
+  --help            Show this message
+`.trim();
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv);
+
+  if (opts.help) {
+    process.stdout.write(USAGE + '\n');
+    return;
+  }
+
+  let allLines;
+  try {
+    allLines = await readAuditFile(opts.file);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`error: could not read "${opts.file}": ${msg}\n`);
+    process.exit(1);
+  }
+
+  const until = opts.until ?? new Date();
+  let since = opts.since;
+  if (!since) {
+    since = new Date(until);
+    since.setDate(since.getDate() - opts.days);
+  }
+
+  const filtered = filterLines(allLines, { since, until });
+  const groups = opts.byTicket ? groupByTicket(filtered) : groupByPhase(filtered);
+  const total = totalStats(groups);
+
+  const sinceStr = since.toISOString().slice(0, 10);
+  const untilStr = until.toISOString().slice(0, 10);
+  const label =
+    opts.since || opts.until ? `${sinceStr} – ${untilStr}` : `Last ${opts.days} days`;
+
+  if (opts.json) {
+    process.stdout.write(formatJson(groups, total, label) + '\n');
+  } else {
+    process.stdout.write(formatTable(groups, total, label) + '\n');
+  }
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(
+    `ferry-cost failed: ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/src/cli/cost/aggregate.ts
+++ b/src/cli/cost/aggregate.ts
@@ -1,0 +1,58 @@
+import type { AuditLine, GroupStats } from './types.js';
+
+export interface FilterOpts {
+  since?: Date;
+  until?: Date;
+}
+
+export function filterLines(lines: AuditLine[], opts: FilterOpts): AuditLine[] {
+  return lines.filter((l) => {
+    const ts = new Date(l.timestamp);
+    if (opts.since && ts < opts.since) return false;
+    if (opts.until && ts > opts.until) return false;
+    return true;
+  });
+}
+
+function accumulate(map: Map<string, GroupStats>, key: string, line: AuditLine): void {
+  const existing = map.get(key);
+  if (existing) {
+    existing.calls++;
+    existing.inputTokens += line.input_tokens;
+    existing.outputTokens += line.output_tokens;
+    existing.costEur += line.cost_eur;
+  } else {
+    map.set(key, {
+      key,
+      calls: 1,
+      inputTokens: line.input_tokens,
+      outputTokens: line.output_tokens,
+      costEur: line.cost_eur,
+    });
+  }
+}
+
+export function groupByPhase(lines: AuditLine[]): GroupStats[] {
+  const map = new Map<string, GroupStats>();
+  for (const line of lines) accumulate(map, line.phase, line);
+  return Array.from(map.values()).sort((a, b) => a.key.localeCompare(b.key));
+}
+
+export function groupByTicket(lines: AuditLine[]): GroupStats[] {
+  const map = new Map<string, GroupStats>();
+  for (const line of lines) accumulate(map, line.ticket, line);
+  return Array.from(map.values()).sort((a, b) => a.key.localeCompare(b.key));
+}
+
+export function totalStats(groups: GroupStats[]): GroupStats {
+  return groups.reduce(
+    (acc, g) => {
+      acc.calls += g.calls;
+      acc.inputTokens += g.inputTokens;
+      acc.outputTokens += g.outputTokens;
+      acc.costEur += g.costEur;
+      return acc;
+    },
+    { key: 'total', calls: 0, inputTokens: 0, outputTokens: 0, costEur: 0 },
+  );
+}

--- a/src/cli/cost/cost.test.ts
+++ b/src/cli/cost/cost.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import { parseAuditLines } from './parse.js';
+import { filterLines, groupByPhase, groupByTicket, totalStats } from './aggregate.js';
+import { formatTable, formatJson } from './format.js';
+import type { AuditLine } from './types.js';
+
+const BASE: AuditLine = {
+  ticket: 'PROJ-1',
+  phase: 'dev',
+  run_id: 'abc123',
+  model: 'claude-sonnet-4-6',
+  input_tokens: 100_000,
+  output_tokens: 10_000,
+  cost_eur: 0.42,
+  outcome: 'success',
+  duration_ms: 5000,
+  timestamp: '2026-04-25T10:00:00.000Z',
+};
+
+const LINES: AuditLine[] = [
+  {
+    ...BASE,
+    phase: 'refine',
+    ticket: 'PROJ-1',
+    cost_eur: 0.1,
+    input_tokens: 50_000,
+    output_tokens: 5_000,
+  },
+  {
+    ...BASE,
+    phase: 'refine',
+    ticket: 'PROJ-2',
+    cost_eur: 0.15,
+    input_tokens: 60_000,
+    output_tokens: 6_000,
+  },
+  {
+    ...BASE,
+    phase: 'dev',
+    ticket: 'PROJ-1',
+    cost_eur: 0.8,
+    input_tokens: 800_000,
+    output_tokens: 80_000,
+  },
+  {
+    ...BASE,
+    phase: 'review',
+    ticket: 'PROJ-1',
+    cost_eur: 0.3,
+    input_tokens: 300_000,
+    output_tokens: 30_000,
+    timestamp: '2026-04-20T10:00:00.000Z',
+  },
+];
+
+describe('parseAuditLines', () => {
+  it('parses valid JSON audit lines', () => {
+    const raw = [JSON.stringify(BASE)];
+    const result = parseAuditLines(raw);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ ticket: 'PROJ-1', phase: 'dev' });
+  });
+
+  it('skips ferry:audit marker lines', () => {
+    const raw = ['[ferry:audit:abc123]', JSON.stringify(BASE)];
+    expect(parseAuditLines(raw)).toHaveLength(1);
+  });
+
+  it('skips empty lines', () => {
+    const raw = ['', '  ', JSON.stringify(BASE)];
+    expect(parseAuditLines(raw)).toHaveLength(1);
+  });
+
+  it('skips malformed JSON', () => {
+    const raw = ['{not valid json}', JSON.stringify(BASE)];
+    expect(parseAuditLines(raw)).toHaveLength(1);
+  });
+
+  it('skips objects missing required fields', () => {
+    const raw = ['{"ticket":"PROJ-1"}', JSON.stringify(BASE)];
+    expect(parseAuditLines(raw)).toHaveLength(1);
+  });
+
+  it('handles interleaved marker + json (raw export format)', () => {
+    const raw = [
+      '[ferry:audit:run1]',
+      JSON.stringify(LINES[0]),
+      '[ferry:audit:run2]',
+      JSON.stringify(LINES[1]),
+    ];
+    expect(parseAuditLines(raw)).toHaveLength(2);
+  });
+});
+
+describe('filterLines', () => {
+  it('returns all lines when no filter', () => {
+    expect(filterLines(LINES, {})).toHaveLength(LINES.length);
+  });
+
+  it('filters by since', () => {
+    const since = new Date('2026-04-24T00:00:00.000Z');
+    const result = filterLines(LINES, { since });
+    expect(result).toHaveLength(3);
+    expect(result.every((l) => new Date(l.timestamp) >= since)).toBe(true);
+  });
+
+  it('filters by until', () => {
+    const until = new Date('2026-04-21T00:00:00.000Z');
+    const result = filterLines(LINES, { until });
+    expect(result).toHaveLength(1);
+  });
+
+  it('filters by since and until', () => {
+    const since = new Date('2026-04-24T00:00:00.000Z');
+    const until = new Date('2026-04-26T00:00:00.000Z');
+    const result = filterLines(LINES, { since, until });
+    expect(result).toHaveLength(3);
+  });
+});
+
+describe('groupByPhase', () => {
+  it('groups lines by phase', () => {
+    const groups = groupByPhase(LINES);
+    const keys = groups.map((g) => g.key);
+    expect(keys).toContain('refine');
+    expect(keys).toContain('dev');
+    expect(keys).toContain('review');
+  });
+
+  it('sums tokens and cost within a phase', () => {
+    const groups = groupByPhase(LINES);
+    const refine = groups.find((g) => g.key === 'refine');
+    expect(refine?.calls).toBe(2);
+    expect(refine?.inputTokens).toBe(110_000);
+    expect(refine?.costEur).toBeCloseTo(0.25);
+  });
+});
+
+describe('groupByTicket', () => {
+  it('groups lines by ticket', () => {
+    const groups = groupByTicket(LINES);
+    const keys = groups.map((g) => g.key);
+    expect(keys).toContain('PROJ-1');
+    expect(keys).toContain('PROJ-2');
+  });
+
+  it('counts calls correctly', () => {
+    const groups = groupByTicket(LINES);
+    const proj1 = groups.find((g) => g.key === 'PROJ-1');
+    expect(proj1?.calls).toBe(3);
+  });
+});
+
+describe('totalStats', () => {
+  it('sums all groups', () => {
+    const groups = groupByPhase(LINES);
+    const total = totalStats(groups);
+    expect(total.calls).toBe(LINES.length);
+    const expectedCost = LINES.reduce((s, l) => s + l.cost_eur, 0);
+    expect(total.costEur).toBeCloseTo(expectedCost);
+  });
+});
+
+describe('formatTable', () => {
+  it('returns a string with header and rows', () => {
+    const groups = groupByPhase(LINES);
+    const total = totalStats(groups);
+    const output = formatTable(groups, total, 'Last 7 days');
+    expect(output).toContain('Phase');
+    expect(output).toContain('Calls');
+    expect(output).toContain('refine');
+    expect(output).toContain('Last 7 days');
+  });
+
+  it('formats large token counts with k/M suffix', () => {
+    const groups = groupByPhase(LINES);
+    const total = totalStats(groups);
+    const output = formatTable(groups, total, 'All time');
+    expect(output).toMatch(/\d+k|\d+\.\d+M/);
+  });
+});
+
+describe('formatJson', () => {
+  it('returns valid JSON with groups, total, and label', () => {
+    const groups = groupByPhase(LINES);
+    const total = totalStats(groups);
+    const raw = formatJson(groups, total, 'Last 7 days');
+    const parsed = JSON.parse(raw) as { groups: unknown[]; total: unknown; label: string };
+    expect(parsed.groups).toHaveLength(groups.length);
+    expect(parsed.label).toBe('Last 7 days');
+  });
+});

--- a/src/cli/cost/format.ts
+++ b/src/cli/cost/format.ts
@@ -1,0 +1,77 @@
+import type { GroupStats } from './types.js';
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${Math.round(n / 1_000)}k`;
+  return String(n);
+}
+
+function fmtEur(n: number): string {
+  return `€${n.toFixed(2)}`;
+}
+
+function fmtEurPrecise(n: number): string {
+  return `€${n.toFixed(3)}`;
+}
+
+function padEnd(s: string, len: number): string {
+  return s.length >= len ? s : s + ' '.repeat(len - s.length);
+}
+
+function padStart(s: string, len: number): string {
+  return s.length >= len ? s : ' '.repeat(len - s.length) + s;
+}
+
+export function formatTable(groups: GroupStats[], total: GroupStats, label: string): string {
+  const rows = groups.map((g) => ({
+    key: g.key,
+    calls: String(g.calls),
+    tokens: `${fmtTokens(g.inputTokens)} / ${fmtTokens(g.outputTokens)}`,
+    cost: fmtEur(g.costEur),
+    avg: fmtEurPrecise(g.calls > 0 ? g.costEur / g.calls : 0),
+  }));
+
+  const header = {
+    key: 'Phase',
+    calls: 'Calls',
+    tokens: 'Tokens (in/out)',
+    cost: 'Est. cost',
+    avg: 'Avg / call',
+  };
+
+  const widths = {
+    key: Math.max(header.key.length, ...rows.map((r) => r.key.length)) + 2,
+    calls: Math.max(header.calls.length, ...rows.map((r) => r.calls.length)) + 2,
+    tokens: Math.max(header.tokens.length, ...rows.map((r) => r.tokens.length)) + 2,
+    cost: Math.max(header.cost.length, ...rows.map((r) => r.cost.length)) + 2,
+    avg: Math.max(header.avg.length, ...rows.map((r) => r.avg.length)) + 2,
+  };
+
+  const rowLine = (r: typeof header): string =>
+    padEnd(r.key, widths.key) +
+    padStart(r.calls, widths.calls) +
+    '  ' +
+    padEnd(r.tokens, widths.tokens) +
+    padStart(r.cost, widths.cost) +
+    padStart(r.avg, widths.avg);
+
+  const totalWidth =
+    widths.key + widths.calls + 2 + widths.tokens + widths.cost + widths.avg;
+  const divider = '─'.repeat(totalWidth);
+
+  const summaryLabel = padEnd(label, widths.key + widths.calls + 2 + widths.tokens);
+  const summaryLine = summaryLabel + padStart(fmtEur(total.costEur), widths.cost);
+
+  return [rowLine(header), divider, ...rows.map(rowLine), divider, summaryLine].join('\n');
+}
+
+export interface JsonOutput {
+  groups: GroupStats[];
+  total: GroupStats;
+  label: string;
+}
+
+export function formatJson(groups: GroupStats[], total: GroupStats, label: string): string {
+  const out: JsonOutput = { groups, total, label };
+  return JSON.stringify(out, null, 2);
+}

--- a/src/cli/cost/format.ts
+++ b/src/cli/cost/format.ts
@@ -55,8 +55,7 @@ export function formatTable(groups: GroupStats[], total: GroupStats, label: stri
     padStart(r.cost, widths.cost) +
     padStart(r.avg, widths.avg);
 
-  const totalWidth =
-    widths.key + widths.calls + 2 + widths.tokens + widths.cost + widths.avg;
+  const totalWidth = widths.key + widths.calls + 2 + widths.tokens + widths.cost + widths.avg;
   const divider = '─'.repeat(totalWidth);
 
   const summaryLabel = padEnd(label, widths.key + widths.calls + 2 + widths.tokens);

--- a/src/cli/cost/parse.ts
+++ b/src/cli/cost/parse.ts
@@ -1,0 +1,45 @@
+import { createReadStream } from 'node:fs';
+import { createInterface } from 'node:readline';
+import type { AuditLine } from './types.js';
+
+function isAuditLine(obj: unknown): obj is AuditLine {
+  if (typeof obj !== 'object' || obj === null) return false;
+  const o = obj as Record<string, unknown>;
+  return (
+    typeof o.ticket === 'string' &&
+    typeof o.phase === 'string' &&
+    typeof o.run_id === 'string' &&
+    typeof o.model === 'string' &&
+    typeof o.input_tokens === 'number' &&
+    typeof o.output_tokens === 'number' &&
+    typeof o.cost_eur === 'number' &&
+    typeof o.outcome === 'string' &&
+    typeof o.duration_ms === 'number' &&
+    typeof o.timestamp === 'string'
+  );
+}
+
+export function parseAuditLines(rawLines: string[]): AuditLine[] {
+  const result: AuditLine[] = [];
+  for (const line of rawLines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('[ferry:audit:')) continue;
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (isAuditLine(parsed)) result.push(parsed);
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return result;
+}
+
+export async function readAuditFile(filePath: string): Promise<AuditLine[]> {
+  const stream = createReadStream(filePath, { encoding: 'utf8' });
+  const rl = createInterface({ input: stream, crlfDelay: Infinity });
+  const rawLines: string[] = [];
+  for await (const line of rl) {
+    rawLines.push(line);
+  }
+  return parseAuditLines(rawLines);
+}

--- a/src/cli/cost/types.ts
+++ b/src/cli/cost/types.ts
@@ -1,0 +1,22 @@
+export interface AuditLine {
+  ticket: string;
+  phase: string;
+  run_id: string;
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  cost_eur: number;
+  outcome: string;
+  duration_ms: number;
+  timestamp: string;
+  triggered_labels?: string[];
+  resolved_mcp_servers?: string[];
+}
+
+export interface GroupStats {
+  key: string;
+  calls: number;
+  inputTokens: number;
+  outputTokens: number;
+  costEur: number;
+}


### PR DESCRIPTION
Implements `ferry cost` (closes #29) as a thin entrypoint in `scripts/ferry-cost.ts` backed by pure logic in `src/cli/cost/`.

**Usage:** `tsx scripts/ferry-cost.ts [--days N] [--since DATE] [--until DATE] [--by-ticket] [--json] [file]`

Reads `ferry-audit.jsonl` and prints spend grouped by phase. Accepts raw GitHub issue comment export format (`[ferry:audit:...]` marker lines are skipped).

Genereted with [Claude Code](https://claude.ai/code)