### PR TITLE
feat: expose developer agent config to consumer repos (closes #65)

### DIFF
--- a/src/agents/developer/dev-action.ts
+++ b/src/agents/developer/dev-action.ts
@@ -173,7 +173,7 @@ async function main(): Promise<void> {
         `[ferry:dev-action] DRY_RUN — not actionable: ${done.reason_if_not_actionable ?? 'no reason given'}`,
       );
     }
-    appendOutput(usage);
+    appendOutput({ ...usage, model });
     process.exit(0);
   }
 
@@ -215,7 +215,7 @@ async function main(): Promise<void> {
       console.log(
         '[ferry:dev-action] DRY_RUN — skipped: git push, PR creation, Jira transition, Jira comment',
       );
-      appendOutput(usage);
+      appendOutput({ ...usage, model });
       process.exit(0);
     }
 
@@ -253,7 +253,7 @@ async function main(): Promise<void> {
     throw err;
   }
 
-  appendOutput(usage);
+  appendOutput({ ...usage, model });
   process.exit(0);
 }
 

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -37,7 +37,11 @@ jobs:
 # Required secrets: FERRY_APP_ID, FERRY_PRIVATE_KEY, FERRY_JIRA_BASE_URL,
 #                   FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN, FERRY_ANTHROPIC_API_KEY
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
-# Optional variables: FERRY_MODEL (default: claude-sonnet-4-6)
+# Optional variables: FERRY_DEV_MODEL (default: claude-sonnet-4-6)
+#                     FERRY_DEV_MAX_ITERATIONS (default: 200)
+#                     FERRY_DEV_MAX_INPUT_TOKENS (default: 500000)
+#                     FERRY_ANTHROPIC_BASE_URL (default: https://api.anthropic.com, var or secret)
+#                     FERRY_PROMPTS_DIR (default: <workspace>/prompts)
 
 name: Ferry — Dev
 

--- a/src/lib/prompts/resolve.ts
+++ b/src/lib/prompts/resolve.ts
@@ -6,7 +6,7 @@ export function resolvePromptPath(
   repoRoot: string,
   _checkExists: (p: string) => boolean = existsSync,
 ): string {
-  const overridesDir = process.env.FERRY_PROMPTS_DIR ?? path.join(repoRoot, 'prompts');
+  const overridesDir = process.env.FERRY_PROMPTS_DIR || path.join(repoRoot, 'prompts');
   const overridePath = path.join(overridesDir, `${name}.md`);
   if (_checkExists(overridePath)) {
     return overridePath;
@@ -23,7 +23,7 @@ export function loadProjectSnippet(
   _checkExists: (p: string) => boolean = existsSync,
   _readFile: (p: string, enc: BufferEncoding) => string = (p, enc) => readFileSync(p, enc),
 ): string | null {
-  const overridesDir = process.env.FERRY_PROMPTS_DIR ?? path.join(repoRoot, 'prompts');
+  const overridesDir = process.env.FERRY_PROMPTS_DIR || path.join(repoRoot, 'prompts');
   const candidates = [
     path.join(overridesDir, '_project.md'),
     path.join(repoRoot, '.ferry', 'prompts', '_project.md'),


### PR DESCRIPTION
Closes #65

## Summary

- `dev-action.ts`: pass `model` in all `appendOutput` calls, enabling `run-agent.outputs.model` in the workflow
- `resolve.ts`: fix `??` → `||` so empty `FERRY_PROMPTS_DIR` env var falls back to default
- `templates.ts`: update `ferry-dev.yml` stub to document all new optional variables

> ⚠️ `.github/workflows/dev.yml` must be updated manually (GitHub App lacks `workflows` scope). See the diff in issue #65.

Generated with [Claude Code](https://claude.ai/code)