### PR TITLE
fix(actions): make composite actions self-contained using github.action_path

### DIFF
--- a/.github/actions/ferry-emit-audit/action.yml
+++ b/.github/actions/ferry-emit-audit/action.yml
@@ -45,14 +45,14 @@ runs:
       with:
         node-version: '20'
         cache: npm
-        cache-dependency-path: .ferry/package-lock.json
+        cache-dependency-path: ${{ github.action_path }}/package-lock.json
     - name: Install Ferry action dependencies
       shell: bash
       run: npm ci --prefer-offline
-      working-directory: .ferry
+      working-directory: ${{ github.action_path }}
     - name: Emit audit line
       shell: bash
-      run: node .ferry/emit-audit-action.js
+      run: node ${{ github.action_path }}/emit-audit-action.js
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         FERRY_AUDIT_ISSUE: ${{ inputs.audit_issue }}

--- a/.github/actions/ferry-emit-audit/emit-audit-action.js
+++ b/.github/actions/ferry-emit-audit/emit-audit-action.js
@@ -1,0 +1,74 @@
+// Self-contained audit emission bundle for ferry-emit-audit composite action.
+// Octokit is loaded via createRequire so it resolves from this action's own node_modules.
+import { createRequire } from 'module';
+
+const _require = createRequire(import.meta.url);
+const { Octokit } = _require('@octokit/rest');
+
+function requireEnv(name) {
+  const val = process.env[name];
+  if (!val) throw new Error(`Missing required environment variable: ${name}`);
+  return val;
+}
+
+const token = requireEnv('GITHUB_TOKEN');
+const auditIssueStr = requireEnv('FERRY_AUDIT_ISSUE');
+const owner = requireEnv('FERRY_OWNER');
+const repo = requireEnv('FERRY_REPO');
+const runId = requireEnv('FERRY_RUN_ID');
+const ticket = requireEnv('FERRY_TICKET');
+const phase = requireEnv('FERRY_PHASE');
+const model = requireEnv('FERRY_MODEL');
+const outcome = requireEnv('FERRY_OUTCOME');
+const startMsStr = requireEnv('FERRY_START_MS');
+
+const auditIssue = parseInt(auditIssueStr, 10);
+if (isNaN(auditIssue)) throw new Error(`FERRY_AUDIT_ISSUE must be a number, got: ${auditIssueStr}`);
+
+const start = parseInt(startMsStr, 10);
+if (isNaN(start)) throw new Error(`FERRY_START_MS must be a number, got: ${startMsStr}`);
+
+const inputTokens = parseInt(process.env['FERRY_INPUT_TOKENS'] ?? '0', 10) || 0;
+const outputTokens = parseInt(process.env['FERRY_OUTPUT_TOKENS'] ?? '0', 10) || 0;
+const costEur = parseFloat(process.env['FERRY_COST_EUR'] ?? '0') || 0;
+
+const octokit = new Octokit({ auth: token });
+
+const marker = `[ferry:audit:${runId}]`;
+
+const MAX_PAGES = 10;
+for (let page = 1; page <= MAX_PAGES; page++) {
+  const existing = await octokit.rest.issues.listComments({
+    owner,
+    repo,
+    issue_number: auditIssue,
+    per_page: 100,
+    page,
+  });
+  if (existing.data.some((c) => typeof c.body === 'string' && c.body.startsWith(marker))) {
+    process.exit(0);
+  }
+  if (existing.data.length < 100) break;
+}
+
+const auditLine = {
+  ticket,
+  phase,
+  run_id: runId,
+  model,
+  input_tokens: inputTokens,
+  output_tokens: outputTokens,
+  cost_eur: costEur,
+  outcome,
+  duration_ms: Math.round(Date.now() - start),
+  timestamp: new Date().toISOString(),
+};
+
+const body = `${marker}\n${JSON.stringify(auditLine)}`;
+
+await octokit.rest.issues.createComment({
+  owner,
+  repo,
+  issue_number: auditIssue,
+  body,
+});

