### PR TITLE
feat: ferry-init collect Jira workspace ARI + project ID

### DIFF
--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -7,6 +7,7 @@ import { stepGitHubApp } from './steps/github-app.js';
 import { buildSecrets, stepSecrets } from './steps/secrets.js';
 import { installWorkflows, scaffoldCodeowners } from './steps/workflows.js';
 import { stepJiraBundle } from './steps/jira-bundle.js';
+import { resolveJiraWorkspaceId, resolveJiraProjectId } from './steps/jira-resolve.js';
 import { stepVerify } from './steps/verify.js';
 import type { FerryConfig } from './types.js';
 
@@ -88,6 +89,35 @@ async function main(): Promise<void> {
   const jiraApiToken = await ask(
     'Jira API token (from https://id.atlassian.com/manage-profile/security/api-tokens)',
   );
+  const jiraProjectKey = await ask('Jira project key (e.g. CHAN, PROJ)');
+
+  print('  Resolving Jira workspace and project IDs from the API...');
+  const [resolvedWorkspaceId, resolvedProjectId] = await Promise.all([
+    resolveJiraWorkspaceId(jiraBaseUrl, jiraEmail, jiraApiToken),
+    resolveJiraProjectId(jiraBaseUrl, jiraEmail, jiraApiToken, jiraProjectKey),
+  ]);
+
+  let workspaceId: string;
+  if (resolvedWorkspaceId) {
+    printSuccess(`Workspace ID resolved: ${resolvedWorkspaceId}`);
+    workspaceId = resolvedWorkspaceId;
+  } else {
+    print('  Could not auto-detect workspace ID.');
+    print('  Find it at: https://admin.atlassian.com → select your org → UUID in the URL');
+    const entered = await ask('Jira workspace ID (cloudId UUID, leave blank for placeholder)');
+    workspaceId = entered || 'YOUR_WORKSPACE_ID';
+  }
+
+  let projectId: string;
+  if (resolvedProjectId) {
+    printSuccess(`Project ID resolved: ${resolvedProjectId}`);
+    projectId = resolvedProjectId;
+  } else {
+    print('  Could not auto-detect project ID.');
+    print('  Find it at: Jira → Project settings → Details → numeric ID (not the key)');
+    const entered = await ask('Jira project numeric ID (leave blank for placeholder)');
+    projectId = entered || 'YOUR_PROJECT_ID';
+  }
 
   print('');
   print('LLM provider:');
@@ -104,6 +134,9 @@ async function main(): Promise<void> {
     jiraBaseUrl,
     jiraEmail,
     jiraApiToken,
+    jiraProjectKey,
+    jiraWorkspaceId: workspaceId,
+    jiraProjectId: projectId,
     anthropicApiKey,
   };
 
@@ -125,7 +158,7 @@ async function main(): Promise<void> {
 
   // ── Step 4: Jira automation bundle ────────────────────────────────────────
   printStep(4, TOTAL_STEPS, 'Generating Jira Automation import bundle');
-  stepJiraBundle(repoRoot, owner, repo);
+  stepJiraBundle(repoRoot, owner, repo, config.jiraWorkspaceId, config.jiraProjectId);
 
   // ── Step 5: Verify ────────────────────────────────────────────────────────
   printStep(5, TOTAL_STEPS, 'Verifying provider API key');

--- a/src/cli/init/init.test.ts
+++ b/src/cli/init/init.test.ts
@@ -45,21 +45,24 @@ describe('buildSecrets', () => {
 
 // ── buildJiraBundle ───────────────────────────────────────────────────────────
 
+const WORKSPACE_ID = '75eb33f5-5dd0-4328-b0e6-8bb3f4e0af91';
+const PROJECT_ID = '10033';
+
 describe('buildJiraBundle', () => {
   it('produces exactly 4 rules', () => {
-    const bundle = buildJiraBundle('acme-corp', 'acme-app');
+    const bundle = buildJiraBundle('acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
     expect(bundle.rules).toHaveLength(4);
   });
 
   it('sets cloud, version, type metadata', () => {
-    const bundle = buildJiraBundle('acme-corp', 'acme-app');
+    const bundle = buildJiraBundle('acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
     expect(bundle.cloud).toBe(true);
     expect(bundle.version).toBe(1);
     expect(bundle.type).toBe('AUTOMATION');
   });
 
   it('uses the correct dispatch URL for all rules', () => {
-    const bundle = buildJiraBundle('my-org', 'my-repo');
+    const bundle = buildJiraBundle('my-org', 'my-repo', WORKSPACE_ID, PROJECT_ID);
     const expected = 'https://api.github.com/repos/my-org/my-repo/dispatches';
     for (const rule of bundle.rules) {
       expect(rule.actions[0]?.value.url).toBe(expected);
@@ -67,7 +70,7 @@ describe('buildJiraBundle', () => {
   });
 
   it('uses the four Ferry event types', () => {
-    const bundle = buildJiraBundle('acme-corp', 'acme-app');
+    const bundle = buildJiraBundle('acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
     const bodies = bundle.rules.map(
       (r) => JSON.parse(r.actions[0]?.value.body ?? '{}') as { event_type: string },
     );
@@ -79,7 +82,7 @@ describe('buildJiraBundle', () => {
   });
 
   it('includes {{issue.key}} in each rule body', () => {
-    const bundle = buildJiraBundle('acme-corp', 'acme-app');
+    const bundle = buildJiraBundle('acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
     for (const rule of bundle.rules) {
       const body = JSON.parse(rule.actions[0]?.value.body ?? '{}') as {
         client_payload: { ticket_key: string };
@@ -89,21 +92,21 @@ describe('buildJiraBundle', () => {
   });
 
   it('creates all rules in DISABLED state', () => {
-    const bundle = buildJiraBundle('acme-corp', 'acme-app');
+    const bundle = buildJiraBundle('acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
     for (const rule of bundle.rules) {
       expect(rule.state).toBe('DISABLED');
     }
   });
 
   it('triggers on ISSUE_TRANSITIONED', () => {
-    const bundle = buildJiraBundle('acme-corp', 'acme-app');
+    const bundle = buildJiraBundle('acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
     for (const rule of bundle.rules) {
       expect(rule.trigger.type).toBe('ISSUE_TRANSITIONED');
     }
   });
 
   it('maps phases to correct Jira column names', () => {
-    const bundle = buildJiraBundle('acme-corp', 'acme-app');
+    const bundle = buildJiraBundle('acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
     const statuses = bundle.rules.map((r) => r.trigger.value.toStatus.name);
     expect(statuses).toContain('Refinement');
     expect(statuses).toContain('In Development');

--- a/src/cli/init/steps/jira-bundle.test.ts
+++ b/src/cli/init/steps/jira-bundle.test.ts
@@ -65,9 +65,7 @@ describe('stepJiraBundle', () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'ferry-jb-ari-'));
     stepJiraBundle(tmpDir, 'acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
     const content = readFileSync(join(tmpDir, 'ferry-jira-automation-rules.json'), 'utf8');
-    expect(content).toContain(
-      `ari:cloud:jira:${WORKSPACE_ID}:project/${PROJECT_ID}`,
-    );
+    expect(content).toContain(`ari:cloud:jira:${WORKSPACE_ID}:project/${PROJECT_ID}`);
   });
 });
 

--- a/src/cli/init/steps/jira-bundle.test.ts
+++ b/src/cli/init/steps/jira-bundle.test.ts
@@ -11,7 +11,10 @@ vi.mock('../prompt.js', () => ({
   printError: vi.fn(),
 }));
 
-import { stepJiraBundle } from './jira-bundle.js';
+import { buildJiraBundle, stepJiraBundle } from './jira-bundle.js';
+
+const WORKSPACE_ID = '75eb33f5-5dd0-4328-b0e6-8bb3f4e0af91';
+const PROJECT_ID = '10033';
 
 describe('stepJiraBundle', () => {
   let tmpDir: string;
@@ -23,7 +26,7 @@ describe('stepJiraBundle', () => {
 
   it('writes ferry-jira-automation-rules.json to the repo root', () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'ferry-jb-test-'));
-    const result = stepJiraBundle(tmpDir, 'acme-corp', 'acme-app');
+    const result = stepJiraBundle(tmpDir, 'acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
     expect(result.ok).toBe(true);
     const outPath = join(tmpDir, 'ferry-jira-automation-rules.json');
     expect(() => readFileSync(outPath, 'utf8')).not.toThrow();
@@ -31,14 +34,14 @@ describe('stepJiraBundle', () => {
 
   it('output file contains valid JSON', () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'ferry-jb-json-'));
-    stepJiraBundle(tmpDir, 'acme-corp', 'acme-app');
+    stepJiraBundle(tmpDir, 'acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
     const content = readFileSync(join(tmpDir, 'ferry-jira-automation-rules.json'), 'utf8');
     expect(() => JSON.parse(content)).not.toThrow();
   });
 
   it('output JSON contains 4 automation rules', () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'ferry-jb-rules-'));
-    stepJiraBundle(tmpDir, 'acme-corp', 'acme-app');
+    stepJiraBundle(tmpDir, 'acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
     const content = readFileSync(join(tmpDir, 'ferry-jira-automation-rules.json'), 'utf8');
     const bundle = JSON.parse(content) as { rules: unknown[] };
     expect(bundle.rules).toHaveLength(4);
@@ -46,15 +49,116 @@ describe('stepJiraBundle', () => {
 
   it('dispatch URL uses correct owner and repo', () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'ferry-jb-url-'));
-    stepJiraBundle(tmpDir, 'my-owner', 'my-repo');
+    stepJiraBundle(tmpDir, 'my-owner', 'my-repo', WORKSPACE_ID, PROJECT_ID);
     const content = readFileSync(join(tmpDir, 'ferry-jira-automation-rules.json'), 'utf8');
     expect(content).toContain('https://api.github.com/repos/my-owner/my-repo/dispatches');
   });
 
   it('output file ends with a newline', () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'ferry-jb-nl-'));
-    stepJiraBundle(tmpDir, 'acme-corp', 'acme-app');
+    stepJiraBundle(tmpDir, 'acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
     const content = readFileSync(join(tmpDir, 'ferry-jira-automation-rules.json'), 'utf8');
     expect(content.endsWith('\n')).toBe(true);
+  });
+
+  it('output contains real ARI in ruleScope', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'ferry-jb-ari-'));
+    stepJiraBundle(tmpDir, 'acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
+    const content = readFileSync(join(tmpDir, 'ferry-jira-automation-rules.json'), 'utf8');
+    expect(content).toContain(
+      `ari:cloud:jira:${WORKSPACE_ID}:project/${PROJECT_ID}`,
+    );
+  });
+});
+
+describe('buildJiraBundle', () => {
+  it('produces exactly 4 rules', () => {
+    const bundle = buildJiraBundle('acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
+    expect(bundle.rules).toHaveLength(4);
+  });
+
+  it('sets cloud, version, type metadata', () => {
+    const bundle = buildJiraBundle('acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
+    expect(bundle.cloud).toBe(true);
+    expect(bundle.version).toBe(1);
+    expect(bundle.type).toBe('AUTOMATION');
+  });
+
+  it('uses the correct dispatch URL for all rules', () => {
+    const bundle = buildJiraBundle('my-org', 'my-repo', WORKSPACE_ID, PROJECT_ID);
+    const expected = 'https://api.github.com/repos/my-org/my-repo/dispatches';
+    for (const rule of bundle.rules) {
+      expect(rule.actions[0]?.value.url).toBe(expected);
+    }
+  });
+
+  it('uses the four Ferry event types', () => {
+    const bundle = buildJiraBundle('acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
+    const bodies = bundle.rules.map(
+      (r) => JSON.parse(r.actions[0]?.value.body ?? '{}') as { event_type: string },
+    );
+    const eventTypes = bodies.map((b) => b.event_type);
+    expect(eventTypes).toContain('ferry-refine');
+    expect(eventTypes).toContain('ferry-dev');
+    expect(eventTypes).toContain('ferry-review');
+    expect(eventTypes).toContain('ferry-iterate');
+  });
+
+  it('includes {{issue.key}} in each rule body', () => {
+    const bundle = buildJiraBundle('acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
+    for (const rule of bundle.rules) {
+      const body = JSON.parse(rule.actions[0]?.value.body ?? '{}') as {
+        client_payload: { ticket_key: string };
+      };
+      expect(body.client_payload.ticket_key).toBe('{{issue.key}}');
+    }
+  });
+
+  it('creates all rules in DISABLED state', () => {
+    const bundle = buildJiraBundle('acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
+    for (const rule of bundle.rules) {
+      expect(rule.state).toBe('DISABLED');
+    }
+  });
+
+  it('triggers on ISSUE_TRANSITIONED', () => {
+    const bundle = buildJiraBundle('acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
+    for (const rule of bundle.rules) {
+      expect(rule.trigger.type).toBe('ISSUE_TRANSITIONED');
+    }
+  });
+
+  it('maps phases to correct Jira column names', () => {
+    const bundle = buildJiraBundle('acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
+    const statuses = bundle.rules.map((r) => r.trigger.value.toStatus.name);
+    expect(statuses).toContain('Refinement');
+    expect(statuses).toContain('In Development');
+    expect(statuses).toContain('In Review');
+    expect(statuses).toContain('Iteration');
+  });
+
+  it('stamps real ARI into ruleScope.resources for every rule', () => {
+    const bundle = buildJiraBundle('acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
+    const expectedAri = `ari:cloud:jira:${WORKSPACE_ID}:project/${PROJECT_ID}`;
+    for (const rule of bundle.rules) {
+      expect(rule.ruleScope.resources).toEqual([expectedAri]);
+    }
+  });
+
+  it('stamps real ARI into trigger.value.eventFilters for every rule', () => {
+    const bundle = buildJiraBundle('acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
+    const expectedAri = `ari:cloud:jira:${WORKSPACE_ID}:project/${PROJECT_ID}`;
+    for (const rule of bundle.rules) {
+      expect(rule.trigger.value.eventFilters).toEqual([expectedAri]);
+    }
+  });
+
+  it('uses placeholder ARI when workspaceId is a placeholder string', () => {
+    const bundle = buildJiraBundle('acme-corp', 'acme-app', 'YOUR_WORKSPACE_ID', 'YOUR_PROJECT_ID');
+    for (const rule of bundle.rules) {
+      expect(rule.ruleScope.resources[0]).toBe(
+        'ari:cloud:jira:YOUR_WORKSPACE_ID:project/YOUR_PROJECT_ID',
+      );
+    }
   });
 });

--- a/src/cli/init/steps/jira-bundle.ts
+++ b/src/cli/init/steps/jira-bundle.ts
@@ -21,12 +21,14 @@ interface JiraTransitionTrigger {
   value: {
     fromStatusCategory?: string;
     toStatus: { name: string };
+    eventFilters: string[];
   };
 }
 
 interface JiraRule {
   name: string;
   state: 'DISABLED';
+  ruleScope: { resources: string[] };
   trigger: JiraTransitionTrigger;
   actions: JiraWebRequestAction[];
 }
@@ -45,8 +47,14 @@ const PHASES = [
   { eventType: 'ferry-iterate', statusName: 'Iteration', label: 'Iterate' },
 ] as const;
 
-export function buildJiraBundle(owner: string, repo: string): JiraAutomationBundle {
+export function buildJiraBundle(
+  owner: string,
+  repo: string,
+  workspaceId: string,
+  projectId: string,
+): JiraAutomationBundle {
   const dispatchUrl = `https://api.github.com/repos/${owner}/${repo}/dispatches`;
+  const ari = `ari:cloud:jira:${workspaceId}:project/${projectId}`;
 
   const rules: JiraRule[] = PHASES.map((phase) => {
     const body = JSON.stringify({
@@ -64,10 +72,12 @@ export function buildJiraBundle(owner: string, repo: string): JiraAutomationBund
     return {
       name: `Ferry — ${phase.label} (column trigger)`,
       state: 'DISABLED',
+      ruleScope: { resources: [ari] },
       trigger: {
         type: 'ISSUE_TRANSITIONED',
         value: {
           toStatus: { name: phase.statusName },
+          eventFilters: [ari],
         },
       },
       actions: [
@@ -98,8 +108,14 @@ export function buildJiraBundle(owner: string, repo: string): JiraAutomationBund
   return { cloud: true, version: 1, type: 'AUTOMATION', rules };
 }
 
-export function stepJiraBundle(repoRoot: string, owner: string, repo: string): StepResult {
-  const bundle = buildJiraBundle(owner, repo);
+export function stepJiraBundle(
+  repoRoot: string,
+  owner: string,
+  repo: string,
+  workspaceId: string,
+  projectId: string,
+): StepResult {
+  const bundle = buildJiraBundle(owner, repo, workspaceId, projectId);
   const outPath = join(repoRoot, 'ferry-jira-automation-rules.json');
   writeFileSync(outPath, JSON.stringify(bundle, null, 2) + '\n', 'utf8');
 

--- a/src/cli/init/steps/jira-resolve.test.ts
+++ b/src/cli/init/steps/jira-resolve.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockHttpsGet = vi.hoisted(() => vi.fn());
+
+vi.mock('../../http.js', () => ({
+  httpsGet: mockHttpsGet,
+  httpsPost: vi.fn(),
+}));
+
+import { resolveJiraWorkspaceId, resolveJiraProjectId } from './jira-resolve.js';
+
+const BASE_URL = 'https://acme.atlassian.net';
+const EMAIL = 'bot@acme.com';
+const TOKEN = 'api-token-abc';
+
+describe('resolveJiraWorkspaceId', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns cloudId on a 200 response', async () => {
+    mockHttpsGet.mockResolvedValue({
+      statusCode: 200,
+      body: JSON.stringify({ cloudId: '75eb33f5-5dd0-4328-b0e6-8bb3f4e0af91' }),
+    });
+    const result = await resolveJiraWorkspaceId(BASE_URL, EMAIL, TOKEN);
+    expect(result).toBe('75eb33f5-5dd0-4328-b0e6-8bb3f4e0af91');
+  });
+
+  it('calls /_edge/tenant_info on the correct hostname', async () => {
+    mockHttpsGet.mockResolvedValue({ statusCode: 200, body: JSON.stringify({ cloudId: 'abc' }) });
+    await resolveJiraWorkspaceId(BASE_URL, EMAIL, TOKEN);
+    const call = mockHttpsGet.mock.calls[0]?.[0] as { hostname: string; path: string };
+    expect(call.hostname).toBe('acme.atlassian.net');
+    expect(call.path).toContain('/_edge/tenant_info');
+  });
+
+  it('returns null when status is not 200', async () => {
+    mockHttpsGet.mockResolvedValue({ statusCode: 401, body: 'Unauthorized' });
+    const result = await resolveJiraWorkspaceId(BASE_URL, EMAIL, TOKEN);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when cloudId is absent from response', async () => {
+    mockHttpsGet.mockResolvedValue({ statusCode: 200, body: JSON.stringify({}) });
+    const result = await resolveJiraWorkspaceId(BASE_URL, EMAIL, TOKEN);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when httpsGet throws a network error', async () => {
+    mockHttpsGet.mockRejectedValue(new Error('ECONNREFUSED'));
+    const result = await resolveJiraWorkspaceId(BASE_URL, EMAIL, TOKEN);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when baseUrl is invalid', async () => {
+    const result = await resolveJiraWorkspaceId('not-a-url', EMAIL, TOKEN);
+    expect(result).toBeNull();
+  });
+
+  it('sends Basic auth header', async () => {
+    mockHttpsGet.mockResolvedValue({ statusCode: 200, body: JSON.stringify({ cloudId: 'x' }) });
+    await resolveJiraWorkspaceId(BASE_URL, EMAIL, TOKEN);
+    const call = mockHttpsGet.mock.calls[0]?.[0] as { headers: Record<string, string> };
+    expect(call.headers['Authorization']).toMatch(/^Basic /);
+  });
+});
+
+describe('resolveJiraProjectId', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns numeric project id on a 200 response', async () => {
+    mockHttpsGet.mockResolvedValue({
+      statusCode: 200,
+      body: JSON.stringify({ id: '10033', key: 'CHAN', name: 'Channel' }),
+    });
+    const result = await resolveJiraProjectId(BASE_URL, EMAIL, TOKEN, 'CHAN');
+    expect(result).toBe('10033');
+  });
+
+  it('calls /rest/api/3/project/<key> on the correct hostname', async () => {
+    mockHttpsGet.mockResolvedValue({ statusCode: 200, body: JSON.stringify({ id: '10033' }) });
+    await resolveJiraProjectId(BASE_URL, EMAIL, TOKEN, 'CHAN');
+    const call = mockHttpsGet.mock.calls[0]?.[0] as { hostname: string; path: string };
+    expect(call.hostname).toBe('acme.atlassian.net');
+    expect(call.path).toContain('/rest/api/3/project/CHAN');
+  });
+
+  it('URL-encodes the project key', async () => {
+    mockHttpsGet.mockResolvedValue({ statusCode: 200, body: JSON.stringify({ id: '10034' }) });
+    await resolveJiraProjectId(BASE_URL, EMAIL, TOKEN, 'MY PROJECT');
+    const call = mockHttpsGet.mock.calls[0]?.[0] as { path: string };
+    expect(call.path).toContain('MY%20PROJECT');
+  });
+
+  it('returns null when status is 404', async () => {
+    mockHttpsGet.mockResolvedValue({ statusCode: 404, body: 'Not Found' });
+    const result = await resolveJiraProjectId(BASE_URL, EMAIL, TOKEN, 'MISSING');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when id field is absent', async () => {
+    mockHttpsGet.mockResolvedValue({ statusCode: 200, body: JSON.stringify({ key: 'CHAN' }) });
+    const result = await resolveJiraProjectId(BASE_URL, EMAIL, TOKEN, 'CHAN');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when httpsGet throws a network error', async () => {
+    mockHttpsGet.mockRejectedValue(new Error('timeout'));
+    const result = await resolveJiraProjectId(BASE_URL, EMAIL, TOKEN, 'CHAN');
+    expect(result).toBeNull();
+  });
+
+  it('sends Basic auth header', async () => {
+    mockHttpsGet.mockResolvedValue({ statusCode: 200, body: JSON.stringify({ id: '10033' }) });
+    await resolveJiraProjectId(BASE_URL, EMAIL, TOKEN, 'CHAN');
+    const call = mockHttpsGet.mock.calls[0]?.[0] as { headers: Record<string, string> };
+    expect(call.headers['Authorization']).toMatch(/^Basic /);
+  });
+});

--- a/src/cli/init/steps/jira-resolve.ts
+++ b/src/cli/init/steps/jira-resolve.ts
@@ -1,0 +1,64 @@
+import { httpsGet } from '../../http.js';
+
+function jiraAuthHeader(email: string, token: string): string {
+  return `Basic ${Buffer.from(`${email}:${token}`).toString('base64')}`;
+}
+
+interface TenantInfoResponse {
+  cloudId?: string;
+}
+
+interface JiraProjectIdResponse {
+  id?: string;
+}
+
+export async function resolveJiraWorkspaceId(
+  baseUrl: string,
+  email: string,
+  token: string,
+): Promise<string | null> {
+  try {
+    const url = new URL(baseUrl);
+    const basePath = url.pathname.replace(/\/$/, '');
+    const res = await httpsGet({
+      hostname: url.hostname,
+      path: `${basePath}/_edge/tenant_info`,
+      headers: {
+        Authorization: jiraAuthHeader(email, token),
+        Accept: 'application/json',
+        'User-Agent': 'ferry-init/1',
+      },
+    });
+    if (res.statusCode !== 200) return null;
+    const data = JSON.parse(res.body) as TenantInfoResponse;
+    return data.cloudId ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveJiraProjectId(
+  baseUrl: string,
+  email: string,
+  token: string,
+  projectKey: string,
+): Promise<string | null> {
+  try {
+    const url = new URL(baseUrl);
+    const basePath = url.pathname.replace(/\/$/, '');
+    const res = await httpsGet({
+      hostname: url.hostname,
+      path: `${basePath}/rest/api/3/project/${encodeURIComponent(projectKey)}`,
+      headers: {
+        Authorization: jiraAuthHeader(email, token),
+        Accept: 'application/json',
+        'User-Agent': 'ferry-init/1',
+      },
+    });
+    if (res.statusCode !== 200) return null;
+    const data = JSON.parse(res.body) as JiraProjectIdResponse;
+    return data.id ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/src/cli/init/types.ts
+++ b/src/cli/init/types.ts
@@ -7,6 +7,9 @@ export interface FerryConfig {
   jiraBaseUrl: string;
   jiraEmail: string;
   jiraApiToken: string;
+  jiraProjectKey: string;
+  jiraWorkspaceId: string;
+  jiraProjectId: string;
   anthropicApiKey: string;
 }
 


### PR DESCRIPTION
Resolves #121

Adds Jira workspace ID and project ID collection to the ferry-init wizard.

The wizard now prompts for a Jira project key, then auto-resolves the workspace cloudId (via `/_edge/tenant_info`) and numeric project ID (via `/rest/api/3/project/<key>`). Both are stamped into every generated rule's `ruleScope.resources` and `trigger.value.eventFilters` as real ARIs (`ari:cloud:jira:<workspaceId>:project/<projectId>`).

Generated with [Claude Code](https://claude.ai/code)