### PR TITLE
feat: per-phase LLM provider selection (Anthropic / OpenAI / Google)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Ferry connects your Jira board to a fully autonomous dev loop — Refiner, Devel
 
 - A replacement for human review — it opens draft PRs, it never merges
 - A general-purpose AI coding assistant — it only acts on explicit Jira column transitions
-- Currently Anthropic-only — Google AI and OpenAI providers exist in code but per-phase provider selection is not yet exposed to consumers; multi-provider support is a planned roadmap item
+- Limited to tool-use phases on Anthropic — the Refiner supports all three providers (`anthropic`, `openai`, `google`); the Developer, Reviewer, and Iterator require `anthropic` today (OpenAI/Google agentic-loop support is planned)
 
 ---
 
@@ -73,7 +73,7 @@ Ferry **never merges** and **never moves Jira columns** autonomously except for 
 
 ---
 
-> ⚠️ **Privacy notice — read before first use.** Ferry transmits the following data to Anthropic (the current LLM provider):
+> ⚠️ **Privacy notice — read before first use.** Ferry transmits the following data to your configured LLM provider(s) (Anthropic by default):
 >
 > - Jira ticket titles, descriptions, comments, and sub-tasks
 > - File contents and diffs from the target GitHub repository
@@ -87,7 +87,7 @@ Ferry **never merges** and **never moves Jira columns** autonomously except for 
 
 - GitHub repository (target repo where Ferry runs)
 - Jira Cloud Standard or Premium (outbound web requests required)
