### PR TITLE
fix(refiner): harden JSON parser against LLM prose preamble / trailing prose (D9)

### DIFF
--- a/.ferry/refiner-action.js
+++ b/.ferry/refiner-action.js
@@ -54673,6 +54673,47 @@ ${escaped}
 ${CLOSE}`;
 }
 
+// src/agents/refiner/parse.ts
+function extractFirstJsonObject(text) {
+  let start = -1;
+  let depth = 0;
+  let inString = false;
+  let escape2 = false;
+  for (let i2 = 0; i2 < text.length; i2++) {
+    const ch = text[i2];
+    if (escape2) {
+      escape2 = false;
+      continue;
+    }
+    if (inString) {
+      if (ch === "\\") {
+        escape2 = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "{") {
+      if (depth === 0) {
+        start = i2;
+      }
+      depth++;
+    } else if (ch === "}") {
+      if (depth > 0) {
+        depth--;
+        if (depth === 0) {
+          return text.slice(start, i2 + 1);
+        }
+      }
+    }
+  }
+  return null;
+}
+
 // src/agents/refiner/schema.ts
 var REFINER_OUTPUT_SCHEMA = {
   $schema: "https://json-schema.org/draft/2020-12/schema",
@@ -54744,24 +54785,24 @@ ${input.ticket.comments.join("\n---\n")}`
     delimitUntrusted(block)
   ].join("\n\n");
 }
