### PR TITLE
feat: configurable Jira column → agent mapping with opt-in auto-transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,13 @@ Jira column move / label / @mention
   Human merges PR
 ```
 
-Ferry **never merges** and **never moves Jira columns** autonomously except for three explicit transitions:
+Ferry **never merges** and **rarely moves Jira columns** autonomously. By default, three auto-transitions are enabled:
 
 1. Developer → In Review (FR18)
-2. Reviewer → Ready to Merge or Changes Requested (FR24)
+2. Reviewer → Changes Requested (FR24, on review findings)
 3. Iterator → In Review (FR28)
+
+All auto-transitions are configurable via `workflow.agents` in `ferry.config.yaml` — set any to `null` to hand control back to humans, or set custom column names to match your board. See [`docs/CONFIGURATION.md`](docs/CONFIGURATION.md#workflowagents) for details.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -171,6 +171,45 @@ Maps Jira ticket labels to MCP server capabilities. If this section is omitted, 
 
 **Unknown labels:** Any `ferry:*` label on a ticket that is not declared in `labels` is logged to stderr and silently ignored.
 
+#### `workflow.agents`
+
+Maps each Ferry agent to a Jira column and controls which auto-transitions are enabled. All fields are optional — omit any section to use the defaults shown below.
+
+```yaml
+workflow:
+  agents:
+    refiner:
+      trigger_column: "Refinement"
+      auto_transition: null           # refiner never auto-transitions
+    developer:
+      trigger_column: "In Development"
+      auto_transition: "In Review"    # FR18 — set null to disable
+    reviewer:
+      trigger_column: "In Review"
+      auto_transition_approve: null   # optional: set to a column to auto-move on approval
+      auto_transition_changes: "Changes Requested"  # FR24 — set null to disable
+    iterator:
+      trigger_column: "Changes Requested"
+      auto_transition: "In Review"    # FR28 — set null to disable
+```
+
+**Defaults reproduce today's behavior exactly** (FR18, FR24, FR28 all enabled with the column names above).
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `workflow.agents.refiner.trigger_column` | `"Refinement"` | Jira column that triggers the Refiner. Used by `ferry-doctor` to validate column existence. |
+| `workflow.agents.developer.trigger_column` | `"In Development"` | Jira column that triggers the Developer. |
+| `workflow.agents.developer.auto_transition` | `"In Review"` | Column to move the ticket into after the Developer finishes (FR18). Set to `null` to disable — humans drive the transition. Requires `FERRY_REVIEW_TRANSITION_ID` secret when non-null. |
+| `workflow.agents.reviewer.trigger_column` | `"In Review"` | Jira column that triggers the Reviewer. |
+| `workflow.agents.reviewer.auto_transition_approve` | `null` | Column to move the ticket into when the Reviewer approves. `null` = no transition (default). Requires `FERRY_APPROVE_TRANSITION_ID` secret when non-null. |
+| `workflow.agents.reviewer.auto_transition_changes` | `"Changes Requested"` | Column to move the ticket into when the Reviewer requests changes (FR24). Set to `null` to disable. Requires `FERRY_ITER_TRANSITION_ID` secret when non-null. |
+| `workflow.agents.iterator.trigger_column` | `"Changes Requested"` | Jira column that triggers the Iterator. |
+| `workflow.agents.iterator.auto_transition` | `"In Review"` | Column to move the ticket into after the Iterator finishes (FR28). Set to `null` to disable. Requires `FERRY_REVIEW_TRANSITION_ID` secret when non-null. |
+
+> **Finding Jira transition IDs for custom columns:** Call `GET https://<your-domain>.atlassian.net/rest/api/3/issue/<TICKET-KEY>/transitions` with Basic Auth. Match the transition `name` to your target column and use the `id` field as the secret value.
+
+> **`ferry-doctor` validates columns:** When `workflow.agents` is present in your config, `ferry-doctor` calls the Jira API to confirm each `trigger_column` and `auto_transition` value exists in your project. Run `ferry-doctor` after changing column names.
+
 ---
 
 ## What is hardcoded vs. configurable
@@ -179,7 +218,6 @@ The following are intentionally not configurable by consumers:
 
 | Parameter | Why hardcoded |
 |-----------|---------------|
-| Jira column transitions (except the two IDs above) | Managed by Ferry's internal state machine |
 | Branch naming (`ferry/<ticket-key>`) | Required by Ferry's state logic |
 | PR/comment fingerprint formats | Required for idempotency |
 | `FERRY_MODEL` env var used by Refiner/Developer workflows | Set to `claude-sonnet-4-6` internally; use `ferry.config.json` to change those models |

--- a/src/agents/developer/dev-action.ts
+++ b/src/agents/developer/dev-action.ts
@@ -42,9 +42,11 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   }
 
   const anthropicAuth = resolveAnthropicAuth({ apiKeyEnv: 'ANTHROPIC_API_KEY' });
-  const reviewTransitionId = dryRun ? '' : requireEnv('FERRY_REVIEW_TRANSITION_ID');
-  const jiraBaseUrl = requireEnv('FERRY_JIRA_BASE_URL');
   const { owner, repo, runner, tracker, ferryCfg } = createGitHubContext(REPO_ROOT);
