### PR TITLE
feat(init): mask secret input in wizard + clarify README Step 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,20 +121,23 @@ Note the returned issue number, then set the variable:
 gh variable set FERRY_AUDIT_ISSUE --body "<issue-number>"
 ```
 
-### Step 2 — Set the 6 required secrets
+### Step 2 — Verify secrets
+
+> **If you ran `ferry-init`**, the wizard already set these six secrets via `gh secret set` (with masked input):
+> `FERRY_APP_ID`, `FERRY_PRIVATE_KEY`, `FERRY_JIRA_BASE_URL`, `FERRY_JIRA_EMAIL`, `FERRY_JIRA_API_TOKEN`, `ANTHROPIC_API_KEY`
+>
+> Verify: `gh secret list --repo YOUR_ORG/YOUR_REPO | grep FERRY` must show all 6 secrets.
+
+**If you skipped the wizard or need to re-set any value**, run the relevant commands manually:
 
 ```bash
+gh secret set FERRY_APP_ID                --body "<github-app-numeric-id>"
+gh secret set FERRY_PRIVATE_KEY           --body "$(cat ferry-app.private-key.pem)"
 gh secret set FERRY_JIRA_BASE_URL         --body "https://YOUR-ORG.atlassian.net"
 gh secret set FERRY_JIRA_EMAIL            --body "you@example.com"
 gh secret set FERRY_JIRA_API_TOKEN        --body "<atlassian-api-token>"
 gh secret set ANTHROPIC_API_KEY           --body "<sk-ant-...>"
-gh secret set FERRY_REVIEW_TRANSITION_ID  --body "<jira-transition-id-for-In-Review>"
-gh secret set FERRY_ITER_TRANSITION_ID    --body "<jira-transition-id-for-Changes-Requested>"
 ```
-
-Verify: `gh secret list --repo YOUR_ORG/YOUR_REPO | grep FERRY` must show 6 secrets and 1 variable.
-
-> **Finding Jira transition IDs:** Run `curl -u you@example.com:<token> https://YOUR-ORG.atlassian.net/rest/api/3/issue/PROJ-1/transitions`. Note the numeric `id` for the "In Review" and "Changes Requested" transitions.
 
 ### Step 3 — Enable workflow permissions
 
@@ -211,8 +214,9 @@ Quick install checklist:
 
 ```
 [ ] Audit issue created + FERRY_AUDIT_ISSUE variable set
-[ ] 6 secrets set (FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN,
-    ANTHROPIC_API_KEY, FERRY_REVIEW_TRANSITION_ID, FERRY_ITER_TRANSITION_ID)
+[ ] 6 secrets confirmed (ferry-init sets them; verify with: gh secret list | grep FERRY)
+    FERRY_APP_ID, FERRY_PRIVATE_KEY, FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL,
+    FERRY_JIRA_API_TOKEN, ANTHROPIC_API_KEY
 [ ] Workflow permissions = read+write
 [ ] 4 Jira automation rules created and enabled
 [ ] Smoke test passed (ferry-refine green, draft PR opened)

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ gh secret set FERRY_JIRA_BASE_URL         --body "https://YOUR-ORG.atlassian.net
 gh secret set FERRY_JIRA_EMAIL            --body "you@example.com"
 gh secret set FERRY_JIRA_API_TOKEN        --body "<atlassian-api-token>"
 gh secret set ANTHROPIC_API_KEY           --body "<sk-ant-...>"
+gh secret set FERRY_REVIEW_TRANSITION_ID  --body "<jira-transition-id-to-in-review>"
+gh secret set FERRY_ITER_TRANSITION_ID    --body "<jira-transition-id-to-changes-requested>"
 ```
 
 ### Step 3 — Enable workflow permissions

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -1,7 +1,16 @@
 #!/usr/bin/env node
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
-import { ask, confirm, closePrompt, print, printStep, printSuccess, printError } from './prompt.js';
+import {
+  ask,
+  askSecret,
+  confirm,
+  closePrompt,
+  print,
+  printStep,
+  printSuccess,
+  printError,
+} from './prompt.js';
 import { workflowTemplates } from './templates.js';
 import { stepGitHubApp } from './steps/github-app.js';
 import { buildSecrets, stepSecrets } from './steps/secrets.js';
