### PR TITLE
fix: ferry-init Jira automation bundle schema + beta label + manual fallback

### DIFF
--- a/src/__fixtures__/jira/automation-rules.export.example.json
+++ b/src/__fixtures__/jira/automation-rules.export.example.json
@@ -1,0 +1,49 @@
+{
+  "cloud": true,
+  "rules": [
+    {
+      "name": "Ferry — Refine (column trigger)",
+      "state": "DISABLED",
+      "trigger": {
+        "component": "TRIGGER",
+        "type": "jira.issue.event.trigger:transitioned",
+        "value": {
+          "eventFilters": ["ari:cloud:jira:YOUR_WORKSPACE_ID:project/YOUR_PROJECT_ID"],
+          "fromStatus": [],
+          "toStatus": [{ "type": "NAME", "value": "Refinement" }],
+          "eventKey": "jira:issue_updated",
+          "issueEvent": "issue_generic"
+        },
+        "schemaVersion": 1
+      },
+      "components": [
+        {
+          "component": "ACTION",
+          "type": "jira.issue.outgoing.webhook",
+          "value": {
+            "url": "https://api.github.com/repos/YOUR_OWNER/YOUR_REPO/dispatches",
+            "method": "POST",
+            "contentType": "custom",
+            "customBody": "{\"event_type\":\"ferry-refine\",\"client_payload\":{\"phase\":\"refine\",\"ticket_key\":\"{{issue.key}}\",\"issue_type\":\"{{issue.issuetype.name}}\",\"actor\":\"{{initiator.displayName}}\",\"source\":\"jira-column\",\"ts\":\"{{now.format(\\\"yyyy-MM-dd'T'HH:mm:ssXXX\\\")}}\"}}",
+            "headers": [
+              { "name": "Accept", "value": "application/vnd.github+json", "headerSecure": false },
+              {
+                "name": "Authorization",
+                "value": "Bearer YOUR_GITHUB_PAT_WITH_REPO_SCOPE",
+                "headerSecure": true
+              },
+              { "name": "X-GitHub-Api-Version", "value": "2022-11-28", "headerSecure": false },
+              { "name": "Content-Type", "value": "application/json", "headerSecure": false }
+            ]
+          },
+          "schemaVersion": 1
+        }
+      ],
+      "ruleScope": { "resources": ["ari:cloud:jira:YOUR_WORKSPACE_ID:project/YOUR_PROJECT_ID"] },
+      "labels": [],
+      "tags": [],
+      "canOtherRuleTrigger": false,
+      "notifyOnError": "FIRSTERROR"
+    }
+  ]
+}

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -139,8 +139,10 @@ async function main(): Promise<void> {
   print('');
   print('Next steps:');
   print('  1. Commit .github/workflows/ferry-*.yml and .github/CODEOWNERS');
-  print('  2. Import ferry-jira-automation-rules.json into Jira Automation');
-  print('     (Project settings → Automation → Import rules)');
+  print('  2. Set up Jira Automation rules (choose one):');
+  print('     a) Manual (recommended): follow ferry-jira-automation-setup.md');
+  print('     b) Import (beta): Jira → Project settings → Automation → Import rules');
+  print('        Upload ferry-jira-automation-rules.beta.json');
   print('  3. Set spend caps on provider billing pages (see links above)');
   print('  4. Set FERRY_AUDIT_ISSUE repository variable to a GitHub Issue number');
   print('     for the audit log (create a blank issue and use its number)');

--- a/src/cli/init/init.test.ts
+++ b/src/cli/init/init.test.ts
@@ -51,25 +51,26 @@ describe('buildJiraBundle', () => {
     expect(bundle.rules).toHaveLength(4);
   });
 
-  it('sets cloud, version, type metadata', () => {
+  it('sets cloud:true with no version or type fields', () => {
     const bundle = buildJiraBundle('acme-corp', 'acme-app');
     expect(bundle.cloud).toBe(true);
-    expect(bundle.version).toBe(1);
-    expect(bundle.type).toBe('AUTOMATION');
+    expect(bundle).not.toHaveProperty('version');
+    expect(bundle).not.toHaveProperty('type');
   });
 
   it('uses the correct dispatch URL for all rules', () => {
     const bundle = buildJiraBundle('my-org', 'my-repo');
     const expected = 'https://api.github.com/repos/my-org/my-repo/dispatches';
     for (const rule of bundle.rules) {
-      expect(rule.actions[0]?.value.url).toBe(expected);
+      expect(rule.components[0]?.value.url).toBe(expected);
     }
   });
 
   it('uses the four Ferry event types', () => {
     const bundle = buildJiraBundle('acme-corp', 'acme-app');
     const bodies = bundle.rules.map(
-      (r) => JSON.parse(r.actions[0]?.value.body ?? '{}') as { event_type: string },
+      (r) =>
+        JSON.parse(r.components[0]?.value.customBody ?? '{}') as { event_type: string },
     );
     const eventTypes = bodies.map((b) => b.event_type);
     expect(eventTypes).toContain('ferry-refine');
@@ -81,7 +82,7 @@ describe('buildJiraBundle', () => {
   it('includes {{issue.key}} in each rule body', () => {
     const bundle = buildJiraBundle('acme-corp', 'acme-app');
     for (const rule of bundle.rules) {
-      const body = JSON.parse(rule.actions[0]?.value.body ?? '{}') as {
+      const body = JSON.parse(rule.components[0]?.value.customBody ?? '{}') as {
         client_payload: { ticket_key: string };
       };
       expect(body.client_payload.ticket_key).toBe('{{issue.key}}');
@@ -95,16 +96,17 @@ describe('buildJiraBundle', () => {
     }
   });
 
-  it('triggers on ISSUE_TRANSITIONED', () => {
+  it('triggers on the real Jira Cloud transitioned event', () => {
     const bundle = buildJiraBundle('acme-corp', 'acme-app');
     for (const rule of bundle.rules) {
-      expect(rule.trigger.type).toBe('ISSUE_TRANSITIONED');
+      expect(rule.trigger.type).toBe('jira.issue.event.trigger:transitioned');
+      expect(rule.trigger.component).toBe('TRIGGER');
     }
   });
 
   it('maps phases to correct Jira column names', () => {
     const bundle = buildJiraBundle('acme-corp', 'acme-app');
-    const statuses = bundle.rules.map((r) => r.trigger.value.toStatus.name);
+    const statuses = bundle.rules.map((r) => r.trigger.value.toStatus[0]?.value);
     expect(statuses).toContain('Refinement');
     expect(statuses).toContain('In Development');
     expect(statuses).toContain('In Review');

--- a/src/cli/init/steps/jira-bundle.test.ts
+++ b/src/cli/init/steps/jira-bundle.test.ts
@@ -11,7 +11,103 @@ vi.mock('../prompt.js', () => ({
   printError: vi.fn(),
 }));
 
-import { stepJiraBundle } from './jira-bundle.js';
+import { buildJiraBundle, stepJiraBundle } from './jira-bundle.js';
+
+describe('buildJiraBundle', () => {
+  it('returns cloud:true at top level with no version or type fields', () => {
+    const bundle = buildJiraBundle('owner', 'repo');
+    expect(bundle.cloud).toBe(true);
+    expect(bundle).not.toHaveProperty('version');
+    expect(bundle).not.toHaveProperty('type');
+  });
+
+  it('returns 4 rules', () => {
+    const bundle = buildJiraBundle('owner', 'repo');
+    expect(bundle.rules).toHaveLength(4);
+  });
+
+  it('each rule uses components array with correct action type', () => {
+    const bundle = buildJiraBundle('owner', 'repo');
+    for (const rule of bundle.rules) {
+      expect(rule).not.toHaveProperty('actions');
+      expect(rule.components).toHaveLength(1);
+      expect(rule.components[0]?.component).toBe('ACTION');
+      expect(rule.components[0]?.type).toBe('jira.issue.outgoing.webhook');
+    }
+  });
+
+  it('trigger uses real Jira Cloud component/type format', () => {
+    const bundle = buildJiraBundle('owner', 'repo');
+    for (const rule of bundle.rules) {
+      expect(rule.trigger.component).toBe('TRIGGER');
+      expect(rule.trigger.type).toBe('jira.issue.event.trigger:transitioned');
+      expect(rule.trigger.schemaVersion).toBe(1);
+    }
+  });
+
+  it('trigger toStatus is an array of NAME objects', () => {
+    const bundle = buildJiraBundle('owner', 'repo');
+    const firstRule = bundle.rules[0]!;
+    expect(Array.isArray(firstRule.trigger.value.toStatus)).toBe(true);
+    expect(firstRule.trigger.value.toStatus[0]).toEqual({ type: 'NAME', value: 'Refinement' });
+  });
+
+  it('trigger value has required event fields', () => {
+    const bundle = buildJiraBundle('owner', 'repo');
+    for (const rule of bundle.rules) {
+      expect(rule.trigger.value.eventKey).toBe('jira:issue_updated');
+      expect(rule.trigger.value.issueEvent).toBe('issue_generic');
+      expect(Array.isArray(rule.trigger.value.eventFilters)).toBe(true);
+    }
+  });
+
+  it('action uses contentType:custom with customBody', () => {
+    const bundle = buildJiraBundle('owner', 'repo');
+    for (const rule of bundle.rules) {
+      const action = rule.components[0]!;
+      expect(action.value.contentType).toBe('custom');
+      expect(typeof action.value.customBody).toBe('string');
+      expect(() => JSON.parse(action.value.customBody)).not.toThrow();
+    }
+  });
+
+  it('Authorization header has headerSecure:true', () => {
+    const bundle = buildJiraBundle('owner', 'repo');
+    for (const rule of bundle.rules) {
+      const headers = rule.components[0]!.value.headers;
+      const authHeader = headers.find((h) => h.name === 'Authorization');
+      expect(authHeader).toBeDefined();
+      expect(authHeader?.headerSecure).toBe(true);
+    }
+  });
+
+  it('non-auth headers have headerSecure:false', () => {
+    const bundle = buildJiraBundle('owner', 'repo');
+    const headers = bundle.rules[0]!.components[0]!.value.headers;
+    for (const h of headers) {
+      if (h.name !== 'Authorization') {
+        expect(h.headerSecure).toBe(false);
+      }
+    }
+  });
+
+  it('dispatch URL uses correct owner and repo', () => {
+    const bundle = buildJiraBundle('my-owner', 'my-repo');
+    for (const rule of bundle.rules) {
+      expect(rule.components[0]!.value.url).toBe(
+        'https://api.github.com/repos/my-owner/my-repo/dispatches',
+      );
+    }
+  });
+
+  it('each rule has ruleScope with ARI placeholder', () => {
+    const bundle = buildJiraBundle('owner', 'repo');
+    for (const rule of bundle.rules) {
+      expect(rule.ruleScope.resources).toHaveLength(1);
+      expect(rule.ruleScope.resources[0]).toContain('YOUR_WORKSPACE_ID');
+    }
+  });
+});
 
 describe('stepJiraBundle', () => {
   let tmpDir: string;
@@ -21,40 +117,64 @@ describe('stepJiraBundle', () => {
     vi.clearAllMocks();
   });
 
-  it('writes ferry-jira-automation-rules.json to the repo root', () => {
+  it('writes ferry-jira-automation-rules.beta.json (not .json)', () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'ferry-jb-test-'));
     const result = stepJiraBundle(tmpDir, 'acme-corp', 'acme-app');
     expect(result.ok).toBe(true);
-    const outPath = join(tmpDir, 'ferry-jira-automation-rules.json');
-    expect(() => readFileSync(outPath, 'utf8')).not.toThrow();
+    const betaPath = join(tmpDir, 'ferry-jira-automation-rules.beta.json');
+    expect(() => readFileSync(betaPath, 'utf8')).not.toThrow();
+    // old filename must NOT be created
+    expect(() => readFileSync(join(tmpDir, 'ferry-jira-automation-rules.json'), 'utf8')).toThrow();
   });
 
-  it('output file contains valid JSON', () => {
+  it('writes ferry-jira-automation-setup.md manual fallback', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'ferry-jb-md-'));
+    stepJiraBundle(tmpDir, 'acme-corp', 'acme-app');
+    const mdPath = join(tmpDir, 'ferry-jira-automation-setup.md');
+    const content = readFileSync(mdPath, 'utf8');
+    expect(content).toContain('Manual Setup');
+    expect(content).toContain('acme-corp/acme-app');
+  });
+
+  it('JSON output is valid and contains 4 rules', () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'ferry-jb-json-'));
     stepJiraBundle(tmpDir, 'acme-corp', 'acme-app');
-    const content = readFileSync(join(tmpDir, 'ferry-jira-automation-rules.json'), 'utf8');
+    const content = readFileSync(
+      join(tmpDir, 'ferry-jira-automation-rules.beta.json'),
+      'utf8',
+    );
     expect(() => JSON.parse(content)).not.toThrow();
-  });
-
-  it('output JSON contains 4 automation rules', () => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'ferry-jb-rules-'));
-    stepJiraBundle(tmpDir, 'acme-corp', 'acme-app');
-    const content = readFileSync(join(tmpDir, 'ferry-jira-automation-rules.json'), 'utf8');
     const bundle = JSON.parse(content) as { rules: unknown[] };
     expect(bundle.rules).toHaveLength(4);
   });
 
-  it('dispatch URL uses correct owner and repo', () => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'ferry-jb-url-'));
-    stepJiraBundle(tmpDir, 'my-owner', 'my-repo');
-    const content = readFileSync(join(tmpDir, 'ferry-jira-automation-rules.json'), 'utf8');
-    expect(content).toContain('https://api.github.com/repos/my-owner/my-repo/dispatches');
-  });
-
-  it('output file ends with a newline', () => {
+  it('JSON output ends with a newline', () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'ferry-jb-nl-'));
     stepJiraBundle(tmpDir, 'acme-corp', 'acme-app');
-    const content = readFileSync(join(tmpDir, 'ferry-jira-automation-rules.json'), 'utf8');
+    const content = readFileSync(
+      join(tmpDir, 'ferry-jira-automation-rules.beta.json'),
+      'utf8',
+    );
     expect(content.endsWith('\n')).toBe(true);
+  });
+
+  it('markdown includes all 4 phase names', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'ferry-jb-phases-'));
+    stepJiraBundle(tmpDir, 'acme-corp', 'acme-app');
+    const content = readFileSync(join(tmpDir, 'ferry-jira-automation-setup.md'), 'utf8');
+    expect(content).toContain('Refinement');
+    expect(content).toContain('In Development');
+    expect(content).toContain('In Review');
+    expect(content).toContain('Iteration');
+  });
+
+  it('markdown does not contain a real Authorization token', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'ferry-jb-auth-'));
+    stepJiraBundle(tmpDir, 'acme-corp', 'acme-app');
+    const content = readFileSync(join(tmpDir, 'ferry-jira-automation-setup.md'), 'utf8');
+    // Must not contain a real GitHub PAT pattern (ghp_ prefix)
+    expect(content).not.toMatch(/ghp_[A-Za-z0-9]{36}/);
+    // Should only contain the placeholder
+    expect(content).toContain('YOUR_GITHUB_PAT_WITH_REPO_SCOPE');
   });
 });

