### PR TITLE
feat: wire reconciler and cost daily-check as required consumer workflows (#108)

### DIFF
--- a/docs/CONSUMER-SETUP.md
+++ b/docs/CONSUMER-SETUP.md
@@ -286,14 +286,9 @@ If **all** of these check, the install is complete.
 
 ---
 
-## Phase 7 — Post-install hardening (recommended)
+## Phase 7 — Operations setup
 
-1. **Anthropic cost cap:** https://console.anthropic.com/settings/limits → set a monthly cap (e.g., $50) as a hard ceiling independent of Ferry's internal governance.
-2. **CODEOWNERS:** Add `.github/workflows/ferry-* @your-handle` to prevent unauthorized edits to the stubs.
-3. **Branch protection on `main`:** Require PR review + green CI before merge. Ferry opens drafts — you remain the last barrier.
-4. **SHA renewal:** Every 1–2 months, redo step 3.2 to bump the pinned SHA. Or configure Dependabot via `package-ecosystem: github-actions`.
-
-### 7.5 — Stale-ticket reconciler (every 30 min)
+### 7.5 — Stale-ticket reconciler (required, every 30 min)
 
 The reconciler sweeps all Ferry-managed tickets and re-triggers any that have stalled — for example, a `repository_dispatch` that was dropped or a ticket whose Jira column drifted out of sync with its state file.
 
@@ -322,11 +317,11 @@ gh variable set FERRY_JIRA_PROJECT --body "CHAN"
 
 **Schedule:** every 30 minutes (configurable — edit the `cron` expression in `ferry-reconcile.yml`).
 
-**Opt-out:** delete `ferry-reconcile.yml` from `.github/workflows/`. Consumers who prefer to re-trigger stalled tickets manually do not need this workflow.
+**Opt-out:** delete `ferry-reconcile.yml` from `.github/workflows/`. Not recommended for production — stalled tickets will require manual re-triggering.
 
 **Permissions required (added automatically by the stub):** `contents: read`, `issues: write`, `actions: write`.
 
-### 7.6 — Daily cost check (06:00 UTC)
+### 7.6 — Daily cost check (required, 06:00 UTC)
 
 The daily cost check reads accumulated `cost_eur` values from the Ferry audit issue, groups them by LLM provider, and fires a `ferry:paused` alert when any provider crosses 50% of the configured monthly cap.
 
@@ -356,9 +351,16 @@ gh variable set FERRY_SPEND_CAP_EUR --body "200"
 
 **Schedule:** daily at 06:00 UTC (configurable — edit the `cron` expression in `ferry-cost-daily.yml`).
 
-**Opt-out:** delete `ferry-cost-daily.yml`. Without this workflow, the only hard cost ceiling is the manual cap set in the Anthropic console (Phase 7, item 1).
+**Opt-out:** delete `ferry-cost-daily.yml`. Not recommended for production — without this workflow, the only hard cost ceiling is the manual cap set in the Anthropic console (§7.7, item 1).
 
 **Permissions required:** `contents: read`, `issues: write`.
+
+### 7.7 — Security hardening (recommended)
+
+1. **Anthropic cost cap:** https://console.anthropic.com/settings/limits → set a monthly cap (e.g., $50) as a hard ceiling independent of Ferry's internal governance.
+2. **CODEOWNERS:** Add `.github/workflows/ferry-* @your-handle` to prevent unauthorized edits to the stubs.
+3. **Branch protection on `main`:** Require PR review + green CI before merge. Ferry opens drafts — you remain the last barrier.
+4. **SHA renewal:** Every 1–2 months, redo step 3.2 to bump the pinned SHA. Or configure Dependabot via `package-ecosystem: github-actions`.
 
 ---
 
@@ -367,7 +369,8 @@ gh variable set FERRY_SPEND_CAP_EUR --body "200"
 | Issue                                           | Status                                                                                              |
 | ----------------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `@v1` tag must exist before install guide works | Required for release — tag must be cut before distributing this guide                               |
-| Stale-ticket reconciler sweep                   | Implemented — see Phase 7.5. Wired via `ferry-reconcile.yml` (issue #79).                           |
+| Stale-ticket reconciler sweep                   | Implemented — see §7.5 (required). Wired via `ferry-reconcile.yml` (issue #79).                     |
+| Daily cost governance                           | Implemented — see §7.6 (required). Wired via `ferry-cost-daily.yml` (issue #108).                  |
 | `.ferry/` agent scripts in consumer workspace   | Tracked in #71 — workflows currently read agent scripts from Ferry repo checkout                    |
 | Anthropic Agent SDK support                     | Planned — current LLM call site uses the Anthropic Messages API; Agent SDK is the next roadmap item |
 
@@ -397,6 +400,8 @@ Phase 5 — Smoke test        [ ] Ticket created
 Phase 6 — Final verification[ ] Lines in audit issue (one per phase run)
                             [ ] Automatic Jira transitions observed
                             [ ] Anthropic cost < $0.50
+Phase 7 — Operations setup  [ ] ferry-reconcile.yml copied and pushed (§7.5 — required)
+                            [ ] ferry-cost-daily.yml copied and pushed (§7.6 — required)
 ```
 
 ---

--- a/examples/consumer-setup/workflows/ferry-cost-daily.yml
+++ b/examples/consumer-setup/workflows/ferry-cost-daily.yml
@@ -1,11 +1,13 @@
 # Copy this file to .github/workflows/ferry-cost-daily.yml in your repository.
-# Replace @v1 with the Ferry release tag you want to pin (e.g. @v1.2.3).
+# Update the FERRY_REF value below to the Ferry release you have pinned.
 #
-# Required variables: FERRY_AUDIT_ISSUE, FERRY_SPEND_CAP_EUR
+# Required variables: FERRY_AUDIT_ISSUE
+# Optional variables: FERRY_SPEND_CAP_EUR (monthly EUR cap — default 200 EUR)
 # Optional secrets (to apply ferry:paused to Jira tickets on threshold breach):
 #   FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN
 #
-# Opt-out: delete this file or rename the workflow to disable scheduling.
+# Production deployments must include this workflow to enforce cost governance.
+# To disable: delete this file or rename the workflow.
 
 name: Ferry — Cost Daily Check
 
@@ -18,7 +20,45 @@ concurrency:
   group: ferry-cost-daily
   cancel-in-progress: false
 
+env:
+  FERRY_REF: v1 # pin to the same release you use for the agent stubs
+
 jobs:
   cost-check:
-    uses: big-emotion/ferry/.github/workflows/cost-daily.yml@v1
-    secrets: inherit
+    name: Check provider spend against cap
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout consumer repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Checkout Ferry source
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: big-emotion/ferry
+          ref: ${{ env.FERRY_REF }}
+          path: _ferry_src
+
+      - name: Set up Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: '20'
+
+      - name: Install Ferry dependencies
+        run: npm ci --prefer-offline
+        working-directory: _ferry_src
+
+      - name: Run daily cost check
+        run: npx tsx src/cost-governance/run.ts
+        working-directory: _ferry_src
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          FERRY_AUDIT_ISSUE: ${{ vars.FERRY_AUDIT_ISSUE }}
+          FERRY_SPEND_CAP_EUR: ${{ vars.FERRY_SPEND_CAP_EUR }}
+          FERRY_JIRA_BASE_URL: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          FERRY_JIRA_EMAIL: ${{ secrets.FERRY_JIRA_EMAIL }}
+          FERRY_JIRA_API_TOKEN: ${{ secrets.FERRY_JIRA_API_TOKEN }}

--- a/src/install-guide.test.ts
+++ b/src/install-guide.test.ts
@@ -358,3 +358,87 @@ describe('Phase 5 — Ferry never merges (install-guide §5.6)', () => {
     expect(doc).toMatch(/Ferry never merges/i);
   });
 });
+
+// ---------------------------------------------------------------------------
+// 15. Phase 7 — Ops workflow stubs (reconciler and cost daily-check)
+// ---------------------------------------------------------------------------
+
+describe('Phase 7 — ops workflow stubs (install-guide §7.5 and §7.6)', () => {
+  const opsStubs = ['ferry-reconcile', 'ferry-cost-daily'];
+
+  for (const stub of opsStubs) {
+    it(`examples/consumer-setup/workflows/${stub}.yml exists`, async () => {
+      const exists = await fileExists(`examples/consumer-setup/workflows/${stub}.yml`);
+      expect(exists, `${stub}.yml must exist for consumers to copy`).toBe(true);
+    });
+  }
+
+  it('ferry-reconcile.yml has a scheduled cron trigger', async () => {
+    const content = await readFile('examples/consumer-setup/workflows/ferry-reconcile.yml');
+    expect(content).toContain('schedule:');
+    expect(content).toContain('cron:');
+  });
+
+  it('ferry-cost-daily.yml has a scheduled cron trigger', async () => {
+    const content = await readFile('examples/consumer-setup/workflows/ferry-cost-daily.yml');
+    expect(content).toContain('schedule:');
+    expect(content).toContain('cron:');
+  });
+
+  it('ferry-reconcile.yml has explicit permissions block with issues: write', async () => {
+    const content = await readFile('examples/consumer-setup/workflows/ferry-reconcile.yml');
+    expect(content).toContain('permissions:');
+    expect(content).toContain('issues: write');
+  });
+
+  it('ferry-cost-daily.yml has explicit permissions block with issues: write', async () => {
+    const content = await readFile('examples/consumer-setup/workflows/ferry-cost-daily.yml');
+    expect(content).toContain('permissions:');
+    expect(content).toContain('issues: write');
+  });
+
+  it('ferry-reconcile.yml passes FERRY_AUDIT_ISSUE', async () => {
+    const content = await readFile('examples/consumer-setup/workflows/ferry-reconcile.yml');
+    expect(content).toContain('FERRY_AUDIT_ISSUE');
+  });
+
+  it('ferry-cost-daily.yml passes FERRY_AUDIT_ISSUE and FERRY_SPEND_CAP_EUR', async () => {
+    const content = await readFile('examples/consumer-setup/workflows/ferry-cost-daily.yml');
+    expect(content).toContain('FERRY_AUDIT_ISSUE');
+    expect(content).toContain('FERRY_SPEND_CAP_EUR');
+  });
+
+  it('ferry-reconcile.yml runs src/reconciler/run.ts directly', async () => {
+    const content = await readFile('examples/consumer-setup/workflows/ferry-reconcile.yml');
+    expect(content, 'reconcile stub must invoke the reconciler entrypoint').toContain(
+      'src/reconciler/run.ts',
+    );
+  });
+
+  it('ferry-cost-daily.yml runs src/cost-governance/run.ts directly', async () => {
+    const content = await readFile('examples/consumer-setup/workflows/ferry-cost-daily.yml');
+    expect(content, 'cost-daily stub must invoke the cost-governance entrypoint').toContain(
+      'src/cost-governance/run.ts',
+    );
+  });
+
+  it('CONSUMER-SETUP.md §7.5 heading marks reconciler as required', async () => {
+    const doc = await readFile('docs/CONSUMER-SETUP.md');
+    expect(doc).toMatch(/7\.5[^\n]*required/i);
+  });
+
+  it('CONSUMER-SETUP.md §7.6 heading marks cost daily-check as required', async () => {
+    const doc = await readFile('docs/CONSUMER-SETUP.md');
+    expect(doc).toMatch(/7\.6[^\n]*required/i);
+  });
+
+  it('CONSUMER-SETUP.md quick checklist includes ferry-reconcile.yml as required', async () => {
+    const doc = await readFile('docs/CONSUMER-SETUP.md');
+    expect(doc).toMatch(/ferry-reconcile\.yml.*required/i);
+  });
+
+  it('CONSUMER-SETUP.md quick checklist includes ferry-cost-daily.yml as required', async () => {
+    const doc = await readFile('docs/CONSUMER-SETUP.md');
+    expect(doc).toMatch(/ferry-cost-daily\.yml.*required/i);
+  });
+});


### PR DESCRIPTION
Closes #108.

## Summary

- Rewrites `ferry-cost-daily.yml` consumer stub — the previous version called a non-existent reusable workflow; now follows the same standalone checkout-and-run pattern as `ferry-reconcile.yml`, with an explicit `permissions:` block and all required env vars
- Restructures `CONSUMER-SETUP.md` Phase 7: separates required ops setup (§7.5 reconciler, §7.6 cost daily-check) from optional security hardening (new §7.7); both ops workflows marked "required" in headings and quick checklist
- Adds 13 structural tests to `src/install-guide.test.ts` asserting stubs exist, have schedule triggers, permissions, env vars, and that the doc marks them as required

## Test plan

- [x] `npm test` includes 13 new tests in `install-guide.test.ts` that verify all acceptance criteria
- [x] All existing install-guide tests continue to pass (no existing content removed)

Generated with [Claude Code](https://claude.ai/code)