-function stripMarkdownFences(text) {
-  return text.replace(/^```(?:json)?\s*\n?/, "").replace(/\n?```\s*$/, "").trim();
-}
 var SAMPLE_MAX = 512;
 function sampleOf(text) {
   return text.length <= SAMPLE_MAX ? text : text.slice(0, SAMPLE_MAX);
 }
 function parseJsonOrThrow(text) {
-  try {
-    return JSON.parse(stripMarkdownFences(text));
-  } catch {
-    throw new FerryError("state-invariant", {
-      reason: "refiner-output-invalid",
-      stage: "parse",
-      sample: sampleOf(text),
-      text_length: text.length
-    });
+  const candidate = extractFirstJsonObject(text);
+  if (candidate !== null) {
+    try {
+      return JSON.parse(candidate);
+    } catch {
+    }
   }
+  throw new FerryError("state-invariant", {
+    reason: "refiner-output-invalid",
+    stage: "parse",
+    sample: sampleOf(text),
+    text_length: text.length
+  });
 }
 function ensureSchemaValid(plan, rawText) {
   if (!validatePlan(plan)) {

--- a/.github/actions/ferry-run-refiner/refiner-action.js
+++ b/.github/actions/ferry-run-refiner/refiner-action.js
@@ -54673,6 +54673,47 @@ ${escaped}
 ${CLOSE}`;
 }
 
+// src/agents/refiner/parse.ts
+function extractFirstJsonObject(text) {
+  let start = -1;
+  let depth = 0;
+  let inString = false;
+  let escape2 = false;
+  for (let i2 = 0; i2 < text.length; i2++) {
+    const ch = text[i2];
+    if (escape2) {
+      escape2 = false;
+      continue;
+    }
+    if (inString) {
+      if (ch === "\\") {
+        escape2 = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+    if (ch === "{") {
+      if (depth === 0) {
+        start = i2;
+      }
+      depth++;
+    } else if (ch === "}") {
+      if (depth > 0) {
+        depth--;
+        if (depth === 0) {
+          return text.slice(start, i2 + 1);
+        }
+      }
+    }
+  }
+  return null;
+}
+
 // src/agents/refiner/schema.ts
 var REFINER_OUTPUT_SCHEMA = {
   $schema: "https://json-schema.org/draft/2020-12/schema",
@@ -54744,24 +54785,24 @@ ${input.ticket.comments.join("\n---\n")}`
     delimitUntrusted(block)
   ].join("\n\n");
 }
-function stripMarkdownFences(text) {
-  return text.replace(/^```(?:json)?\s*\n?/, "").replace(/\n?```\s*$/, "").trim();
-}
 var SAMPLE_MAX = 512;
 function sampleOf(text) {
   return text.length <= SAMPLE_MAX ? text : text.slice(0, SAMPLE_MAX);
 }
 function parseJsonOrThrow(text) {
-  try {
-    return JSON.parse(stripMarkdownFences(text));
-  } catch {
-    throw new FerryError("state-invariant", {
-      reason: "refiner-output-invalid",
-      stage: "parse",
-      sample: sampleOf(text),
-      text_length: text.length
-    });
+  const candidate = extractFirstJsonObject(text);
+  if (candidate !== null) {
+    try {
+      return JSON.parse(candidate);
+    } catch {
+    }
   }
+  throw new FerryError("state-invariant", {
+    reason: "refiner-output-invalid",
+    stage: "parse",
+    sample: sampleOf(text),
+    text_length: text.length
+  });
 }
 function ensureSchemaValid(plan, rawText) {
   if (!validatePlan(plan)) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Ferry uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Refiner JSON parser hardened against LLM prose preamble and trailing prose (D9)** — replaced the previous fence-strip-then-parse approach with a bracket-counting extractor (`src/agents/refiner/parse.ts`) that finds the first balanced `{...}` substring in the raw LLM output. Any preamble ("Here is the plan:"), trailing prose, or code-fenced wrapping is now transparent to the parser. Resolves the confirmed prod failure from run `25262368292` (`big-emotion/ethniafrica`, 2026-05-02, `ferry-run-refiner@v0.5.2`).
+
+---
+
 ## [0.5.3] — 2026-05-03
 
 ### Fixed

--- a/src/agents/refiner/parse.ts
+++ b/src/agents/refiner/parse.ts
@@ -1,0 +1,52 @@
+/**
+ * Extracts the first balanced JSON object from arbitrary LLM text.
+ *
+ * Uses bracket counting with string-literal awareness so that `{`/`}` inside
+ * quoted values (or embedded code fences) don't confuse the depth counter.
+ * Returns null when no balanced object is found.
+ */
+export function extractFirstJsonObject(text: string): string | null {
+  let start = -1;
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+
+    if (escape) {
+      escape = false;
+      continue;
+    }
+
+    if (inString) {
+      if (ch === '\\') {
+        escape = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (ch === '{') {
+      if (depth === 0) {
+        start = i;
+      }
+      depth++;
+    } else if (ch === '}') {
+      if (depth > 0) {
+        depth--;
+        if (depth === 0) {
+          return text.slice(start, i + 1);
+        }
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/agents/refiner/refine.test.ts
+++ b/src/agents/refiner/refine.test.ts
@@ -74,7 +74,7 @@ describe('runRefiner happy path (Story 3-1)', () => {
   });
 });
 
-describe('runRefiner markdown fence stripping', () => {
+describe('runRefiner markdown fence stripping (regression guard)', () => {
   it('parses JSON wrapped in ```json fences', async () => {
     const fencedLlm: LlmCall = async () => ({
       text: '```json\n' + JSON.stringify(validPlan) + '\n```',
@@ -91,6 +91,63 @@ describe('runRefiner markdown fence stripping', () => {
     });
     const result = await runRefiner({ ticket, callLlm: fencedLlm, runLink: 'r' });
     expect(result.plan).toEqual(validPlan);
+  });
+});
+
+describe('runRefiner prose preamble / trailing prose (D9)', () => {
+  it('parses JSON preceded by prose preamble', async () => {
+    const preambleLlm: LlmCall = async () => ({
+      text: 'Here is the plan:\n\n' + JSON.stringify(validPlan),
+      usage: null,
+    });
+    const result = await runRefiner({ ticket, callLlm: preambleLlm, runLink: 'r' });
+    expect(result.plan).toEqual(validPlan);
+  });
+
+  it('parses JSON followed by trailing prose', async () => {
+    const trailingLlm: LlmCall = async () => ({
+      text: JSON.stringify(validPlan) + '\n\nLet me know if you need changes.',
+      usage: null,
+    });
+    const result = await runRefiner({ ticket, callLlm: trailingLlm, runLink: 'r' });
+    expect(result.plan).toEqual(validPlan);
+  });
+
+  it('parses JSON without any code fences', async () => {
+    const noFenceLlm: LlmCall = async () => ({
+      text: JSON.stringify(validPlan),
+      usage: null,
+    });
+    const result = await runRefiner({ ticket, callLlm: noFenceLlm, runLink: 'r' });
+    expect(result.plan).toEqual(validPlan);
+  });
+
+  it('parses JSON with nested code fences inside string fields', async () => {
+    const planWithFences = {
+      ...validPlan,
+      subtasks: [
+        {
+          title: 'Add code block',
+          description: '```ts\nconsole.log("hello")\n```',
+        },
+      ],
+    };
+    const nestedFenceLlm: LlmCall = async () => ({
+      text: 'Sure thing:\n\n' + JSON.stringify(planWithFences),
+      usage: null,
+    });
+    const result = await runRefiner({ ticket, callLlm: nestedFenceLlm, runLink: 'r' });
+    expect(result.plan).toEqual(planWithFences);
+  });
+
+  it('throws state-invariant when LLM returns only prose with no JSON object', async () => {
+    const proseLlm: LlmCall = async () => ({
+      text: 'I cannot help with that request.',
+      usage: null,
+    });
+    await expect(runRefiner({ ticket, callLlm: proseLlm, runLink: 'r' })).rejects.toBeInstanceOf(
+      FerryError,
+    );
   });
 });
 

--- a/src/agents/refiner/refine.ts
+++ b/src/agents/refiner/refine.ts
@@ -10,6 +10,7 @@ import { createRequire } from 'module';
 import type { ValidateFunction } from 'ajv';
 import { FerryError } from '../../lib/errors/index.js';
 import { delimitUntrusted } from '../../lib/llm/delimit-untrusted.js';
+import { extractFirstJsonObject } from './parse.js';
 import { REFINER_OUTPUT_SCHEMA, getRefinerTouchPathsCap, type RefinerOutput } from './schema.js';
 
 const _require = createRequire(import.meta.url);
@@ -91,13 +92,6 @@ function buildPrompt(input: RefinerInput): string {
   ].join('\n\n');
 }
 
-function stripMarkdownFences(text: string): string {
-  return text
-    .replace(/^```(?:json)?\s*\n?/, '')
-    .replace(/\n?```\s*$/, '')
-    .trim();
-}
-
 const SAMPLE_MAX = 512;
 
 function sampleOf(text: string): string {
@@ -105,16 +99,20 @@ function sampleOf(text: string): string {
 }
 
 function parseJsonOrThrow(text: string): unknown {
-  try {
-    return JSON.parse(stripMarkdownFences(text));
-  } catch {
-    throw new FerryError('state-invariant', {
-      reason: 'refiner-output-invalid',
-      stage: 'parse',
-      sample: sampleOf(text),
-      text_length: text.length,
-    });
+  const candidate = extractFirstJsonObject(text);
+  if (candidate !== null) {
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      // fall through to throw below
+    }
   }
+  throw new FerryError('state-invariant', {
+    reason: 'refiner-output-invalid',
+    stage: 'parse',
+    sample: sampleOf(text),
+    text_length: text.length,
+  });
 }
 
 function ensureSchemaValid(plan: unknown, rawText: string): asserts plan is RefinerOutput {


### PR DESCRIPTION
Closes #160

Replace the strip-and-parse approach with a bracket-counting extractor in `src/agents/refiner/parse.ts` that finds the first balanced `{...}` substring in the raw LLM output. Any preamble, trailing prose, or code-fence wrapping is now transparent to the parser, resolving the confirmed prod failure from run 25262368292.

Generated with [Claude Code](https://claude.ai/code)