### PR TITLE
feat: ferry-init: make Jira status names configurable

### DIFF
--- a/docs/CONSUMER-SETUP.md
+++ b/docs/CONSUMER-SETUP.md
@@ -43,9 +43,9 @@ Four agents chain automatically:
 
 ### 1.2 — Verify Jira columns
 
-Ferry expects the Jira board to use these exact column names for each phase:
+Ferry's Jira Automation rules trigger on status names that you supply to `ferry-init`. The wizard prompts for each name with sensible defaults:
 
-| Column name (exact)   | Phase triggered                          |
+| Default column name   | Phase triggered                          |
 | --------------------- | ---------------------------------------- |
 | **Refinement**        | Refiner agent                            |
 | **In Development**    | Developer agent                          |
@@ -53,7 +53,9 @@ Ferry expects the Jira board to use these exact column names for each phase:
 | **Changes Requested** | Iterator agent (auto-set by FR24)        |
 | **Ready to Merge**    | Human review + merge                     |
 
-✅ **Verification:** Open your board → confirm these 5 columns exist. If not, add them via **Project Settings → Board → Columns**. Column names are case-sensitive — use the exact names above.
+If your Jira project already uses different status names, enter them when the wizard asks — the generated automation rules will use whatever names you provide. Column names are case-sensitive and must match exactly what appears in your Jira board.
+
+✅ **Verification:** Open your board → confirm the 5 columns exist (using either the default names or your custom names). If any are missing, add them via **Project Settings → Board → Columns**.
 
 ---
 
@@ -455,7 +457,7 @@ Phase 7 — Operations setup  [ ] ferry-reconcile.yml copied and pushed (§7.5 �
 | "Action not found: `./.github/actions/ferry-*`" | You copied Ferry's internal workflows. Use the consumer stubs from `examples/consumer-setup/workflows/`                                     |
 | "Resource not accessible by integration"        | Repo workflow permissions ceiling too low — enable **Read and write permissions** under Settings → Actions → General                        |
 | Review workflow hangs (never starts jobs)       | Remove any `concurrency:` block in your consumer `ferry-review.yml` — it causes a deadlock; concurrency is managed by the reusable workflow |
-| Preflight fails: "Jira column mismatch"         | Your board column names don't match exactly — see Phase 1.2 for the required names                                                          |
+| Preflight fails: "Jira column mismatch"         | Your board column names don't match what you gave `ferry-init` — see Phase 1.2; re-run `ferry-init` with the correct names if needed        |
 
 ---
 

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -7,7 +7,7 @@ import { workflowTemplates } from './templates.js';
 import { stepGitHubApp } from './steps/github-app.js';
 import { buildSecrets, stepSecrets } from './steps/secrets.js';
 import { installWorkflows, scaffoldCodeowners } from './steps/workflows.js';
-import { stepJiraBundle } from './steps/jira-bundle.js';
+import { stepJiraBundle, DEFAULT_STATUS_NAMES } from './steps/jira-bundle.js';
 import { resolveJiraWorkspaceId, resolveJiraProjectId } from './steps/jira-resolve.js';
 import { stepVerify } from './steps/verify.js';
 import type { FerryConfig } from './types.js';
@@ -126,6 +126,13 @@ async function main(): Promise<void> {
   }
 
   print('');
+  print('Jira column names (press Enter to accept defaults):');
+  const refineStatus = await ask('Refiner trigger status', DEFAULT_STATUS_NAMES.refine);
+  const devStatus = await ask('Developer trigger status', DEFAULT_STATUS_NAMES.dev);
+  const reviewStatus = await ask('Reviewer trigger status', DEFAULT_STATUS_NAMES.review);
+  const iterateStatus = await ask('Iterator trigger status', DEFAULT_STATUS_NAMES.iterate);
+
+  print('');
   print('LLM provider:');
   const anthropicApiKey = await ask('Anthropic API key (sk-ant-...)');
 
@@ -164,7 +171,12 @@ async function main(): Promise<void> {
 
   // ── Step 4: Jira automation bundle ────────────────────────────────────────
   printStep(4, TOTAL_STEPS, 'Generating Jira Automation import bundle');
-  stepJiraBundle(repoRoot, owner, repo, config.jiraWorkspaceId, config.jiraProjectId);
+  stepJiraBundle(repoRoot, owner, repo, config.jiraWorkspaceId, config.jiraProjectId, {
+    refine: refineStatus || DEFAULT_STATUS_NAMES.refine,
+    dev: devStatus || DEFAULT_STATUS_NAMES.dev,
+    review: reviewStatus || DEFAULT_STATUS_NAMES.review,
+    iterate: iterateStatus || DEFAULT_STATUS_NAMES.iterate,
+  });
 
   // ── Step 5: Verify ────────────────────────────────────────────────────────
   printStep(5, TOTAL_STEPS, 'Verifying provider API key');

--- a/src/cli/init/init.test.ts
+++ b/src/cli/init/init.test.ts
@@ -112,7 +112,7 @@ describe('buildJiraBundle', () => {
     expect(statuses).toContain('Refinement');
     expect(statuses).toContain('In Development');
     expect(statuses).toContain('In Review');
-    expect(statuses).toContain('Iteration');
+    expect(statuses).toContain('Changes Requested');
   });
 });
 

