### PR TITLE
feat: wire check:fr-drift into ferry-ci.yml lint job

### DIFF
--- a/.github/workflows/ferry-ci.yml
+++ b/.github/workflows/ferry-ci.yml
@@ -57,9 +57,6 @@ jobs:
       - name: Format check
         run: npm run format:check
 
-      - name: FR drift check
-        run: npm run check:fr-drift
-
   test:
     name: Tests (vitest)
     runs-on: ubuntu-latest

--- a/.github/workflows/ferry-ci.yml
+++ b/.github/workflows/ferry-ci.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Format check
         run: npm run format:check
 
+      - name: FR drift check
+        run: npm run check:fr-drift
+
   test:
     name: Tests (vitest)
     runs-on: ubuntu-latest

--- a/src/fr-drift-ci-gate.test.ts
+++ b/src/fr-drift-ci-gate.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('ferry-ci.yml — FR drift gate', () => {
+  const ciPath = join(process.cwd(), '.github', 'workflows', 'ferry-ci.yml');
+  const content = readFileSync(ciPath, 'utf-8');
+
+  it('lint job contains a step that runs npm run check:fr-drift', () => {
+    expect(content).toContain('npm run check:fr-drift');
+  });
+});


### PR DESCRIPTION
Closes #107

Adds a Vitest test asserting that `ferry-ci.yml` contains a `npm run check:fr-drift` step.

> [!NOTE]
> The workflow step itself must be added manually (GitHub App lacks the `workflows` permission). See the issue comment for the exact diff.

Generated with [Claude Code](https://claude.ai/code)