### PR TITLE
docs(mcp): clarify scope, add coverage matrix, and add Figma example

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,9 +339,20 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) to contribute.
 
 ## MCP remote servers (HTTP/SSE)
 
-The developer agent can call **remote MCP servers** directly through the Anthropic Messages API (beta connector `mcp-client-2025-11-20`). The API proxies all MCP tool calls server-side — Ferry does not run any local MCP client.
+The Developer and Iterator agents can call **remote MCP servers** directly through the Anthropic Messages API (beta connector `mcp-client-2025-11-20`). The API proxies all MCP tool calls server-side — Ferry does not run any local MCP client.
 
-### Enabling MCP for the developer agent
+**Agent coverage:**
+
+| Agent     | MCP support |
+| --------- | ----------- |
+| Refiner   | No          |
+| Developer | Yes         |
+| Reviewer  | No          |
+| Iterator  | Yes         |
+
+The Refiner runs a single-turn LLM call and the Reviewer uses its own agentic tool loop — neither reads `AGENT_MCP_SERVERS`.
+
+### Enabling MCP for the developer & iterator agents
 
 Set the `AGENT_MCP_SERVERS` environment variable (repository variable or secret) to a JSON array:
 
@@ -384,6 +395,47 @@ Each entry accepts:
 ```json
 AGENT_MCP_SERVERS=[{"name":"context7","url":"https://mcp.context7.com/mcp"}]
 ```
+
+**End-to-end example — Figma for UI refactors**
+
+This walkthrough shows how to wire Figma's MCP server so the Developer consults the linked design frame before editing UI code.
+
+**Step 1 — Declare the server in the pool** (`AGENT_MCP_SERVERS` repo variable):
+
+```json
+[
+  {
+    "name": "figma",
+    "url": "https://mcp.figma.com/mcp",
+    "authorization_token": "<your-figma-pat>",
+    "allowed_tools": ["get_node", "get_file"]
+  }
+]
+```
+
+**Step 2 — Map a `ferry:*` label** in `ferry.config.yaml`:
+
+```yaml
+labels:
+  ferry:mcp/figma:
+    mcp_servers: [figma]
+```
+
+**Step 3 — Tell the agent to use it** in `prompts/dev.extra.md`:
+
+```markdown
+## Figma design reference
+
+When the ticket description or a comment references a Figma frame URL or node ID,
+call `figma.get_node` with that node ID **before** editing any UI component.
+Use the returned layout and style properties to guide your implementation.
+
+If no Figma link is present, skip the tool call entirely.
+```
+
+**Step 4 — Label the Jira ticket** with `ferry:mcp/figma` before moving it to _In Development_.
+
+**Failure mode to avoid.** If `prompts/dev.extra.md` does not explicitly instruct the agent to call `figma.get_node`, the Developer may refactor the UI component without ever consulting the Figma frame — even though the tool is available. MCP tools are passive; the agent must be told when to invoke them.
 
 **Audit logs**
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -144,7 +144,7 @@ Ferry supports three LLM providers: **`anthropic`**, **`openai`**, and **`google
 | `review`  | `anthropic`                     | Uses an agentic tool-use loop; OpenAI/Google support is planned |
 | `iterate` | `anthropic`                     | Uses an agentic tool-use loop; OpenAI/Google support is planned |
 
-> **MCP:** Model Context Protocol (MCP) server integration is Anthropic-only and is not available when using other providers.
+> **MCP:** Model Context Protocol (MCP) server integration is Anthropic-only and is not available when using other providers. MCP availability is also independent of the provider support table above — even with `provider: anthropic`, **only the Developer and Iterator agents consume `AGENT_MCP_SERVERS`**. The Refiner and Reviewer do not load MCP servers regardless of provider or configuration.
 
 | Field                     | Default               | Description                                                                                                                                |
 | ------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -218,6 +218,21 @@ git:
 #### `labels`
 
 Maps Jira ticket labels to MCP server capabilities. If this section is omitted, the full MCP server pool is used unchanged. If the section is present, only MCP servers enabled by the ticket's labels are activated.
+
+> **MCP configuration is split across two locations:**
+> - **Pool of servers** (name, URL, token) — declared in the `AGENT_MCP_SERVERS` GitHub Actions repo **variable** (`gh variable set AGENT_MCP_SERVERS '...'`). This is where all known MCP servers are registered.
+> - **Per-ticket activation** — declared here in `ferry.config.yaml` § `labels:`. A `ferry:*` label on the Jira ticket selects which servers from the pool are active for that ticket.
+>
+> A label entry that names a server not present in `AGENT_MCP_SERVERS` is silently ignored at runtime. The pool variable is not part of `ferry.config.yaml`.
+
+**Adding a new MCP server — 3 steps:**
+
+1. **Declare in the pool** — add an entry to the `AGENT_MCP_SERVERS` repo variable:
+   ```bash
+   gh variable set AGENT_MCP_SERVERS '[{"name":"figma","url":"https://mcp.figma.com/mcp","authorization_token":"<pat>"}]'
+   ```
+2. **Map a `ferry:*` label** — add an entry under `labels:` in `ferry.config.yaml` referencing the server name.
+3. **Activate per ticket** — add the matching `ferry:*` label to your Jira ticket before triggering the Developer or Iterator.
 
 ```json
 "labels": {


### PR DESCRIPTION
Implements the wave 1 documentation changes from #165:

- Renames README MCP section to cover Developer & Iterator
- Adds agent coverage matrix (Refiner/Reviewer: No, Developer/Iterator: Yes)
- Adds Figma end-to-end walkthrough with failure mode callout
- Adds split-config callout in CONFIGURATION.md § labels
- Adds 3-step checklist for adding a new MCP server
- Expands MCP note under models table (Developer/Iterator only)

Closes #165

Generated with [Claude Code](https://claude.ai/code)