### PR TITLE
feat: open PRs as draft and flip to ready on reviewer approval

### DIFF
--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -179,6 +179,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
     );
     await runner.addLabelsToPR({ owner, repo, prNumber }, ['ferry:approved']);
     await runner.removeLabelFromPR({ owner, repo, prNumber }, 'ferry:reviewing').catch(() => {});
+    await runner.markPRReadyForReview(owner, repo, prNumber);
     await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
   } else {
     const hasIteratorMarker = existingComments.some((c) => c.includes('[ferry:iterator:'));

--- a/src/e2e/pipeline.test.ts
+++ b/src/e2e/pipeline.test.ts
@@ -69,6 +69,8 @@ interface MockIO {
   addLabelsSpy: ReturnType<typeof vi.fn>;
   /** Spy for octokit.pulls.merge / octokit.rest.pulls.merge — must never fire */
   mergeSpy: ReturnType<typeof vi.fn>;
+  /** Spy for octokit.graphql (markPullRequestReadyForReview) */
+  graphqlSpy: ReturnType<typeof vi.fn>;
   callLlm: LlmCall;
 }
 
@@ -113,6 +115,7 @@ function buildMockIO(): MockIO {
   };
 
   const mergeSpy = vi.fn(); // must remain uncalled for the entire pipeline run
+  const graphqlSpy = vi.fn().mockResolvedValue({});
 
   const pullsMock = {
     create: vi.fn().mockResolvedValue({
@@ -138,6 +141,7 @@ function buildMockIO(): MockIO {
         base: { ref: 'main' },
         head: { ref: `ferry/${TICKET_KEY}`, sha: HEAD_SHA },
         mergeable: true,
+        node_id: 'PR_kwMockNodeId',
       },
     }),
     listFiles: vi.fn().mockResolvedValue({ data: [] }),
@@ -162,6 +166,7 @@ function buildMockIO(): MockIO {
     checks: checksMock,
     repos: reposMock,
     paginate: vi.fn().mockResolvedValue([]),
+    graphql: graphqlSpy,
     rest: { issues: issuesMock, pulls: pullsMock, checks: checksMock, repos: reposMock },
   } as unknown as Octokit;
 
@@ -182,7 +187,7 @@ function buildMockIO(): MockIO {
     usage: { inputTokens: 100, outputTokens: 50, costEur: 0.01 },
   });
 
-  return { octokit, tracker, runner, auditComments, addLabelsSpy, mergeSpy, callLlm };
+  return { octokit, tracker, runner, auditComments, addLabelsSpy, mergeSpy, graphqlSpy, callLlm };
 }
 
 // ─── Phase runners ────────────────────────────────────────────────────────────
@@ -263,6 +268,7 @@ async function runReviewPhase(
     );
     await io.runner.addLabelsToPR(prRef, ['ferry:approved']); // FR24 approved path
     await io.runner.removeLabelFromPR(prRef, 'ferry:reviewing');
