### PR TITLE
fix: use FERRY_AGENT_ROLE env var in skip-task-type-action (issue #74)

### DIFF
--- a/.github/actions/ferry-run-developer/action.yml
+++ b/.github/actions/ferry-run-developer/action.yml
@@ -53,6 +53,7 @@ runs:
       shell: bash
       run: node ${{ github.action_path }}/skip-task-type-action.js
       env:
+        FERRY_AGENT_ROLE: developer
         FERRY_ENVELOPE_PAYLOAD: ${{ inputs.payload }}
         FERRY_JIRA_BASE_URL: ${{ inputs.jira_base_url }}
         FERRY_JIRA_EMAIL: ${{ inputs.jira_email }}

--- a/.github/actions/ferry-run-iterator/action.yml
+++ b/.github/actions/ferry-run-iterator/action.yml
@@ -60,6 +60,7 @@ runs:
       shell: bash
       run: node ${{ github.action_path }}/skip-task-type-action.js
       env:
+        FERRY_AGENT_ROLE: iterator
         FERRY_ENVELOPE_PAYLOAD: ${{ inputs.payload }}
         FERRY_JIRA_BASE_URL: ${{ inputs.jira_base_url }}
         FERRY_JIRA_EMAIL: ${{ inputs.jira_email }}

--- a/.github/actions/ferry-run-refiner/action.yml
+++ b/.github/actions/ferry-run-refiner/action.yml
@@ -37,6 +37,7 @@ runs:
       shell: bash
       run: node ${{ github.action_path }}/skip-task-type-action.js
       env:
+        FERRY_AGENT_ROLE: refiner
         FERRY_ENVELOPE_PAYLOAD: ${{ inputs.payload }}
         FERRY_JIRA_BASE_URL: ${{ inputs.jira_base_url }}
         FERRY_JIRA_EMAIL: ${{ inputs.jira_email }}

--- a/.github/actions/ferry-run-reviewer/action.yml
+++ b/.github/actions/ferry-run-reviewer/action.yml
@@ -56,6 +56,7 @@ runs:
       shell: bash
       run: node ${{ github.action_path }}/skip-task-type-action.js
       env:
+        FERRY_AGENT_ROLE: reviewer
         FERRY_ENVELOPE_PAYLOAD: ${{ inputs.payload }}
         FERRY_JIRA_BASE_URL: ${{ inputs.jira_base_url }}
         FERRY_JIRA_EMAIL: ${{ inputs.jira_email }}

--- a/src/agents/refiner/refine.ts
+++ b/src/agents/refiner/refine.ts
@@ -92,7 +92,10 @@ function buildPrompt(input: RefinerInput): string {
 }
 
 function stripMarkdownFences(text: string): string {
-  return text.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '').trim();
+  return text
+    .replace(/^```(?:json)?\s*\n?/, '')
+    .replace(/\n?```\s*$/, '')
+    .trim();
 }
 
 function parseJsonOrThrow(text: string): unknown {

--- a/src/lib/dispatch/skip-task-type-action.ts
+++ b/src/lib/dispatch/skip-task-type-action.ts
@@ -23,7 +23,17 @@ if (!issueType) process.exit(0);
 const skip = shouldSkipForTaskType(issueType);
 if (!skip.skip) process.exit(0);
 
-const role = 'refiner';
+const VALID_ROLES = ['refiner', 'developer', 'reviewer', 'iterator'] as const;
+type AgentRole = (typeof VALID_ROLES)[number];
+
+const rawRole = process.env.FERRY_AGENT_ROLE;
+if (!rawRole || !(VALID_ROLES as readonly string[]).includes(rawRole)) {
+  console.error(
+    `[ferry:dispatch] FERRY_AGENT_ROLE must be one of ${VALID_ROLES.join(', ')} — got: ${rawRole ?? '(unset)'}`,
+  );
+  process.exit(1);
+}
+const role = rawRole as AgentRole;
 const body = buildTaskSkipComment(role, envelope.event_id);
 
 await postComment({


### PR DESCRIPTION
Fixes #74

Replace hardcoded `'refiner'` role in `skip-task-type-action.ts` with a `FERRY_AGENT_ROLE` env var read at runtime. Each agent `action.yml` now passes its correct role value, and the script validates against the allowed set and exits with an error if the var is missing or unrecognised.

Generated with [Claude Code](https://claude.ai/code)