@@ -89,7 +98,7 @@ async function main(): Promise<void> {
   print('Jira credentials:');
   const jiraBaseUrl = await ask('Jira base URL (e.g. https://acme.atlassian.net)');
   const jiraEmail = await ask('Jira account email');
-  const jiraApiToken = await ask(
+  const jiraApiToken = await askSecret(
     'Jira API token (from https://id.atlassian.com/manage-profile/security/api-tokens)',
   );
   const jiraProjectKey = await ask('Jira project key (e.g. CHAN, PROJ)');
@@ -131,7 +140,7 @@ async function main(): Promise<void> {
 
   print('');
   print('LLM provider:');
-  const anthropicApiKey = await ask('Anthropic API key (sk-ant-...)');
+  const anthropicApiKey = await askSecret('Anthropic API key (sk-ant-...)');
 
   closePrompt();
 

--- a/src/cli/init/prompt.test.ts
+++ b/src/cli/init/prompt.test.ts
@@ -83,6 +83,13 @@ describe('askSecret', () => {
       configurable: true,
     });
 
+    if (!('setRawMode' in process.stdin)) {
+      Object.defineProperty(process.stdin, 'setRawMode', {
+        value: vi.fn(),
+        writable: true,
+        configurable: true,
+      });
+    }
     const setRawModeSpy = vi.spyOn(process.stdin, 'setRawMode').mockReturnThis();
     vi.spyOn(process.stdin, 'resume').mockReturnThis();
     vi.spyOn(process.stdin, 'pause').mockReturnThis();
@@ -90,12 +97,10 @@ describe('askSecret', () => {
     vi.spyOn(process.stdin, 'removeListener').mockReturnThis();
 
     let capturedHandler: ((char: string) => void) | undefined;
-    vi.spyOn(process.stdin, 'on').mockImplementation(
-      ((event: string, handler: unknown) => {
-        if (event === 'data') capturedHandler = handler as (char: string) => void;
-        return process.stdin;
-      }) as typeof process.stdin.on,
-    );
+    vi.spyOn(process.stdin, 'on').mockImplementation(((event: string, handler: unknown) => {
+      if (event === 'data') capturedHandler = handler as (char: string) => void;
+      return process.stdin;
+    }) as typeof process.stdin.on);
 
     const promise = askSecret('Secret key');
 
@@ -122,6 +127,13 @@ describe('askSecret', () => {
       configurable: true,
     });
 
+    if (!('setRawMode' in process.stdin)) {
+      Object.defineProperty(process.stdin, 'setRawMode', {
+        value: vi.fn(),
+        writable: true,
+        configurable: true,
+      });
+    }
     vi.spyOn(process.stdin, 'setRawMode').mockReturnThis();
     vi.spyOn(process.stdin, 'resume').mockReturnThis();
     vi.spyOn(process.stdin, 'pause').mockReturnThis();
@@ -129,12 +141,10 @@ describe('askSecret', () => {
     vi.spyOn(process.stdin, 'removeListener').mockReturnThis();
 
     let capturedHandler: ((char: string) => void) | undefined;
-    vi.spyOn(process.stdin, 'on').mockImplementation(
-      ((event: string, handler: unknown) => {
-        if (event === 'data') capturedHandler = handler as (char: string) => void;
-        return process.stdin;
-      }) as typeof process.stdin.on,
-    );
+    vi.spyOn(process.stdin, 'on').mockImplementation(((event: string, handler: unknown) => {
+      if (event === 'data') capturedHandler = handler as (char: string) => void;
+      return process.stdin;
+    }) as typeof process.stdin.on);
 
     const promise = askSecret('Secret key');
 

--- a/src/cli/init/prompt.test.ts
+++ b/src/cli/init/prompt.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockQuestion = vi.hoisted(() => vi.fn());
+const mockClose = vi.hoisted(() => vi.fn());
+
+vi.mock('node:readline/promises', () => ({
+  createInterface: vi.fn(() => ({
+    question: mockQuestion,
+    close: mockClose,
+  })),
+}));
+
+import { ask, askSecret } from './prompt.js';
+
+describe('ask', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns trimmed answer', async () => {
+    mockQuestion.mockResolvedValueOnce('  hello  ');
+    const result = await ask('Name');
+    expect(result).toBe('hello');
+  });
+
+  it('returns default when answer is empty', async () => {
+    mockQuestion.mockResolvedValueOnce('');
+    const result = await ask('Name', 'default-value');
+    expect(result).toBe('default-value');
+  });
+
+  it('returns typed answer over default', async () => {
+    mockQuestion.mockResolvedValueOnce('custom');
+    const result = await ask('Name', 'default-value');
+    expect(result).toBe('custom');
+  });
+});
+
+describe('askSecret', () => {
+  const originalIsTTY = process.stdin.isTTY;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: originalIsTTY,
+      writable: true,
+      configurable: true,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('delegates to ask() in non-TTY environments (no masking needed)', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: false,
+      writable: true,
+      configurable: true,
+    });
+    mockQuestion.mockResolvedValueOnce('  sk-ant-secret  ');
+    const result = await askSecret('API key');
+    expect(result).toBe('sk-ant-secret');
+    // readline.question was called (via ask fallback), confirming delegation
+    expect(mockQuestion).toHaveBeenCalledOnce();
+  });
+
+  it('returns empty string when user provides no input in non-TTY', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: false,
+      writable: true,
+      configurable: true,
+    });
+    mockQuestion.mockResolvedValueOnce('');
+    const result = await askSecret('API key');
+    expect(result).toBe('');
+  });
+
+  it('uses setRawMode(true) in TTY mode to suppress echo', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+
+    const setRawModeSpy = vi.spyOn(process.stdin, 'setRawMode').mockReturnThis();
+    vi.spyOn(process.stdin, 'resume').mockReturnThis();
+    vi.spyOn(process.stdin, 'pause').mockReturnThis();
+    vi.spyOn(process.stdin, 'setEncoding').mockReturnThis();
+    vi.spyOn(process.stdin, 'removeListener').mockReturnThis();
+
+    let capturedHandler: ((char: string) => void) | undefined;
+    vi.spyOn(process.stdin, 'on').mockImplementation(
+      ((event: string, handler: unknown) => {
+        if (event === 'data') capturedHandler = handler as (char: string) => void;
+        return process.stdin;
+      }) as typeof process.stdin.on,
+    );
+
+    const promise = askSecret('Secret key');
+
+    // Simulate typing then pressing Enter
+    expect(capturedHandler).toBeDefined();
+    capturedHandler!('a');
+    capturedHandler!('b');
+    capturedHandler!('c');
+    capturedHandler!('\r');
+
+    const result = await promise;
+
+    expect(result).toBe('abc');
+    // Must have enabled raw mode to suppress terminal echo
+    expect(setRawModeSpy).toHaveBeenCalledWith(true);
+    // readline.question must NOT have been invoked (raw mode bypasses readline)
+    expect(mockQuestion).not.toHaveBeenCalled();
+  });
+
+  it('handles backspace in TTY mode', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+
+    vi.spyOn(process.stdin, 'setRawMode').mockReturnThis();
+    vi.spyOn(process.stdin, 'resume').mockReturnThis();
+    vi.spyOn(process.stdin, 'pause').mockReturnThis();
+    vi.spyOn(process.stdin, 'setEncoding').mockReturnThis();
+    vi.spyOn(process.stdin, 'removeListener').mockReturnThis();
+
+    let capturedHandler: ((char: string) => void) | undefined;
+    vi.spyOn(process.stdin, 'on').mockImplementation(
+      ((event: string, handler: unknown) => {
+        if (event === 'data') capturedHandler = handler as (char: string) => void;
+        return process.stdin;
+      }) as typeof process.stdin.on,
+    );
+
+    const promise = askSecret('Secret key');
+
+    capturedHandler!('a');
+    capturedHandler!('b');
+    capturedHandler!('c');
+    capturedHandler!(String.fromCharCode(127)); // DEL (backspace)
+    capturedHandler!('\r');
+
+    const result = await promise;
+    expect(result).toBe('ab');
+  });
+});