--- a/src/cli/init/steps/jira-bundle.test.ts
+++ b/src/cli/init/steps/jira-bundle.test.ts
@@ -11,7 +11,7 @@ vi.mock('../prompt.js', () => ({
   printError: vi.fn(),
 }));
 
-import { buildJiraBundle, stepJiraBundle } from './jira-bundle.js';
+import { buildJiraBundle, stepJiraBundle, DEFAULT_STATUS_NAMES } from './jira-bundle.js';
 
 const WORKSPACE_ID = '75eb33f5-5dd0-4328-b0e6-8bb3f4e0af91';
 const PROJECT_ID = '10033';
@@ -52,7 +52,32 @@ describe('buildJiraBundle', () => {
     const bundle = buildJiraBundle('owner', 'repo', WORKSPACE_ID, PROJECT_ID);
     const firstRule = bundle.rules[0]!;
     expect(Array.isArray(firstRule.trigger.value.toStatus)).toBe(true);
-    expect(firstRule.trigger.value.toStatus[0]).toEqual({ type: 'NAME', value: 'Refinement' });
+    expect(firstRule.trigger.value.toStatus[0]).toEqual({
+      type: 'NAME',
+      value: DEFAULT_STATUS_NAMES.refine,
+    });
+  });
+
+  it('uses custom status names when provided', () => {
+    const custom = {
+      refine: 'Ready for Refine',
+      dev: 'Ready for Dev',
+      review: 'Awaiting Review',
+      iterate: 'Needs Changes',
+    };
+    const bundle = buildJiraBundle('owner', 'repo', WORKSPACE_ID, PROJECT_ID, custom);
+    const statuses = bundle.rules.map((r) => r.trigger.value.toStatus[0]?.value);
+    expect(statuses).toContain('Ready for Refine');
+    expect(statuses).toContain('Ready for Dev');
+    expect(statuses).toContain('Awaiting Review');
+    expect(statuses).toContain('Needs Changes');
+  });
+
+  it('default iterate status is Changes Requested not Iteration', () => {
+    const bundle = buildJiraBundle('owner', 'repo', WORKSPACE_ID, PROJECT_ID);
+    const statuses = bundle.rules.map((r) => r.trigger.value.toStatus[0]?.value);
+    expect(statuses).toContain('Changes Requested');
+    expect(statuses).not.toContain('Iteration');
   });
 
   it('trigger value has required event fields', () => {
@@ -172,14 +197,30 @@ describe('stepJiraBundle', () => {
     expect(content.endsWith('\n')).toBe(true);
   });
 
-  it('markdown includes all 4 phase names', () => {
+  it('markdown includes all 4 default phase status names', () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'ferry-jb-phases-'));
     stepJiraBundle(tmpDir, 'acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID);
     const content = readFileSync(join(tmpDir, 'ferry-jira-automation-setup.md'), 'utf8');
     expect(content).toContain('Refinement');
     expect(content).toContain('In Development');
     expect(content).toContain('In Review');
-    expect(content).toContain('Iteration');
+    expect(content).toContain('Changes Requested');
+  });
+
+  it('markdown uses custom status names when provided', () => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'ferry-jb-custom-'));
+    const custom = {
+      refine: 'Backlog Refine',
+      dev: 'Ready for Dev',
+      review: 'Awaiting Review',
+      iterate: 'Needs Rework',
+    };
+    stepJiraBundle(tmpDir, 'acme-corp', 'acme-app', WORKSPACE_ID, PROJECT_ID, custom);
+    const content = readFileSync(join(tmpDir, 'ferry-jira-automation-setup.md'), 'utf8');
+    expect(content).toContain('Backlog Refine');
+    expect(content).toContain('Ready for Dev');
+    expect(content).toContain('Awaiting Review');
+    expect(content).toContain('Needs Rework');
   });
 
   it('markdown does not contain a real Authorization token', () => {

--- a/src/cli/init/steps/jira-bundle.ts
+++ b/src/cli/init/steps/jira-bundle.ts
@@ -56,23 +56,40 @@ interface JiraAutomationBundle {
   rules: JiraRule[];
 }
 
-const PHASES = [
-  { eventType: 'ferry-refine', statusName: 'Refinement', label: 'Refine' },
-  { eventType: 'ferry-dev', statusName: 'In Development', label: 'Dev' },
-  { eventType: 'ferry-review', statusName: 'In Review', label: 'Review' },
-  { eventType: 'ferry-iterate', statusName: 'Iteration', label: 'Iterate' },
-] as const;
+export interface StatusNames {
+  refine: string;
+  dev: string;
+  review: string;
+  iterate: string;
+}
+
+export const DEFAULT_STATUS_NAMES: StatusNames = {
+  refine: 'Refinement',
+  dev: 'In Development',
+  review: 'In Review',
+  iterate: 'Changes Requested',
+};
+
+function buildPhases(statusNames: StatusNames) {
+  return [
+    { eventType: 'ferry-refine', statusName: statusNames.refine, label: 'Refine' },
+    { eventType: 'ferry-dev', statusName: statusNames.dev, label: 'Dev' },
+    { eventType: 'ferry-review', statusName: statusNames.review, label: 'Review' },
+    { eventType: 'ferry-iterate', statusName: statusNames.iterate, label: 'Iterate' },
+  ] as const;
+}
 
 export function buildJiraBundle(
   owner: string,
   repo: string,
   workspaceId: string,
   projectId: string,
+  statusNames: StatusNames = DEFAULT_STATUS_NAMES,
 ): JiraAutomationBundle {
   const dispatchUrl = `https://api.github.com/repos/${owner}/${repo}/dispatches`;
   const ari = `ari:cloud:jira:${workspaceId}:project/${projectId}`;
 
-  const rules: JiraRule[] = PHASES.map((phase) => {
+  const rules: JiraRule[] = buildPhases(statusNames).map((phase) => {
     const customBody = JSON.stringify({
       event_type: phase.eventType,
       client_payload: {
@@ -135,10 +152,14 @@ export function buildJiraBundle(
   return { cloud: true, rules };
 }
 
-function buildManualSetupDoc(owner: string, repo: string): string {
+function buildManualSetupDoc(
+  owner: string,
+  repo: string,
+  statusNames: StatusNames = DEFAULT_STATUS_NAMES,
+): string {
   const dispatchUrl = `https://api.github.com/repos/${owner}/${repo}/dispatches`;
 
-  const rules = PHASES.map((phase) => {
+  const rules = buildPhases(statusNames).map((phase) => {
     const body = JSON.stringify(
       {
         event_type: phase.eventType,
@@ -232,13 +253,14 @@ export function stepJiraBundle(
   repo: string,
   workspaceId: string,
   projectId: string,
+  statusNames: StatusNames = DEFAULT_STATUS_NAMES,
 ): StepResult {
-  const bundle = buildJiraBundle(owner, repo, workspaceId, projectId);
+  const bundle = buildJiraBundle(owner, repo, workspaceId, projectId, statusNames);
   const jsonPath = join(repoRoot, 'ferry-jira-automation-rules.beta.json');
   writeFileSync(jsonPath, JSON.stringify(bundle, null, 2) + '\n', 'utf8');
 
   const mdPath = join(repoRoot, 'ferry-jira-automation-setup.md');
-  writeFileSync(mdPath, buildManualSetupDoc(owner, repo), 'utf8');
+  writeFileSync(mdPath, buildManualSetupDoc(owner, repo, statusNames), 'utf8');
 
   printSuccess(`Generated ferry-jira-automation-rules.beta.json`);
   printSuccess(`Generated ferry-jira-automation-setup.md (manual fallback)`);


### PR DESCRIPTION
Fixes #122

Wizard now prompts for the 4 Jira status names with documented defaults instead of hardcoding them, so consumers with existing workflows don't need to rename their Jira statuses.

**Changes:**
- Add `StatusNames` interface and `DEFAULT_STATUS_NAMES` to `jira-bundle.ts`
- `buildJiraBundle()` and `stepJiraBundle()` accept optional `statusNames` param (backward-compatible defaults)
- ferry-init wizard prompts for each name before the LLM key step
- Fix long-standing bug: default iterate status was `'Iteration'`, now `'Changes Requested'`
- Tests cover custom names and corrected default
- Docs §1.2 updated to describe wizard-driven constraint

Generated with [Claude Code](https://claude.ai/code)