### PR TITLE
feat: add ferry doctor end-to-end health check

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "private": true,
   "type": "module",
   "bin": {
-    "ferry-init": "./dist/cli/init/index.js"
+    "ferry-init": "./dist/cli/init/index.js",
+    "ferry-doctor": "./dist/cli/doctor/index.js"
   },
   "scripts": {
     "build:ferry": "node scripts/build-ferry-actions.mjs",
     "ferry-init": "tsx src/cli/init/index.ts",
+    "ferry-doctor": "tsx src/cli/doctor/index.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/cli/doctor/checks/dispatch.ts
+++ b/src/cli/doctor/checks/dispatch.ts
@@ -1,0 +1,170 @@
+import { execSync } from 'node:child_process';
+import type { CheckResult } from '../types.js';
+
+const PROBE_TICKET = 'FERRY-DOCTOR-0';
+const PROBE_EVENT_TYPE = 'ferry-refine';
+const POLL_INTERVAL_MS = 3_000;
+const POLL_TIMEOUT_MS = 45_000;
+
+interface WorkflowRun {
+  databaseId: number;
+  status: string;
+  conclusion: string | null;
+  url: string;
+  headBranch: string;
+  event: string;
+}
+
+function triggerDispatch(repo: string, eventId: string): void {
+  const payload = JSON.stringify({
+    event_type: PROBE_EVENT_TYPE,
+    client_payload: {
+      phase: 'refine',
+      ticket_key: PROBE_TICKET,
+      event_id: eventId,
+      issue_type: 'Task',
+      actor: 'ferry-doctor',
+      source: 'doctor-probe',
+    },
+  });
+  execSync(
+    `gh api repos/${repo}/dispatches --method POST --input -`,
+    {
+      input: payload,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    },
+  );
+}
+
+function listRecentRuns(repo: string, after: number): WorkflowRun[] {
+  try {
+    const out = execSync(
+      `gh run list --repo ${repo} --workflow ferry-refine.yml --limit 5 --json databaseId,status,conclusion,url,headBranch,event`,
+      { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] },
+    );
+    const runs = JSON.parse(out) as WorkflowRun[];
+    return runs.filter((r) => r.databaseId > after);
+  } catch {
+    return [];
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function checkSyntheticDispatch(opts: {
+  repo: string;
+  noDispatch: boolean;
+}): Promise<CheckResult> {
+  const { repo, noDispatch } = opts;
+
+  if (noDispatch) {
+    return {
+      label: 'Synthetic dispatch',
+      status: 'skip',
+      detail: 'Skipped (--no-dispatch flag)',
+      remedy: 'Remove --no-dispatch to enable the end-to-end workflow probe',
+    };
+  }
+
+  const eventId = `doctor-${Date.now()}`;
+
+  // Record highest existing run ID before triggering
+  let baselineId = 0;
+  try {
+    const existing = listRecentRuns(repo, 0);
+    baselineId = existing.reduce((max, r) => Math.max(max, r.databaseId), 0);
+  } catch {
+    // ignore
+  }
+
+  // Trigger
+  try {
+    triggerDispatch(repo, eventId);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('permission') || msg.includes('403')) {
+      return {
+        label: 'Synthetic dispatch',
+        status: 'red',
+        detail: 'Permission denied triggering repository_dispatch',
+        remedy:
+          'Ensure gh CLI is authenticated with a token that has `repo` scope: `gh auth refresh -s repo`',
+      };
+    }
+    if (msg.includes('not found') || msg.includes('404')) {
+      return {
+        label: 'Synthetic dispatch',
+        status: 'red',
+        detail: `Repo "${repo}" not found or dispatch not allowed`,
+        remedy:
+          'Verify the repo name is correct and `ferry-refine.yml` is committed to the default branch',
+      };
+    }
+    return {
+      label: 'Synthetic dispatch',
+      status: 'red',
+      detail: `Dispatch failed: ${msg}`,
+      remedy: 'Check gh CLI authentication and internet connectivity',
+    };
+  }
+
+  // Poll for the workflow run to appear
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  let foundRun: WorkflowRun | undefined;
+
+  while (Date.now() < deadline) {
+    await sleep(POLL_INTERVAL_MS);
+    const newRuns = listRecentRuns(repo, baselineId);
+    if (newRuns.length > 0) {
+      foundRun = newRuns[0];
+      break;
+    }
+  }
+
+  if (!foundRun) {
+    return {
+      label: 'Synthetic dispatch',
+      status: 'yellow',
+      detail: 'Dispatch sent but no workflow run appeared within 45 s',
+      remedy:
+        'Verify ferry-refine.yml exists on the default branch and triggers on `ferry-refine` events. Check the Actions tab manually.',
+    };
+  }
+
+  // Capture narrowed value in a const so closures below see WorkflowRun, not WorkflowRun|undefined
+  const confirmedRun: WorkflowRun = foundRun;
+
+  // Give the run a few more seconds to progress past the initial gate step
+  await sleep(6_000);
+  const updatedRuns = listRecentRuns(repo, baselineId);
+  const updated =
+    updatedRuns.find((r) => r.databaseId === confirmedRun.databaseId) ?? confirmedRun;
+
+  const runUrl = updated.url;
+
+  if (updated.status === 'completed' && updated.conclusion === 'failure') {
+    return {
+      label: 'Synthetic dispatch',
+      status: 'yellow',
+      detail: `Run started and reached gate step (expected failure with fake ticket) — ${runUrl}`,
+      remedy: 'This is expected behaviour for a probe run — the gate rejected the fake ticket key',
+    };
+  }
+
+  if (updated.status === 'in_progress' || updated.status === 'queued') {
+    return {
+      label: 'Synthetic dispatch',
+      status: 'green',
+      detail: `Run #${updated.databaseId} is ${updated.status} — workflow wired up correctly`,
+    };
+  }
+
+  return {
+    label: 'Synthetic dispatch',
+    status: 'green',
+    detail: `Run #${updated.databaseId} completed (${updated.conclusion ?? 'unknown'}) — gate reached`,
+  };
+}

--- a/src/cli/doctor/checks/github-app.ts
+++ b/src/cli/doctor/checks/github-app.ts
@@ -1,0 +1,194 @@
+import { createSign } from 'node:crypto';
+import { httpsGet, httpsPost } from '../http.js';
+import type { CheckResult } from '../types.js';
+
+const REQUIRED_PERMISSIONS: Record<string, string> = {
+  contents: 'write',
+  pull_requests: 'write',
+  issues: 'write',
+  metadata: 'read',
+};
+
+function base64url(buf: Buffer): string {
+  return buf.toString('base64').replace(/={1,2}$/, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+export function makeAppJwt(appId: string, privateKey: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64url(Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })));
+  const payload = base64url(
+    Buffer.from(JSON.stringify({ iat: now - 60, exp: now + 600, iss: appId })),
+  );
+  const data = `${header}.${payload}`;
+  const sign = createSign('RSA-SHA256');
+  sign.update(data);
+  const sig = base64url(sign.sign(privateKey));
+  return `${data}.${sig}`;
+}
+
+interface Installation {
+  id: number;
+  account: { login: string };
+}
+
+interface AccessToken {
+  token: string;
+  permissions: Record<string, string>;
+}
+
+export async function checkGitHubApp(opts: {
+  appId: string;
+  privateKey: string;
+  repo: string;
+}): Promise<CheckResult> {
+  const { appId, privateKey, repo } = opts;
+
+  if (!appId || !privateKey) {
+    return {
+      label: 'GitHub App',
+      status: 'skip',
+      detail: 'No App ID / private key provided — skipping',
+      remedy: 'Provide --app-id and --private-key-path, or set FERRY_APP_ID / FERRY_PRIVATE_KEY',
+    };
+  }
+
+  let jwt: string;
+  try {
+    jwt = makeAppJwt(appId, privateKey);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      label: 'GitHub App',
+      status: 'red',
+      detail: `Could not sign JWT: ${msg}`,
+      remedy: 'Verify FERRY_PRIVATE_KEY is a valid RSA PEM. Re-download from GitHub App settings.',
+    };
+  }
+
+  const authHeader = `Bearer ${jwt}`;
+
+  // Get installations
+  let installations: Installation[];
+  try {
+    const res = await httpsGet({
+      hostname: 'api.github.com',
+      path: '/app/installations',
+      headers: {
+        Authorization: authHeader,
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'ferry-doctor/1',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+    if (res.statusCode === 401) {
+      return {
+        label: 'GitHub App',
+        status: 'red',
+        detail: 'JWT rejected (401) — private key does not match App ID',
+        remedy:
+          'Re-download the private key from GitHub → App settings → Generate a new private key',
+      };
+    }
+    if (res.statusCode !== 200) {
+      return {
+        label: 'GitHub App',
+        status: 'red',
+        detail: `Unexpected status ${res.statusCode} from /app/installations`,
+        remedy: 'Check GitHub App permissions and that the app is installed on this account',
+      };
+    }
+    installations = JSON.parse(res.body) as Installation[];
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      label: 'GitHub App',
+      status: 'red',
+      detail: `Network error reaching api.github.com: ${msg}`,
+      remedy: 'Check internet connectivity and GitHub API status at githubstatus.com',
+    };
+  }
+
+  if (installations.length === 0) {
+    return {
+      label: 'GitHub App',
+      status: 'red',
+      detail: 'App has no installations',
+      remedy:
+        'Install the GitHub App on your org/account: App settings → Install App → select the repo',
+    };
+  }
+
+  // Find installation matching the repo's owner, fall back to first available
+  const [owner] = repo.split('/') as [string, string];
+  const byOwner = installations.find(
+    (i) => i.account.login.toLowerCase() === owner.toLowerCase(),
+  );
+  const installation: Installation = byOwner ?? (installations[0] as Installation);
+
+  // Mint installation access token
+  let token: AccessToken;
+  try {
+    const res = await httpsPost(
+      {
+        hostname: 'api.github.com',
+        path: `/app/installations/${installation.id}/access_tokens`,
+        headers: {
+          Authorization: authHeader,
+          Accept: 'application/vnd.github+json',
+          'User-Agent': 'ferry-doctor/1',
+          'X-GitHub-Api-Version': '2022-11-28',
+          'Content-Length': '0',
+        },
+      },
+      '',
+    );
+    if (res.statusCode !== 201) {
+      return {
+        label: 'GitHub App',
+        status: 'red',
+        detail: `Token creation returned ${res.statusCode}`,
+        remedy:
+          'Verify the App is installed and the private key is current. Check GitHub App settings.',
+      };
+    }
+    token = JSON.parse(res.body) as AccessToken;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      label: 'GitHub App',
+      status: 'red',
+      detail: `Failed to mint installation token: ${msg}`,
+      remedy: 'Check internet connectivity and GitHub API status',
+    };
+  }
+
+  // Check permissions
+  const missing: string[] = [];
+  const insufficient: string[] = [];
+
+  for (const [perm, required] of Object.entries(REQUIRED_PERMISSIONS)) {
+    const granted = token.permissions[perm];
+    if (!granted) {
+      missing.push(perm);
+    } else if (required === 'write' && granted === 'read') {
+      insufficient.push(`${perm} (needs write, has read)`);
+    }
+  }
+
+  if (missing.length > 0 || insufficient.length > 0) {
+    const problems = [...missing.map((p) => `${p} missing`), ...insufficient].join(', ');
+    return {
+      label: 'GitHub App',
+      status: 'red',
+      detail: `Permission issues: ${problems}`,
+      remedy:
+        'In GitHub App settings → Permissions, set: Contents=write, Pull requests=write, Issues=write, Metadata=read',
+    };
+  }
+
+  return {
+    label: 'GitHub App',
+    status: 'green',
+    detail: `Installation token minted; permissions OK (installation #${installation.id})`,
+  };
+}