-- Anthropic account (the current LLM provider; multi-provider support is on the roadmap)
+- Anthropic account (required for all phases); OpenAI or Google AI accounts if you configure those providers for the Refiner
 - **Story** issue type (and Task, Bug, Spike if your project uses them) must be enabled in the Jira project
 
 ---

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -25,6 +25,13 @@ Add these under **Settings → Secrets and variables → Actions → Secrets** i
 | `FERRY_JIRA_API_TOKEN` | Atlassian API token — [generate one here](https://id.atlassian.com/manage-profile/security/api-tokens) |
 | `ANTHROPIC_API_KEY` | Anthropic API key — [get one here](https://console.anthropic.com/account/keys) |
 
+### Required when using non-Anthropic providers
+
+| Secret | Provider | Description |
+|--------|----------|-------------|
+| `FERRY_OPENAI_KEY` | `openai` | OpenAI API key — required when any phase is configured with `provider: openai` |
+| `FERRY_GOOGLE_AI_KEY` | `google` | Google AI API key — required when any phase is configured with `provider: google` |
+
 ### Required for specific agents
 
 | Secret | Used by | Description |
@@ -50,11 +57,15 @@ Add these under **Settings → Secrets and variables → Actions → Variables**
 
 | Variable | Default | Affects | Description |
 |----------|---------|---------|-------------|
-| `FERRY_REVIEW_MODEL` | `claude-sonnet-4-6` | Reviewer agent | Override the model used by the Reviewer. Must be a model ID supported by the configured provider. |
-| `FERRY_ITER_MODEL` | `claude-sonnet-4-6` | Iterator agent | Override the model used by the Iterator. |
+| `FERRY_REFINER_PROVIDER` | (from config) | Refiner agent | Override the LLM provider for the Refiner. Must be `anthropic`, `openai`, or `google`. |
+| `FERRY_REFINER_MODEL` | (from config) | Refiner agent | Override the model ID for the Refiner. |
+| `FERRY_DEV_PROVIDER` | (from config) | Developer agent | Override the LLM provider for the Developer. Currently only `anthropic` is supported for agentic phases. |
+| `FERRY_DEV_MODEL` | (from config) | Developer agent | Override the model ID for the Developer. |
+| `FERRY_REVIEW_PROVIDER` | (from config) | Reviewer agent | Override the LLM provider for the Reviewer. Currently only `anthropic` is supported for agentic phases. |
+| `FERRY_REVIEW_MODEL` | `claude-sonnet-4-6` | Reviewer agent | Override the model ID for the Reviewer. |
+| `FERRY_ITER_PROVIDER` | (from config) | Iterator agent | Override the LLM provider for the Iterator. Currently only `anthropic` is supported for agentic phases. |
+| `FERRY_ITER_MODEL` | `claude-sonnet-4-6` | Iterator agent | Override the model ID for the Iterator. |
 | `FERRY_ITER_MAX_INPUT_TOKENS` | `500000` | Iterator agent | Input token budget per Iterator run. Mapped to `limits.max_tokens_per_run` internally. |
-
-> **Note:** There is no `FERRY_DEV_MODEL` or `FERRY_REFINE_MODEL` repository variable — those agents use their defaults from `ferry.config.json`. Use the config file to override those models.
 
 ---
 
@@ -113,20 +124,29 @@ Ferry reads the config file from `GITHUB_WORKSPACE` (the checked-out repo root) 
 
 #### `models`
 
-Each agent can be configured independently. All `models.*` fields are optional.
+Each agent phase can be configured independently. All `models.*` fields are optional.
+
+Ferry supports three LLM providers: **`anthropic`**, **`openai`**, and **`google`**. Provider support varies by phase:
+
+| Phase | Supported providers | Notes |
+|-------|---------------------|-------|
+| `refiner` | `anthropic`, `openai`, `google` | Uses a single-turn LLM call — all providers work |
+| `dev` | `anthropic` | Uses an agentic tool-use loop; OpenAI/Google support is planned |
+| `review` | `anthropic` | Uses an agentic tool-use loop; OpenAI/Google support is planned |
+| `iterate` | `anthropic` | Uses an agentic tool-use loop; OpenAI/Google support is planned |
+
+> **MCP:** Model Context Protocol (MCP) server integration is Anthropic-only and is not available when using other providers.
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `models.refiner.provider` | `"anthropic"` | LLM provider. Currently only `"anthropic"` is wired through the consumer workflow stubs. |
-| `models.refiner.model` | `"claude-sonnet-4-6"` | Model ID for the Refiner agent |
-| `models.dev.provider` | `"anthropic"` | LLM provider for the Developer agent |
-| `models.dev.model` | `"claude-opus-4-5"` | Model ID for the Developer agent |
-| `models.review.provider` | `"anthropic"` | LLM provider for the Reviewer agent |
-| `models.review.model` | `"claude-sonnet-4-6"` | Model ID for the Reviewer agent (overridden by `FERRY_REVIEW_MODEL` var) |
-| `models.iterate.provider` | `"anthropic"` | LLM provider for the Iterator agent |
-| `models.iterate.model` | `"claude-sonnet-4-6"` | Model ID for the Iterator agent (overridden by `FERRY_ITER_MODEL` var) |
-
-> Ferry currently uses the Anthropic Messages API exclusively. Anthropic Agent SDK support is the next roadmap item.
+| `models.refiner.provider` | `"anthropic"` | LLM provider for the Refiner agent. Accepts `"anthropic"`, `"openai"`, or `"google"`. |
+| `models.refiner.model` | `"claude-sonnet-4-6"` | Model ID for the Refiner agent (overridden by `FERRY_REFINER_MODEL` env var) |
+| `models.dev.provider` | `"anthropic"` | LLM provider for the Developer agent. Currently only `"anthropic"` is supported. |
+| `models.dev.model` | `"claude-opus-4-5"` | Model ID for the Developer agent (overridden by `FERRY_DEV_MODEL` env var) |
+| `models.review.provider` | `"anthropic"` | LLM provider for the Reviewer agent. Currently only `"anthropic"` is supported. |
+| `models.review.model` | `"claude-sonnet-4-6"` | Model ID for the Reviewer agent (overridden by `FERRY_REVIEW_MODEL` env var) |
+| `models.iterate.provider` | `"anthropic"` | LLM provider for the Iterator agent. Currently only `"anthropic"` is supported. |
+| `models.iterate.model` | `"claude-sonnet-4-6"` | Model ID for the Iterator agent (overridden by `FERRY_ITER_MODEL` env var) |
 
 #### `limits`
 
@@ -182,7 +202,7 @@ The following are intentionally not configurable by consumers:
 | Jira column transitions (except the two IDs above) | Managed by Ferry's internal state machine |
 | Branch naming (`ferry/<ticket-key>`) | Required by Ferry's state logic |
 | PR/comment fingerprint formats | Required for idempotency |
-| `FERRY_MODEL` env var used by Refiner/Developer workflows | Set to `claude-sonnet-4-6` internally; use `ferry.config.json` to change those models |
+| Internal workflow defaults for Refiner/Developer | Set via `ferry.config.json`; use the `models.*` fields or `FERRY_*_MODEL` / `FERRY_*_PROVIDER` env vars to override |
 | Audit issue comment format | Required for deduplication |
 
 ---
@@ -194,7 +214,12 @@ For any given setting, the last value wins:
 ```
 ferry.config.json defaults
   → ferry.config.json values
-    → GitHub repository variables (FERRY_REVIEW_MODEL, FERRY_ITER_MODEL, FERRY_ITER_MAX_INPUT_TOKENS)
+    → Environment / repository variables
+        (FERRY_REFINER_PROVIDER, FERRY_REFINER_MODEL,
+         FERRY_DEV_PROVIDER, FERRY_DEV_MODEL,
+         FERRY_REVIEW_PROVIDER, FERRY_REVIEW_MODEL,
+         FERRY_ITER_PROVIDER, FERRY_ITER_MODEL,
+         FERRY_ITER_MAX_INPUT_TOKENS)
 ```
 
-Secrets are credentials only — they do not participate in model or limit configuration.
+Secrets (`ANTHROPIC_API_KEY`, `FERRY_OPENAI_KEY`, `FERRY_GOOGLE_AI_KEY`) are credentials only — they do not participate in model or limit configuration.

--- a/src/agents/developer/dev-action.ts
+++ b/src/agents/developer/dev-action.ts
@@ -17,6 +17,7 @@ import {
 import type { EventEnvelopeV1 } from '../../lib/envelope/types.js';
 import type { Logger } from '../../lib/agent-runtime/index.js';
 import { isDryRun } from '../../lib/dry-run.js';
+import { FerryError } from '../../lib/errors/index.js';
 import { formatDeveloperCommit } from './commit.js';
 import { formatPullRequestTitle, formatPullRequestBody } from './pr.js';
 import {
@@ -45,6 +46,16 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const reviewTransitionId = dryRun ? '' : requireEnv('FERRY_REVIEW_TRANSITION_ID');
   const jiraBaseUrl = requireEnv('FERRY_JIRA_BASE_URL');
   const { owner, repo, runner, tracker, ferryCfg } = createGitHubContext(REPO_ROOT);
+  const { provider: devProvider } = ferryCfg.models.dev;
+  if (devProvider !== 'anthropic') {
+    throw new FerryError('state-invariant', {
+      reason: 'unsupported-provider',
+      provider: devProvider,
+      phase: 'developer',
+      detail:
+        "The developer phase requires provider 'anthropic'. OpenAI and Google support for agentic phases is planned for a future release.",
+    });
+  }
 
   const issue = await tracker.getIssue(ticketKey);
   const labels = issue.labels.join(', ');
@@ -166,7 +177,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
         reason: done.reason_if_not_actionable ?? 'no reason given',
       });
     }
-    appendOutput({ ...usage, model });
+    appendOutput({ ...usage, model, provider: devProvider });
     process.exit(0);
   }
 
