### PR TITLE
feat(cli): publish ferry-init/ferry-doctor to npm (#63)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ferry",
+  "name": "ferry-init",
   "version": "0.1.0",
   "description": "Ferry — GitHub Actions–native agent pipeline for Jira-driven automated development",
   "type": "module",
@@ -7,8 +7,34 @@
     "ferry-init": "./dist/cli/init/index.js",
     "ferry-doctor": "./dist/cli/doctor/index.js"
   },
+  "files": [
+    "dist/cli/",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/big-emotion/ferry.git"
+  },
+  "homepage": "https://github.com/big-emotion/ferry#readme",
+  "bugs": {
+    "url": "https://github.com/big-emotion/ferry/issues"
+  },
+  "license": "MIT",
+  "keywords": [
+    "ferry",
+    "github-actions",
+    "jira",
+    "cli",
+    "automation"
+  ],
   "scripts": {
+    "build:cli": "node scripts/build-cli.mjs",
     "build:ferry": "node scripts/build-ferry-actions.mjs",
+    "prepublishOnly": "npm run build:cli",
     "ferry-init": "tsx src/cli/init/index.ts",
     "ferry-doctor": "tsx src/cli/doctor/index.ts",
     "ferry-reconcile": "tsx src/reconciler/run.ts",

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -1,0 +1,31 @@
+import { build } from 'esbuild';
+import { mkdirSync, chmodSync } from 'node:fs';
+
+mkdirSync('dist/cli/init', { recursive: true });
+mkdirSync('dist/cli/doctor', { recursive: true });
+
+const shared = {
+  bundle: true,
+  platform: 'node',
+  target: 'node20',
+  format: 'esm',
+  minify: false,
+};
+
+await Promise.all([
+  build({
+    ...shared,
+    entryPoints: ['src/cli/init/index.ts'],
+    outfile: 'dist/cli/init/index.js',
+  }),
+  build({
+    ...shared,
+    entryPoints: ['src/cli/doctor/index.ts'],
+    outfile: 'dist/cli/doctor/index.js',
+  }),
+]);
+
+chmodSync('dist/cli/init/index.js', 0o755);
+chmodSync('dist/cli/doctor/index.js', 0o755);
+
+console.log('Built dist/cli/ bundles.');


### PR DESCRIPTION
## Summary

Closes #63. Adds an esbuild build pipeline so `npx ferry-init` and `npx ferry-doctor` work for end users straight from npm.

- New `scripts/build-cli.mjs` bundles `src/cli/{init,doctor}/index.ts` → `dist/cli/{init,doctor}/index.js` (ESM, node20). Both bundles are self-contained — only `node:` builtins remain after bundling, so the published package needs no runtime dep installs.
- `package.json` renamed to `ferry-init` so `npx ferry-init` resolves the registry package directly. Added `build:cli`, `prepublishOnly`, `files`, `publishConfig.access=public`, `repository`, `homepage`, `bugs`, `license`, `keywords`.

`npm pack --dry-run` ships 5 files (~21 kB tarball): `LICENSE`, `README.md`, `package.json`, `dist/cli/init/index.js`, `dist/cli/doctor/index.js`.

After publishing:
- `npx ferry-init` → runs the install wizard (package name match).
- `npx -p ferry-init ferry-doctor` → runs the doctor (same package, second bin).

## CI publish workflow (follow-up)

Per the issue's "CI publishes a new version on every release tag" criterion, add a workflow that triggers on `v*` tags and runs `npm publish`. I cannot modify `.github/workflows/` from this branch (CODEOWNERS-protected), so I left it for a maintainer. Suggested snippet:

```yaml
name: Publish to npm
on:
  push:
    tags: ['v*']
jobs:
  publish:
    runs-on: ubuntu-latest
    permissions: { contents: read, id-token: write }
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-node@v4
        with:
          node-version: '20'
          registry-url: 'https://registry.npmjs.org'
      - run: npm ci
      - run: npm run build:cli
      - run: npm publish --provenance --access public
        env:
          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
```

## Test plan

- [x] `npm run build:cli` produces both bundles with shebangs and 0755 perms
- [x] `node dist/cli/init/index.js` and `node dist/cli/doctor/index.js` print their banners/help
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check`
- [x] `npm test` — 882/882 passing
- [x] `npm pack --dry-run` shows the expected 5 files
- [ ] Maintainer wires the publish workflow + sets `NPM_TOKEN`