+    await io.runner.markPRReadyForReview(OWNER, REPO, PR_NUMBER);
   } else {
     await io.tracker.postComment(
       ticketKey,
@@ -380,7 +386,7 @@ describe('E2E pipeline: refine → dev → review → iterate', () => {
   });
 
   describe('FR24 approved path', () => {
-    it('adds ferry:approved label and emits no iter transition (exactly one outcome)', async () => {
+    it('adds ferry:approved label, flips PR to ready, and emits no iter transition', async () => {
       const io = buildMockIO();
       await runRefinePhase(io);
       await runDevPhase(io);
@@ -395,6 +401,12 @@ describe('E2E pipeline: refine → dev → review → iterate', () => {
       // ferry:approved label is added
       expect(io.addLabelsSpy).toHaveBeenCalledWith(
         expect.objectContaining({ labels: ['ferry:approved'] }),
+      );
+
+      // PR is flipped from draft to ready for review via GraphQL
+      expect(io.graphqlSpy).toHaveBeenCalledWith(
+        expect.stringContaining('markPullRequestReadyForReview'),
+        expect.objectContaining({ pullRequestId: 'PR_kwMockNodeId' }),
       );
 
       // Exactly one FR24 outcome (label, not transition)

--- a/src/lib/dispatch/runner/github-actions/index.test.ts
+++ b/src/lib/dispatch/runner/github-actions/index.test.ts
@@ -121,9 +121,7 @@ describe('GitHubActionsRunner', () => {
       });
       const url = await runner.createPR(OWNER, REPO, 'feature-branch', 'main', 'title', 'body');
       expect(url).toBe('https://github.com/acme/ferry/pull/99');
-      expect(mock.pulls.create).toHaveBeenCalledWith(
-        expect.objectContaining({ draft: true }),
-      );
+      expect(mock.pulls.create).toHaveBeenCalledWith(expect.objectContaining({ draft: true }));
     });
 
     it('returns existing PR url when creation fails (PR already exists)', async () => {

--- a/src/lib/dispatch/runner/github-actions/index.test.ts
+++ b/src/lib/dispatch/runner/github-actions/index.test.ts
@@ -24,6 +24,7 @@ type MockOctokit = {
     createDispatchEvent: ReturnType<typeof vi.fn>;
   };
   paginate: ReturnType<typeof vi.fn>;
+  graphql: ReturnType<typeof vi.fn>;
 };
 
 function makeMockOctokit(): MockOctokit {
@@ -49,6 +50,7 @@ function makeMockOctokit(): MockOctokit {
       createDispatchEvent: vi.fn(),
     },
     paginate: vi.fn(),
+    graphql: vi.fn(),
   };
 }
 
@@ -113,12 +115,15 @@ describe('GitHubActionsRunner', () => {
   });
 
   describe('createPR', () => {
-    it('returns html_url when PR creation succeeds', async () => {
+    it('opens PR as draft and returns html_url', async () => {
       mock.pulls.create.mockResolvedValue({
         data: { html_url: 'https://github.com/acme/ferry/pull/99' },
       });
       const url = await runner.createPR(OWNER, REPO, 'feature-branch', 'main', 'title', 'body');
       expect(url).toBe('https://github.com/acme/ferry/pull/99');
+      expect(mock.pulls.create).toHaveBeenCalledWith(
+        expect.objectContaining({ draft: true }),
+      );
     });
 
     it('returns existing PR url when creation fails (PR already exists)', async () => {
@@ -136,6 +141,39 @@ describe('GitHubActionsRunner', () => {
       await expect(
         runner.createPR(OWNER, REPO, 'feature-branch', 'main', 'title', 'body'),
       ).rejects.toThrow('Failed to create or find PR');
+    });
+  });
+
+  describe('markPRReadyForReview', () => {
+    it('fetches node_id then calls markPullRequestReadyForReview mutation', async () => {
+      mock.pulls.get.mockResolvedValue({
+        data: {
+          number: 42,
+          title: 'Fix',
+          base: { ref: 'main' },
+          head: { ref: 'ferry/CHAN-1', sha: 'cafebabe' },
+          mergeable: true,
+          node_id: 'PR_kwABCDEF',
+        },
+      });
+      mock.graphql.mockResolvedValue({ markPullRequestReadyForReview: { pullRequest: { id: 'PR_kwABCDEF' } } });
+
+      await runner.markPRReadyForReview(OWNER, REPO, 42);
+
+      expect(mock.pulls.get).toHaveBeenCalledWith({ owner: OWNER, repo: REPO, pull_number: 42 });
+      expect(mock.graphql).toHaveBeenCalledWith(
+        expect.stringContaining('markPullRequestReadyForReview'),
+        { pullRequestId: 'PR_kwABCDEF' },
+      );
+    });
+
+    it('propagates errors from GraphQL call', async () => {
+      mock.pulls.get.mockResolvedValue({
+        data: { node_id: 'PR_kwABCDEF', number: 42, title: 'Fix', base: { ref: 'main' }, head: { ref: 'b', sha: 's' }, mergeable: null },
+      });
+      mock.graphql.mockRejectedValue(new Error('GraphQL error'));
+
+      await expect(runner.markPRReadyForReview(OWNER, REPO, 42)).rejects.toThrow('GraphQL error');
     });
   });
 

--- a/src/lib/dispatch/runner/github-actions/index.test.ts
+++ b/src/lib/dispatch/runner/github-actions/index.test.ts
@@ -156,7 +156,9 @@ describe('GitHubActionsRunner', () => {
           node_id: 'PR_kwABCDEF',
         },
       });
-      mock.graphql.mockResolvedValue({ markPullRequestReadyForReview: { pullRequest: { id: 'PR_kwABCDEF' } } });
+      mock.graphql.mockResolvedValue({
+        markPullRequestReadyForReview: { pullRequest: { id: 'PR_kwABCDEF' } },
+      });
 
       await runner.markPRReadyForReview(OWNER, REPO, 42);
 
@@ -169,7 +171,14 @@ describe('GitHubActionsRunner', () => {
 
     it('propagates errors from GraphQL call', async () => {
       mock.pulls.get.mockResolvedValue({
-        data: { node_id: 'PR_kwABCDEF', number: 42, title: 'Fix', base: { ref: 'main' }, head: { ref: 'b', sha: 's' }, mergeable: null },
+        data: {
+          node_id: 'PR_kwABCDEF',
+          number: 42,
+          title: 'Fix',
+          base: { ref: 'main' },
+          head: { ref: 'b', sha: 's' },
+          mergeable: null,
+        },
       });
       mock.graphql.mockRejectedValue(new Error('GraphQL error'));
 

--- a/src/lib/dispatch/runner/github-actions/index.ts
+++ b/src/lib/dispatch/runner/github-actions/index.ts
@@ -129,7 +129,15 @@ export class GitHubActionsRunner implements CIRunner {
     body: string,
   ): Promise<string> {
     try {
-      const { data } = await this.octokit.pulls.create({ owner, repo, head, base, title, body });
+      const { data } = await this.octokit.pulls.create({
+        owner,
+        repo,
+        head,
+        base,
+        title,
+        body,
+        draft: true,
+      });
       return data.html_url;
     } catch {
       // PR may already exist — find and return its URL
@@ -143,6 +151,19 @@ export class GitHubActionsRunner implements CIRunner {
       if (existing.length > 0) return existing[0].html_url;
       throw new Error(`Failed to create or find PR for head branch ${head}`);
     }
+  }
+
+  async markPRReadyForReview(owner: string, repo: string, prNumber: number): Promise<void> {
+    const { data } = await this.octokit.pulls.get({ owner, repo, pull_number: prNumber });
+    // GitHub REST does not support draft → ready; GraphQL mutation is required
+    await this.octokit.graphql(
+      `mutation($pullRequestId: ID!) {
+        markPullRequestReadyForReview(input: { pullRequestId: $pullRequestId }) {
+          pullRequest { id }
+        }
+      }`,
+      { pullRequestId: data.node_id },
+    );
   }
 
   async commentOnPR(prRef: PRRef, body: string): Promise<void> {

--- a/src/lib/dispatch/runner/types.ts
+++ b/src/lib/dispatch/runner/types.ts
@@ -50,6 +50,7 @@ export interface CIRunner {
     title: string,
     body: string,
   ): Promise<string>;
+  markPRReadyForReview(owner: string, repo: string, prNumber: number): Promise<void>;
   commentOnPR(prRef: PRRef, body: string): Promise<void>;
   addLabelsToPR(prRef: PRRef, labels: string[]): Promise<void>;
   removeLabelFromPR(prRef: PRRef, label: string): Promise<void>;


### PR DESCRIPTION
Closes #139: Developer opens PR as draft, Reviewer flips to ready when CI is green and ferry:approved is applied.

Generated with [Claude Code](https://claude.ai/code)