@@ -209,7 +220,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
         diff: diffOutput,
       });
       logger.info('DRY_RUN — skipped: git push, PR creation, Jira transition, Jira comment');
-      appendOutput({ ...usage, model });
+      appendOutput({ ...usage, model, provider: devProvider });
       process.exit(0);
     }
 
@@ -247,7 +258,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
     throw err;
   }
 
-  appendOutput({ ...usage, model });
+  appendOutput({ ...usage, model, provider: devProvider });
   process.exit(0);
 }
 

--- a/src/agents/iterator/iterate-action.ts
+++ b/src/agents/iterator/iterate-action.ts
@@ -4,6 +4,7 @@ import { checkIdempotencyMarker } from '../../lib/io/idempotency.js';
 import { TOOL_SCHEMAS, COMMIT_PROGRESS_SCHEMA, executeTool } from '../developer/tools.js';
 import { createAnthropicAgentLoop } from '../../lib/llm/agent-loop/anthropic.js';
 import { resolveAnthropicAuth } from '../../lib/llm/anthropic-auth.js';
+import { FerryError } from '../../lib/errors/index.js';
 import { checkIterationCap } from './cap.js';
 import { decideIteratorTransition } from './transition.js';
 import { formatCommitMessage } from './prompt.js';
@@ -36,7 +37,16 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const anthropicAuth = resolveAnthropicAuth({ apiKeyEnv: 'ANTHROPIC_API_KEY' });
   const reviewTransitionId = requireEnv('FERRY_REVIEW_TRANSITION_ID');
   const { owner, repo, runner, tracker, ferryCfg } = createGitHubContext(REPO_ROOT);
-  const model = ferryCfg.models.iterate.model;
+  const { provider: iterProvider, model } = ferryCfg.models.iterate;
+  if (iterProvider !== 'anthropic') {
+    throw new FerryError('state-invariant', {
+      reason: 'unsupported-provider',
+      provider: iterProvider,
+      phase: 'iterator',
+      detail:
+        "The iterator phase requires provider 'anthropic'. OpenAI and Google support for agentic phases is planned for a future release.",
+    });
+  }
 
   const issue = await tracker.getIssue(ticketKey);
   const existingComments = issue.comments;
@@ -71,7 +81,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
         `${eventMarker} No open PR found for branch ${branchName}. Cannot iterate.`,
       );
     }
-    appendOutput({ input_tokens: 0, output_tokens: 0, model });
+    appendOutput({ input_tokens: 0, output_tokens: 0, model, provider: iterProvider });
     return;
   }
 
@@ -88,7 +98,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
         `${eventMarker} No review comment found on PR#${prNumber}. Cannot iterate.`,
       );
     }
-    appendOutput({ input_tokens: 0, output_tokens: 0, model });
+    appendOutput({ input_tokens: 0, output_tokens: 0, model, provider: iterProvider });
     return;
   }
 
@@ -100,7 +110,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const { skipped } = checkIdempotencyMarker(idempotencyMarker, existingComments);
   if (skipped) {
     logger.info('review comment already handled, skipping', { review_comment_id: latestReview.id });
-    appendOutput({ input_tokens: 0, output_tokens: 0, model });
+    appendOutput({ input_tokens: 0, output_tokens: 0, model, provider: iterProvider });
     return;
   }
 
@@ -110,7 +120,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
       ticketKey,
       `${idempotencyMarker} PR#${prNumber} review shows Approved — no iteration needed.`,
     );