--- a/src/cli/doctor/checks/jira.ts
+++ b/src/cli/doctor/checks/jira.ts
@@ -1,0 +1,145 @@
+import { httpsGet } from '../http.js';
+import type { CheckResult } from '../types.js';
+
+function jiraAuthHeader(email: string, token: string): string {
+  return `Basic ${Buffer.from(`${email}:${token}`).toString('base64')}`;
+}
+
+interface JiraMyselfResponse {
+  displayName?: string;
+  emailAddress?: string;
+}
+
+interface JiraProjectResponse {
+  key?: string;
+  name?: string;
+}
+
+export async function checkJira(opts: {
+  jiraBaseUrl: string;
+  jiraEmail: string;
+  jiraApiToken: string;
+  jiraProjectKey: string;
+}): Promise<CheckResult> {
+  const { jiraBaseUrl, jiraEmail, jiraApiToken, jiraProjectKey } = opts;
+
+  if (!jiraBaseUrl || !jiraEmail || !jiraApiToken) {
+    return {
+      label: 'Jira reachable',
+      status: 'skip',
+      detail: 'Jira credentials not provided — skipping',
+      remedy:
+        'Provide --jira-url, --jira-email, --jira-token, or set FERRY_JIRA_BASE_URL / FERRY_JIRA_EMAIL / FERRY_JIRA_API_TOKEN',
+    };
+  }
+
+  let hostname: string;
+  let basePath: string;
+  try {
+    const url = new URL(jiraBaseUrl);
+    hostname = url.hostname;
+    basePath = url.pathname.replace(/\/$/, '');
+  } catch {
+    return {
+      label: 'Jira reachable',
+      status: 'red',
+      detail: `Invalid Jira URL: ${jiraBaseUrl}`,
+      remedy: 'FERRY_JIRA_BASE_URL must be a valid URL, e.g. https://acme.atlassian.net',
+    };
+  }
+
+  const headers = {
+    Authorization: jiraAuthHeader(jiraEmail, jiraApiToken),
+    Accept: 'application/json',
+    'User-Agent': 'ferry-doctor/1',
+  };
+
+  // Check /myself
+  let displayName: string;
+  try {
+    const res = await httpsGet({
+      hostname,
+      path: `${basePath}/rest/api/3/myself`,
+      headers,
+    });
+
+    if (res.statusCode === 401 || res.statusCode === 403) {
+      return {
+        label: 'Jira reachable',
+        status: 'red',
+        detail: `Authentication failed (${res.statusCode}) for ${jiraEmail}`,
+        remedy:
+          'Verify FERRY_JIRA_EMAIL and FERRY_JIRA_API_TOKEN. Generate a new token at id.atlassian.com/manage-profile/security/api-tokens',
+      };
+    }
+    if (res.statusCode !== 200) {
+      return {
+        label: 'Jira reachable',
+        status: 'red',
+        detail: `Unexpected status ${res.statusCode} from Jira /myself`,
+        remedy: `Check that ${jiraBaseUrl} is reachable and the Jira instance is active`,
+      };
+    }
+
+    const body = JSON.parse(res.body) as JiraMyselfResponse;
+    displayName = body.displayName ?? jiraEmail;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      label: 'Jira reachable',
+      status: 'red',
+      detail: `Network error reaching Jira: ${msg}`,
+      remedy: `Check that ${jiraBaseUrl} is reachable and FERRY_JIRA_BASE_URL is correct`,
+    };
+  }
+
+  // Check project key (optional — skip if not provided)
+  if (!jiraProjectKey) {
+    return {
+      label: 'Jira reachable',
+      status: 'green',
+      detail: `Authenticated as ${displayName} — no project key to verify`,
+    };
+  }
+
+  try {
+    const res = await httpsGet({
+      hostname,
+      path: `${basePath}/rest/api/3/project/${encodeURIComponent(jiraProjectKey)}`,
+      headers,
+    });
+
+    if (res.statusCode === 404) {
+      return {
+        label: 'Jira reachable',
+        status: 'red',
+        detail: `Authenticated as ${displayName} but project "${jiraProjectKey}" not found`,
+        remedy: `Verify the project key is correct and ${jiraEmail} has access to it in Jira`,
+      };
+    }
+    if (res.statusCode !== 200) {
+      return {
+        label: 'Jira reachable',
+        status: 'yellow',
+        detail: `Authenticated as ${displayName}; project check returned ${res.statusCode}`,
+        remedy: `Manually verify that project "${jiraProjectKey}" exists and is accessible`,
+      };
+    }
+
+    const project = JSON.parse(res.body) as JiraProjectResponse;
+    const projectName = project.name ?? jiraProjectKey;
+    return {
+      label: 'Jira reachable',
+      status: 'green',
+      detail: `${displayName} authenticated; project "${projectName}" (${jiraProjectKey}) resolved`,
+    };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      label: 'Jira reachable',
+      status: 'yellow',
+      detail: `Authenticated as ${displayName}; project check failed: ${msg}`,
+      remedy: 'Manually verify Jira project key and account permissions',
+    };
+  }
+}