--- a/src/cli/init/prompt.ts
+++ b/src/cli/init/prompt.ts
@@ -17,6 +17,52 @@ export async function ask(question: string, defaultValue?: string): Promise<stri
   return trimmed || defaultValue || '';
 }
 
+const CTRL_C = String.fromCharCode(3);
+const CTRL_D = String.fromCharCode(4);
+const BACKSPACE = String.fromCharCode(8);
+const DEL = String.fromCharCode(127);
+
+export async function askSecret(question: string): Promise<string> {
+  if (!process.stdin.isTTY) {
+    // Non-TTY (CI, pipes): the OS won't echo input anyway
+    return ask(question);
+  }
+
+  // Close the shared readline to avoid conflicts while in raw mode
+  closePrompt();
+
+  return new Promise<string>((resolve) => {
+    let value = '';
+    output.write(`${question}: `);
+
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.setEncoding('utf8');
+
+    const onData = (char: string): void => {
+      if (char === '\r' || char === '\n' || char === CTRL_D) {
+        process.stdin.setRawMode(false);
+        process.stdin.pause();
+        process.stdin.removeListener('data', onData);
+        output.write('\n');
+        resolve(value);
+      } else if (char === CTRL_C) {
+        process.stdin.setRawMode(false);
+        process.stdin.pause();
+        process.stdin.removeListener('data', onData);
+        output.write('\n');
+        process.exit(130);
+      } else if (char === DEL || char === BACKSPACE) {
+        value = value.slice(0, -1);
+      } else if (char.charCodeAt(0) >= 32) {
+        value += char;
+      }
+    };
+
+    process.stdin.on('data', onData);
+  });
+}
+
 export async function confirm(question: string, defaultYes = false): Promise<boolean> {
   const hint = defaultYes ? 'Y/n' : 'y/N';
   const answer = await ask(`${question} (${hint})`);


### PR DESCRIPTION
Closes #137

## Changes

- `askSecret()` in `src/cli/init/prompt.ts`: uses raw-mode stdin in TTY to suppress terminal echo, falls back to `ask()` in non-TTY
- `src/cli/init/index.ts`: use `askSecret` for Jira API token and Anthropic API key prompts
- `src/cli/init/prompt.test.ts` (new): unit tests for non-TTY delegation, TTY raw-mode masking, backspace
- `README.md`: Step 2 now confirms wizard sets secrets; manual commands kept for users who skipped

Generated with [Claude Code](https://claude.ai/code)