-    appendOutput({ input_tokens: 0, output_tokens: 0, model });
+    appendOutput({ input_tokens: 0, output_tokens: 0, model, provider: iterProvider });
     return;
   }
 
@@ -123,7 +133,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
       ticketKey,
       `${idempotencyMarker} Branch ${branchName} not found on origin. Cannot iterate.`,
     );
-    appendOutput({ input_tokens: 0, output_tokens: 0, model });
+    appendOutput({ input_tokens: 0, output_tokens: 0, model, provider: iterProvider });
     return;
   }
 
@@ -190,7 +200,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
       ticketKey,
       `${idempotencyMarker} Cannot fix — ${done.reason_if_not_actionable ?? 'no reason given'}`,
     );
-    appendOutput({ ...usage, model });
+    appendOutput({ ...usage, model, provider: iterProvider });
     process.exit(0);
   }
 
@@ -220,7 +230,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
     `${idempotencyMarker} Iteration ${next_iteration} complete. Pushed fixes to PR#${prNumber}. Moved back to Review.`,
   );
 
-  appendOutput({ ...usage, model });
+  appendOutput({ ...usage, model, provider: iterProvider });
   process.exit(0);
 }
 

--- a/src/agents/refiner/refiner-action.ts
+++ b/src/agents/refiner/refiner-action.ts
@@ -1,9 +1,8 @@
 import { pathToFileURL } from 'node:url';
-import Anthropic from '@anthropic-ai/sdk';
 import { createTrackerFromEnv } from '../../lib/io/tracker/factory.js';
 import { isDryRun } from '../../lib/dry-run.js';
 import { loadFerryConfig } from '../../lib/config.js';
-import { resolveAnthropicAuth } from '../../lib/llm/anthropic-auth.js';
+import { createLlmCall } from '../../lib/llm/call.js';
 import { runAgent, createLogger } from '../../lib/agent-runtime/index.js';
 import type { Logger } from '../../lib/agent-runtime/index.js';
 import { runRefiner } from './refine.js';
@@ -68,31 +67,9 @@ export async function run(envelope: EventEnvelopeV1, deps: RefinerActionDeps): P
 }
 
 async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
-  const anthropicAuth = resolveAnthropicAuth({ apiKeyEnv: 'ANTHROPIC_API_KEY' });
-  const anthropic = new Anthropic(anthropicAuth);
   const ferryCfg = loadFerryConfig(REPO_ROOT);
-  const model = ferryCfg.models.refiner.model;
-
-  const callLlm: LlmCall = async (prompt) => {
-    const msg = await anthropic.messages.create({
-      model,
-      max_tokens: ferryCfg.limits.max_tokens_per_message,
-      messages: [{ role: 'user', content: prompt }],
-    });
-    const text = msg.content
-      .filter((c): c is Anthropic.TextBlock => c.type === 'text')
-      .map((c) => c.text)
-      .join('');
-    return {
-      text,
-      usage: {
-        inputTokens: msg.usage.input_tokens,
-        outputTokens: msg.usage.output_tokens,
-        costEur: 0,
-      },
-    };
-  };
-
+  const route = ferryCfg.models.refiner;
+  const callLlm: LlmCall = createLlmCall(route);
   const tracker = createTrackerFromEnv();
   await run(envelope, { tracker, callLlm, logger });
 }

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -5,6 +5,7 @@ import { checkIdempotencyMarker } from '../../lib/io/idempotency.js';
 import { gateCi } from './ci-gate.js';
 import { detectMergeConflicts, buildFileList, runReviewLoop } from './review-loop.js';
 import { resolveCapabilities } from '../../lib/labels/capabilities.js';
+import { FerryError } from '../../lib/errors/index.js';
 import {
   requireEnv,
   appendOutput,
@@ -27,7 +28,16 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
 
   const iterTransitionId = requireEnv('FERRY_ITER_TRANSITION_ID');
   const { owner, repo, runner, tracker, ferryCfg } = createGitHubContext(REPO_ROOT);
-  const model = ferryCfg.models.review.model;
+  const { provider, model } = ferryCfg.models.review;
+  if (provider !== 'anthropic') {
+    throw new FerryError('state-invariant', {
+      reason: 'unsupported-provider',
+      provider,
+      phase: 'reviewer',
+      detail:
+        "The reviewer phase requires provider 'anthropic'. OpenAI and Google support for agentic phases is planned for a future release.",
+    });
+  }
 
   const issue = await tracker.getIssue(ticketKey);
   const existingComments = issue.comments;
@@ -48,7 +58,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
         `${errorMarker} No open PR found for branch ${branchName}. Cannot review.`,
       );
     }
-    appendOutput({ input_tokens: 0, output_tokens: 0, model });
+    appendOutput({ input_tokens: 0, output_tokens: 0, model, provider });
     return;
   }
 
