### PR TITLE
security: replace execSync template strings with execFileSync in dev agent

### DIFF
--- a/src/agents/developer/dev-action.ts
+++ b/src/agents/developer/dev-action.ts
@@ -1,4 +1,4 @@
-import { execSync, execFileSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { delimitUntrusted } from '../../lib/llm/delimit-untrusted.js';
 import {
   requireEnv,
@@ -77,13 +77,13 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
 
   let resumeContext = '';
   try {
-    execSync(`git ls-remote --exit-code --heads origin ${branchName}`, {
+    execFileSync('git', ['ls-remote', '--exit-code', '--heads', 'origin', branchName], {
       cwd: REPO_ROOT,
       stdio: 'pipe',
     });
-    execSync(`git fetch origin ${branchName}`, { cwd: REPO_ROOT });
-    execSync(`git checkout ${branchName}`, { cwd: REPO_ROOT });
-    const existingLog = execSync('git log origin/main..HEAD --oneline', {
+    execFileSync('git', ['fetch', 'origin', branchName], { cwd: REPO_ROOT });
+    execFileSync('git', ['checkout', branchName], { cwd: REPO_ROOT });
+    const existingLog = execFileSync('git', ['log', 'origin/main..HEAD', '--oneline'], {
       cwd: REPO_ROOT,
       encoding: 'utf8',
     }).trim();
@@ -95,7 +95,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
       });
     }
   } catch {
-    execSync(`git checkout -B ${branchName}`, { cwd: REPO_ROOT });
+    execFileSync('git', ['checkout', '-B', branchName], { cwd: REPO_ROOT });
     logger.info('created branch', { branch: branchName });
   }
 
@@ -178,11 +178,14 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   });
 
   try {
-    execSync('git add -A', { cwd: REPO_ROOT });
-    const finalStatus = execSync('git status --porcelain', { cwd: REPO_ROOT, encoding: 'utf8' });
+    execFileSync('git', ['add', '-A'], { cwd: REPO_ROOT });
+    const finalStatus = execFileSync('git', ['status', '--porcelain'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    });
     if (finalStatus.trim()) {
       await secretScan();
-      execSync(`git commit -m ${JSON.stringify(done.commit_message ?? commitMessage)}`, {
+      execFileSync('git', ['commit', '-m', done.commit_message ?? commitMessage], {
         cwd: REPO_ROOT,
       });
     }
@@ -210,7 +213,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
       process.exit(0);
     }
 
-    execSync(`git push origin ${branchName} --force-with-lease`, { cwd: REPO_ROOT });
+    execFileSync('git', ['push', 'origin', branchName, '--force-with-lease'], { cwd: REPO_ROOT });
 
     const prTitle = formatPullRequestTitle({ ticketKey, summary: done.summary });
     const prBody = formatPullRequestBody({

--- a/src/agents/developer/loop.ts
+++ b/src/agents/developer/loop.ts
@@ -22,7 +22,10 @@ export async function runAgentLoop(opts: {
     executeTool,
     commitProgress: async (root, branch, message, scan) => {
       execFileSync('git', ['add', '-A'], { cwd: root });
-      const status = execFileSync('git', ['status', '--porcelain'], { cwd: root, encoding: 'utf8' });
+      const status = execFileSync('git', ['status', '--porcelain'], {
+        cwd: root,
+        encoding: 'utf8',
+      });
       if (!status.trim()) return 'nothing to commit';
       await scan();
       execFileSync('git', ['commit', '-m', message], { cwd: root });

--- a/src/agents/developer/loop.ts
+++ b/src/agents/developer/loop.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import Anthropic from '@anthropic-ai/sdk';
 import { createAnthropicAgentLoop } from '../../lib/llm/agent-loop/anthropic.js';
 import type { AgentLoopResult } from '../../lib/llm/agent-loop/types.js';
@@ -21,12 +21,12 @@ export async function runAgentLoop(opts: {
     model,
     executeTool,
     commitProgress: async (root, branch, message, scan) => {
-      execSync('git add -A', { cwd: root });
-      const status = execSync('git status --porcelain', { cwd: root, encoding: 'utf8' });
+      execFileSync('git', ['add', '-A'], { cwd: root });
+      const status = execFileSync('git', ['status', '--porcelain'], { cwd: root, encoding: 'utf8' });
       if (!status.trim()) return 'nothing to commit';
       await scan();
-      execSync(`git commit -m ${JSON.stringify(message)}`, { cwd: root });
-      execSync(`git push origin ${branch} --force-with-lease`, { cwd: root });
+      execFileSync('git', ['commit', '-m', message], { cwd: root });
+      execFileSync('git', ['push', 'origin', branch, '--force-with-lease'], { cwd: root });
       return 'committed and pushed';
     },
   });

--- a/src/agents/developer/run-agent-loop.test.ts
+++ b/src/agents/developer/run-agent-loop.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import Anthropic from '@anthropic-ai/sdk';
 
 vi.mock('node:child_process', () => ({
-  execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { runAgentLoop } from './loop.js';
 
 type FakeMessage = {
@@ -27,7 +27,7 @@ function makeMock(responses: FakeMessage[]) {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockExecSync = execSync as any;
+const mockExecFileSync = execFileSync as any;
 
 const doneResponse: FakeMessage = {
   stop_reason: 'tool_use',
@@ -135,8 +135,8 @@ describe('runAgentLoop', () => {
         capturedContent = res['content'] as string | undefined;
       });
 
-      mockExecSync.mockReturnValueOnce(''); // git add -A
-      mockExecSync.mockReturnValueOnce(''); // git status (empty → nothing to commit)
+      mockExecFileSync.mockReturnValueOnce(''); // git add -A
+      mockExecFileSync.mockReturnValueOnce(''); // git status (empty → nothing to commit)
 
       await runAgentLoop({
         ...baseOpts,
@@ -153,8 +153,8 @@ describe('runAgentLoop', () => {
         capturedContent = res['content'] as string | undefined;
       });
 
-      mockExecSync.mockReturnValueOnce(''); // git add -A
-      mockExecSync.mockReturnValueOnce('   \n  '); // git status (whitespace only)
+      mockExecFileSync.mockReturnValueOnce(''); // git add -A
+      mockExecFileSync.mockReturnValueOnce('   \n  '); // git status (whitespace only)
 
       await runAgentLoop({
         ...baseOpts,
@@ -171,10 +171,10 @@ describe('runAgentLoop', () => {
         capturedContent = res['content'] as string | undefined;
       });
 
-      mockExecSync.mockReturnValueOnce(''); // git add -A
-      mockExecSync.mockReturnValueOnce('M src/foo.ts'); // git status
-      mockExecSync.mockReturnValueOnce(''); // git commit
-      mockExecSync.mockReturnValueOnce(''); // git push
+      mockExecFileSync.mockReturnValueOnce(''); // git add -A
+      mockExecFileSync.mockReturnValueOnce('M src/foo.ts'); // git status
+      mockExecFileSync.mockReturnValueOnce(''); // git commit
+      mockExecFileSync.mockReturnValueOnce(''); // git push
 
       await runAgentLoop({
         ...baseOpts,
@@ -189,10 +189,10 @@ describe('runAgentLoop', () => {
       const scan = vi.fn().mockResolvedValue(undefined);
       const create = makeCommitProgressCreate();
 
-      mockExecSync.mockReturnValueOnce(''); // git add -A
-      mockExecSync.mockReturnValueOnce('M src/foo.ts'); // git status
-      mockExecSync.mockReturnValueOnce(''); // git commit
-      mockExecSync.mockReturnValueOnce(''); // git push
+      mockExecFileSync.mockReturnValueOnce(''); // git add -A
+      mockExecFileSync.mockReturnValueOnce('M src/foo.ts'); // git status
+      mockExecFileSync.mockReturnValueOnce(''); // git commit
+      mockExecFileSync.mockReturnValueOnce(''); // git push
 
       await runAgentLoop({
         ...baseOpts,
@@ -209,8 +209,8 @@ describe('runAgentLoop', () => {
         capturedIsError = res['is_error'] as boolean | undefined;
       });
 
-      mockExecSync.mockReturnValueOnce(''); // git add -A
-      mockExecSync.mockReturnValueOnce('M src/secret.ts'); // git status
+      mockExecFileSync.mockReturnValueOnce(''); // git add -A
+      mockExecFileSync.mockReturnValueOnce('M src/secret.ts'); // git status
 
       await runAgentLoop({
         ...baseOpts,
@@ -221,8 +221,8 @@ describe('runAgentLoop', () => {
       });
 
       expect(capturedIsError).toBe(true);
-      // git commit and git push should NOT have been called — only 2 execSync calls
-      expect(mockExecSync.mock.calls).toHaveLength(2);
+      // git commit and git push should NOT have been called — only 2 execFileSync calls
+      expect(mockExecFileSync.mock.calls).toHaveLength(2);
     });
 
     it('propagates push failure as is_error tool result', async () => {
@@ -231,10 +231,10 @@ describe('runAgentLoop', () => {
         capturedIsError = res['is_error'] as boolean | undefined;
       });
 
-      mockExecSync.mockReturnValueOnce(''); // git add -A
-      mockExecSync.mockReturnValueOnce('M src/foo.ts'); // git status
-      mockExecSync.mockReturnValueOnce(''); // git commit
-      mockExecSync.mockImplementationOnce(() => {
+      mockExecFileSync.mockReturnValueOnce(''); // git add -A
+      mockExecFileSync.mockReturnValueOnce('M src/foo.ts'); // git status
+      mockExecFileSync.mockReturnValueOnce(''); // git commit
+      mockExecFileSync.mockImplementationOnce(() => {
         throw new Error('[rejected] non-fast-forward');
       }); // git push fails
 
@@ -250,10 +250,10 @@ describe('runAgentLoop', () => {
     it('pushes to the branch name passed in opts', async () => {
       const create = makeCommitProgressCreate();
 
-      mockExecSync.mockReturnValueOnce(''); // git add -A
-      mockExecSync.mockReturnValueOnce('A new-file.ts'); // git status
-      mockExecSync.mockReturnValueOnce(''); // git commit
-      mockExecSync.mockReturnValueOnce(''); // git push
+      mockExecFileSync.mockReturnValueOnce(''); // git add -A
+      mockExecFileSync.mockReturnValueOnce('A new-file.ts'); // git status
+      mockExecFileSync.mockReturnValueOnce(''); // git commit
+      mockExecFileSync.mockReturnValueOnce(''); // git push
 
       await runAgentLoop({
         ...baseOpts,
@@ -262,12 +262,12 @@ describe('runAgentLoop', () => {
         secretScan: async () => {},
       });
 
-      const pushCall = (mockExecSync.mock.calls as Array<[string, unknown]>).find(([cmd]) =>
-        cmd.includes('git push'),
+      const pushCall = (mockExecFileSync.mock.calls as Array<[string, string[], unknown]>).find(
+        ([, args]) => Array.isArray(args) && args.includes('push'),
       );
       expect(pushCall).toBeDefined();
-      expect(pushCall![0]).toContain('ferry/PROJ-42');
-      expect(pushCall![0]).toContain('--force-with-lease');
+      expect(pushCall![1]).toContain('ferry/PROJ-42');
+      expect(pushCall![1]).toContain('--force-with-lease');
     });
   });
 });

--- a/src/agents/restricted-imports.test.ts
+++ b/src/agents/restricted-imports.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect } from 'vitest';
 import { execSync } from 'child_process';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+function collectTs(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      results.push(...collectTs(full));
+    } else if (entry.endsWith('.ts')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
 
 describe('agent lint guardrails', () => {
   it('blocks direct @octokit/rest imports in src/agents/**', () => {
@@ -16,5 +31,12 @@ describe('agent lint guardrails', () => {
       const output = `${anyErr.stdout?.toString?.() ?? ''}\n${anyErr.stderr?.toString?.() ?? ''}`;
       expect(output).toContain('no-restricted-imports');
     }
+  });
+
+  it('no execSync with template literals in src/agents/', () => {
+    const agentsDir = join(process.cwd(), 'src/agents');
+    const files = collectTs(agentsDir);
+    const violations = files.filter((f) => /execSync\s*\(`/.test(readFileSync(f, 'utf8')));
+    expect(violations).toEqual([]);
   });
 });


### PR DESCRIPTION
Migrates all `execSync(template-literal)` calls in `src/agents/developer/` to `execFileSync('git', [...args])` to eliminate the shell-injection pattern. Also converts static-string execSync git calls for consistency so the module no longer imports execSync at all.

Adds a Vitest guardrail in `restricted-imports.test.ts` that scans every .ts file under `src/agents/` and fails if any `execSync(`...`)` template call is found.

Closes #81

Generated with [Claude Code](https://claude.ai/code)