### PR TITLE
feat(ci): add check-bundle job to catch .ferry/ drift

### DIFF
--- a/.github/workflows/ferry-ci.yml
+++ b/.github/workflows/ferry-ci.yml
@@ -86,6 +86,27 @@ jobs:
           path: coverage/
           retention-days: 7
 
+  check-bundle:
+    name: Bundle Drift (check:bundle)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check bundle drift
+        run: npm run check:bundle
+
   gitleaks:
     name: Secret Scan (gitleaks)
     runs-on: ubuntu-latest

--- a/src/install-guide.test.ts
+++ b/src/install-guide.test.ts
@@ -358,3 +358,21 @@ describe('Phase 5 — Ferry never merges (install-guide §5.6)', () => {
     expect(doc).toMatch(/Ferry never merges/i);
   });
 });
+
+// ---------------------------------------------------------------------------
+// 15. Bundle drift CI gate — ferry-ci.yml must run check:bundle
+// ---------------------------------------------------------------------------
+
+describe('CI gate — bundle drift check (ferry-ci.yml)', () => {
+  it('ferry-ci.yml contains a check-bundle job', async () => {
+    const ci = await readFile('.github/workflows/ferry-ci.yml');
+    expect(ci, 'ferry-ci.yml must define a check-bundle job').toContain('check-bundle:');
+  });
+
+  it('ferry-ci.yml check-bundle job runs npm run check:bundle', async () => {
+    const ci = await readFile('.github/workflows/ferry-ci.yml');
+    expect(ci, 'check-bundle job must call npm run check:bundle').toContain(
+      'npm run check:bundle',
+    );
+  });
+});

--- a/src/install-guide.test.ts
+++ b/src/install-guide.test.ts
@@ -371,8 +371,6 @@ describe('CI gate — bundle drift check (ferry-ci.yml)', () => {
 
   it('ferry-ci.yml check-bundle job runs npm run check:bundle', async () => {
     const ci = await readFile('.github/workflows/ferry-ci.yml');
-    expect(ci, 'check-bundle job must call npm run check:bundle').toContain(
-      'npm run check:bundle',
-    );
+    expect(ci, 'check-bundle job must call npm run check:bundle').toContain('npm run check:bundle');
   });
 });


### PR DESCRIPTION
Adds a new `check-bundle` CI job that rebuilds .ferry/ from src/ and fails if committed bundles diverge from the rebuilt output. Also adds tests in src/install-guide.test.ts asserting the job and step are present.

Note: the .github/workflows/ferry-ci.yml change must be added manually (see issue #106 comment for the exact YAML block).

Closes #106

Generated with [Claude Code](https://claude.ai/code)