--- a/.github/actions/ferry-emit-audit/package-lock.json
+++ b/.github/actions/ferry-emit-audit/package-lock.json
@@ -1,0 +1,194 @@
+{
+  "name": "ferry-emit-audit-action",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ferry-emit-audit-action",
+      "version": "0.0.0",
+      "dependencies": {
+        "@octokit/rest": "^22.0.1"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
+      "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-request-log": "^6.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "license": "MIT"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+      "license": "MIT"
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
+    }
+  }
+}

--- a/.github/actions/ferry-emit-audit/package.json
+++ b/.github/actions/ferry-emit-audit/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "ferry-emit-audit-action",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@octokit/rest": "^22.0.1"
+  }
+}

--- a/.github/actions/ferry-envelope-validate/action.yml
+++ b/.github/actions/ferry-envelope-validate/action.yml
@@ -12,13 +12,13 @@ runs:
       with:
         node-version: '20'
         cache: npm
-        cache-dependency-path: .ferry/package-lock.json
+        cache-dependency-path: ${{ github.action_path }}/package-lock.json
     - name: Install Ferry action dependencies
       shell: bash
       run: npm ci --prefer-offline
-      working-directory: .ferry
+      working-directory: ${{ github.action_path }}
     - name: Validate envelope
       shell: bash
-      run: node .ferry/validate-action.js
+      run: node ${{ github.action_path }}/validate-action.js
       env:
         FERRY_ENVELOPE_PAYLOAD: ${{ inputs.payload }}

--- a/.github/actions/ferry-envelope-validate/package-lock.json
+++ b/.github/actions/ferry-envelope-validate/package-lock.json
@@ -1,0 +1,64 @@
+{
+  "name": "ferry-envelope-validate-action",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ferry-envelope-validate-action",
+      "version": "0.0.0",
+      "dependencies": {
+        "ajv": "^8.0.0",
+        "ajv-formats": "^3.0.1"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  }
+}

--- a/.github/actions/ferry-envelope-validate/package.json
+++ b/.github/actions/ferry-envelope-validate/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "ferry-envelope-validate-action",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "ajv": "^8.0.0",
+    "ajv-formats": "^3.0.1"
+  }
+}

--- a/.github/actions/ferry-envelope-validate/schemas/event.v1.schema.json
+++ b/.github/actions/ferry-envelope-validate/schemas/event.v1.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ferry.dev/schemas/event.v1.json",
+  "type": "object",
+  "required": ["version", "event_id", "ticket_key", "phase", "source", "ts"],
+  "properties": {
+    "version": { "const": "v1" },
+    "event_id": { "type": "string", "minLength": 1, "pattern": "^([0-9A-HJKMNP-TV-Z]{26}|\\d{13}-[A-Z][A-Z0-9_]+-\\d+)$" },
+    "ticket_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+-\\d+$" },
+    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile"] },
+    "source": {
+      "enum": ["jira-column", "jira-label", "jira-mention", "reconciler"]
+    },
+    "instructions": { "type": "string" },
+    "ticket_type": { "enum": ["Story", "Task", "Bug", "Spike"] },
+    "issue_type": { "type": "string" },
+    "ts": { "type": "string", "minLength": 1 }
+  },
+  "additionalProperties": false
+}

