### PR TITLE
fix: weight cache_read_input_tokens at 0.1× in agent-loop budget cap

### DIFF
--- a/src/lib/llm/agent-loop/anthropic.test.ts
+++ b/src/lib/llm/agent-loop/anthropic.test.ts
@@ -541,6 +541,87 @@ describe('createAnthropicAgentLoop — stdio MCP tools', () => {
   });
 });
 
+describe('createAnthropicAgentLoop — input-token budget cap', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    restorePoolDefaults();
+  });
+
+  // The cap check fires at the TOP of each iteration, checking usage accumulated
+  // from prior iterations. iter 1 always starts with zeros, so a two-turn setup
+  // (tool call + done) is needed to exercise the cap on iter 2.
+
+  it('does not trip cap when large cache_read_input_tokens stay under weighted limit', async () => {
+    // iter 1: API returns 100 input + 5000 cache_read. billable-equiv = 100 + 500 = 600 < 1000 cap.
+    // iter 2 check: 600 < 1000 → passes → done is called.
+    const toolResponse: FakeResponse = {
+      stop_reason: 'tool_use',
+      content: [{ type: 'tool_use', id: 'tu_r', name: 'read_file', input: { path: 'x.ts' } }],
+      usage: { input_tokens: 100, output_tokens: 10, cache_read_input_tokens: 5000 },
+    };
+    const execTool = vi
+      .fn<(r: string, n: string, i: Record<string, unknown>) => Promise<string>>()
+      .mockResolvedValueOnce('content');
+    const mock = makeMock([toolResponse, doneResponse]);
+    const loop = createAnthropicAgentLoop({
+      model: 'm',
+      client: mock as unknown as Anthropic,
+      executeTool: execTool,
+      maxInputTokens: 1000,
+    });
+
+    await expect(loop.run(baseInput)).resolves.toBeDefined();
+  });
+
+  it('throws spend-cap when billable-equivalent tokens exceed the cap', async () => {
+    // iter 1: 600 input + 9000 cache_read → billable-equiv = 600 + 900 = 1500 > 999 cap.
+    // iter 2 check: 1500 > 999 → throws spend-cap.
+    const toolResponse: FakeResponse = {
+      stop_reason: 'tool_use',
+      content: [{ type: 'tool_use', id: 'tu_r', name: 'read_file', input: { path: 'x.ts' } }],
+      usage: { input_tokens: 600, output_tokens: 10, cache_read_input_tokens: 9000 },
+    };
+    const execTool = vi
+      .fn<(r: string, n: string, i: Record<string, unknown>) => Promise<string>>()
+      .mockResolvedValueOnce('content');
+    const mock = makeMock([toolResponse, doneResponse]);
+    const loop = createAnthropicAgentLoop({
+      model: 'm',
+      client: mock as unknown as Anthropic,
+      executeTool: execTool,
+      maxInputTokens: 999,
+    });
+
+    const err = await loop.run(baseInput).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(FerryError);
+    expect((err as FerryError).code).toBe('spend-cap');
+  });
+
+  it('reports billable-equivalent consumed value (not raw token sum) in error', async () => {
+    // iter 1: 100 input + 10000 cache_read → billable-equiv = 100 + 1000 = 1100.
+    // iter 2 check: 1100 > 999 → consumed is 1100, not 10100 (raw sum).
+    const toolResponse: FakeResponse = {
+      stop_reason: 'tool_use',
+      content: [{ type: 'tool_use', id: 'tu_r', name: 'read_file', input: { path: 'x.ts' } }],
+      usage: { input_tokens: 100, output_tokens: 10, cache_read_input_tokens: 10000 },
+    };
+    const execTool = vi
+      .fn<(r: string, n: string, i: Record<string, unknown>) => Promise<string>>()
+      .mockResolvedValueOnce('content');
+    const mock = makeMock([toolResponse, doneResponse]);
+    const loop = createAnthropicAgentLoop({
+      model: 'm',
+      client: mock as unknown as Anthropic,
+      executeTool: execTool,
+      maxInputTokens: 999,
+    });
+
+    const err = await loop.run(baseInput).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(FerryError);
+    expect((err as FerryError).context).toMatchObject({ consumed: 1100 });
+  });
+});
+
 describe('createAnthropicAgentLoop — LOG_VERBOSITY=debug structured events', () => {
   beforeEach(() => {
     vi.resetAllMocks();

--- a/src/lib/llm/agent-loop/anthropic.ts
+++ b/src/lib/llm/agent-loop/anthropic.ts
@@ -234,15 +234,17 @@ export function createAnthropicAgentLoop(opts: {
       iter++;
       const iterStart = Date.now();
 
-      if (
-        usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens >
-        maxInputTokens
-      ) {
+      // Anthropic bills cache reads at ~10% of fresh input tokens; weight them
+      // accordingly so the cap approximates dollar spend rather than raw volume.
+      const billableEquiv =
+        usage.input_tokens +
+        usage.cache_read_input_tokens * 0.1 +
+        usage.cache_creation_input_tokens;
+      if (billableEquiv > maxInputTokens) {
         throw new FerryError('spend-cap', {
           reason: 'input-token-budget-exceeded',
           cap: maxInputTokens,
-          consumed:
-            usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens,
+          consumed: billableEquiv,
         });
       }
 


### PR DESCRIPTION
Anthropic bills cache reads at ~10% of fresh input tokens. Counting them at full weight caused the spend-cap to fire at ~10× the actual billable cost, tripping prematurely on long developer runs with heavy cache usage (ETNI-18 post-mortem, job 74201019444).

Closes #176

Generated with [Claude Code](https://claude.ai/code)