--- a/src/cli/doctor/checks/llm.ts
+++ b/src/cli/doctor/checks/llm.ts
@@ -1,0 +1,68 @@
+import { httpsPost } from '../http.js';
+import type { CheckResult } from '../types.js';
+
+async function probeAnthropic(apiKey: string): Promise<{ ok: boolean; detail: string }> {
+  const body = JSON.stringify({
+    model: 'claude-haiku-4-5-20251001',
+    max_tokens: 1,
+    messages: [{ role: 'user', content: 'ping' }],
+  });
+
+  try {
+    const res = await httpsPost(
+      {
+        hostname: 'api.anthropic.com',
+        path: '/v1/messages',
+        headers: {
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+          'content-type': 'application/json',
+          'content-length': String(Buffer.byteLength(body)),
+        },
+      },
+      body,
+    );
+
+    if (res.statusCode === 200 || res.statusCode === 201) {
+      return { ok: true, detail: 'Anthropic key valid (claude-haiku-4-5 responded)' };
+    }
+    if (res.statusCode === 401 || res.statusCode === 403) {
+      return { ok: false, detail: `Anthropic key rejected (${res.statusCode})` };
+    }
+    if (res.statusCode === 429) {
+      return { ok: true, detail: 'Anthropic key valid (rate-limited, but key accepted)' };
+    }
+    return { ok: false, detail: `Anthropic API returned unexpected status ${res.statusCode}` };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, detail: `Network error reaching Anthropic: ${msg}` };
+  }
+}
+
+export async function checkLlmKeys(opts: { anthropicApiKey: string }): Promise<CheckResult> {
+  const { anthropicApiKey } = opts;
+
+  if (!anthropicApiKey) {
+    return {
+      label: 'LLM keys valid',
+      status: 'skip',
+      detail: 'No Anthropic API key provided — skipping',
+      remedy:
+        'Provide --anthropic-key or set FERRY_ANTHROPIC_API_KEY. Generate at console.anthropic.com/account/keys',
+    };
+  }
+
+  const { ok, detail } = await probeAnthropic(anthropicApiKey);
+
+  if (ok) {
+    return { label: 'LLM keys valid', status: 'green', detail };
+  }
+
+  return {
+    label: 'LLM keys valid',
+    status: 'red',
+    detail,
+    remedy:
+      'Generate a new key at console.anthropic.com/account/keys, then re-run `npx ferry-init --overwrite`',
+  };
+}

