### PR TITLE
fix(reviewer): replace binary hasIteratorMarker with count-based cap check

### DIFF
--- a/.ferry/review-action.js
+++ b/.ferry/review-action.js
@@ -11563,6 +11563,13 @@ function createGitHubContext(repoRoot) {
   return { owner, repo, runner, tracker, ferryCfg };
 }
 
+// src/agents/reviewer/changes-guard.ts
+function countPriorIterations(existingComments) {
+  return existingComments.filter(
+    (c) => c.includes("[ferry:iterator:") && c.includes("complete. Pushed fixes to PR#")
+  ).length;
+}
+
 // src/agents/reviewer/review-action.ts
 var REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main(envelope, logger) {
@@ -11712,13 +11719,15 @@ async function main(envelope, logger) {
       await tracker.postTransition(ticketKey, approveTransitionId);
     }
   } else {
-    const hasIteratorMarker = existingComments.some((c) => c.includes("[ferry:iterator:"));
+    const priorIterations = countPriorIterations(existingComments);
+    const cap = ferryCfg.limits.max_iterations;
+    const capReached = priorIterations >= cap;
     await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
-    if (!hasIteratorMarker) {
+    if (!capReached) {
       const changesNote = shouldTransitionChanges ? " Moved to Dev Iteration." : "";
       await tracker.postComment(
         ticketKey,
-        `${idempotencyMarker} Changes requested.${changesNote} See PR#${prNumber} for details.`
+        `${idempotencyMarker} Changes requested (iteration ${priorIterations + 1}/${cap}).${changesNote} See PR#${prNumber} for details.`
       );
       if (shouldTransitionChanges) {
         await tracker.postTransition(ticketKey, iterTransitionId);
@@ -11726,7 +11735,7 @@ async function main(envelope, logger) {
     } else {
       await tracker.postComment(
         ticketKey,
-        `${idempotencyMarker} Changes requested (re-review). See PR#${prNumber} comments and move ticket manually.`
+        `${idempotencyMarker} Changes requested (re-review). Iteration cap (${cap}) reached — see PR#${prNumber} and move ticket manually.`
       );
     }
   }

--- a/.ferry/review-action.js
+++ b/.ferry/review-action.js
@@ -11735,7 +11735,7 @@ async function main(envelope, logger) {
     } else {
       await tracker.postComment(
         ticketKey,
-        `${idempotencyMarker} Changes requested (re-review). Iteration cap (${cap}) reached — see PR#${prNumber} and move ticket manually.`
+        `${idempotencyMarker} Changes requested (re-review). Iteration cap (${cap}) reached; see PR#${prNumber} and move ticket manually.`
       );
     }
   }

--- a/scripts/build-ferry-actions.mjs
+++ b/scripts/build-ferry-actions.mjs
@@ -14,7 +14,6 @@ const shared = {
   target: 'node20',
   format: 'esm',
   minify: false,
-  charset: 'utf8',
   // Expose a real `require` at the top of each ESM bundle so transitive CJS
   // deps (e.g. google-auth-library) can resolve dynamic require('child_process')
   // calls instead of hitting esbuild's "Dynamic require of X is not supported" shim.

--- a/scripts/build-ferry-actions.mjs
+++ b/scripts/build-ferry-actions.mjs
@@ -14,6 +14,7 @@ const shared = {
   target: 'node20',
   format: 'esm',
   minify: false,
+  charset: 'utf8',
   // Expose a real `require` at the top of each ESM bundle so transitive CJS
   // deps (e.g. google-auth-library) can resolve dynamic require('child_process')
   // calls instead of hitting esbuild's "Dynamic require of X is not supported" shim.

--- a/src/agents/reviewer/changes-guard.ts
+++ b/src/agents/reviewer/changes-guard.ts
@@ -1,0 +1,9 @@
+/**
+ * Counts prior completed iterator cycles by scanning Jira issue comments.
+ * Mirrors the filter used in iterate-action.ts so both agents agree on the count.
+ */
+export function countPriorIterations(existingComments: string[]): number {
+  return existingComments.filter(
+    (c) => c.includes('[ferry:iterator:') && c.includes('complete. Pushed fixes to PR#'),
+  ).length;
+}

--- a/src/agents/reviewer/review-action.test.ts
+++ b/src/agents/reviewer/review-action.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { countPriorIterations } from './changes-guard.js';
+
+const iteratorComment = (n: number) =>
+  `[ferry:iterator:abc${n}] Iteration ${n} complete. Pushed fixes to PR#42. Moved back to Review.`;
+
+const reviewerComment = (sha: string) =>
+  `[ferry:reviewer:${sha}] Changes requested (iteration 1/3). Moved to Dev Iteration. See PR#42 for details.`;
+
+describe('reviewer changes guard — countPriorIterations', () => {
+  it('returns 0 when there are no comments at all', () => {
+    expect(countPriorIterations([])).toBe(0);
+  });
+
+  it('returns 0 when only reviewer comments are present (no iterator cycle yet)', () => {
+    expect(countPriorIterations([reviewerComment('aaa1111')])).toBe(0);
+  });
+
+  it('returns 1 after one completed iterator cycle', () => {
+    const comments = [reviewerComment('aaa1111'), iteratorComment(1)];
+    expect(countPriorIterations(comments)).toBe(1);
+  });
+
+  it('returns 2 after two completed iterator cycles', () => {
+    const comments = [
+      reviewerComment('aaa1111'),
+      iteratorComment(1),
+      reviewerComment('bbb2222'),
+      iteratorComment(2),
+    ];
+    expect(countPriorIterations(comments)).toBe(2);
+  });
+
+  it('returns cap (3) after three completed iterator cycles', () => {
+    const cap = 3;
+    const comments = [
+      reviewerComment('aaa1111'),
+      iteratorComment(1),
+      reviewerComment('bbb2222'),
+      iteratorComment(2),
+      reviewerComment('ccc3333'),
+      iteratorComment(3),
+    ];
+    expect(countPriorIterations(comments)).toBe(cap);
+  });
+
+  it('does not count iterator comments that lack the completion phrase', () => {
+    const incompleteMarker = '[ferry:iterator:abc1] No open PR found for branch ferry/PROJ-1.';
+    expect(countPriorIterations([incompleteMarker])).toBe(0);
+  });
+
+  it('capReached is false for 0, 1, 2 prior iterations (below default cap of 3)', () => {
+    const cap = 3;
+    for (const n of [0, 1, 2]) {
+      const comments = Array.from({ length: n }, (_, i) => iteratorComment(i + 1));
+      const priorIterations = countPriorIterations(comments);
+      expect(priorIterations < cap).toBe(true);
+    }
+  });
+
+  it('capReached is true at cap (3) prior iterations', () => {
+    const cap = 3;
+    const comments = Array.from({ length: cap }, (_, i) => iteratorComment(i + 1));
+    const priorIterations = countPriorIterations(comments);
+    expect(priorIterations >= cap).toBe(true);
+  });
+});

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -18,6 +18,7 @@ import {
   byPrHeadSha,
   runAgent,
 } from '../../lib/agent-runtime/index.js';
+import { countPriorIterations } from './changes-guard.js';
 import type { EventEnvelopeV1 } from '../../lib/envelope/types.js';
 import type { Logger } from '../../lib/agent-runtime/index.js';
 
@@ -204,15 +205,17 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
       await tracker.postTransition(ticketKey, approveTransitionId);
     }
   } else {
-    const hasIteratorMarker = existingComments.some((c) => c.includes('[ferry:iterator:'));
+    const priorIterations = countPriorIterations(existingComments);
+    const cap = ferryCfg.limits.max_iterations;
+    const capReached = priorIterations >= cap;
 
     await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
 
-    if (!hasIteratorMarker) {
+    if (!capReached) {
       const changesNote = shouldTransitionChanges ? ' Moved to Dev Iteration.' : '';
       await tracker.postComment(
         ticketKey,
-        `${idempotencyMarker} Changes requested.${changesNote} See PR#${prNumber} for details.`,
+        `${idempotencyMarker} Changes requested (iteration ${priorIterations + 1}/${cap}).${changesNote} See PR#${prNumber} for details.`,
       );
       if (shouldTransitionChanges) {
         await tracker.postTransition(ticketKey, iterTransitionId);
@@ -220,7 +223,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
     } else {
       await tracker.postComment(
         ticketKey,
-        `${idempotencyMarker} Changes requested (re-review). See PR#${prNumber} comments and move ticket manually.`,
+        `${idempotencyMarker} Changes requested (re-review). Iteration cap (${cap}) reached — see PR#${prNumber} and move ticket manually.`,
       );
     }
   }

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -223,7 +223,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
     } else {
       await tracker.postComment(
         ticketKey,
-        `${idempotencyMarker} Changes requested (re-review). Iteration cap (${cap}) reached — see PR#${prNumber} and move ticket manually.`,
+        `${idempotencyMarker} Changes requested (re-review). Iteration cap (${cap}) reached; see PR#${prNumber} and move ticket manually.`,
       );
     }
   }


### PR DESCRIPTION
Fixes the Review↔Iterate auto-loop breaking after the first iteration (#168).

The reviewer now counts prior completed iterator cycles and compares against `limits.max_iterations` (default 3), auto-transitioning until the cap is reached instead of stopping after the first reviewer→iterator cycle.

Also adds the "iteration N/M" hint in Jira comments and a dedicated `countPriorIterations` helper (`changes-guard.ts`) with unit tests covering 0, 1, 2, and cap prior iterations.

Closes #168

Generated with [Claude Code](https://claude.ai/code)