### PR TITLE
feat(ferry-init): emit @v1 stubs and add retag-major.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,3 +101,6 @@ jobs:
           gh release create "v${{ steps.notes.outputs.version }}" \
             --title "v${{ steps.notes.outputs.version }}" \
             --generate-notes
+
+      - name: Update moving major tag
+        run: bash scripts/retag-major.sh "${{ github.ref_name }}"

--- a/scripts/retag-major.sh
+++ b/scripts/retag-major.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Force-update the moving Actions-style major tag (e.g. v1) to the commit
+# pointed to by the semver tag passed as $1.
+#
+# Usage: scripts/retag-major.sh v0.3.0
+#
+# Wire this into .github/workflows/release.yml after "Create GitHub Release":
+#
+#   - name: Update moving major tag
+#     run: bash scripts/retag-major.sh "${{ github.ref_name }}"
+#
+# Mapping convention: v0.x.x releases move the v1 tag (pre-1.0 line).
+# v1.x.x releases move v1, v2.x.x move v2, and so on.
+set -euo pipefail
+
+TAG="${1:?Usage: retag-major.sh <semver-tag> (e.g. v0.3.0)}"
+COMMIT=$(git rev-list -n1 "$TAG")
+
+VERSION_CORE="${TAG#v}"
+MAJOR="${VERSION_CORE%%.*}"
+
+if [ "$MAJOR" -eq 0 ]; then
+  MAJOR_TAG="v1"
+else
+  MAJOR_TAG="v${MAJOR}"
+fi
+
+git tag --force "$MAJOR_TAG" "$COMMIT"
+git push --force origin "refs/tags/${MAJOR_TAG}"
+echo "Moved ${MAJOR_TAG} → ${COMMIT} (released as ${TAG})"

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import { createRequire } from 'node:module';
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 import { ask, confirm, closePrompt, print, printStep, printSuccess, printError } from './prompt.js';
@@ -12,8 +11,6 @@ import { resolveJiraWorkspaceId, resolveJiraProjectId } from './steps/jira-resol
 import { stepVerify } from './steps/verify.js';
 import type { FerryConfig } from './types.js';
 
-const _require = createRequire(import.meta.url);
-const { version: pkgVersion } = _require('../../../package.json') as { version: string };
 const FERRY_VERSION_DEFAULT = 'v1';
 
 const TOTAL_STEPS = 5;

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -14,7 +14,7 @@ import type { FerryConfig } from './types.js';
 
 const _require = createRequire(import.meta.url);
 const { version: pkgVersion } = _require('../../../package.json') as { version: string };
-const FERRY_VERSION_DEFAULT = `v${pkgVersion}`;
+const FERRY_VERSION_DEFAULT = 'v1';
 
 const TOTAL_STEPS = 5;
 


### PR DESCRIPTION
Closes #125.

- `ferry-init` now defaults to `v1` instead of the specific semver tag, so scaffolded consumer workflows reference `@v1` and auto-update without manual edits on each release.
- `scripts/retag-major.sh` force-updates the moving major tag (`v1` for `v0.x.x` releases) after each release.

> [!NOTE]
> One manual step required: add `bash scripts/retag-major.sh "${{ github.ref_name }}"` to `.github/workflows/release.yml` after the release creation steps.

Generated with [Claude Code](https://claude.ai/code)