+  const devWorkflow = ferryCfg.workflow.agents.developer;
+  const shouldAutoTransition = devWorkflow.auto_transition !== null;
+  const reviewTransitionId = (dryRun || !shouldAutoTransition) ? '' : requireEnv('FERRY_REVIEW_TRANSITION_ID');
+  const jiraBaseUrl = requireEnv('FERRY_JIRA_BASE_URL');
 
   const issue = await tracker.getIssue(ticketKey);
   const labels = issue.labels.join(', ');
@@ -228,10 +230,13 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
 
     const prUrl = await runner.createPR(owner, repo, branchName, 'main', prTitle, prBody);
 
-    await tracker.postTransition(ticketKey, reviewTransitionId);
+    if (shouldAutoTransition) {
+      await tracker.postTransition(ticketKey, reviewTransitionId);
+    }
+    const transitionNote = shouldAutoTransition ? ' Moved to Review.' : '';
     await tracker.postComment(
       ticketKey,
-      `${idempotencyMarker} Implementation complete — PR: ${prUrl}. Moved to Review.`,
+      `${idempotencyMarker} Implementation complete — PR: ${prUrl}.${transitionNote}`,
     );
   } catch (err) {
     if (!dryRun) {

--- a/src/agents/iterator/iterate-action.ts
+++ b/src/agents/iterator/iterate-action.ts
@@ -34,8 +34,10 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
 
   const anthropicAuth = resolveAnthropicAuth({ apiKeyEnv: 'ANTHROPIC_API_KEY' });
-  const reviewTransitionId = requireEnv('FERRY_REVIEW_TRANSITION_ID');
   const { owner, repo, runner, tracker, ferryCfg } = createGitHubContext(REPO_ROOT);
+  const iteratorWorkflow = ferryCfg.workflow.agents.iterator;
+  const shouldAutoTransition = iteratorWorkflow.auto_transition !== null;
+  const reviewTransitionId = shouldAutoTransition ? requireEnv('FERRY_REVIEW_TRANSITION_ID') : '';
   const model = ferryCfg.models.iterate.model;
 
   const issue = await tracker.getIssue(ticketKey);
@@ -212,12 +214,15 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   }
   execFileSync('git', ['push', 'origin', branchName, '--force-with-lease'], { cwd: REPO_ROOT });
 
-  await tracker.postTransition(ticketKey, reviewTransitionId);
+  if (shouldAutoTransition) {
+    await tracker.postTransition(ticketKey, reviewTransitionId);
+  }
 
   const { next_iteration } = decideIteratorTransition({ current_iteration: priorIterations });
+  const transitionNote = shouldAutoTransition ? ' Moved back to Review.' : '';
   await tracker.postComment(
     ticketKey,
-    `${idempotencyMarker} Iteration ${next_iteration} complete. Pushed fixes to PR#${prNumber}. Moved back to Review.`,
+    `${idempotencyMarker} Iteration ${next_iteration} complete. Pushed fixes to PR#${prNumber}.${transitionNote}`,
   );
 
   appendOutput({ ...usage, model });

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -25,8 +25,12 @@ const REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
 
-  const iterTransitionId = requireEnv('FERRY_ITER_TRANSITION_ID');
   const { owner, repo, runner, tracker, ferryCfg } = createGitHubContext(REPO_ROOT);
+  const reviewerWorkflow = ferryCfg.workflow.agents.reviewer;
+  const shouldTransitionChanges = reviewerWorkflow.auto_transition_changes !== null;
+  const shouldTransitionApprove = reviewerWorkflow.auto_transition_approve !== null;
+  const iterTransitionId = shouldTransitionChanges ? requireEnv('FERRY_ITER_TRANSITION_ID') : '';
+  const approveTransitionId = shouldTransitionApprove ? requireEnv('FERRY_APPROVE_TRANSITION_ID') : '';
   const model = ferryCfg.models.review.model;
 
   const issue = await tracker.getIssue(ticketKey);
@@ -84,15 +88,18 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
 
     const ciMessage =
       ciOutcome.findings[0]?.message ?? 'CI checks failed. See the Actions run for details.';
+    const ciTransitionNote = shouldTransitionChanges ? ' Moved to Dev Iteration.' : '';
     await tracker.postComment(
       ticketKey,
-      `${idempotencyMarker} CI checks failed. Moved to Dev Iteration.`,
+      `${idempotencyMarker} CI checks failed.${ciTransitionNote}`,
     );
     await runner.commentOnPR(
       { owner, repo, prNumber },
       `${idempotencyMarker}\n\n**CI failed:** ${ciMessage}`,
     );
-    await tracker.postTransition(ticketKey, iterTransitionId);
+    if (shouldTransitionChanges) {
+      await tracker.postTransition(ticketKey, iterTransitionId);
+    }
     appendOutput({ input_tokens: 0, output_tokens: 0, model });
     return;
   }
