### PR TITLE
docs: surface limits.max_iterations as configurable (issue #140)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Ferry connects your Jira board to a fully autonomous dev loop — Refiner, Devel
 | **Refiner**   | Refinement     | Reads the ticket, creates sub-tasks, awaits human approval     |
 | **Developer** | In Development | Reads approved sub-tasks, opens a draft PR on `ferry/<ticket>` |
 | **Reviewer**  | In Review      | Reads PR diff (green CI only), posts fingerprinted findings    |
-| **Iterator**  | Iteration      | Applies findings, re-triggers Reviewer (max 3 rounds)          |
+| **Iterator**  | Iteration      | Applies findings, re-triggers Reviewer (max 3 rounds by default; configurable via `limits.max_iterations`) |
 
 ---
 
@@ -59,7 +59,7 @@ Jira column move / label / @mention
   │   Refiner   │  → reads ticket → creates sub-tasks → awaits human approval
   │  Developer  │  → reads sub-tasks → opens draft PR on ferry/<ticket> branch
   │  Reviewer   │  → reads PR diff (green CI only) → posts fingerprinted findings
-  │  Iterator   │  → applies findings → re-triggers Reviewer (max 3 rounds)
+  │  Iterator   │  → applies findings → re-triggers Reviewer (max limits.max_iterations rounds, default 3)
   └─────────────┘
         ↓
   Human merges PR

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -134,7 +134,7 @@ All `limits.*` fields are optional and accept positive numbers.
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `limits.max_iterations` | `3` | Maximum review→iterate cycles before Ferry stops and marks the ticket as needing human review |
+| `limits.max_iterations` | `3` | **Integer, ≥ 1; recommended range 1–10.** Number of review→iterate cycles the Iterator runs before Ferry halts. When the cap is exceeded while findings remain, Ferry throws an oscillation error and stops — the ticket stays in its current Jira column for manual resolution. |
 | `limits.max_agent_iterations` | `200` | Internal LLM agent loop cap per single agent run (guards against runaway tool-call loops) |
 | `limits.max_tokens_per_run` | `500000` | Input token budget per agent run (overridden by `FERRY_ITER_MAX_INPUT_TOKENS` for Iterator) |
 | `limits.max_tokens_per_message` | `16384` | Maximum output tokens per individual LLM API call |

--- a/src/cli/doctor/checks/config.ts
+++ b/src/cli/doctor/checks/config.ts
@@ -8,10 +8,9 @@ export function checkConfigLimits(opts: { repoRoot: string }): CheckResult {
   const { repoRoot } = opts;
 
   const jsonPath = join(repoRoot, 'ferry.config.json');
-  const yamlPath =
-    existsSync(join(repoRoot, 'ferry.config.yaml'))
-      ? join(repoRoot, 'ferry.config.yaml')
-      : join(repoRoot, 'ferry.config.yml');
+  const yamlPath = existsSync(join(repoRoot, 'ferry.config.yaml'))
+    ? join(repoRoot, 'ferry.config.yaml')
+    : join(repoRoot, 'ferry.config.yml');
 
   const hasJson = existsSync(jsonPath);
   const hasYaml = !hasJson && existsSync(yamlPath);

--- a/src/cli/doctor/checks/config.ts
+++ b/src/cli/doctor/checks/config.ts
@@ -1,0 +1,81 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { CheckResult } from '../types.js';
+
+const MAX_ITERATIONS_SOFT_CEILING = 10;
+
+export function checkConfigLimits(opts: { repoRoot: string }): CheckResult {
+  const { repoRoot } = opts;
+
+  const jsonPath = join(repoRoot, 'ferry.config.json');
+  const yamlPath =
+    existsSync(join(repoRoot, 'ferry.config.yaml'))
+      ? join(repoRoot, 'ferry.config.yaml')
+      : join(repoRoot, 'ferry.config.yml');
+
+  const hasJson = existsSync(jsonPath);
+  const hasYaml = !hasJson && existsSync(yamlPath);
+
+  if (!hasJson && !hasYaml) {
+    return {
+      label: 'Config limits',
+      status: 'green',
+      detail: 'No ferry.config.* found — using defaults (limits.max_iterations: 3)',
+    };
+  }
+
+  if (hasYaml) {
+    return {
+      label: 'Config limits',
+      status: 'skip',
+      detail: 'YAML config detected — limit checks only run for ferry.config.json',
+    };
+  }
+
+  let raw: Record<string, unknown>;
+  try {
+    raw = JSON.parse(readFileSync(jsonPath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return {
+      label: 'Config limits',
+      status: 'yellow',
+      detail: 'ferry.config.json could not be parsed — skipping limit checks',
+      remedy: 'Ensure ferry.config.json contains valid JSON',
+    };
+  }
+
+  const limits = raw.limits as Record<string, unknown> | undefined;
+  if (!limits || typeof limits['max_iterations'] === 'undefined') {
+    return {
+      label: 'Config limits',
+      status: 'green',
+      detail: 'limits.max_iterations not set — using default (3)',
+    };
+  }
+
+  const val = limits['max_iterations'];
+
+  if (typeof val !== 'number' || !Number.isInteger(val) || val < 1) {
+    return {
+      label: 'Config limits',
+      status: 'red',
+      detail: `limits.max_iterations must be a positive integer, got: ${String(val)}`,
+      remedy: 'Set limits.max_iterations to a positive integer in the range 1–10',
+    };
+  }
+
+  if (val > MAX_ITERATIONS_SOFT_CEILING) {
+    return {
+      label: 'Config limits',
+      status: 'yellow',
+      detail: `limits.max_iterations = ${val} is unusually high (recommended: 1–${MAX_ITERATIONS_SOFT_CEILING}). High values risk runaway review cycles.`,
+      remedy: `Consider lowering limits.max_iterations to ${MAX_ITERATIONS_SOFT_CEILING} or below`,
+    };
+  }
+
+  return {
+    label: 'Config limits',
+    status: 'green',
+    detail: `limits.max_iterations = ${val} (within recommended range 1–${MAX_ITERATIONS_SOFT_CEILING})`,
+  };
+}

--- a/src/cli/doctor/doctor.test.ts
+++ b/src/cli/doctor/doctor.test.ts
@@ -6,6 +6,7 @@ import { generateKeyPairSync } from 'node:crypto';
 import { renderTable } from './table.js';
 import { checkWorkflowDrift } from './checks/workflows.js';
 import { checkPromptOverrides } from './checks/prompts.js';
+import { checkConfigLimits } from './checks/config.js';
 import { listRepoSecrets } from './checks/secrets.js';
 import { makeAppJwt } from './checks/github-app.js';
 import type { CheckResult } from './types.js';
@@ -271,5 +272,82 @@ describe('makeAppJwt', () => {
     };
     expect(payload.iss).toBe('42');
     expect(payload.exp).toBeGreaterThan(payload.iat);
+  });
+});
+
+// ── checkConfigLimits ─────────────────────────────────────────────────────────
+
+describe('checkConfigLimits', () => {
+  function makeRoot(config?: Record<string, unknown>): string {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'ferry-doctor-config-'));
+    if (config !== undefined) {
+      writeFileSync(join(repoRoot, 'ferry.config.json'), JSON.stringify(config), 'utf8');
+    }
+    return repoRoot;
+  }
+
+  it('returns green when no config file exists', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'ferry-doctor-noconfig-'));
+    const result = checkConfigLimits({ repoRoot });
+    expect(result.status).toBe('green');
+    expect(result.detail).toContain('defaults');
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it('returns green when limits.max_iterations is not set', () => {
+    const repoRoot = makeRoot({ models: {} });
+    const result = checkConfigLimits({ repoRoot });
+    expect(result.status).toBe('green');
+    expect(result.detail).toContain('default');
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it('returns green for a value in the recommended range', () => {
+    const repoRoot = makeRoot({ limits: { max_iterations: 5 } });
+    const result = checkConfigLimits({ repoRoot });
+    expect(result.status).toBe('green');
+    expect(result.detail).toContain('5');
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it('returns yellow when max_iterations exceeds the soft ceiling', () => {
+    const repoRoot = makeRoot({ limits: { max_iterations: 15 } });
+    const result = checkConfigLimits({ repoRoot });
+    expect(result.status).toBe('yellow');
+    expect(result.detail).toContain('15');
+    expect(result.remedy).toBeTruthy();
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it('returns red when max_iterations is less than 1', () => {
+    const repoRoot = makeRoot({ limits: { max_iterations: 0 } });
+    const result = checkConfigLimits({ repoRoot });
+    expect(result.status).toBe('red');
+    expect(result.detail).toContain('0');
+    expect(result.remedy).toBeTruthy();
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it('returns red when max_iterations is not an integer', () => {
+    const repoRoot = makeRoot({ limits: { max_iterations: 2.5 } });
+    const result = checkConfigLimits({ repoRoot });
+    expect(result.status).toBe('red');
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it('returns yellow when config JSON is malformed', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'ferry-doctor-badjson-'));
+    writeFileSync(join(repoRoot, 'ferry.config.json'), '{ not valid json', 'utf8');
+    const result = checkConfigLimits({ repoRoot });
+    expect(result.status).toBe('yellow');
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it('returns skip for a YAML config file', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'ferry-doctor-yaml-'));
+    writeFileSync(join(repoRoot, 'ferry.config.yaml'), 'limits:\n  max_iterations: 3\n', 'utf8');
+    const result = checkConfigLimits({ repoRoot });
+    expect(result.status).toBe('skip');
+    rmSync(repoRoot, { recursive: true, force: true });
   });
 });

--- a/src/cli/doctor/index.ts
+++ b/src/cli/doctor/index.ts
@@ -10,6 +10,7 @@ import { checkSyntheticDispatch } from './checks/dispatch.js';
 import { checkWorkflowDrift } from './checks/workflows.js';
 import { checkPromptOverrides } from './checks/prompts.js';
 import { checkUpdateAvailable } from './checks/update-available.js';
+import { checkConfigLimits } from './checks/config.js';
 import { renderTable } from './table.js';
 import type { DoctorConfig } from './types.js';
 
@@ -108,6 +109,7 @@ Checks run in order:
   6. Workflow files         — compare .github/workflows/ferry-*.yml vs current release
   7. Prompt overrides       — warn on full prompts/<agent>.md overrides; suggest .extra.md
   8. Update available       — compare pinned ref in workflows to latest npm release
+  9. Config limits          — warn if limits.max_iterations is outside the recommended range (1–10)
 
 Exit code: 0 if all checks green/yellow, 1 if any check red.
 `);
@@ -143,6 +145,7 @@ Exit code: 0 if all checks green/yellow, 1 if any check red.
     checkWorkflowDrift({ repoRoot: config.repoRoot, ferryVersion: config.ferryVersion }),
     checkPromptOverrides({ repoRoot: config.repoRoot }),
     checkUpdateAvailable({ repoRoot: config.repoRoot }),
+    checkConfigLimits({ repoRoot: config.repoRoot }),
   ]);
 
   process.stdout.write(renderTable(results));


### PR DESCRIPTION
Closes #140

## Changes

- `README.md`: agent table and diagram now reference `limits.max_iterations` instead of presenting the 3-round cap as hardcoded
- `docs/CONFIGURATION.md`: enriched `limits.max_iterations` entry with type, recommended range (1–10), and what happens when the cap is hit
- `src/cli/doctor/checks/config.ts`: new ferry-doctor check that warns when `limits.max_iterations` is outside the recommended range
- `src/cli/doctor/doctor.test.ts`: 8 new tests for the config limits check

Generated with [Claude Code](https://claude.ai/code)