--- a/src/cli/doctor/checks/secrets.ts
+++ b/src/cli/doctor/checks/secrets.ts
@@ -1,0 +1,55 @@
+import { execSync } from 'node:child_process';
+import type { CheckResult } from '../types.js';
+
+const REQUIRED_SECRETS = [
+  'FERRY_APP_ID',
+  'FERRY_PRIVATE_KEY',
+  'FERRY_JIRA_BASE_URL',
+  'FERRY_JIRA_EMAIL',
+  'FERRY_JIRA_API_TOKEN',
+  'FERRY_ANTHROPIC_API_KEY',
+];
+
+export function listRepoSecrets(repo: string): string[] {
+  try {
+    const out = execSync(`gh secret list --repo ${repo} --json name`, {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const parsed = JSON.parse(out) as Array<{ name: string }>;
+    return parsed.map((s) => s.name);
+  } catch {
+    return [];
+  }
+}
+
+export function checkSecrets(repo: string): CheckResult {
+  let existing: string[];
+  try {
+    existing = listRepoSecrets(repo);
+  } catch {
+    return {
+      label: 'Secrets present',
+      status: 'red',
+      detail: 'Could not query secrets — is gh CLI authenticated?',
+      remedy: 'Run `gh auth status` and re-authenticate if needed',
+    };
+  }
+
+  const missing = REQUIRED_SECRETS.filter((s) => !existing.includes(s));
+
+  if (missing.length === 0) {
+    return {
+      label: 'Secrets present',
+      status: 'green',
+      detail: `All ${REQUIRED_SECRETS.length} FERRY_* secrets found`,
+    };
+  }
+
+  return {
+    label: 'Secrets present',
+    status: 'red',
+    detail: `Missing: ${missing.join(', ')}`,
+    remedy: `Run \`npx ferry-init\` to set the missing secrets, or set them manually via \`gh secret set <NAME> --repo ${repo}\``,
+  };
+}

--- a/src/cli/doctor/checks/workflows.ts
+++ b/src/cli/doctor/checks/workflows.ts
@@ -1,0 +1,55 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { workflowTemplates } from '../../init/templates.js';
+import type { CheckResult } from '../types.js';
+
+export function checkWorkflowDrift(opts: {
+  repoRoot: string;
+  ferryVersion: string;
+}): CheckResult {
+  const { repoRoot, ferryVersion } = opts;
+  const workflowDir = join(repoRoot, '.github', 'workflows');
+  const templates = workflowTemplates(ferryVersion);
+
+  const missing: string[] = [];
+  const drifted: string[] = [];
+  const upToDate: string[] = [];
+
+  for (const tmpl of templates) {
+    const filePath = join(workflowDir, tmpl.filename);
+    if (!existsSync(filePath)) {
+      missing.push(tmpl.filename);
+      continue;
+    }
+    const existing = readFileSync(filePath, 'utf8');
+    if (existing !== tmpl.content) {
+      drifted.push(tmpl.filename);
+    } else {
+      upToDate.push(tmpl.filename);
+    }
+  }
+
+  if (missing.length > 0) {
+    return {
+      label: 'Workflow files',
+      status: 'red',
+      detail: `Missing: ${missing.join(', ')}`,
+      remedy: `Run \`npx ferry-init\` to install the missing workflow files`,
+    };
+  }
+
+  if (drifted.length > 0) {
+    return {
+      label: 'Workflow files',
+      status: 'yellow',
+      detail: `${drifted.length} file(s) differ from Ferry ${ferryVersion}: ${drifted.join(', ')}`,
+      remedy: `Run \`npx ferry-init --overwrite\` to update the workflows to the current Ferry release`,
+    };
+  }
+
+  return {
+    label: 'Workflow files',
+    status: 'green',
+    detail: `All ${upToDate.length} workflow files match Ferry ${ferryVersion}`,
+  };
+}

--- a/src/cli/doctor/doctor.test.ts
+++ b/src/cli/doctor/doctor.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest';
+import { mkdirSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { generateKeyPairSync } from 'node:crypto';
+import { renderTable } from './table.js';
+import { checkWorkflowDrift } from './checks/workflows.js';
+import { listRepoSecrets } from './checks/secrets.js';
+import { makeAppJwt } from './checks/github-app.js';
+import type { CheckResult } from './types.js';
+
+// ── renderTable ───────────────────────────────────────────────────────────────
+
+describe('renderTable', () => {
+  it('renders green checks with ✓ icon', () => {
+    const results: CheckResult[] = [
+      { label: 'Secrets present', status: 'green', detail: 'All 6 secrets found' },
+    ];
+    const out = renderTable(results);
+    expect(out).toContain('✓');
+    expect(out).toContain('All 6 secrets found');
+  });
+
+  it('renders red checks with ✗ icon and remedy', () => {
+    const results: CheckResult[] = [
+      {
+        label: 'GitHub App',
+        status: 'red',
+        detail: 'Token rejected',
+        remedy: 'Re-download PEM',
+      },
+    ];
+    const out = renderTable(results);
+    expect(out).toContain('✗');
+    expect(out).toContain('Token rejected');
+    expect(out).toContain('Re-download PEM');
+  });
+
+  it('renders yellow checks with ⚠ icon and remedy', () => {
+    const results: CheckResult[] = [
+      { label: 'Workflow files', status: 'yellow', detail: '1 file drifted', remedy: 'rerun init' },
+    ];
+    const out = renderTable(results);
+    expect(out).toContain('⚠');
+    expect(out).toContain('rerun init');
+  });
+
+  it('renders skip checks with – icon and no remedy', () => {
+    const results: CheckResult[] = [
+      { label: 'Synthetic dispatch', status: 'skip', detail: 'Skipped' },
+    ];
+    const out = renderTable(results);
+    expect(out).toContain('–');
+    expect(out).not.toContain('→');
+  });
+
+  it('summary line says "All N checks passed" when all green', () => {
+    const results: CheckResult[] = [
+      { label: 'Check A', status: 'green', detail: 'ok' },
+      { label: 'Check B', status: 'green', detail: 'ok' },
+    ];
+    expect(renderTable(results)).toContain('All 2 checks passed');
+  });
+
+  it('summary line mentions failures when any red', () => {
+    const results: CheckResult[] = [
+      { label: 'Check A', status: 'red', detail: 'fail' },
+      { label: 'Check B', status: 'green', detail: 'ok' },
+    ];
+    expect(renderTable(results)).toContain('1 check(s) failed');
+  });
+
+  it('does not print remedy for green checks', () => {
+    const results: CheckResult[] = [
+      { label: 'Check A', status: 'green', detail: 'all good', remedy: 'should not appear' },
+    ];
+    expect(renderTable(results)).not.toContain('should not appear');
+  });
+
+  it('summary line mentions warnings when yellow but no red', () => {
+    const results: CheckResult[] = [
+      { label: 'Check A', status: 'yellow', detail: 'warn' },
+      { label: 'Check B', status: 'green', detail: 'ok' },
+    ];
+    expect(renderTable(results)).toContain('warning(s)');
+  });
+});
+
+// ── checkWorkflowDrift ────────────────────────────────────────────────────────
+
+describe('checkWorkflowDrift', () => {
+  it('returns red when workflow dir is missing', () => {
+    const result = checkWorkflowDrift({ repoRoot: '/nonexistent/path-xyz', ferryVersion: 'v1' });
+    expect(result.status).toBe('red');
+    expect(result.detail).toContain('Missing');
+    expect(result.remedy).toBeTruthy();
+  });
+
+  it('returns green when all files match templates', async () => {
+    const { workflowTemplates } = await import('../init/templates.js');
+    const repoRoot = mkdtempSync(join(tmpdir(), 'ferry-doctor-test-'));
+    const workflowDir = join(repoRoot, '.github', 'workflows');
+    mkdirSync(workflowDir, { recursive: true });
+
+    for (const tmpl of workflowTemplates('v1')) {
+      writeFileSync(join(workflowDir, tmpl.filename), tmpl.content, 'utf8');
+    }
+
+    const result = checkWorkflowDrift({ repoRoot, ferryVersion: 'v1' });
+    expect(result.status).toBe('green');
+    expect(result.detail).toContain('match');
+
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it('returns yellow when a file differs from the current template', async () => {
+    const { workflowTemplates } = await import('../init/templates.js');
+    const repoRoot = mkdtempSync(join(tmpdir(), 'ferry-doctor-drift-'));
+    const workflowDir = join(repoRoot, '.github', 'workflows');
+    mkdirSync(workflowDir, { recursive: true });
+
+    const templates = workflowTemplates('v1');
+    for (const tmpl of templates) {
+      const content =
+        tmpl.filename === 'ferry-refine.yml'
+          ? tmpl.content + '\n# extra line — simulated drift\n'
+          : tmpl.content;
+      writeFileSync(join(workflowDir, tmpl.filename), content, 'utf8');
+    }
+
+    const result = checkWorkflowDrift({ repoRoot, ferryVersion: 'v1' });
+    expect(result.status).toBe('yellow');
+    expect(result.detail).toContain('ferry-refine.yml');
+    expect(result.remedy).toContain('--overwrite');
+
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it('returns red when some files are missing and others are present', async () => {
+    const { workflowTemplates } = await import('../init/templates.js');
+    const repoRoot = mkdtempSync(join(tmpdir(), 'ferry-doctor-partial-'));
+    const workflowDir = join(repoRoot, '.github', 'workflows');
+    mkdirSync(workflowDir, { recursive: true });
+
+    const templates = workflowTemplates('v1');
+    // Only install the first 3
+    for (const tmpl of templates.slice(0, 3)) {
+      writeFileSync(join(workflowDir, tmpl.filename), tmpl.content, 'utf8');
+    }
+
+    const result = checkWorkflowDrift({ repoRoot, ferryVersion: 'v1' });
+    expect(result.status).toBe('red');
+
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+});
+
+// ── listRepoSecrets ───────────────────────────────────────────────────────────
+
+describe('listRepoSecrets', () => {
+  it('returns empty array when gh CLI is not available or repo not found', () => {
+    const result = listRepoSecrets('nonexistent-org/nonexistent-repo-xyz-12345');
+    expect(Array.isArray(result)).toBe(true);
+  });
+});
+
+// ── makeAppJwt ────────────────────────────────────────────────────────────────
+
+describe('makeAppJwt', () => {
+  it('throws when private key is not a valid PEM', () => {
+    expect(() => makeAppJwt('12345', 'not-a-valid-pem-string')).toThrow();
+  });
+
+  it('returns a three-part JWT for a valid RSA key', () => {
+    const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const pem = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
+
+    const jwt = makeAppJwt('99999', pem);
+    const parts = jwt.split('.');
+    expect(parts).toHaveLength(3);
+  });
+
+  it('JWT header decodes to RS256 algorithm', () => {
+    const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const pem = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
+
+    const jwt = makeAppJwt('12345', pem);
+    const [headerB64] = jwt.split('.');
+    const header = JSON.parse(Buffer.from(headerB64!, 'base64url').toString()) as {
+      alg: string;
+      typ: string;
+    };
+    expect(header.alg).toBe('RS256');
+    expect(header.typ).toBe('JWT');
+  });
+
+  it('JWT payload contains iss matching the appId', () => {
+    const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const pem = privateKey.export({ type: 'pkcs8', format: 'pem' }) as string;
+
+    const jwt = makeAppJwt('42', pem);
+    const parts = jwt.split('.');
+    const payload = JSON.parse(Buffer.from(parts[1]!, 'base64url').toString()) as {
+      iss: string;
+      iat: number;
+      exp: number;
+    };
+    expect(payload.iss).toBe('42');
+    expect(payload.exp).toBeGreaterThan(payload.iat);
+  });
+});

--- a/src/cli/doctor/http.ts
+++ b/src/cli/doctor/http.ts
@@ -1,0 +1,37 @@
+import https from 'node:https';
+import type { RequestOptions } from 'node:https';
+
+export interface HttpResponse {
+  statusCode: number;
+  body: string;
+}
+
+export function httpsRequest(options: RequestOptions, body?: string): Promise<HttpResponse> {
+  return new Promise((resolve, reject) => {
+    const req = https.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk: Buffer | string) => {
+        data += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+      });
+      res.on('end', () => {
+        resolve({ statusCode: res.statusCode ?? 0, body: data });
+      });
+    });
+    req.on('error', reject);
+    req.setTimeout(15_000, () => {
+      req.destroy(new Error('Request timed out'));
+    });
+    if (body !== undefined) {
+      req.write(body);
+    }
+    req.end();
+  });
+}
+
+export function httpsGet(options: RequestOptions): Promise<HttpResponse> {
+  return httpsRequest({ ...options, method: 'GET' });
+}
+
+export function httpsPost(options: RequestOptions, body: string): Promise<HttpResponse> {
+  return httpsRequest({ ...options, method: 'POST' }, body);
+}

--- a/src/cli/doctor/index.ts
+++ b/src/cli/doctor/index.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { checkSecrets } from './checks/secrets.js';
+import { checkGitHubApp } from './checks/github-app.js';
+import { checkJira } from './checks/jira.js';
+import { checkLlmKeys } from './checks/llm.js';
+import { checkSyntheticDispatch } from './checks/dispatch.js';
+import { checkWorkflowDrift } from './checks/workflows.js';
+import { renderTable } from './table.js';
+import type { DoctorConfig } from './types.js';
+
+function detectRepo(): string | undefined {
+  try {
+    const remote = execSync('git remote get-url origin', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    const match = remote.match(/github\.com[:/]([^/]+\/[^/.]+)/);
+    return match ? match[1] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getArg(argv: string[], flag: string): string | undefined {
+  const idx = argv.indexOf(flag);
+  return idx >= 0 ? argv[idx + 1] : undefined;
+}
+
+function hasFlag(argv: string[], flag: string): boolean {
+  return argv.includes(flag);
+}
+
+function readPrivateKey(path: string): string {
+  const resolved = resolve(path.replace(/^~/, process.env['HOME'] ?? '~'));
+  if (!existsSync(resolved)) {
+    throw new Error(`Private key file not found: ${resolved}`);
+  }
+  return readFileSync(resolved, 'utf8').trim();
+}
+
+function parseConfig(argv: string[]): DoctorConfig {
+  const repo =
+    getArg(argv, '--repo') ?? process.env['FERRY_DOCTOR_REPO'] ?? detectRepo() ?? '';
+
+  const appId = getArg(argv, '--app-id') ?? process.env['FERRY_APP_ID'] ?? '';
+
+  let privateKey =
+    getArg(argv, '--private-key') ??
+    process.env['FERRY_PRIVATE_KEY'] ??
+    '';
+  const pkPath = getArg(argv, '--private-key-path');
+  if (pkPath && !privateKey) {
+    try {
+      privateKey = readPrivateKey(pkPath);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      process.stderr.write(`Warning: ${msg}\n`);
+    }
+  }
+
+  return {
+    repo,
+    appId,
+    privateKey,
+    jiraBaseUrl: getArg(argv, '--jira-url') ?? process.env['FERRY_JIRA_BASE_URL'] ?? '',
+    jiraEmail: getArg(argv, '--jira-email') ?? process.env['FERRY_JIRA_EMAIL'] ?? '',
+    jiraApiToken: getArg(argv, '--jira-token') ?? process.env['FERRY_JIRA_API_TOKEN'] ?? '',
+    jiraProjectKey: getArg(argv, '--jira-project') ?? process.env['FERRY_JIRA_PROJECT_KEY'] ?? '',
+    anthropicApiKey:
+      getArg(argv, '--anthropic-key') ?? process.env['FERRY_ANTHROPIC_API_KEY'] ?? '',
+    ferryVersion: getArg(argv, '--version') ?? 'v1',
+    repoRoot: getArg(argv, '--repo-root') ?? process.cwd(),
+    noDispatch: hasFlag(argv, '--no-dispatch'),
+  };
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+
+  if (hasFlag(argv, '--help') || hasFlag(argv, '-h')) {
+    process.stdout.write(`
+ferry doctor — end-to-end health check for a Ferry installation
+
+Usage:
+  npx ferry-doctor [options]
+
+Options:
+  --repo <owner/repo>          GitHub repository (default: auto-detect from git remote)
+  --app-id <id>                GitHub App ID (default: FERRY_APP_ID env var)
+  --private-key <pem>          GitHub App private key PEM string (default: FERRY_PRIVATE_KEY)
+  --private-key-path <path>    Path to the .pem file (alternative to --private-key)
+  --jira-url <url>             Jira base URL (default: FERRY_JIRA_BASE_URL)
+  --jira-email <email>         Jira account email (default: FERRY_JIRA_EMAIL)
+  --jira-token <token>         Jira API token (default: FERRY_JIRA_API_TOKEN)
+  --jira-project <key>         Jira project key to verify (default: FERRY_JIRA_PROJECT_KEY)
+  --anthropic-key <key>        Anthropic API key (default: FERRY_ANTHROPIC_API_KEY)
+  --version <tag>              Ferry version tag for workflow drift check (default: v1)
+  --repo-root <path>           Path to the repo root (default: cwd)
+  --no-dispatch                Skip the synthetic dispatch probe
+  -h, --help                   Show this help
+
+Checks run in order:
+  1. Secrets present        — all 6 FERRY_* repo secrets exist
+  2. GitHub App             — mint installation token, verify permissions
+  3. Jira reachable         — /myself + project key resolution
+  4. LLM keys valid         — 1-token Anthropic sanity call
+  5. Synthetic dispatch     — trigger ferry-refine + poll for run start
+  6. Workflow files         — compare .github/workflows/ferry-*.yml vs current release
+
+Exit code: 0 if all checks green/yellow, 1 if any check red.
+`);
+    process.exit(0);
+  }
+
+  const config = parseConfig(argv);
+
+  if (!config.repo) {
+    process.stderr.write(
+      'Error: could not detect GitHub repo. Pass --repo owner/repo or run inside a git checkout.\n',
+    );
+    process.exit(1);
+  }
+
+  process.stdout.write(`\n  ferry doctor — checking ${config.repo}\n`);
+
+  const results = await Promise.all([
+    checkSecrets(config.repo),
+    checkGitHubApp({
+      appId: config.appId,
+      privateKey: config.privateKey,
+      repo: config.repo,
+    }),
+    checkJira({
+      jiraBaseUrl: config.jiraBaseUrl,
+      jiraEmail: config.jiraEmail,
+      jiraApiToken: config.jiraApiToken,
+      jiraProjectKey: config.jiraProjectKey,
+    }),
+    checkLlmKeys({ anthropicApiKey: config.anthropicApiKey }),
+    checkSyntheticDispatch({ repo: config.repo, noDispatch: config.noDispatch }),
+    checkWorkflowDrift({ repoRoot: config.repoRoot, ferryVersion: config.ferryVersion }),
+  ]);
+
+  process.stdout.write(renderTable(results));
+
+  const anyRed = results.some((r) => r.status === 'red');
+  process.exit(anyRed ? 1 : 0);
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`Unexpected error: ${msg}\n`);
+  process.exit(1);
+});

--- a/src/cli/doctor/table.ts
+++ b/src/cli/doctor/table.ts
@@ -1,0 +1,55 @@
+import type { CheckResult, CheckStatus } from './types.js';
+
+const ICONS: Record<CheckStatus, string> = {
+  green: '✓',
+  yellow: '⚠',
+  red: '✗',
+  skip: '–',
+};
+
+const LABELS: Record<CheckStatus, string> = {
+  green: 'OK',
+  yellow: 'WARN',
+  red: 'FAIL',
+  skip: 'SKIP',
+};
+
+function pad(s: string, len: number): string {
+  return s.length >= len ? s : s + ' '.repeat(len - s.length);
+}
+
+export function renderTable(results: CheckResult[]): string {
+  const lines: string[] = [];
+  const labelWidth = Math.max(...results.map((r) => r.label.length), 20);
+
+  lines.push('');
+  lines.push('  ' + '─'.repeat(labelWidth + 30));
+
+  for (const r of results) {
+    const icon = ICONS[r.status];
+    const statusTag = LABELS[r.status];
+    const label = pad(r.label, labelWidth);
+    lines.push(`  ${icon}  ${label}  [${statusTag}]  ${r.detail}`);
+    if (r.remedy && (r.status === 'red' || r.status === 'yellow')) {
+      lines.push(`       ${' '.repeat(labelWidth)}         → ${r.remedy}`);
+    }
+  }
+
+  lines.push('  ' + '─'.repeat(labelWidth + 30));
+  lines.push('');
+
+  const reds = results.filter((r) => r.status === 'red').length;
+  const yellows = results.filter((r) => r.status === 'yellow').length;
+  const greens = results.filter((r) => r.status === 'green').length;
+
+  if (reds > 0) {
+    lines.push(`  ✗  ${reds} check(s) failed — ferry will not function until resolved`);
+  } else if (yellows > 0) {
+    lines.push(`  ⚠  ${greens} checks passed, ${yellows} warning(s) — review before going live`);
+  } else {
+    lines.push(`  ✓  All ${greens} checks passed — ferry is healthy`);
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}

--- a/src/cli/doctor/types.ts
+++ b/src/cli/doctor/types.ts
@@ -1,0 +1,22 @@
+export type CheckStatus = 'green' | 'yellow' | 'red' | 'skip';
+
+export interface CheckResult {
+  label: string;
+  status: CheckStatus;
+  detail: string;
+  remedy?: string;
+}
+
+export interface DoctorConfig {
+  repo: string;
+  appId: string;
+  privateKey: string;
+  jiraBaseUrl: string;
+  jiraEmail: string;
+  jiraApiToken: string;
+  jiraProjectKey: string;
+  anthropicApiKey: string;
+  ferryVersion: string;
+  repoRoot: string;
+  noDispatch: boolean;
+}


### PR DESCRIPTION
Implements `ferry doctor` as requested in #23.

Adds a new CLI command (sibling to `ferry-init`) that runs 6 checks and prints a green/yellow/red summary table:

1. **Secrets present** — all 6 FERRY_* secrets via `gh secret list`
2. **GitHub App** — JWT + installation token, permission check
3. **Jira reachable** — `/rest/api/3/myself` + project key resolution
4. **LLM keys valid** — 1-token Anthropic probe
5. **Synthetic dispatch** — fires `ferry-refine` event, polls for run start (45 s)
6. **Workflow files** — diffs local .github/workflows/ferry-*.yml against templates

Each failing check includes a remediation hint. Exit code 1 on any red.

Closes #23

Generated with [Claude Code](https://claude.ai/code)