### PR TITLE
fix(cli): default ferry workflow ref to package version instead of v1

### DIFF
--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -33,7 +33,8 @@ function detectRepo(): string | undefined {
 function parseArgs(argv: string[]): { overwrite: boolean; version: string } {
   const overwrite = argv.includes('--overwrite');
   const versionIdx = argv.findIndex((a) => a === '--version');
-  const version = versionIdx >= 0 ? (argv[versionIdx + 1] ?? FERRY_VERSION_DEFAULT) : FERRY_VERSION_DEFAULT;
+  const version =
+    versionIdx >= 0 ? (argv[versionIdx + 1] ?? FERRY_VERSION_DEFAULT) : FERRY_VERSION_DEFAULT;
   return { overwrite, version };
 }
 

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { createRequire } from 'node:module';
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import { ask, confirm, closePrompt, print, printStep, printSuccess, printError } from './prompt.js';
@@ -9,6 +10,10 @@ import { installWorkflows, scaffoldCodeowners } from './steps/workflows.js';
 import { stepJiraBundle } from './steps/jira-bundle.js';
 import { stepVerify } from './steps/verify.js';
 import type { FerryConfig } from './types.js';
+
+const _require = createRequire(import.meta.url);
+const { version: pkgVersion } = _require('../../../package.json') as { version: string };
+const FERRY_VERSION_DEFAULT = `v${pkgVersion}`;
 
 const TOTAL_STEPS = 5;
 
@@ -28,7 +33,7 @@ function detectRepo(): string | undefined {
 function parseArgs(argv: string[]): { overwrite: boolean; version: string } {
   const overwrite = argv.includes('--overwrite');
   const versionIdx = argv.findIndex((a) => a === '--version');
-  const version = versionIdx >= 0 ? (argv[versionIdx + 1] ?? 'v1') : 'v1';
+  const version = versionIdx >= 0 ? (argv[versionIdx + 1] ?? FERRY_VERSION_DEFAULT) : FERRY_VERSION_DEFAULT;
   return { overwrite, version };
 }
 


### PR DESCRIPTION
Decouples the envelope schema version (`v1`) from the workflow git ref in ferry-init. The default for `ferryVersion` is now read from package.json at runtime, so generated workflow stubs reference `@v0.3.0` (or whatever the installed version is) instead of the nonexistent `@v1` tag.

Closes #118.

Generated with [Claude Code](https://claude.ai/code)