### PR TITLE
feat: ferry-init CLI — automate install (GitHub App, secrets, workflows, Jira rules)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,12 @@
   "description": "Ferry — GitHub Actions–native agent pipeline for Jira-driven automated development",
   "private": true,
   "type": "module",
+  "bin": {
+    "ferry-init": "./dist/cli/init/index.js"
+  },
   "scripts": {
     "build:ferry": "node scripts/build-ferry-actions.mjs",
+    "ferry-init": "tsx src/cli/init/index.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+import { ask, confirm, closePrompt, print, printStep, printSuccess, printError } from './prompt.js';
+import { workflowTemplates } from './templates.js';
+import { stepGitHubApp } from './steps/github-app.js';
+import { buildSecrets, stepSecrets } from './steps/secrets.js';
+import { installWorkflows, scaffoldCodeowners } from './steps/workflows.js';
+import { stepJiraBundle } from './steps/jira-bundle.js';
+import { stepVerify } from './steps/verify.js';
+import type { FerryConfig } from './types.js';
+
+const TOTAL_STEPS = 5;
+
+function detectRepo(): string | undefined {
+  try {
+    const remote = execSync('git remote get-url origin', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    const match = remote.match(/github\.com[:/]([^/]+\/[^/.]+)/);
+    return match ? match[1] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseArgs(argv: string[]): { overwrite: boolean; version: string } {
+  const overwrite = argv.includes('--overwrite');
+  const versionIdx = argv.findIndex((a) => a === '--version');
+  const version = versionIdx >= 0 ? (argv[versionIdx + 1] ?? 'v1') : 'v1';
+  return { overwrite, version };
+}
+
+async function main(): Promise<void> {
+  const { overwrite, version } = parseArgs(process.argv.slice(2));
+
+  print('');
+  print('╔════════════════════════════════════════╗');
+  print('║           ferry-init  v0.1             ║');
+  print('║  Set up Ferry in your GitHub repo      ║');
+  print('╚════════════════════════════════════════╝');
+  print('');
+  print('This wizard will:');
+  print('  1. Guide you through creating a GitHub App');
+  print('  2. Set 6 repository secrets via the gh CLI');
+  print('  3. Install 6 Ferry workflow stubs into .github/workflows/');
+  print('  4. Generate a Jira Automation import bundle');
+  print('  5. Verify your Anthropic API key');
+  print('');
+  print('Prerequisites: gh CLI installed and authenticated (run `gh auth status`)');
+  print('');
+
+  const ready = await confirm('Ready to start?', true);
+  if (!ready) {
+    print('Aborted.');
+    closePrompt();
+    process.exit(0);
+  }
+
+  // Detect or prompt for owner/repo
+  const detected = detectRepo();
+  const repoInput = await ask(
+    'GitHub repo (owner/repo)',
+    detected,
+  );
+  if (!repoInput || !repoInput.includes('/')) {
+    printError('Repo must be in the form owner/repo');
+    closePrompt();
+    process.exit(1);
+  }
+  const [owner, repo] = repoInput.split('/') as [string, string];
+  const fullRepo = `${owner}/${repo}`;
+
+  const repoRoot = process.cwd();
+
+  // ── Step 1: GitHub App ────────────────────────────────────────────────────
+  printStep(1, TOTAL_STEPS, 'GitHub App setup');
+  const ghApp = await stepGitHubApp(owner);
+  if (!ghApp.result.ok) {
+    printError(ghApp.result.reason);
+    closePrompt();
+    process.exit(1);
+  }
+
+  // ── Collect remaining secrets ─────────────────────────────────────────────
+  print('');
+  print('Jira credentials:');
+  const jiraBaseUrl = await ask('Jira base URL (e.g. https://acme.atlassian.net)');
+  const jiraEmail = await ask('Jira account email');
+  const jiraApiToken = await ask(
+    'Jira API token (from https://id.atlassian.com/manage-profile/security/api-tokens)',
+  );
+
+  print('');
+  print('LLM provider:');
+  const anthropicApiKey = await ask('Anthropic API key (sk-ant-...)');
+
+  closePrompt();
+
+  const config: FerryConfig = {
+    owner,
+    repo,
+    ferryVersion: version,
+    appId: ghApp.appId,
+    privateKey: ghApp.privateKey,
+    jiraBaseUrl,
+    jiraEmail,
+    jiraApiToken,
+    anthropicApiKey,
+  };
+
+  // ── Step 2: Secrets ───────────────────────────────────────────────────────
+  printStep(2, TOTAL_STEPS, `Setting secrets on ${fullRepo}`);
+  const secrets = buildSecrets(config);
+  const secretsResult = await stepSecrets(fullRepo, secrets, overwrite);
+  if (!secretsResult.ok) {
+    printError(secretsResult.reason);
+    print('You can re-run ferry-init to retry.');
+  }
+
+  // ── Step 3: Workflows ─────────────────────────────────────────────────────
+  printStep(3, TOTAL_STEPS, 'Installing workflow files');
+  const templates = workflowTemplates(config.ferryVersion);
+  const workflowDir = join(repoRoot, '.github', 'workflows');
+  installWorkflows(workflowDir, templates, overwrite);
+  scaffoldCodeowners(repoRoot, owner);
+
+  // ── Step 4: Jira automation bundle ────────────────────────────────────────
+  printStep(4, TOTAL_STEPS, 'Generating Jira Automation import bundle');
+  stepJiraBundle(repoRoot, owner, repo);
+
+  // ── Step 5: Verify ────────────────────────────────────────────────────────
+  printStep(5, TOTAL_STEPS, 'Verifying provider API key');
+  const verifyResult = await stepVerify(config.anthropicApiKey);
+
+  // ── Summary ───────────────────────────────────────────────────────────────
+  print('');
+  print('════════════════════════════════════════');
+  print('  Setup complete!');
+  print('════════════════════════════════════════');
+  print('');
+  print('Next steps:');
+  print('  1. Commit .github/workflows/ferry-*.yml and .github/CODEOWNERS');
+  print('  2. Import ferry-jira-automation-rules.json into Jira Automation');
+  print('     (Project settings → Automation → Import rules)');
+  print('  3. Set spend caps on provider billing pages (see links above)');
+  print('  4. Set FERRY_AUDIT_ISSUE repository variable to a GitHub Issue number');
+  print('     for the audit log (create a blank issue and use its number)');
+  print('  5. Move a Jira ticket to "Refinement" — watch the Actions tab!');
+  print('');
+
+  if (!secretsResult.ok || !verifyResult.ok) {
+    printError('Some steps had warnings — review the output above before proceeding.');
+    process.exit(1);
+  }
+
+  printSuccess('All steps passed. Ferry is ready to run.');
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  printError(`Unexpected error: ${msg}`);
+  process.exit(1);
+});

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -60,10 +60,7 @@ async function main(): Promise<void> {
 
   // Detect or prompt for owner/repo
   const detected = detectRepo();
-  const repoInput = await ask(
-    'GitHub repo (owner/repo)',
-    detected,
-  );
+  const repoInput = await ask('GitHub repo (owner/repo)', detected);
   if (!repoInput || !repoInput.includes('/')) {
     printError('Repo must be in the form owner/repo');
     closePrompt();

--- a/src/cli/init/init.test.ts
+++ b/src/cli/init/init.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import { buildSecrets } from './steps/secrets.js';
+import { buildJiraBundle } from './steps/jira-bundle.js';
+import { workflowTemplates } from './templates.js';
+
+// ── buildSecrets ─────────────────────────────────────────────────────────────
+
+describe('buildSecrets', () => {
+  const cfg = {
+    appId: '1234567',
+    privateKey: '-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----',
+    jiraBaseUrl: 'https://acme.atlassian.net',
+    jiraEmail: 'bot@acme.com',
+    jiraApiToken: 'token-abc',
+    anthropicApiKey: 'sk-ant-abc',
+  };
+
+  it('returns 6 secrets', () => {
+    expect(buildSecrets(cfg)).toHaveLength(6);
+  });
+
+  it('maps correct secret names', () => {
+    const names = buildSecrets(cfg).map((s) => s.name);
+    expect(names).toContain('FERRY_APP_ID');
+    expect(names).toContain('FERRY_PRIVATE_KEY');
+    expect(names).toContain('FERRY_JIRA_BASE_URL');
+    expect(names).toContain('FERRY_JIRA_EMAIL');
+    expect(names).toContain('FERRY_JIRA_API_TOKEN');
+    expect(names).toContain('FERRY_ANTHROPIC_API_KEY');
+  });
+
+  it('propagates values correctly', () => {
+    const secrets = buildSecrets(cfg);
+    const entry = secrets.find((s) => s.name === 'FERRY_APP_ID');
+    expect(entry?.value).toBe('1234567');
+  });
+
+  it('includes description for each secret', () => {
+    const secrets = buildSecrets(cfg);
+    for (const s of secrets) {
+      expect(s.description.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── buildJiraBundle ───────────────────────────────────────────────────────────
+
+describe('buildJiraBundle', () => {
+  it('produces exactly 4 rules', () => {
+    const bundle = buildJiraBundle('acme-corp', 'acme-app');
+    expect(bundle.rules).toHaveLength(4);
+  });
+
+  it('sets cloud, version, type metadata', () => {
+    const bundle = buildJiraBundle('acme-corp', 'acme-app');
+    expect(bundle.cloud).toBe(true);
+    expect(bundle.version).toBe(1);
+    expect(bundle.type).toBe('AUTOMATION');
+  });
+
+  it('uses the correct dispatch URL for all rules', () => {
+    const bundle = buildJiraBundle('my-org', 'my-repo');
+    const expected = 'https://api.github.com/repos/my-org/my-repo/dispatches';
+    for (const rule of bundle.rules) {
+      expect(rule.actions[0]?.value.url).toBe(expected);
+    }
+  });
+
+  it('uses the four Ferry event types', () => {
+    const bundle = buildJiraBundle('acme-corp', 'acme-app');
+    const bodies = bundle.rules.map(
+      (r) => JSON.parse(r.actions[0]?.value.body ?? '{}') as { event_type: string },
+    );
+    const eventTypes = bodies.map((b) => b.event_type);
+    expect(eventTypes).toContain('ferry-refine');
+    expect(eventTypes).toContain('ferry-dev');
+    expect(eventTypes).toContain('ferry-review');
+    expect(eventTypes).toContain('ferry-iterate');
+  });
+
+  it('includes {{issue.key}} in each rule body', () => {
+    const bundle = buildJiraBundle('acme-corp', 'acme-app');
+    for (const rule of bundle.rules) {
+      const body = JSON.parse(rule.actions[0]?.value.body ?? '{}') as {
+        client_payload: { ticket_key: string };
+      };
+      expect(body.client_payload.ticket_key).toBe('{{issue.key}}');
+    }
+  });
+
+  it('creates all rules in DISABLED state', () => {
+    const bundle = buildJiraBundle('acme-corp', 'acme-app');
+    for (const rule of bundle.rules) {
+      expect(rule.state).toBe('DISABLED');
+    }
+  });
+
+  it('triggers on ISSUE_TRANSITIONED', () => {
+    const bundle = buildJiraBundle('acme-corp', 'acme-app');
+    for (const rule of bundle.rules) {
+      expect(rule.trigger.type).toBe('ISSUE_TRANSITIONED');
+    }
+  });
+
+  it('maps phases to correct Jira column names', () => {
+    const bundle = buildJiraBundle('acme-corp', 'acme-app');
+    const statuses = bundle.rules.map((r) => r.trigger.value.toStatus.name);
+    expect(statuses).toContain('Refinement');
+    expect(statuses).toContain('In Development');
+    expect(statuses).toContain('In Review');
+    expect(statuses).toContain('Iteration');
+  });
+});
+
+// ── workflowTemplates ─────────────────────────────────────────────────────────
+
+describe('workflowTemplates', () => {
+  it('returns 6 workflow files', () => {
+    expect(workflowTemplates('v1')).toHaveLength(6);
+  });
+
+  it('includes all required workflow filenames', () => {
+    const names = workflowTemplates('v1').map((t) => t.filename);
+    expect(names).toContain('ferry-refine.yml');
+    expect(names).toContain('ferry-dev.yml');
+    expect(names).toContain('ferry-review.yml');
+    expect(names).toContain('ferry-iterate.yml');
+    expect(names).toContain('ferry-reconciler.yml');
+    expect(names).toContain('ferry-audit-daily.yml');
+  });
+
+  it('embeds the ferry version tag in each agent workflow', () => {
+    const templates = workflowTemplates('v2');
+    const agentFiles = [
+      'ferry-refine.yml',
+      'ferry-dev.yml',
+      'ferry-review.yml',
+      'ferry-iterate.yml',
+    ];
+    for (const tmpl of templates) {
+      if (agentFiles.includes(tmpl.filename)) {
+        expect(tmpl.content).toContain('@v2');
+      }
+    }
+  });
+
+  it('each agent workflow calls the Ferry reusable workflow', () => {
+    const agentFiles = [
+      'ferry-refine.yml',
+      'ferry-dev.yml',
+      'ferry-review.yml',
+      'ferry-iterate.yml',
+    ];
+    for (const tmpl of workflowTemplates('v1')) {
+      if (agentFiles.includes(tmpl.filename)) {
+        expect(tmpl.content).toContain('big-emotion/ferry/.github/workflows/');
+        expect(tmpl.content).toContain('secrets: inherit');
+      }
+    }
+  });
+
+  it('ferry-dev.yml declares write permissions', () => {
+    const dev = workflowTemplates('v1').find((t) => t.filename === 'ferry-dev.yml');
+    expect(dev?.content).toContain('contents: write');
+    expect(dev?.content).toContain('pull-requests: write');
+  });
+
+  it('ferry-review.yml declares checks: read permission', () => {
+    const review = workflowTemplates('v1').find((t) => t.filename === 'ferry-review.yml');
+    expect(review?.content).toContain('checks: read');
+  });
+
+  it('ferry-refine.yml triggers on ferry-refine event', () => {
+    const refine = workflowTemplates('v1').find((t) => t.filename === 'ferry-refine.yml');
+    expect(refine?.content).toContain('ferry-refine');
+  });
+});

--- a/src/cli/init/prompt.ts
+++ b/src/cli/init/prompt.ts
@@ -1,0 +1,56 @@
+import { createInterface, type Interface } from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+
+let _rl: Interface | null = null;
+
+function rl(): Interface {
+  if (!_rl) {
+    _rl = createInterface({ input, output, terminal: false });
+  }
+  return _rl;
+}
+
+export async function ask(question: string, defaultValue?: string): Promise<string> {
+  const prompt = defaultValue ? `${question} [${defaultValue}]: ` : `${question}: `;
+  const answer = await rl().question(prompt);
+  const trimmed = answer.trim();
+  return trimmed || defaultValue || '';
+}
+
+export async function confirm(question: string, defaultYes = false): Promise<boolean> {
+  const hint = defaultYes ? 'Y/n' : 'y/N';
+  const answer = await ask(`${question} (${hint})`);
+  if (!answer) return defaultYes;
+  return answer.toLowerCase().startsWith('y');
+}
+
+export function closePrompt(): void {
+  if (_rl) {
+    _rl.close();
+    _rl = null;
+  }
+}
+
+export function print(msg: string): void {
+  process.stdout.write(msg + '\n');
+}
+
+export function printStep(step: number, total: number, title: string): void {
+  print(`\n[${step}/${total}] ${title}`);
+}
+
+export function printSuccess(msg: string): void {
+  print(`  ✓ ${msg}`);
+}
+
+export function printSkip(msg: string): void {
+  print(`  – ${msg}`);
+}
+
+export function printWarn(msg: string): void {
+  print(`  ! ${msg}`);
+}
+
+export function printError(msg: string): void {
+  print(`  ✗ ${msg}`);
+}

--- a/src/cli/init/steps/github-app.ts
+++ b/src/cli/init/steps/github-app.ts
@@ -1,0 +1,81 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { ask, print, printSuccess, printWarn } from '../prompt.js';
+import type { StepResult } from '../types.js';
+
+const NEW_APP_URL = 'https://github.com/settings/apps/new';
+const DOCS_URL = 'https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app';
+
+export async function stepGitHubApp(
+  owner: string,
+  existingAppId?: string,
+): Promise<{ result: StepResult; appId: string; privateKey: string }> {
+  print('');
+  print('Ferry uses a GitHub App (not a PAT) so it can post as a bot identity.');
+  print('');
+  print('Quick guide:');
+  print(`  1. Open: ${NEW_APP_URL}`);
+  print(`     (docs: ${DOCS_URL})`);
+  print('  2. Name: e.g. "ferry-<your-org>"');
+  print('  3. Homepage URL: any placeholder URL');
+  print('  4. Webhook: uncheck Active');
+  print('  5. Repository permissions:');
+  print('       Contents       → Read and write');
+  print('       Pull requests  → Read and write');
+  print('       Issues         → Read and write');
+  print('       Metadata       → Read-only (auto)');
+  print('  6. "Where can this app be installed?" → Only on this account');
+  print('  7. Create GitHub App → note the App ID shown on the settings page');
+  print('  8. Click "Generate a private key" → the browser saves a .pem file');
+  print(`  9. Install the app on the "${owner}" org/account (left sidebar → Install App)`);
+  print('');
+
+  if (existingAppId) {
+    printWarn(`An App ID is already configured (${existingAppId}). Press Enter to keep it.`);
+  }
+
+  const appId = await ask('App ID (numeric, from the App settings page)', existingAppId);
+  if (!appId) {
+    return { result: { ok: false, reason: 'App ID is required' }, appId: '', privateKey: '' };
+  }
+  if (!/^\d+$/.test(appId)) {
+    return {
+      result: { ok: false, reason: `App ID must be numeric, got: ${appId}` },
+      appId: '',
+      privateKey: '',
+    };
+  }
+
+  print('');
+  const pemPath = await ask(
+    'Path to the downloaded .pem private key file (e.g. ~/Downloads/ferry-acme.pem)',
+  );
+  if (!pemPath) {
+    return {
+      result: { ok: false, reason: 'Private key path is required' },
+      appId: '',
+      privateKey: '',
+    };
+  }
+
+  const resolvedPath = resolve(pemPath.replace(/^~/, process.env.HOME ?? '~'));
+  if (!existsSync(resolvedPath)) {
+    return {
+      result: { ok: false, reason: `File not found: ${resolvedPath}` },
+      appId: '',
+      privateKey: '',
+    };
+  }
+
+  const privateKey = readFileSync(resolvedPath, 'utf8').trim();
+  if (!privateKey.includes('-----BEGIN')) {
+    return {
+      result: { ok: false, reason: `${resolvedPath} does not look like a PEM file` },
+      appId: '',
+      privateKey: '',
+    };
+  }
+
+  printSuccess(`GitHub App configured (ID: ${appId}, key loaded from ${resolvedPath})`);
+  return { result: { ok: true }, appId, privateKey };
+}

--- a/src/cli/init/steps/jira-bundle.ts
+++ b/src/cli/init/steps/jira-bundle.ts
@@ -1,0 +1,120 @@
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { printSuccess, print } from '../prompt.js';
+import type { StepResult } from '../types.js';
+
+interface JiraWebRequestAction {
+  type: 'SEND_WEB_REQUEST';
+  value: {
+    url: string;
+    method: 'POST';
+    body: string;
+    headers: Array<{ name: string; value: string }>;
+    delayUnit: 'SECONDS';
+    delay: '0';
+    waitForResponse: false;
+  };
+}
+
+interface JiraTransitionTrigger {
+  type: 'ISSUE_TRANSITIONED';
+  value: {
+    fromStatusCategory?: string;
+    toStatus: { name: string };
+  };
+}
+
+interface JiraRule {
+  name: string;
+  state: 'DISABLED';
+  trigger: JiraTransitionTrigger;
+  actions: JiraWebRequestAction[];
+}
+
+interface JiraAutomationBundle {
+  cloud: true;
+  version: 1;
+  type: 'AUTOMATION';
+  rules: JiraRule[];
+}
+
+const PHASES = [
+  { eventType: 'ferry-refine', statusName: 'Refinement', label: 'Refine' },
+  { eventType: 'ferry-dev', statusName: 'In Development', label: 'Dev' },
+  { eventType: 'ferry-review', statusName: 'In Review', label: 'Review' },
+  { eventType: 'ferry-iterate', statusName: 'Iteration', label: 'Iterate' },
+] as const;
+
+export function buildJiraBundle(owner: string, repo: string): JiraAutomationBundle {
+  const dispatchUrl = `https://api.github.com/repos/${owner}/${repo}/dispatches`;
+
+  const rules: JiraRule[] = PHASES.map((phase) => {
+    const body = JSON.stringify({
+      event_type: phase.eventType,
+      client_payload: {
+        phase: phase.label.toLowerCase(),
+        ticket_key: '{{issue.key}}',
+        issue_type: '{{issue.issuetype.name}}',
+        actor: '{{initiator.displayName}}',
+        source: 'jira-column',
+        ts: "{{now.format(\"yyyy-MM-dd'T'HH:mm:ssXXX\")}}",
+      },
+    });
+
+    return {
+      name: `Ferry — ${phase.label} (column trigger)`,
+      state: 'DISABLED',
+      trigger: {
+        type: 'ISSUE_TRANSITIONED',
+        value: {
+          toStatus: { name: phase.statusName },
+        },
+      },
+      actions: [
+        {
+          type: 'SEND_WEB_REQUEST',
+          value: {
+            url: dispatchUrl,
+            method: 'POST',
+            body,
+            headers: [
+              { name: 'Accept', value: 'application/vnd.github+json' },
+              {
+                name: 'Authorization',
+                value: 'Bearer YOUR_GITHUB_PAT_WITH_REPO_SCOPE',
+              },
+              { name: 'X-GitHub-Api-Version', value: '2022-11-28' },
+              { name: 'Content-Type', value: 'application/json' },
+            ],
+            delayUnit: 'SECONDS',
+            delay: '0',
+            waitForResponse: false,
+          },
+        },
+      ],
+    };
+  });
+
+  return { cloud: true, version: 1, type: 'AUTOMATION', rules };
+}
+
+export function stepJiraBundle(repoRoot: string, owner: string, repo: string): StepResult {
+  const bundle = buildJiraBundle(owner, repo);
+  const outPath = join(repoRoot, 'ferry-jira-automation-rules.json');
+  writeFileSync(outPath, JSON.stringify(bundle, null, 2) + '\n', 'utf8');
+
+  printSuccess(`Generated ferry-jira-automation-rules.json`);
+  print('');
+  print('  To import these Automation rules into Jira:');
+  print('  1. Jira → Project settings → Automation');
+  print('  2. Top-right menu → Import rules');
+  print('  3. Upload ferry-jira-automation-rules.json');
+  print(
+    '  4. Replace YOUR_GITHUB_PAT_WITH_REPO_SCOPE in each rule with a fine-grained PAT',
+  );
+  print('     that has Contents: write on your repo (or use a GitHub App installation token).');
+  print('  5. Set the "To status" in each rule to match your Jira column names exactly.');
+  print('  6. Enable each rule.');
+
+  return { ok: true };
+}

--- a/src/cli/init/steps/jira-bundle.ts
+++ b/src/cli/init/steps/jira-bundle.ts
@@ -57,7 +57,7 @@ export function buildJiraBundle(owner: string, repo: string): JiraAutomationBund
         issue_type: '{{issue.issuetype.name}}',
         actor: '{{initiator.displayName}}',
         source: 'jira-column',
-        ts: "{{now.format(\"yyyy-MM-dd'T'HH:mm:ssXXX\")}}",
+        ts: '{{now.format("yyyy-MM-dd\'T\'HH:mm:ssXXX")}}',
       },
     });
 
@@ -109,9 +109,7 @@ export function stepJiraBundle(repoRoot: string, owner: string, repo: string): S
   print('  1. Jira → Project settings → Automation');
   print('  2. Top-right menu → Import rules');
   print('  3. Upload ferry-jira-automation-rules.json');
-  print(
-    '  4. Replace YOUR_GITHUB_PAT_WITH_REPO_SCOPE in each rule with a fine-grained PAT',
-  );
+  print('  4. Replace YOUR_GITHUB_PAT_WITH_REPO_SCOPE in each rule with a fine-grained PAT');
   print('     that has Contents: write on your repo (or use a GitHub App installation token).');
   print('  5. Set the "To status" in each rule to match your Jira column names exactly.');
   print('  6. Enable each rule.');

--- a/src/cli/init/steps/secrets.ts
+++ b/src/cli/init/steps/secrets.ts
@@ -1,0 +1,83 @@
+import { execSync } from 'node:child_process';
+import { printSuccess, printSkip, printError } from '../prompt.js';
+import type { SecretEntry, StepResult } from '../types.js';
+
+export function buildSecrets(config: {
+  appId: string;
+  privateKey: string;
+  jiraBaseUrl: string;
+  jiraEmail: string;
+  jiraApiToken: string;
+  anthropicApiKey: string;
+}): SecretEntry[] {
+  return [
+    { name: 'FERRY_APP_ID', value: config.appId, description: 'GitHub App numeric ID' },
+    {
+      name: 'FERRY_PRIVATE_KEY',
+      value: config.privateKey,
+      description: 'GitHub App RSA private key (PEM)',
+    },
+    { name: 'FERRY_JIRA_BASE_URL', value: config.jiraBaseUrl, description: 'Jira instance URL' },
+    { name: 'FERRY_JIRA_EMAIL', value: config.jiraEmail, description: 'Jira account email' },
+    {
+      name: 'FERRY_JIRA_API_TOKEN',
+      value: config.jiraApiToken,
+      description: 'Atlassian API token',
+    },
+    {
+      name: 'FERRY_ANTHROPIC_API_KEY',
+      value: config.anthropicApiKey,
+      description: 'Anthropic API key',
+    },
+  ];
+}
+
+export function listExistingSecrets(repo: string): string[] {
+  try {
+    const output = execSync(`gh secret list --repo ${repo} --json name`, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const parsed = JSON.parse(output) as Array<{ name: string }>;
+    return parsed.map((s) => s.name);
+  } catch {
+    return [];
+  }
+}
+
+export function setSecret(repo: string, name: string, value: string): void {
+  execSync(`gh secret set ${name} --repo ${repo}`, {
+    input: value,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+export async function stepSecrets(
+  repo: string,
+  secrets: SecretEntry[],
+  overwrite: boolean,
+): Promise<StepResult> {
+  const existing = listExistingSecrets(repo);
+  const errors: string[] = [];
+
+  for (const secret of secrets) {
+    if (existing.includes(secret.name) && !overwrite) {
+      printSkip(`${secret.name} already set — skipping`);
+      continue;
+    }
+    try {
+      setSecret(repo, secret.name, secret.value);
+      printSuccess(`Set ${secret.name}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      printError(`Failed to set ${secret.name}: ${msg}`);
+      errors.push(secret.name);
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, reason: `Failed to set secrets: ${errors.join(', ')}` };
+  }
+  return { ok: true };
+}

--- a/src/cli/init/steps/verify.ts
+++ b/src/cli/init/steps/verify.ts
@@ -1,0 +1,95 @@
+import https from 'node:https';
+import type { RequestOptions } from 'node:https';
+import { printSuccess, printError, printWarn, print } from '../prompt.js';
+import type { StepResult } from '../types.js';
+
+const BILLING_LINKS = [
+  {
+    provider: 'Anthropic',
+    url: 'https://console.anthropic.com/settings/limits',
+    tip: 'Set a monthly spend limit (≤ 200 USD recommended for pilots)',
+  },
+  {
+    provider: 'Google AI',
+    url: 'https://console.cloud.google.com/billing',
+    tip: 'Enable budget alerts at 50% and 100% of your target',
+  },
+  {
+    provider: 'OpenAI',
+    url: 'https://platform.openai.com/settings/organization/billing/limits',
+    tip: 'Set a monthly hard limit',
+  },
+];
+
+function httpsPost(
+  options: RequestOptions,
+  body: string,
+): Promise<{ statusCode: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk: Buffer | string) => {
+        data += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      });
+      res.on('end', () => {
+        resolve({ statusCode: res.statusCode ?? 0, body: data });
+      });
+    });
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+export async function verifyAnthropicKey(apiKey: string): Promise<boolean> {
+  const body = JSON.stringify({
+    model: 'claude-haiku-4-5-20251001',
+    max_tokens: 1,
+    messages: [{ role: 'user', content: 'ping' }],
+  });
+
+  try {
+    const res = await httpsPost(
+      {
+        hostname: 'api.anthropic.com',
+        path: '/v1/messages',
+        method: 'POST',
+        headers: {
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(body),
+        },
+        timeout: 10_000,
+      },
+      body,
+    );
+    return res.statusCode !== 401 && res.statusCode !== 403;
+  } catch {
+    return false;
+  }
+}
+
+export async function stepVerify(anthropicApiKey: string): Promise<StepResult> {
+  print('  Verifying Anthropic API key...');
+
+  const valid = await verifyAnthropicKey(anthropicApiKey);
+  if (valid) {
+    printSuccess('Anthropic API key is valid');
+  } else {
+    printError('Anthropic API key is invalid or unreachable');
+    printWarn('Check the key at https://console.anthropic.com/account/keys');
+  }
+
+  print('');
+  print('  Set spend caps before your first dispatch (cannot be automated):');
+  for (const link of BILLING_LINKS) {
+    print(`  • ${link.provider}: ${link.url}`);
+    print(`    ${link.tip}`);
+  }
+
+  if (!valid) {
+    return { ok: false, reason: 'Anthropic API key verification failed' };
+  }
+  return { ok: true };
+}

--- a/src/cli/init/steps/workflows.ts
+++ b/src/cli/init/steps/workflows.ts
@@ -1,0 +1,67 @@
+import { mkdirSync, existsSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { printSuccess, printSkip, printWarn } from '../prompt.js';
+import type { WorkflowEntry, StepResult } from '../types.js';
+
+export function installWorkflows(
+  workflowDir: string,
+  templates: WorkflowEntry[],
+  overwrite: boolean,
+): StepResult {
+  mkdirSync(workflowDir, { recursive: true });
+
+  const skipped: string[] = [];
+  const installed: string[] = [];
+
+  for (const tmpl of templates) {
+    const dest = join(workflowDir, tmpl.filename);
+
+    if (existsSync(dest)) {
+      const existing = readFileSync(dest, 'utf8');
+      if (existing === tmpl.content) {
+        printSkip(`${tmpl.filename} already up-to-date`);
+        skipped.push(tmpl.filename);
+        continue;
+      }
+      if (!overwrite) {
+        printWarn(
+          `${tmpl.filename} exists with different content — skipping (use --overwrite to replace)`,
+        );
+        skipped.push(tmpl.filename);
+        continue;
+      }
+    }
+
+    writeFileSync(dest, tmpl.content, 'utf8');
+    printSuccess(`Wrote ${tmpl.filename}`);
+    installed.push(tmpl.filename);
+  }
+
+  if (installed.length === 0 && skipped.length > 0) {
+    return { ok: true };
+  }
+  return { ok: true };
+}
+
+export function scaffoldCodeowners(repoRoot: string, owner: string): StepResult {
+  const codeownersPath = join(repoRoot, '.github', 'CODEOWNERS');
+
+  if (existsSync(codeownersPath)) {
+    const existing = readFileSync(codeownersPath, 'utf8');
+    const ferryEntry = `.github/workflows/ferry-*.yml @${owner}`;
+    if (existing.includes('ferry-')) {
+      printSkip('CODEOWNERS already has ferry entries');
+      return { ok: true };
+    }
+    writeFileSync(codeownersPath, existing.trimEnd() + '\n' + ferryEntry + '\n', 'utf8');
+    printSuccess('Added ferry workflow entry to CODEOWNERS');
+    return { ok: true };
+  }
+
+  const content = `# Ferry workflow files — only repo admins should modify these
+.github/workflows/ferry-*.yml @${owner}
+`;
+  writeFileSync(codeownersPath, content, 'utf8');
+  printSuccess('Created .github/CODEOWNERS');
+  return { ok: true };
+}

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -1,0 +1,174 @@
+import type { WorkflowEntry } from './types.js';
+
+export function workflowTemplates(version: string): WorkflowEntry[] {
+  return [
+    {
+      filename: 'ferry-refine.yml',
+      content: `# Managed by ferry-init. Re-run \`npx ferry-init\` to update.
+# Required secrets: FERRY_APP_ID, FERRY_PRIVATE_KEY, FERRY_JIRA_BASE_URL,
+#                   FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN, FERRY_ANTHROPIC_API_KEY
+# Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
+
+name: Ferry — Refine
+
+on:
+  repository_dispatch:
+    types: [ferry-refine]
+
+permissions:
+  contents: read
+  issues: write
+
+# Concurrency is managed by the reusable workflow. Adding a block here would deadlock.
+
+jobs:
+  refine:
+    uses: big-emotion/ferry/.github/workflows/refine.yml@${version}
+    with:
+      ticket_key: \${{ github.event.client_payload.ticket_key }}
+      event_id: \${{ github.event.client_payload.event_id }}
+      payload: \${{ toJson(github.event.client_payload) }}
+    secrets: inherit
+`,
+    },
+    {
+      filename: 'ferry-dev.yml',
+      content: `# Managed by ferry-init. Re-run \`npx ferry-init\` to update.
+# Required secrets: FERRY_APP_ID, FERRY_PRIVATE_KEY, FERRY_JIRA_BASE_URL,
+#                   FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN, FERRY_ANTHROPIC_API_KEY
+# Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
+# Optional variables: FERRY_MODEL (default: claude-sonnet-4-6)
+
+name: Ferry — Dev
+
+on:
+  repository_dispatch:
+    types: [ferry-dev]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+# Concurrency is managed by the reusable workflow. Adding a block here would deadlock.
+
+jobs:
+  dev:
+    uses: big-emotion/ferry/.github/workflows/dev.yml@${version}
+    with:
+      ticket_key: \${{ github.event.client_payload.ticket_key }}
+      event_id: \${{ github.event.client_payload.event_id }}
+      payload: \${{ toJson(github.event.client_payload) }}
+    secrets: inherit
+`,
+    },
+    {
+      filename: 'ferry-review.yml',
+      content: `# Managed by ferry-init. Re-run \`npx ferry-init\` to update.
+# Required secrets: FERRY_APP_ID, FERRY_PRIVATE_KEY, FERRY_JIRA_BASE_URL,
+#                   FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN, FERRY_ANTHROPIC_API_KEY
+# Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
+# Optional variables: FERRY_REVIEW_MODEL (default: claude-sonnet-4-6)
+
+name: Ferry — Review
+
+on:
+  repository_dispatch:
+    types: [ferry-review]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  checks: read
+
+# Concurrency is managed by the reusable workflow. Adding a block here would deadlock.
+
+jobs:
+  review:
+    uses: big-emotion/ferry/.github/workflows/review.yml@${version}
+    with:
+      ticket_key: \${{ github.event.client_payload.ticket_key }}
+      event_id: \${{ github.event.client_payload.event_id }}
+      payload: \${{ toJson(github.event.client_payload) }}
+    secrets: inherit
+`,
+    },
+    {
+      filename: 'ferry-iterate.yml',
+      content: `# Managed by ferry-init. Re-run \`npx ferry-init\` to update.
+# Required secrets: FERRY_APP_ID, FERRY_PRIVATE_KEY, FERRY_JIRA_BASE_URL,
+#                   FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN, FERRY_ANTHROPIC_API_KEY
+# Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
+# Optional variables: FERRY_ITER_MODEL (default: claude-sonnet-4-6)
+#                     FERRY_ITER_MAX_INPUT_TOKENS (default: 500000)
+
+name: Ferry — Iterate
+
+on:
+  repository_dispatch:
+    types: [ferry-iterate]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+# Concurrency is managed by the reusable workflow. Adding a block here would deadlock.
+
+jobs:
+  iterate:
+    uses: big-emotion/ferry/.github/workflows/iterate.yml@${version}
+    with:
+      ticket_key: \${{ github.event.client_payload.ticket_key }}
+      event_id: \${{ github.event.client_payload.event_id }}
+      payload: \${{ toJson(github.event.client_payload) }}
+    secrets: inherit
+`,
+    },
+    {
+      filename: 'ferry-reconciler.yml',
+      content: `# Managed by ferry-init. Re-run \`npx ferry-init\` to update.
+# Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
+
+name: Ferry — Reconciler
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ferry-reconciler
+  cancel-in-progress: true
+
+jobs:
+  reconciler:
+    uses: big-emotion/ferry/.github/workflows/reconciler.yml@${version}
+    secrets: inherit
+`,
+    },
+    {
+      filename: 'ferry-audit-daily.yml',
+      content: `# Managed by ferry-init. Re-run \`npx ferry-init\` to update.
+# This workflow runs daily governance checks (spend monitoring, event pruning).
+
+name: Ferry — Audit Daily
+
+on:
+  schedule:
+    - cron: '0 9 * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: ferry-audit-daily
+  cancel-in-progress: true
+
+jobs:
+  audit-daily:
+    uses: big-emotion/ferry/.github/workflows/audit-daily.yml@${version}
+    secrets: inherit
+`,
+    },
+  ];
+}

--- a/src/cli/init/types.ts
+++ b/src/cli/init/types.ts
@@ -1,0 +1,24 @@
+export interface FerryConfig {
+  owner: string;
+  repo: string;
+  ferryVersion: string;
+  appId: string;
+  privateKey: string;
+  jiraBaseUrl: string;
+  jiraEmail: string;
+  jiraApiToken: string;
+  anthropicApiKey: string;
+}
+
+export interface SecretEntry {
+  name: string;
+  value: string;
+  description: string;
+}
+
+export interface WorkflowEntry {
+  filename: string;
+  content: string;
+}
+
+export type StepResult = { ok: true } | { ok: false; reason: string };


### PR DESCRIPTION
Closes #22

Implements `npx ferry-init` (or `npm run ferry-init`) as a 5-step wizard that automates the entire Ferry setup process.

## Changes

- `src/cli/init/` — new CLI package (10 files, ~600 LoC of implementation + ~200 LoC of tests)
- `package.json` — added `ferry-init` script and `bin` field

## What it does

1. **GitHub App setup** — deep-link guide + prompts for App ID + .pem file path
2. **Secrets** — sets 6 repo secrets via `gh secret set` (idempotent)
3. **Workflows** — writes 6 consumer workflow stubs into `.github/workflows/`
4. **Jira bundle** — generates `ferry-jira-automation-rules.json` (4 rules, import in one click)
5. **Verify** — dry-run HTTP call for Anthropic key + billing deep-links

Generated with [Claude Code](https://claude.ai/code)