--- a/.github/actions/ferry-envelope-validate/validate-action.js
+++ b/.github/actions/ferry-envelope-validate/validate-action.js
@@ -1,0 +1,56 @@
+// Self-contained envelope validation bundle for ferry-envelope-validate composite action.
+// AJV is loaded via createRequire so it resolves from this action's own node_modules.
+import { createRequire } from 'module';
+import { appendFileSync } from 'fs';
+
+const _require = createRequire(import.meta.url);
+
+const eventSchema = _require('./schemas/event.v1.schema.json');
+const { Ajv2020 } = _require('ajv/dist/2020');
+const addFormats = _require('ajv-formats');
+
+const ajv = new Ajv2020({ strict: true });
+addFormats.default(ajv);
+const validateFn = ajv.compile(eventSchema);
+
+function validateEnvelope(raw) {
+  if (!validateFn(raw)) {
+    const safePaths = (validateFn.errors ?? []).map((e) => `${e.instancePath} ${e.keyword}`);
+    const err = new Error(`[ferry:state-invariant] ${JSON.stringify({ paths: safePaths })}`);
+    err.name = 'FerryError';
+    throw err;
+  }
+  if (raw.instructions !== undefined) {
+    raw.instructions = raw.instructions.slice(0, 2000);
+  }
+  return raw;
+}
+
+const raw = process.env.FERRY_ENVELOPE_PAYLOAD;
+if (!raw) {
+  console.error('[ferry:envelope] FERRY_ENVELOPE_PAYLOAD is not set');
+  process.exit(1);
+}
+
+let parsed;
+try {
+  parsed = JSON.parse(raw);
+} catch {
+  console.error('[ferry:envelope] FERRY_ENVELOPE_PAYLOAD is not valid JSON');
+  process.exit(1);
+}
+
+try {
+  const envelope = validateEnvelope(parsed);
+  const output = process.env.GITHUB_OUTPUT;
+  if (output) {
+    appendFileSync(
+      output,
+      `ticket_key=${envelope.ticket_key}\nphase=${envelope.phase}\nevent_id=${envelope.event_id}\n`,
+    );
+  }
+  process.exit(0);
+} catch (e) {
+  console.error('[ferry:envelope] Envelope validation failed:', e.message);
+  process.exit(1);
+}