@@ -64,7 +74,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const { skipped } = checkIdempotencyMarker(idempotencyMarker, existingComments);
   if (skipped) {
     logger.info('already processed, skipping', { sha: headSha.slice(0, 7) });
-    appendOutput({ input_tokens: 0, output_tokens: 0, model });
+    appendOutput({ input_tokens: 0, output_tokens: 0, model, provider });
     return;
   }
 
@@ -78,7 +88,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
         ticketKey,
         `${idempotencyMarker} CI checks are still pending on ${headSha.slice(0, 7)}. Will retry when CI completes.`,
       );
-      appendOutput({ input_tokens: 0, output_tokens: 0, model });
+      appendOutput({ input_tokens: 0, output_tokens: 0, model, provider });
       return;
     }
 
@@ -93,7 +103,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
       `${idempotencyMarker}\n\n**CI failed:** ${ciMessage}`,
     );
     await tracker.postTransition(ticketKey, iterTransitionId);
-    appendOutput({ input_tokens: 0, output_tokens: 0, model });
+    appendOutput({ input_tokens: 0, output_tokens: 0, model, provider });
     return;
   }
 
@@ -199,7 +209,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
     }
   }
 
-  appendOutput({ input_tokens: inputTokens, output_tokens: outputTokens, model });
+  appendOutput({ input_tokens: inputTokens, output_tokens: outputTokens, model, provider });
 }
 
 void runAgent('reviewer', main);

