### PR TITLE
ci: add bundle drift check for .ferry/ bundles

### DIFF
--- a/.github/workflows/ferry-ci.yml
+++ b/.github/workflows/ferry-ci.yml
@@ -80,28 +80,6 @@ jobs:
           path: coverage/
           retention-days: 7
 
-  bundle-drift:
-    name: Bundle Drift
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '20'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Rebuild ferry bundles
-        run: npm run build:ferry
-
-      - name: Fail if .ferry/ is stale
-        run: git diff --exit-code .ferry/
-
   gitleaks:
     name: Secret Scan (gitleaks)
     runs-on: ubuntu-latest

--- a/.github/workflows/ferry-ci.yml
+++ b/.github/workflows/ferry-ci.yml
@@ -80,6 +80,28 @@ jobs:
           path: coverage/
           retention-days: 7
 
+  bundle-drift:
+    name: Bundle Drift
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Rebuild ferry bundles
+        run: npm run build:ferry
+
+      - name: Fail if .ferry/ is stale
+        run: git diff --exit-code .ferry/
+
   gitleaks:
     name: Secret Scan (gitleaks)
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,12 +12,34 @@ npm run format:check
 
 All gates (tests, typecheck, lint, format, gitleaks, and CodeQL in CI) must pass before opening a PR against `main`. CI runs them automatically on every push.
 
+### Before pushing: rebuild `.ferry/` bundles if you touched `src/`
+
+The `.ferry/` directory contains committed JavaScript bundles that GitHub Actions actually executes. They are built from `src/` via:
+
+```bash
+npm run build:ferry
+```
+
+**If you modify anything under `src/`, you must rebuild before pushing.** A stale bundle causes silent drift between source and runtime — CI will catch this, but rebuilding locally is faster:
+
+```bash
+npm run build:ferry
+git add .ferry/
+git commit -m "build: rebuild ferry bundles"
+```
+
+You can verify the bundles are up-to-date with:
+
+```bash
+npm run check:bundle   # builds, then fails if .ferry/ has uncommitted changes
+```
+
 ### Local hooks (Husky)
 
 `npm install` automatically wires two strict Git hooks (via the `prepare` script):
 
 - **`pre-commit`** — `lint-staged` runs Prettier and ESLint (`--max-warnings=0`) on staged files only. Fast (~1s).
-- **`pre-push`** — full CI parity: `typecheck && lint && format:check && test`. Refuses the push if any gate is red. ~5s.
+- **`pre-push`** — full CI parity: `typecheck && lint && format:check && test && check:bundle`. Refuses the push if any gate is red, including stale bundles.
 
 `--no-verify` bypasses both hooks and is **not** considered a normal workflow — only use it intentionally and accept that CI will catch the issue. The authoritative enforcement is server-side branch protection (see below).
 
@@ -36,6 +58,7 @@ To make `main` truly unbreakable, enable the following at
     - `Lint & Format`
     - `Secret Scan (gitleaks)`
     - `Analyze (javascript-typescript)` (CodeQL)
+    - `Bundle Drift`
 - ☑ Do not allow bypassing the above settings
 - ☑ Restrict who can push to matching branches (admins only, or empty list)
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lint:fix": "eslint src --fix",
     "format:check": "prettier --check 'src/**/*.ts'",
     "audit:ci": "node scripts/npm-audit-check.mjs",
+    "check:bundle": "npm run build:ferry && git diff --exit-code .ferry/",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/src/agents/restricted-imports.test.ts
+++ b/src/agents/restricted-imports.test.ts
@@ -4,9 +4,12 @@ import { execSync } from 'child_process';
 describe('agent lint guardrails', () => {
   it('blocks direct @octokit/rest imports in src/agents/**', () => {
     try {
-      execSync('npx eslint src/agents/__lint-fixtures__/restricted-imports.ts --no-ignore', {
-        stdio: 'pipe',
-      });
+      execSync(
+        'node_modules/.bin/eslint src/agents/__lint-fixtures__/restricted-imports.ts --no-ignore',
+        {
+          stdio: 'pipe',
+        },
+      );
       throw new Error('Expected eslint to fail but it succeeded');
     } catch (e) {
       const anyErr = e as unknown as { stdout?: Buffer; stderr?: Buffer };


### PR DESCRIPTION
Closes #84

## Summary

- Adds `check:bundle` npm script that rebuilds `.ferry/` from `src/` and fails if any bundle is stale
- Documents the rebuild requirement in `CONTRIBUTING.md` with a dedicated section
- Updates the branch protection required checks list to include `Bundle Drift`

Two items require manual addition (GitHub App lacks `workflows` permission):
- `.github/workflows/ferry-ci.yml`: add the `bundle-drift` job (snippet in issue comment)
- `.husky/pre-push`: add the `check:bundle` step (snippet in issue comment)

Generated with [Claude Code](https://claude.ai/code)