--- a/scripts/build-ferry-actions.mjs
+++ b/scripts/build-ferry-actions.mjs
@@ -83,4 +83,38 @@ writeFileSync('.ferry/package.json', JSON.stringify({
 
 execSync('npm install --prefer-offline', { cwd: '.ferry', stdio: 'inherit' });
 
+// --- Self-contained composite action bundles ---
+// Copy the built validate-action bundle and schema into the composite action
+// directory so consumers can use `uses: big-emotion/ferry/.github/actions/…@v1`
+// without needing .ferry/ in their own workspace (fixes issue #64).
+
+const validateActionDir = '.github/actions/ferry-envelope-validate';
+mkdirSync(`${validateActionDir}/schemas`, { recursive: true });
+copyFileSync('.ferry/validate-action.js', `${validateActionDir}/validate-action.js`);
+copyFileSync('src/schemas/event.v1.schema.json', `${validateActionDir}/schemas/event.v1.schema.json`);
+writeFileSync(`${validateActionDir}/package.json`, JSON.stringify({
+  name: 'ferry-envelope-validate-action',
+  version: '0.0.0',
+  private: true,
+  type: 'module',
+  dependencies: {
+    'ajv': '^8.0.0',
+    'ajv-formats': '^3.0.1',
+  },
+}, null, 2) + '\n');
+execSync('npm install --prefer-offline', { cwd: validateActionDir, stdio: 'inherit' });
+
+const emitAuditActionDir = '.github/actions/ferry-emit-audit';
+copyFileSync('.ferry/emit-audit-action.js', `${emitAuditActionDir}/emit-audit-action.js`);
+writeFileSync(`${emitAuditActionDir}/package.json`, JSON.stringify({
+  name: 'ferry-emit-audit-action',
+  version: '0.0.0',
+  private: true,
+  type: 'module',
+  dependencies: {
+    '@octokit/rest': '^22.0.1',
+  },
+}, null, 2) + '\n');
+execSync('npm install --prefer-offline', { cwd: emitAuditActionDir, stdio: 'inherit' });
+
 console.log('Built .ferry/ action bundles.');

--- a/src/cli/doctor/checks/dispatch.ts
+++ b/src/cli/doctor/checks/dispatch.ts
@@ -27,14 +27,11 @@ function triggerDispatch(repo: string, eventId: string): void {
       source: 'doctor-probe',
     },
   });
-  execSync(
-    `gh api repos/${repo}/dispatches --method POST --input -`,
-    {
-      input: payload,
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    },
-  );
+  execSync(`gh api repos/${repo}/dispatches --method POST --input -`, {
+    input: payload,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
 }
 
 function listRecentRuns(repo: string, after: number): WorkflowRun[] {
@@ -140,8 +137,7 @@ export async function checkSyntheticDispatch(opts: {
   // Give the run a few more seconds to progress past the initial gate step
   await sleep(6_000);
   const updatedRuns = listRecentRuns(repo, baselineId);
-  const updated =
-    updatedRuns.find((r) => r.databaseId === confirmedRun.databaseId) ?? confirmedRun;
+  const updated = updatedRuns.find((r) => r.databaseId === confirmedRun.databaseId) ?? confirmedRun;
 
   const runUrl = updated.url;
 

--- a/src/cli/doctor/checks/github-app.ts
+++ b/src/cli/doctor/checks/github-app.ts
@@ -10,7 +10,11 @@ const REQUIRED_PERMISSIONS: Record<string, string> = {
 };
 
 function base64url(buf: Buffer): string {
-  return buf.toString('base64').replace(/={1,2}$/, '').replace(/\+/g, '-').replace(/\//g, '_');
+  return buf
+    .toString('base64')
+    .replace(/={1,2}$/, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
 }
 
 export function makeAppJwt(appId: string, privateKey: string): string {
@@ -120,9 +124,7 @@ export async function checkGitHubApp(opts: {
 
   // Find installation matching the repo's owner, fall back to first available
   const [owner] = repo.split('/') as [string, string];
-  const byOwner = installations.find(
-    (i) => i.account.login.toLowerCase() === owner.toLowerCase(),
-  );
+  const byOwner = installations.find((i) => i.account.login.toLowerCase() === owner.toLowerCase());
   const installation: Installation = byOwner ?? (installations[0] as Installation);
 
   // Mint installation access token

--- a/src/cli/doctor/checks/workflows.ts
+++ b/src/cli/doctor/checks/workflows.ts
@@ -3,10 +3,7 @@ import { join } from 'node:path';
 import { workflowTemplates } from '../../init/templates.js';
 import type { CheckResult } from '../types.js';
 
-export function checkWorkflowDrift(opts: {
-  repoRoot: string;
-  ferryVersion: string;
-}): CheckResult {
+export function checkWorkflowDrift(opts: { repoRoot: string; ferryVersion: string }): CheckResult {
   const { repoRoot, ferryVersion } = opts;
   const workflowDir = join(repoRoot, '.github', 'workflows');
   const templates = workflowTemplates(ferryVersion);

--- a/src/cli/doctor/index.ts
+++ b/src/cli/doctor/index.ts
@@ -42,15 +42,11 @@ function readPrivateKey(path: string): string {
 }
 
 function parseConfig(argv: string[]): DoctorConfig {
-  const repo =
-    getArg(argv, '--repo') ?? process.env['FERRY_DOCTOR_REPO'] ?? detectRepo() ?? '';
+  const repo = getArg(argv, '--repo') ?? process.env['FERRY_DOCTOR_REPO'] ?? detectRepo() ?? '';
 
   const appId = getArg(argv, '--app-id') ?? process.env['FERRY_APP_ID'] ?? '';
 
-  let privateKey =
-    getArg(argv, '--private-key') ??
-    process.env['FERRY_PRIVATE_KEY'] ??
-    '';
+  let privateKey = getArg(argv, '--private-key') ?? process.env['FERRY_PRIVATE_KEY'] ?? '';
   const pkPath = getArg(argv, '--private-key-path');
   if (pkPath && !privateKey) {
     try {


### PR DESCRIPTION
Fixes #64

The two composite actions referenced `.ferry/` relative to the consumer's workspace, which consumers don't have. This caused "Some specified paths were not resolved" failures on every consumer workflow run.

**Changes:**
- Both `action.yml` files updated to use `${{ github.action_path }}` instead of `.ferry/`
- `validate-action.js` + `schemas/event.v1.schema.json` added to `ferry-envelope-validate/`
- `emit-audit-action.js` added to `ferry-emit-audit/`
- `package.json` + `package-lock.json` added to both action directories
- `scripts/build-ferry-actions.mjs` updated to regenerate these files on `npm run build:ferry`

Generated with [Claude Code](https://claude.ai/code)