### PR TITLE
docs: clarify Developer branch name format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Ferry connects your Jira board to a fully autonomous dev loop — Refiner, Devel
 | Phase         | Jira column    | What the agent does                                            |
 | ------------- | -------------- | -------------------------------------------------------------- |
 | **Refiner**   | Refinement     | Reads the ticket, creates sub-tasks, awaits human approval     |
-| **Developer** | In Development | Reads approved sub-tasks, opens a draft PR on `ferry/<ticket>` |
+| **Developer** | In Development | Reads approved sub-tasks, opens a draft PR on `ferry/<TICKET-KEY>` (e.g. `ferry/PROJ-42`) |
 | **Reviewer**  | In Review      | Reads PR diff (green CI only), posts fingerprinted findings    |
 | **Iterator**  | Iteration      | Applies findings, re-triggers Reviewer (max 3 rounds)          |
 
@@ -57,7 +57,7 @@ Jira column move / label / @mention
         ↓
   ┌─────────────┐
   │   Refiner   │  → reads ticket → creates sub-tasks → awaits human approval
-  │  Developer  │  → reads sub-tasks → opens draft PR on ferry/<ticket> branch
+  │  Developer  │  → reads sub-tasks → opens draft PR on ferry/<TICKET-KEY> branch
   │  Reviewer   │  → reads PR diff (green CI only) → posts fingerprinted findings
   │  Iterator   │  → applies findings → re-triggers Reviewer (max 3 rounds)
   └─────────────┘


### PR DESCRIPTION
Replace ambiguous `ferry/<ticket>` with `ferry/<TICKET-KEY>` and add a concrete example (`ferry/PROJ-42`) at README.md:43 and README.md:60, to match the hardcoded format in dev-action.ts:74.

Closes #136

Generated with [Claude Code](https://claude.ai/code)