--- a/src/cli/init/steps/jira-bundle.ts
+++ b/src/cli/init/steps/jira-bundle.ts
@@ -1,40 +1,62 @@
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { printSuccess, print } from '../prompt.js';
+import { printSuccess, printWarn, print } from '../prompt.js';
 import type { StepResult } from '../types.js';
 
-interface JiraWebRequestAction {
-  type: 'SEND_WEB_REQUEST';
-  value: {
-    url: string;
-    method: 'POST';
-    body: string;
-    headers: Array<{ name: string; value: string }>;
-    delayUnit: 'SECONDS';
-    delay: '0';
-    waitForResponse: false;
-  };
+// Placeholder for site-specific Atlassian Resource Identifier.
+// Users must replace with their actual workspace and project IDs.
+const ARI_PLACEHOLDER = 'ari:cloud:jira:YOUR_WORKSPACE_ID:project/YOUR_PROJECT_ID';
+
+interface JiraHeader {
+  name: string;
+  value: string;
+  headerSecure: boolean;
 }
 
-interface JiraTransitionTrigger {
-  type: 'ISSUE_TRANSITIONED';
-  value: {
-    fromStatusCategory?: string;
-    toStatus: { name: string };
-  };
+interface JiraActionValue {
+  url: string;
+  method: 'POST';
+  contentType: 'custom';
+  customBody: string;
+  headers: JiraHeader[];
+}
+
+interface JiraComponent {
+  component: 'ACTION';
+  type: 'jira.issue.outgoing.webhook';
+  value: JiraActionValue;
+  schemaVersion: 1;
+}
+
+interface JiraTriggerValue {
+  eventFilters: string[];
+  fromStatus: Array<{ type: 'NAME'; value: string }>;
+  toStatus: Array<{ type: 'NAME'; value: string }>;
+  eventKey: 'jira:issue_updated';
+  issueEvent: 'issue_generic';
+}
+
+interface JiraTrigger {
+  component: 'TRIGGER';
+  type: 'jira.issue.event.trigger:transitioned';
+  value: JiraTriggerValue;
+  schemaVersion: 1;
 }
 
 interface JiraRule {
   name: string;
   state: 'DISABLED';
-  trigger: JiraTransitionTrigger;
-  actions: JiraWebRequestAction[];
+  trigger: JiraTrigger;
+  components: JiraComponent[];
+  ruleScope: { resources: string[] };
+  labels: string[];
+  tags: string[];
+  canOtherRuleTrigger: boolean;
+  notifyOnError: 'FIRSTERROR';
 }
 
 interface JiraAutomationBundle {
   cloud: true;
-  version: 1;
-  type: 'AUTOMATION';
   rules: JiraRule[];
 }
 
@@ -49,7 +71,7 @@ export function buildJiraBundle(owner: string, repo: string): JiraAutomationBund
   const dispatchUrl = `https://api.github.com/repos/${owner}/${repo}/dispatches`;
 
   const rules: JiraRule[] = PHASES.map((phase) => {
-    const body = JSON.stringify({
+    const customBody = JSON.stringify({
       event_type: phase.eventType,
       client_payload: {
         phase: phase.label.toLowerCase(),
@@ -57,7 +79,7 @@ export function buildJiraBundle(owner: string, repo: string): JiraAutomationBund
         issue_type: '{{issue.issuetype.name}}',
         actor: '{{initiator.displayName}}',
         source: 'jira-column',
-        ts: '{{now.format("yyyy-MM-dd\'T\'HH:mm:ssXXX")}}',
+        ts: "{{now.format(\"yyyy-MM-dd'T'HH:mm:ssXXX\")}}",
       },
     });
 
@@ -65,54 +87,168 @@ export function buildJiraBundle(owner: string, repo: string): JiraAutomationBund
       name: `Ferry — ${phase.label} (column trigger)`,
       state: 'DISABLED',
       trigger: {
-        type: 'ISSUE_TRANSITIONED',
+        component: 'TRIGGER',
+        type: 'jira.issue.event.trigger:transitioned',
         value: {
-          toStatus: { name: phase.statusName },
+          eventFilters: [ARI_PLACEHOLDER],
+          fromStatus: [],
+          toStatus: [{ type: 'NAME', value: phase.statusName }],
+          eventKey: 'jira:issue_updated',
+          issueEvent: 'issue_generic',
         },
+        schemaVersion: 1,
       },
-      actions: [
+      components: [
         {
-          type: 'SEND_WEB_REQUEST',
+          component: 'ACTION',
+          type: 'jira.issue.outgoing.webhook',
           value: {
             url: dispatchUrl,
             method: 'POST',
-            body,
+            contentType: 'custom',
+            customBody,
             headers: [
-              { name: 'Accept', value: 'application/vnd.github+json' },
+              { name: 'Accept', value: 'application/vnd.github+json', headerSecure: false },
               {
                 name: 'Authorization',
+                // headerSecure: true so Jira treats this as a secret field
                 value: 'Bearer YOUR_GITHUB_PAT_WITH_REPO_SCOPE',
+                headerSecure: true,
               },
-              { name: 'X-GitHub-Api-Version', value: '2022-11-28' },
-              { name: 'Content-Type', value: 'application/json' },
+              { name: 'X-GitHub-Api-Version', value: '2022-11-28', headerSecure: false },
+              { name: 'Content-Type', value: 'application/json', headerSecure: false },
             ],
-            delayUnit: 'SECONDS',
-            delay: '0',
-            waitForResponse: false,
           },
+          schemaVersion: 1,
         },
       ],
+      ruleScope: { resources: [ARI_PLACEHOLDER] },
+      labels: [],
+      tags: [],
+      canOtherRuleTrigger: false,
+      notifyOnError: 'FIRSTERROR',
     };
   });
 
-  return { cloud: true, version: 1, type: 'AUTOMATION', rules };
+  return { cloud: true, rules };
+}
+
+function buildManualSetupDoc(owner: string, repo: string): string {
+  const dispatchUrl = `https://api.github.com/repos/${owner}/${repo}/dispatches`;
+
+  const rules = PHASES.map((phase) => {
+    const body = JSON.stringify(
+      {
+        event_type: phase.eventType,
+        client_payload: {
+          phase: phase.label.toLowerCase(),
+          ticket_key: '{{issue.key}}',
+          issue_type: '{{issue.issuetype.name}}',
+          actor: '{{initiator.displayName}}',
+          source: 'jira-column',
+          ts: "{{now.format(\"yyyy-MM-dd'T'HH:mm:ssXXX\")}}",
+        },
+      },
+      null,
+      2,
+    );
+
+    return `### Rule: Ferry — ${phase.label} (column trigger)
+
+**Trigger:** When: Issue → Status changed → To status: \`${phase.statusName}\`
+
+**Action:** Send web request
+- URL: \`${dispatchUrl}\`
+- Method: \`POST\`
+- Web request body: Custom data
+
+Headers:
+| Name | Value | Secret? |
+|------|-------|---------|
+| \`Accept\` | \`application/vnd.github+json\` | No |
+| \`Authorization\` | \`Bearer YOUR_GITHUB_PAT_WITH_REPO_SCOPE\` | **Yes** |
+| \`X-GitHub-Api-Version\` | \`2022-11-28\` | No |
+| \`Content-Type\` | \`application/json\` | No |
+
+Custom body:
+\`\`\`json
+${body}
+\`\`\`
+`;
+  });
+
+  return `# Ferry — Jira Automation Manual Setup
+
+This file was generated by \`ferry-init\` as a manual-setup fallback.
+Use it to create Jira Automation rules by hand if the JSON import does not work.
+
+> **Why manual?** The JSON import format changes between Jira Cloud versions.
+> Creating rules manually in the UI always works on every Jira tier (Free, Standard, Premium).
+
+## Prerequisites
+
+- A GitHub fine-grained Personal Access Token (PAT) with **Contents: write** permission
+  on \`${owner}/${repo}\`, OR a GitHub App installation token. Replace
+  \`YOUR_GITHUB_PAT_WITH_REPO_SCOPE\` in every rule below with that token.
+- Jira Automation enabled on your project (included in all Jira Cloud tiers).
+
+## Steps for each rule
+
+1. Go to your Jira project → **Project settings** → **Automation**
+2. Click **Create rule** (top-right)
+3. Add the trigger and action as described below
+4. Click **Save** — leave the rule **Disabled** until your column names match exactly
+5. Enable each rule once you have verified column names in your board
+
+> **Column names must match exactly.** Update the "To status" in each rule to match the
+> column names on your Jira board. The defaults below are suggestions.
+
+---
+
+${rules.join('\n---\n\n')}
+---
+
+## Security notes
+
+- Mark the \`Authorization\` header as **secret** in the Jira UI (toggle the lock icon).
+  This prevents the token from appearing in Jira audit logs.
+- Rotate your PAT if it is ever exposed.
+- Never commit a real token to this file — this file is safe to commit as-is since
+  it only contains the placeholder \`YOUR_GITHUB_PAT_WITH_REPO_SCOPE\`.
+
+## Verifying a rule works
+
+After enabling a rule, move a Jira issue to the target column and check:
+1. The Jira Automation audit log (Project settings → Automation → rule → Audit log)
+2. The GitHub Actions tab on \`${owner}/${repo}\` — a workflow run should appear within seconds.
+`;
 }
 
 export function stepJiraBundle(repoRoot: string, owner: string, repo: string): StepResult {
   const bundle = buildJiraBundle(owner, repo);
-  const outPath = join(repoRoot, 'ferry-jira-automation-rules.json');
-  writeFileSync(outPath, JSON.stringify(bundle, null, 2) + '\n', 'utf8');
+  const jsonPath = join(repoRoot, 'ferry-jira-automation-rules.beta.json');
+  writeFileSync(jsonPath, JSON.stringify(bundle, null, 2) + '\n', 'utf8');
 
-  printSuccess(`Generated ferry-jira-automation-rules.json`);
+  const mdPath = join(repoRoot, 'ferry-jira-automation-setup.md');
+  writeFileSync(mdPath, buildManualSetupDoc(owner, repo), 'utf8');
+
+  printSuccess(`Generated ferry-jira-automation-rules.beta.json`);
+  printSuccess(`Generated ferry-jira-automation-setup.md (manual fallback)`);
   print('');
-  print('  To import these Automation rules into Jira:');
-  print('  1. Jira → Project settings → Automation');
-  print('  2. Top-right menu → Import rules');
-  print('  3. Upload ferry-jira-automation-rules.json');
-  print('  4. Replace YOUR_GITHUB_PAT_WITH_REPO_SCOPE in each rule with a fine-grained PAT');
-  print('     that has Contents: write on your repo (or use a GitHub App installation token).');
-  print('  5. Set the "To status" in each rule to match your Jira column names exactly.');
-  print('  6. Enable each rule.');
+  printWarn('The JSON import is BETA — Jira Cloud\'s import format changes frequently.');
+  printWarn(
+    'Before importing the JSON, replace the two YOUR_* placeholders with your Jira',
+  );
+  printWarn('workspace ID and project ID (see ferry-jira-automation-setup.md for details).');
+  print('');
+  print('  Option A — JSON import (beta):');
+  print('    1. Jira → Project settings → Automation → Import rules (top-right menu)');
+  print('    2. Upload ferry-jira-automation-rules.beta.json');
+  print('    3. Replace YOUR_GITHUB_PAT_WITH_REPO_SCOPE in each rule');
+  print('    4. Enable each rule');
+  print('');
+  print('  Option B — Manual setup (recommended):');
+  print('    Follow ferry-jira-automation-setup.md — step-by-step UI walkthrough');
 
   return { ok: true };
 }


### PR DESCRIPTION
Closes #119

## Summary

- Fix Jira automation JSON schema to match real Jira Cloud export format (correct trigger/action types, remove bogus fields)
- Rename output to `ferry-jira-automation-rules.beta.json` with a clear beta warning
- Always generate `ferry-jira-automation-setup.md` as a manual fallback with step-by-step Jira UI instructions
- Mark Authorization header as `headerSecure: true`

Generated with [Claude Code](https://claude.ai/code)