--- a/src/cli/doctor/checks/llm.test.ts
+++ b/src/cli/doctor/checks/llm.test.ts
@@ -17,7 +17,7 @@ describe('checkLlmKeys', () => {
   it('returns skip when anthropicApiKey is empty', async () => {
     const result = await checkLlmKeys({ anthropicApiKey: '' });
     expect(result.status).toBe('skip');
-    expect(result.detail).toContain('No Anthropic API key');
+    expect(result.detail).toContain('ANTHROPIC_API_KEY');
   });
 
   it('returns green for a 200 response', async () => {

--- a/src/cli/doctor/checks/llm.ts
+++ b/src/cli/doctor/checks/llm.ts
@@ -1,4 +1,5 @@
 import { httpsPost } from '../../http.js';
+import { loadFerryConfig } from '../../../lib/config.js';
 import type { CheckResult } from '../types.js';
 
 async function probeAnthropic(apiKey: string): Promise<{ ok: boolean; detail: string }> {
@@ -39,30 +40,78 @@ async function probeAnthropic(apiKey: string): Promise<{ ok: boolean; detail: st
   }
 }
 
-export async function checkLlmKeys(opts: { anthropicApiKey: string }): Promise<CheckResult> {
-  const { anthropicApiKey } = opts;
+export async function checkLlmKeys(opts: {
+  anthropicApiKey: string;
+  openaiApiKey?: string;
+  googleApiKey?: string;
+  repoRoot?: string;
+}): Promise<CheckResult> {
+  const { anthropicApiKey, openaiApiKey = '', googleApiKey = '', repoRoot } = opts;
 
-  if (!anthropicApiKey) {
-    return {
-      label: 'LLM keys valid',
-      status: 'skip',
-      detail: 'No Anthropic API key provided — skipping',
-      remedy:
-        'Provide --anthropic-key or set ANTHROPIC_API_KEY. Generate at console.anthropic.com/account/keys',
-    };
+  // Determine which providers are required by the ferry config.
+  const requiredProviders = new Set<string>(['anthropic']);
+  if (repoRoot) {
+    try {
+      const cfg = loadFerryConfig(repoRoot);
+      for (const route of Object.values(cfg.models)) {
+        requiredProviders.add(route.provider);
+      }
+    } catch {
+      // Config may not exist in doctor context; fall back to Anthropic-only check.
+    }
   }
 
-  const { ok, detail } = await probeAnthropic(anthropicApiKey);
+  const missing: string[] = [];
+  const details: string[] = [];
 
-  if (ok) {
-    return { label: 'LLM keys valid', status: 'green', detail };
+  if (requiredProviders.has('anthropic')) {
+    if (!anthropicApiKey) {
+      missing.push('ANTHROPIC_API_KEY (required for anthropic provider)');
+    } else {
+      const { ok, detail } = await probeAnthropic(anthropicApiKey);
+      if (ok) {
+        details.push(detail);
+      } else {
+        return {
+          label: 'LLM keys valid',
+          status: 'red',
+          detail,
+          remedy:
+            'Generate a new key at console.anthropic.com/account/keys, then re-run `npx -p @big-emotion/ferry ferry-init --overwrite`',
+        };
+      }
+    }
+  }
+
+  if (requiredProviders.has('openai')) {
+    if (!openaiApiKey) {
+      missing.push('FERRY_OPENAI_KEY (required for openai provider)');
+    } else {
+      details.push('OpenAI key present');
+    }
+  }
+
+  if (requiredProviders.has('google')) {
+    if (!googleApiKey) {
+      missing.push('FERRY_GOOGLE_AI_KEY (required for google provider)');
+    } else {
+      details.push('Google AI key present');
+    }
+  }
+
+  if (missing.length > 0) {
+    const missingList = missing.join(', ');
+    return {
+      label: 'LLM keys valid',
+      status: requiredProviders.has('anthropic') && !anthropicApiKey ? 'skip' : 'yellow',
+      detail: `Missing keys for configured providers: ${missingList}`,
+      remedy: `Add the missing secrets to your repository: ${missingList}`,
+    };
   }
 
   return {
     label: 'LLM keys valid',
-    status: 'red',
-    detail,
-    remedy:
-      'Generate a new key at console.anthropic.com/account/keys, then re-run `npx -p @big-emotion/ferry ferry-init --overwrite`',
+    status: 'green',
+    detail: details.join('; '),
   };
 }

--- a/src/cli/doctor/index.ts
+++ b/src/cli/doctor/index.ts
@@ -69,6 +69,8 @@ function parseConfig(argv: string[]): DoctorConfig {
     jiraApiToken: getArg(argv, '--jira-token') ?? process.env['FERRY_JIRA_API_TOKEN'] ?? '',
     jiraProjectKey: getArg(argv, '--jira-project') ?? process.env['FERRY_JIRA_PROJECT_KEY'] ?? '',
     anthropicApiKey: getArg(argv, '--anthropic-key') ?? process.env['ANTHROPIC_API_KEY'] ?? '',
+    openaiApiKey: getArg(argv, '--openai-key') ?? process.env['FERRY_OPENAI_KEY'] ?? '',
+    googleApiKey: getArg(argv, '--google-key') ?? process.env['FERRY_GOOGLE_AI_KEY'] ?? '',
     ferryVersion: getArg(argv, '--version') ?? 'v1',
     repoRoot: getArg(argv, '--repo-root') ?? process.cwd(),
     noDispatch: hasFlag(argv, '--no-dispatch'),
@@ -95,6 +97,8 @@ Options:
   --jira-token <token>         Jira API token (default: FERRY_JIRA_API_TOKEN)
   --jira-project <key>         Jira project key to verify (default: FERRY_JIRA_PROJECT_KEY)
   --anthropic-key <key>        Anthropic API key (default: ANTHROPIC_API_KEY)
+  --openai-key <key>           OpenAI API key (default: FERRY_OPENAI_KEY)
+  --google-key <key>           Google AI API key (default: FERRY_GOOGLE_AI_KEY)
   --version <tag>              Ferry version tag for workflow drift check (default: v1)
   --repo-root <path>           Path to the repo root (default: cwd)
   --no-dispatch                Skip the synthetic dispatch probe
@@ -140,7 +144,12 @@ Exit code: 0 if all checks green/yellow, 1 if any check red.
       jiraApiToken: config.jiraApiToken,
       jiraProjectKey: config.jiraProjectKey,
     }),
-    checkLlmKeys({ anthropicApiKey: config.anthropicApiKey }),
+    checkLlmKeys({
+      anthropicApiKey: config.anthropicApiKey,
+      openaiApiKey: config.openaiApiKey,
+      googleApiKey: config.googleApiKey,
+      repoRoot: config.repoRoot,
+    }),
     checkSyntheticDispatch({ repo: config.repo, noDispatch: config.noDispatch }),
     checkWorkflowDrift({ repoRoot: config.repoRoot, ferryVersion: config.ferryVersion }),
     checkPromptOverrides({ repoRoot: config.repoRoot }),

--- a/src/cli/doctor/types.ts
+++ b/src/cli/doctor/types.ts
@@ -16,6 +16,8 @@ export interface DoctorConfig {
   jiraApiToken: string;
   jiraProjectKey: string;
   anthropicApiKey: string;
+  openaiApiKey: string;
+  googleApiKey: string;
   ferryVersion: string;
   repoRoot: string;
   noDispatch: boolean;

--- a/src/lib/agent-runtime/output.ts
+++ b/src/lib/agent-runtime/output.ts
@@ -4,11 +4,13 @@ export function appendOutput(usage: {
   input_tokens: number;
   output_tokens: number;
   model?: string;
+  provider?: string;
 }): void {
   const githubOutput = process.env.GITHUB_OUTPUT;
   if (githubOutput) {
     let out = `input_tokens=${usage.input_tokens}\noutput_tokens=${usage.output_tokens}\n`;
     if (usage.model) out += `model=${usage.model}\n`;
+    if (usage.provider) out += `provider=${usage.provider}\n`;
     appendFileSync(githubOutput, out);
   }
 }

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -148,6 +148,27 @@ describe('loadFerryConfig', () => {
   });
 
   describe('env var overrides', () => {
+    it('FERRY_REFINER_PROVIDER overrides config file provider', () => {
+      mockNoConfigFile();
+      vi.stubEnv('FERRY_REFINER_PROVIDER', 'openai');
+      const cfg = loadFerryConfig('/repo');
+      expect(cfg.models.refiner.provider).toBe('openai');
+    });
+
+    it('FERRY_REFINER_MODEL overrides config file model', () => {
+      mockNoConfigFile();
+      vi.stubEnv('FERRY_REFINER_MODEL', 'gpt-4.1');
+      const cfg = loadFerryConfig('/repo');
+      expect(cfg.models.refiner.model).toBe('gpt-4.1');
+    });
+
+    it('FERRY_DEV_PROVIDER overrides config file provider', () => {
+      mockNoConfigFile();
+      vi.stubEnv('FERRY_DEV_PROVIDER', 'google');
+      const cfg = loadFerryConfig('/repo');
+      expect(cfg.models.dev.provider).toBe('google');
+    });
+
     it('FERRY_DEV_MODEL overrides config file model', () => {
       mockConfigFile('ferry.config.json', JSON.stringify({}));
       vi.stubEnv('FERRY_DEV_MODEL', 'claude-haiku-4-5-20251001');
@@ -155,11 +176,25 @@ describe('loadFerryConfig', () => {
       expect(cfg.models.dev.model).toBe('claude-haiku-4-5-20251001');
     });
 
+    it('FERRY_REVIEW_PROVIDER overrides config file provider', () => {
+      mockNoConfigFile();
+      vi.stubEnv('FERRY_REVIEW_PROVIDER', 'openai');
+      const cfg = loadFerryConfig('/repo');
+      expect(cfg.models.review.provider).toBe('openai');
+    });
+
     it('FERRY_REVIEW_MODEL overrides config file model', () => {
       mockNoConfigFile();
       vi.stubEnv('FERRY_REVIEW_MODEL', 'claude-haiku-4-5-20251001');
       const cfg = loadFerryConfig('/repo');
       expect(cfg.models.review.model).toBe('claude-haiku-4-5-20251001');
+    });
+
+    it('FERRY_ITER_PROVIDER overrides config file provider', () => {
+      mockNoConfigFile();
+      vi.stubEnv('FERRY_ITER_PROVIDER', 'google');
+      const cfg = loadFerryConfig('/repo');
+      expect(cfg.models.iterate.provider).toBe('google');
     });
 
     it('FERRY_ITER_MODEL overrides config file model', () => {
@@ -214,6 +249,13 @@ describe('loadFerryConfig', () => {
       expect(cfg.limits.max_agent_iterations).toBe(
         DEFAULT_FERRY_CONFIG.limits.max_agent_iterations,
       );
+    });
+
+    it('ignores unknown FERRY_REFINER_PROVIDER values', () => {
+      mockNoConfigFile();
+      vi.stubEnv('FERRY_REFINER_PROVIDER', 'unknown-provider');
+      const cfg = loadFerryConfig('/repo');
+      expect(cfg.models.refiner.provider).toBe(DEFAULT_FERRY_CONFIG.models.refiner.provider);
     });
   });
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -305,12 +305,31 @@ function applyEnvOverrides(cfg: FerryConfig): FerryConfig {
   const models = { ...cfg.models };
   const limits = { ...cfg.limits };
 
+  const providerFromEnv = (val: string | undefined): LlmRoute['provider'] | undefined => {
+    if (val === 'anthropic' || val === 'openai' || val === 'google') return val;
+    return undefined;
+  };
+
+  const refinerProvider = providerFromEnv(process.env.FERRY_REFINER_PROVIDER);
+  if (refinerProvider) models.refiner = { ...models.refiner, provider: refinerProvider };
+  if (process.env.FERRY_REFINER_MODEL) {
+    models.refiner = { ...models.refiner, model: process.env.FERRY_REFINER_MODEL };
+  }
+
+  const devProvider = providerFromEnv(process.env.FERRY_DEV_PROVIDER);
+  if (devProvider) models.dev = { ...models.dev, provider: devProvider };
   if (process.env.FERRY_DEV_MODEL) {
     models.dev = { ...models.dev, model: process.env.FERRY_DEV_MODEL };
   }
+
+  const reviewProvider = providerFromEnv(process.env.FERRY_REVIEW_PROVIDER);
+  if (reviewProvider) models.review = { ...models.review, provider: reviewProvider };
   if (process.env.FERRY_REVIEW_MODEL) {
     models.review = { ...models.review, model: process.env.FERRY_REVIEW_MODEL };
   }
+
+  const iterProvider = providerFromEnv(process.env.FERRY_ITER_PROVIDER);
+  if (iterProvider) models.iterate = { ...models.iterate, provider: iterProvider };
   if (process.env.FERRY_ITER_MODEL) {
     models.iterate = { ...models.iterate, model: process.env.FERRY_ITER_MODEL };
   }

--- a/src/lib/llm/call.test.ts
+++ b/src/lib/llm/call.test.ts
@@ -74,18 +74,18 @@ describe('createLlmCall', () => {
   describe('Anthropic provider', () => {
     const route: LlmRoute = { provider: 'anthropic', model: 'claude-sonnet-4-6' };
 
-    it('throws FerryError("state-invariant") when FERRY_ANTHROPIC_KEY is missing', () => {
-      vi.stubEnv('FERRY_ANTHROPIC_KEY', '');
+    it('throws FerryError("state-invariant") when ANTHROPIC_API_KEY is missing', () => {
+      vi.stubEnv('ANTHROPIC_API_KEY', '');
       expect(() => createLlmCall(route)).toThrow(
         expect.objectContaining({
           code: 'state-invariant',
-          context: { reason: 'missing-env', key: 'FERRY_ANTHROPIC_KEY' },
+          context: { reason: 'missing-env', key: 'ANTHROPIC_API_KEY' },
         }),
       );
     });
 
     it('calls messages.create with correct args and returns LlmResult', async () => {
-      vi.stubEnv('FERRY_ANTHROPIC_KEY', 'test-key');
+      vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
       const llmCall = createLlmCall(route);
       const result = await llmCall('hello');
 
@@ -104,7 +104,7 @@ describe('createLlmCall', () => {
 
     it('uses CLAUDE_CODE_OAUTH_TOKEN when set, initialises SDK with authToken', async () => {
       vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', 'oauth-tok-xyz');
-      vi.stubEnv('FERRY_ANTHROPIC_KEY', '');
+      vi.stubEnv('ANTHROPIC_API_KEY', '');
       createLlmCall(route);
       expect(Anthropic).toHaveBeenCalledWith(
         expect.objectContaining({ authToken: 'oauth-tok-xyz' }),
@@ -114,8 +114,8 @@ describe('createLlmCall', () => {
       );
     });
 
-    it('falls back to FERRY_ANTHROPIC_KEY when CLAUDE_CODE_OAUTH_TOKEN is unset', () => {
-      vi.stubEnv('FERRY_ANTHROPIC_KEY', 'sk-ant-abc');
+    it('falls back to ANTHROPIC_API_KEY when CLAUDE_CODE_OAUTH_TOKEN is unset', () => {
+      vi.stubEnv('ANTHROPIC_API_KEY', 'sk-ant-abc');
       vi.stubEnv('CLAUDE_CODE_OAUTH_TOKEN', '');
       createLlmCall(route);
       expect(Anthropic).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'sk-ant-abc' }));
@@ -125,7 +125,7 @@ describe('createLlmCall', () => {
     });
 
     it('maps RateLimitError to FerryError("spend-cap") immediately (no retry)', async () => {
-      vi.stubEnv('FERRY_ANTHROPIC_KEY', 'test-key');
+      vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
       const RLE = Anthropic.RateLimitError as unknown as ZeroArgClass;
       anthropicMockCreate.mockRejectedValueOnce(new RLE());
       const llmCall = createLlmCall(route);
@@ -134,7 +134,7 @@ describe('createLlmCall', () => {
 
     it('maps 5xx APIError through retry → FerryError("unknown") after exhaustion', async () => {
       vi.useFakeTimers();
-      vi.stubEnv('FERRY_ANTHROPIC_KEY', 'test-key');
+      vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
       const AE = Anthropic.APIError as unknown as ZeroArgClass;
       const serverErr = Object.assign(new AE(), { status: 500 });
       anthropicMockCreate
@@ -245,7 +245,7 @@ describe('createLlmCall', () => {
 
   describe('LlmResult shape', () => {
     it('LlmResult has text, usage with inputTokens/outputTokens/costEur', async () => {
-      vi.stubEnv('FERRY_ANTHROPIC_KEY', 'test-key');
+      vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
       const route: LlmRoute = { provider: 'anthropic', model: 'claude-sonnet-4-6' };
       const llmCall = createLlmCall(route);
       const result = await llmCall('prompt');

--- a/src/lib/llm/call.ts
+++ b/src/lib/llm/call.ts
@@ -33,7 +33,7 @@ function requireEnv(key: string): string {
 
 export function createLlmCall(route: LlmRoute): LlmCall {
   if (route.provider === 'anthropic') {
-    const auth = resolveAnthropicAuth({ apiKeyEnv: 'FERRY_ANTHROPIC_KEY' });
+    const auth = resolveAnthropicAuth({ apiKeyEnv: 'ANTHROPIC_API_KEY' });
     const client = new Anthropic(auth);
     return retry(
       (prompt: string) =>


### PR DESCRIPTION
Closes #142 - per-phase LLM provider selection.

## Summary

- Refiner now routes through `createLlmCall()` supporting all three providers end-to-end
- New env vars: `FERRY_REFINER_PROVIDER`, `FERRY_DEV_PROVIDER`, `FERRY_REVIEW_PROVIDER`, `FERRY_ITER_PROVIDER`
- Developer/Reviewer/Iterator validate Anthropic-only with a clear error (follow-on PR for full agentic-loop abstraction)
- ferry-doctor checks per-provider API keys (`FERRY_OPENAI_KEY`, `FERRY_GOOGLE_AI_KEY`)
- `appendOutput` emits `provider=` alongside `model=` for all phases
- `createLlmCall` switched to `ANTHROPIC_API_KEY` (consistent with all agent workflows)
- Docs updated with provider support matrix, env var table, new secrets

Closes #142

Generated with [Claude Code](https://claude.ai/code)