@@ -181,17 +188,23 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
     await runner.removeLabelFromPR({ owner, repo, prNumber }, 'ferry:reviewing').catch(() => {});
     await runner.markPRReadyForReview(owner, repo, prNumber);
     await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
+    if (shouldTransitionApprove) {
+      await tracker.postTransition(ticketKey, approveTransitionId);
+    }
   } else {
     const hasIteratorMarker = existingComments.some((c) => c.includes('[ferry:iterator:'));
 
     await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
 
     if (!hasIteratorMarker) {
+      const changesNote = shouldTransitionChanges ? ' Moved to Dev Iteration.' : '';
       await tracker.postComment(
         ticketKey,
-        `${idempotencyMarker} Changes requested. Moved to Dev Iteration. See PR#${prNumber} for details.`,
+        `${idempotencyMarker} Changes requested.${changesNote} See PR#${prNumber} for details.`,
       );
-      await tracker.postTransition(ticketKey, iterTransitionId);
+      if (shouldTransitionChanges) {
+        await tracker.postTransition(ticketKey, iterTransitionId);
+      }
     } else {
       await tracker.postComment(
         ticketKey,

--- a/src/cli/doctor/checks/workflow-columns.ts
+++ b/src/cli/doctor/checks/workflow-columns.ts
@@ -1,0 +1,186 @@
+import { createRequire } from 'node:module';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { httpsGet } from '../../http.js';
+import type { CheckResult } from '../types.js';
+
+const _require = createRequire(import.meta.url);
+
+function jiraAuthHeader(email: string, token: string): string {
+  return `Basic ${Buffer.from(`${email}:${token}`).toString('base64')}`;
+}
+
+interface JiraStatus {
+  id: string;
+  name: string;
+}
+
+interface JiraIssueTypeWithStatuses {
+  statuses: JiraStatus[];
+}
+
+function parseYaml(content: string): unknown {
+  const mod = _require('yaml') as { parse: (s: string) => unknown };
+  return mod.parse(content);
+}
+
+function readRawConfig(repoRoot: string): Record<string, unknown> | null {
+  const jsonPath = join(repoRoot, 'ferry.config.json');
+  if (existsSync(jsonPath)) {
+    try {
+      return JSON.parse(readFileSync(jsonPath, 'utf8')) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+  for (const ext of ['ferry.config.yaml', 'ferry.config.yml']) {
+    const yamlPath = join(repoRoot, ext);
+    if (!existsSync(yamlPath)) continue;
+    try {
+      return parseYaml(readFileSync(yamlPath, 'utf8')) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function collectWorkflowColumns(raw: Record<string, unknown>): string[] | null {
+  const workflow = raw.workflow as Record<string, unknown> | undefined;
+  if (!workflow) return null;
+  const agents = workflow.agents as Record<string, unknown> | undefined;
+  if (!agents) return null;
+
+  const columns: string[] = [];
+  const push = (val: unknown): void => {
+    if (typeof val === 'string' && val.trim()) columns.push(val.trim());
+  };
+
+  for (const agentKey of ['refiner', 'developer', 'reviewer', 'iterator']) {
+    const agent = agents[agentKey] as Record<string, unknown> | undefined;
+    if (!agent) continue;
+    push(agent.trigger_column);
+    push(agent.auto_transition);
+    push(agent.auto_transition_approve);
+    push(agent.auto_transition_changes);
+  }
+
+  return columns.length > 0 ? [...new Set(columns)] : null;
+}
+
+export async function checkWorkflowColumns(opts: {
+  repoRoot: string;
+  jiraBaseUrl: string;
+  jiraEmail: string;
+  jiraApiToken: string;
+  jiraProjectKey: string;
+}): Promise<CheckResult> {
+  const { repoRoot, jiraBaseUrl, jiraEmail, jiraApiToken, jiraProjectKey } = opts;
+
+  const raw = readRawConfig(repoRoot);
+  if (!raw) {
+    return {
+      label: 'Workflow columns',
+      status: 'skip',
+      detail: 'No ferry.config.* found or config could not be parsed — skipping column validation',
+    };
+  }
+
+  const columns = collectWorkflowColumns(raw);
+  if (columns === null) {
+    return {
+      label: 'Workflow columns',
+      status: 'skip',
+      detail: 'No workflow.agents section in config — using defaults',
+    };
+  }
+
+  if (!jiraBaseUrl || !jiraEmail || !jiraApiToken || !jiraProjectKey) {
+    return {
+      label: 'Workflow columns',
+      status: 'skip',
+      detail: 'Jira credentials not provided — skipping column validation',
+      remedy: 'Provide --jira-url, --jira-email, --jira-token, --jira-project to validate columns',
+    };
+  }
+
+  let hostname: string;
+  let basePath: string;
+  try {
+    const url = new URL(jiraBaseUrl);
+    hostname = url.hostname;
+    basePath = url.pathname.replace(/\/$/, '');
+  } catch {
+    return {
+      label: 'Workflow columns',
+      status: 'skip',
+      detail: 'Invalid Jira URL — skipping column validation',
+    };
+  }
+
+  const headers = {
+    Authorization: jiraAuthHeader(jiraEmail, jiraApiToken),
+    Accept: 'application/json',
+    'User-Agent': 'ferry-doctor/1',
+  };
+
+  let projectStatuses: string[];
+  try {
+    const res = await httpsGet({
+      hostname,
+      path: `${basePath}/rest/api/3/project/${encodeURIComponent(jiraProjectKey)}/statuses`,
+      headers,
+    });
+
+    if (res.statusCode === 404) {
+      return {
+        label: 'Workflow columns',
+        status: 'yellow',
+        detail: `Project "${jiraProjectKey}" not found — cannot validate columns`,
+        remedy: 'Verify FERRY_JIRA_PROJECT_KEY is correct',
+      };
+    }
+    if (res.statusCode !== 200) {
+      return {
+        label: 'Workflow columns',
+        status: 'yellow',
+        detail: `Jira returned status ${res.statusCode} fetching project statuses`,
+        remedy: 'Check Jira credentials and project key',
+      };
+    }
+
+    const data = JSON.parse(res.body) as JiraIssueTypeWithStatuses[];
+    const statusSet = new Set<string>();
+    for (const issueType of data) {
+      for (const s of issueType.statuses) {
+        statusSet.add(s.name);
+      }
+    }
+    projectStatuses = [...statusSet];
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      label: 'Workflow columns',
+      status: 'yellow',
+      detail: `Could not fetch Jira project statuses: ${msg}`,
+      remedy: 'Check network connectivity and Jira credentials',
+    };
+  }
+
+  const missing = columns.filter((c) => !projectStatuses.includes(c));
+
+  if (missing.length > 0) {
+    return {
+      label: 'Workflow columns',
+      status: 'red',
+      detail: `Column(s) not found in Jira project "${jiraProjectKey}": ${missing.join(', ')}`,
+      remedy: `Update workflow.agents column names in ferry.config.yaml to match your Jira board. Available: ${projectStatuses.join(', ')}`,
+    };
+  }
+
+  return {
+    label: 'Workflow columns',
+    status: 'green',
+    detail: `All ${columns.length} configured column(s) exist in Jira project "${jiraProjectKey}"`,
+  };
+}

--- a/src/cli/doctor/index.ts
+++ b/src/cli/doctor/index.ts
@@ -11,6 +11,7 @@ import { checkWorkflowDrift } from './checks/workflows.js';
 import { checkPromptOverrides } from './checks/prompts.js';
 import { checkUpdateAvailable } from './checks/update-available.js';
 import { checkConfigLimits } from './checks/config.js';
+import { checkWorkflowColumns } from './checks/workflow-columns.js';
 import { renderTable } from './table.js';
 import type { DoctorConfig } from './types.js';
 
@@ -101,15 +102,16 @@ Options:
   -h, --help                   Show this help
 
 Checks run in order:
-  1. Secrets present        — all 8 required repo secrets exist
-  2. GitHub App             — mint installation token, verify permissions
-  3. Jira reachable         — /myself + project key resolution
-  4. LLM keys valid         — 1-token Anthropic sanity call
-  5. Synthetic dispatch     — trigger ferry-refine + poll for run start
-  6. Workflow files         — compare .github/workflows/ferry-*.yml vs current release
-  7. Prompt overrides       — warn on full prompts/<agent>.md overrides; suggest .extra.md
-  8. Update available       — compare pinned ref in workflows to latest npm release
-  9. Config limits          — warn if limits.max_iterations is outside the recommended range (1–10)
+  1.  Secrets present        — all 8 required repo secrets exist
+  2.  GitHub App             — mint installation token, verify permissions
+  3.  Jira reachable         — /myself + project key resolution
+  4.  LLM keys valid         — 1-token Anthropic sanity call
+  5.  Synthetic dispatch     — trigger ferry-refine + poll for run start
+  6.  Workflow files         — compare .github/workflows/ferry-*.yml vs current release
+  7.  Prompt overrides       — warn on full prompts/<agent>.md overrides; suggest .extra.md
+  8.  Update available       — compare pinned ref in workflows to latest npm release
+  9.  Config limits          — warn if limits.max_iterations is outside the recommended range (1–10)
+  10. Workflow columns       — validate workflow.agents column names exist in Jira project
 
 Exit code: 0 if all checks green/yellow, 1 if any check red.
 `);
@@ -146,6 +148,13 @@ Exit code: 0 if all checks green/yellow, 1 if any check red.
     checkPromptOverrides({ repoRoot: config.repoRoot }),
     checkUpdateAvailable({ repoRoot: config.repoRoot }),
     checkConfigLimits({ repoRoot: config.repoRoot }),
+    checkWorkflowColumns({
+      repoRoot: config.repoRoot,
+      jiraBaseUrl: config.jiraBaseUrl,
+      jiraEmail: config.jiraEmail,
+      jiraApiToken: config.jiraApiToken,
+      jiraProjectKey: config.jiraProjectKey,
+    }),
   ]);
 
   process.stdout.write(renderTable(results));

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { execSync } from 'node:child_process';
+import { existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   ask,
@@ -10,6 +11,7 @@ import {
   printStep,
   printSuccess,
   printError,
+  printSkip,
 } from './prompt.js';
 import { workflowTemplates } from './templates.js';
 import { stepGitHubApp } from './steps/github-app.js';
@@ -139,6 +141,25 @@ async function main(): Promise<void> {
   const iterateStatus = await ask('Iterator trigger status', DEFAULT_STATUS_NAMES.iterate);
 
   print('');
+  print('Auto-transitions (column to move to after each step, leave blank to disable):');
+  const devAutoTransition = await ask(
+    'Developer → after implementation (moves to)',
+    'In Review',
+  );
+  const reviewerChangesAutoTransition = await ask(
+    'Reviewer → after requesting changes (moves to)',
+    'Changes Requested',
+  );
+  const reviewerApproveAutoTransition = await ask(
+    'Reviewer → after approving (moves to, blank = no transition)',
+    '',
+  );
+  const iteratorAutoTransition = await ask(
+    'Iterator → after iteration (moves to)',
+    'In Review',
+  );
+
+  print('');
   print('LLM provider:');
   const anthropicApiKey = await askSecret('Anthropic API key (sk-ant-...)');
 
@@ -168,12 +189,39 @@ async function main(): Promise<void> {
     print('You can re-run ferry-init to retry.');
   }
 
-  // ── Step 3: Workflows ─────────────────────────────────────────────────────
+  // ── Step 3: Workflows + ferry.config.yaml ────────────────────────────────
   printStep(3, TOTAL_STEPS, 'Installing workflow files');
   const templates = workflowTemplates(config.ferryVersion);
   const workflowDir = join(repoRoot, '.github', 'workflows');
   installWorkflows(workflowDir, templates, overwrite);
   scaffoldCodeowners(repoRoot, owner);
+
+  const configPath = join(repoRoot, 'ferry.config.yaml');
+  if (!existsSync(configPath) || overwrite) {
+    const nullable = (val: string): string => val.trim() ? `"${val.trim()}"` : 'null';
+    const workflowYaml = [
+      'workflow:',
+      '  agents:',
+      '    refiner:',
+      `      trigger_column: "${refineStatus || DEFAULT_STATUS_NAMES.refine}"`,
+      '      auto_transition: null',
+      '    developer:',
+      `      trigger_column: "${devStatus || DEFAULT_STATUS_NAMES.dev}"`,
+      `      auto_transition: ${nullable(devAutoTransition)}`,
+      '    reviewer:',
+      `      trigger_column: "${reviewStatus || DEFAULT_STATUS_NAMES.review}"`,
+      `      auto_transition_approve: ${nullable(reviewerApproveAutoTransition)}`,
+      `      auto_transition_changes: ${nullable(reviewerChangesAutoTransition)}`,
+      '    iterator:',
+      `      trigger_column: "${iterateStatus || DEFAULT_STATUS_NAMES.iterate}"`,
+      `      auto_transition: ${nullable(iteratorAutoTransition)}`,
+      '',
+    ].join('\n');
+    writeFileSync(configPath, workflowYaml, 'utf8');
+    printSuccess('Generated ferry.config.yaml with workflow.agents settings');
+  } else {
+    printSkip('ferry.config.yaml already exists — skipping (use --overwrite to replace)');
+  }
 
   // ── Step 4: Jira automation bundle ────────────────────────────────────────
   printStep(4, TOTAL_STEPS, 'Generating Jira Automation import bundle');
@@ -195,7 +243,7 @@ async function main(): Promise<void> {
   print('════════════════════════════════════════');
   print('');
   print('Next steps:');
-  print('  1. Commit .github/workflows/ferry-*.yml and .github/CODEOWNERS');
+  print('  1. Commit .github/workflows/ferry-*.yml, ferry.config.yaml, and .github/CODEOWNERS');
   print('  2. Set up Jira Automation rules (choose one):');
   print('     a) Manual (recommended): follow ferry-jira-automation-setup.md');
   print('     b) Import (beta): Jira → Project settings → Automation → Import rules');

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -142,10 +142,7 @@ async function main(): Promise<void> {
 
   print('');
   print('Auto-transitions (column to move to after each step, leave blank to disable):');
-  const devAutoTransition = await ask(
-    'Developer → after implementation (moves to)',
-    'In Review',
-  );
+  const devAutoTransition = await ask('Developer → after implementation (moves to)', 'In Review');
   const reviewerChangesAutoTransition = await ask(
     'Reviewer → after requesting changes (moves to)',
     'Changes Requested',
@@ -154,10 +151,7 @@ async function main(): Promise<void> {
     'Reviewer → after approving (moves to, blank = no transition)',
     '',
   );
-  const iteratorAutoTransition = await ask(
-    'Iterator → after iteration (moves to)',
-    'In Review',
-  );
+  const iteratorAutoTransition = await ask('Iterator → after iteration (moves to)', 'In Review');
 
   print('');
   print('LLM provider:');
@@ -198,7 +192,7 @@ async function main(): Promise<void> {
 
   const configPath = join(repoRoot, 'ferry.config.yaml');
   if (!existsSync(configPath) || overwrite) {
-    const nullable = (val: string): string => val.trim() ? `"${val.trim()}"` : 'null';
+    const nullable = (val: string): string => (val.trim() ? `"${val.trim()}"` : 'null');
     const workflowYaml = [
       'workflow:',
       '  agents:',

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -328,4 +328,133 @@ describe('loadFerryConfig', () => {
       expect(() => loadFerryConfig('/repo')).toThrow(FerryError);
     });
   });
+
+  describe('workflow.agents section', () => {
+    it('defaults include all workflow.agents settings', () => {
+      mockNoConfigFile();
+      const cfg = loadFerryConfig('/repo');
+      expect(cfg.workflow.agents.refiner.trigger_column).toBe('Refinement');
+      expect(cfg.workflow.agents.refiner.auto_transition).toBeNull();
+      expect(cfg.workflow.agents.developer.trigger_column).toBe('In Development');
+      expect(cfg.workflow.agents.developer.auto_transition).toBe('In Review');
+      expect(cfg.workflow.agents.reviewer.trigger_column).toBe('In Review');
+      expect(cfg.workflow.agents.reviewer.auto_transition_approve).toBeNull();
+      expect(cfg.workflow.agents.reviewer.auto_transition_changes).toBe('Changes Requested');
+      expect(cfg.workflow.agents.iterator.trigger_column).toBe('Changes Requested');
+      expect(cfg.workflow.agents.iterator.auto_transition).toBe('In Review');
+    });
+
+    it('merges partial workflow.agents from config', () => {
+      mockConfigFile(
+        'ferry.config.json',
+        JSON.stringify({
+          workflow: {
+            agents: {
+              developer: { trigger_column: 'Dev Queue', auto_transition: null },
+            },
+          },
+        }),
+      );
+      const cfg = loadFerryConfig('/repo');
+      expect(cfg.workflow.agents.developer.trigger_column).toBe('Dev Queue');
+      expect(cfg.workflow.agents.developer.auto_transition).toBeNull();
+      // Non-configured agents keep defaults
+      expect(cfg.workflow.agents.reviewer.trigger_column).toBe('In Review');
+      expect(cfg.workflow.agents.reviewer.auto_transition_changes).toBe('Changes Requested');
+    });
+
+    it('allows null auto_transition for developer', () => {
+      mockConfigFile(
+        'ferry.config.json',
+        JSON.stringify({ workflow: { agents: { developer: { auto_transition: null } } } }),
+      );
+      const cfg = loadFerryConfig('/repo');
+      expect(cfg.workflow.agents.developer.auto_transition).toBeNull();
+    });
+
+    it('allows null auto_transition_changes for reviewer', () => {
+      mockConfigFile(
+        'ferry.config.json',
+        JSON.stringify({
+          workflow: { agents: { reviewer: { auto_transition_changes: null } } },
+        }),
+      );
+      const cfg = loadFerryConfig('/repo');
+      expect(cfg.workflow.agents.reviewer.auto_transition_changes).toBeNull();
+    });
+
+    it('allows setting auto_transition_approve for reviewer', () => {
+      mockConfigFile(
+        'ferry.config.json',
+        JSON.stringify({
+          workflow: { agents: { reviewer: { auto_transition_approve: 'Ready to Merge' } } },
+        }),
+      );
+      const cfg = loadFerryConfig('/repo');
+      expect(cfg.workflow.agents.reviewer.auto_transition_approve).toBe('Ready to Merge');
+    });
+
+    it('throws on invalid auto_transition type', () => {
+      mockConfigFile(
+        'ferry.config.json',
+        JSON.stringify({
+          workflow: { agents: { developer: { auto_transition: 42 } } },
+        }),
+      );
+      let thrown: FerryError | null = null;
+      try {
+        loadFerryConfig('/repo');
+      } catch (e) {
+        thrown = e as FerryError;
+      }
+      expect(thrown).toBeInstanceOf(FerryError);
+      const errors = thrown?.context?.errors as string[];
+      expect(errors.some((e) => e.includes('workflow.agents.developer.auto_transition'))).toBe(true);
+    });
+
+    it('throws on invalid trigger_column type', () => {
+      mockConfigFile(
+        'ferry.config.json',
+        JSON.stringify({
+          workflow: { agents: { refiner: { trigger_column: 123 } } },
+        }),
+      );
+      let thrown: FerryError | null = null;
+      try {
+        loadFerryConfig('/repo');
+      } catch (e) {
+        thrown = e as FerryError;
+      }
+      expect(thrown).toBeInstanceOf(FerryError);
+      const errors = thrown?.context?.errors as string[];
+      expect(errors.some((e) => e.includes('workflow.agents.refiner.trigger_column'))).toBe(true);
+    });
+
+    it('supports custom column names for all agents', () => {
+      mockConfigFile(
+        'ferry.config.json',
+        JSON.stringify({
+          workflow: {
+            agents: {
+              refiner: { trigger_column: 'Ready for Refinement' },
+              developer: { trigger_column: 'In Progress', auto_transition: 'Code Review' },
+              reviewer: {
+                trigger_column: 'Code Review',
+                auto_transition_approve: 'Ready to Deploy',
+                auto_transition_changes: 'Needs Work',
+              },
+              iterator: { trigger_column: 'Needs Work', auto_transition: 'Code Review' },
+            },
+          },
+        }),
+      );
+      const cfg = loadFerryConfig('/repo');
+      expect(cfg.workflow.agents.refiner.trigger_column).toBe('Ready for Refinement');
+      expect(cfg.workflow.agents.developer.trigger_column).toBe('In Progress');
+      expect(cfg.workflow.agents.developer.auto_transition).toBe('Code Review');
+      expect(cfg.workflow.agents.reviewer.auto_transition_approve).toBe('Ready to Deploy');
+      expect(cfg.workflow.agents.reviewer.auto_transition_changes).toBe('Needs Work');
+      expect(cfg.workflow.agents.iterator.auto_transition).toBe('Code Review');
+    });
+  });
 });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -15,6 +15,40 @@ export interface LabelCapability {
   tools?: string[];
 }
 
+export interface RefinerWorkflowAgentConfig {
+  trigger_column: string;
+  auto_transition: null;
+}
+
+export interface DeveloperWorkflowAgentConfig {
+  trigger_column: string;
+  /** Column name to transition into after implementation. null = no auto-transition. */
+  auto_transition: string | null;
+}
+
+export interface ReviewerWorkflowAgentConfig {
+  trigger_column: string;
+  /** Column name to transition into on approval. null = no auto-transition (default). */
+  auto_transition_approve: string | null;
+  /** Column name to transition into when changes are requested. null = no auto-transition. */
+  auto_transition_changes: string | null;
+}
+
+export interface IteratorWorkflowAgentConfig {
+  trigger_column: string;
+  /** Column name to transition into after iteration. null = no auto-transition. */
+  auto_transition: string | null;
+}
+
+export interface WorkflowConfig {
+  agents: {
+    refiner: RefinerWorkflowAgentConfig;
+    developer: DeveloperWorkflowAgentConfig;
+    reviewer: ReviewerWorkflowAgentConfig;
+    iterator: IteratorWorkflowAgentConfig;
+  };
+}
+
 export interface FerryConfig {
   models: {
     refiner: LlmRoute;
@@ -39,6 +73,7 @@ export interface FerryConfig {
     dev_allowlist: string[];
   };
   labels?: Record<string, LabelCapability>;
+  workflow: WorkflowConfig;
 }
 
 export const DEFAULT_FERRY_CONFIG: FerryConfig = {
@@ -58,6 +93,18 @@ export const DEFAULT_FERRY_CONFIG: FerryConfig = {
   ticket_types: {
     refine_allowlist: ['Story', 'Bug', 'Spike'],
     dev_allowlist: ['Story', 'Bug', 'Spike'],
+  },
+  workflow: {
+    agents: {
+      refiner: { trigger_column: 'Refinement', auto_transition: null },
+      developer: { trigger_column: 'In Development', auto_transition: 'In Review' },
+      reviewer: {
+        trigger_column: 'In Review',
+        auto_transition_approve: null,
+        auto_transition_changes: 'Changes Requested',
+      },
+      iterator: { trigger_column: 'Changes Requested', auto_transition: 'In Review' },
+    },
   },
 };
 
@@ -102,6 +149,79 @@ function validateStringArray(val: unknown, fieldPath: string): ValidationError[]
     return [`${fieldPath}: must be an array of strings`];
   }
   return [];
+}
+
+function validateStringOrNull(val: unknown, fieldPath: string): ValidationError[] {
+  if (val !== null && typeof val !== 'string') {
+    return [`${fieldPath}: must be a string or null`];
+  }
+  return [];
+}
+
+function validateWorkflowAgentBase(val: unknown, fieldPath: string): ValidationError[] {
+  if (!val || typeof val !== 'object') return [`${fieldPath}: must be an object`];
+  const v = val as Record<string, unknown>;
+  if (v.trigger_column !== undefined && typeof v.trigger_column !== 'string') {
+    return [`${fieldPath}.trigger_column: must be a string`];
+  }
+  return [];
+}
+
+function validateWorkflow(val: unknown): ValidationError[] {
+  if (!val || typeof val !== 'object') return ['workflow: must be an object'];
+  const w = val as Record<string, unknown>;
+  const errs: ValidationError[] = [];
+
+  if (w.agents === undefined) return errs;
+  if (!w.agents || typeof w.agents !== 'object') {
+    errs.push('workflow.agents: must be an object');
+    return errs;
+  }
+  const agents = w.agents as Record<string, unknown>;
+
+  if (agents.refiner !== undefined) {
+    errs.push(...validateWorkflowAgentBase(agents.refiner, 'workflow.agents.refiner'));
+  }
+  if (agents.developer !== undefined) {
+    errs.push(...validateWorkflowAgentBase(agents.developer, 'workflow.agents.developer'));
+    const dev = agents.developer as Record<string, unknown>;
+    if ('auto_transition' in dev && dev.auto_transition !== undefined) {
+      errs.push(
+        ...validateStringOrNull(dev.auto_transition, 'workflow.agents.developer.auto_transition'),
+      );
+    }
+  }
+  if (agents.reviewer !== undefined) {
+    errs.push(...validateWorkflowAgentBase(agents.reviewer, 'workflow.agents.reviewer'));
+    const rev = agents.reviewer as Record<string, unknown>;
+    if ('auto_transition_approve' in rev && rev.auto_transition_approve !== undefined) {
+      errs.push(
+        ...validateStringOrNull(
+          rev.auto_transition_approve,
+          'workflow.agents.reviewer.auto_transition_approve',
+        ),
+      );
+    }
+    if ('auto_transition_changes' in rev && rev.auto_transition_changes !== undefined) {
+      errs.push(
+        ...validateStringOrNull(
+          rev.auto_transition_changes,
+          'workflow.agents.reviewer.auto_transition_changes',
+        ),
+      );
+    }
+  }
+  if (agents.iterator !== undefined) {
+    errs.push(...validateWorkflowAgentBase(agents.iterator, 'workflow.agents.iterator'));
+    const iter = agents.iterator as Record<string, unknown>;
+    if ('auto_transition' in iter && iter.auto_transition !== undefined) {
+      errs.push(
+        ...validateStringOrNull(iter.auto_transition, 'workflow.agents.iterator.auto_transition'),
+      );
+    }
+  }
+
+  return errs;
 }
 
 function validateConfigShape(raw: unknown): ValidationError[] {
@@ -168,6 +288,10 @@ function validateConfigShape(raw: unknown): ValidationError[] {
         if (e.tools !== undefined) errs.push(...validateStringArray(e.tools, `${fieldPath}.tools`));
       }
     }
+  }
+
+  if (c.workflow !== undefined) {
+    errs.push(...validateWorkflow(c.workflow));
   }
 
   return errs;
@@ -296,6 +420,55 @@ function mergeWithDefaults(raw: RawConfig): FerryConfig {
       dev_allowlist: strArr(t.dev_allowlist, DEFAULT_FERRY_CONFIG.ticket_types.dev_allowlist),
     },
     ...(labels !== undefined ? { labels } : {}),
+    workflow: mergeWorkflow(raw.workflow),
+  };
+}
+
+function mergeWorkflow(rawWorkflow: unknown): WorkflowConfig {
+  const def = DEFAULT_FERRY_CONFIG.workflow;
+  if (!rawWorkflow || typeof rawWorkflow !== 'object') return def;
+  const w = rawWorkflow as Record<string, unknown>;
+  if (!w.agents || typeof w.agents !== 'object') return def;
+  const agents = w.agents as Record<string, unknown>;
+
+  const str = (val: unknown, def: string): string =>
+    typeof val === 'string' ? val : def;
+  const strOrNull = (obj: Record<string, unknown>, key: string, def: string | null): string | null =>
+    key in obj ? (obj[key] === null ? null : typeof obj[key] === 'string' ? (obj[key] as string) : def) : def;
+
+  const refinerRaw = agents.refiner && typeof agents.refiner === 'object'
+    ? (agents.refiner as Record<string, unknown>) : {};
+  const devRaw = agents.developer && typeof agents.developer === 'object'
+    ? (agents.developer as Record<string, unknown>) : {};
+  const revRaw = agents.reviewer && typeof agents.reviewer === 'object'
+    ? (agents.reviewer as Record<string, unknown>) : {};
+  const iterRaw = agents.iterator && typeof agents.iterator === 'object'
+    ? (agents.iterator as Record<string, unknown>) : {};
+
+  return {
+    agents: {
+      refiner: {
+        trigger_column: str(refinerRaw.trigger_column, def.agents.refiner.trigger_column),
+        auto_transition: null,
+      },
+      developer: {
+        trigger_column: str(devRaw.trigger_column, def.agents.developer.trigger_column),
+        auto_transition: strOrNull(devRaw, 'auto_transition', def.agents.developer.auto_transition),
+      },
+      reviewer: {
+        trigger_column: str(revRaw.trigger_column, def.agents.reviewer.trigger_column),
+        auto_transition_approve: strOrNull(
+          revRaw, 'auto_transition_approve', def.agents.reviewer.auto_transition_approve,
+        ),
+        auto_transition_changes: strOrNull(
+          revRaw, 'auto_transition_changes', def.agents.reviewer.auto_transition_changes,
+        ),
+      },
+      iterator: {
+        trigger_column: str(iterRaw.trigger_column, def.agents.iterator.trigger_column),
+        auto_transition: strOrNull(iterRaw, 'auto_transition', def.agents.iterator.auto_transition),
+      },
+    },
   };
 }
 


### PR DESCRIPTION
Closes #143 — adds `workflow.agents` to `ferry.config.yaml` so consumers can map any Jira column to each agent and control which auto-transitions fire.

**Defaults reproduce today's behavior exactly** (FR18/FR24/FR28 all enabled with current column names).

GGenerated with [Claude Code](https://claude.ai/code)