### PR TITLE
feat: agent-loop prune message history to stop token-cap blow-ups

### DIFF
--- a/.ferry/dev-action.js
+++ b/.ferry/dev-action.js
@@ -12014,6 +12014,21 @@ function isHttpMcpServer(s) {
 }
 
 // src/lib/llm/agent-loop/anthropic.ts
+var KEEP_LAST_TURNS = 6;
+var STUB = "[truncated: tool result elided to save context]";
+function pruneMessageHistory(messages) {
+  const cutoff = messages.length - KEEP_LAST_TURNS * 2;
+  if (cutoff <= 1) return;
+  for (let i = 1; i < cutoff; i++) {
+    const msg = messages[i];
+    if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+    const content = msg.content;
+    if (!content.some((b) => b.type === "tool_result" && b.content !== STUB)) continue;
+    msg.content = content.map(
+      (b) => b.type === "tool_result" && b.content !== STUB ? { ...b, content: STUB } : b
+    );
+  }
+}
 function buildMcpParams(mcpServers) {
   const mcpServerParams = mcpServers.map((s) => ({
     type: "url",
@@ -12126,6 +12141,7 @@ function createAnthropicAgentLoop(opts) {
           consumed: usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens
         });
       }
+      pruneMessageHistory(messages);
       const baseParams = {
         model: opts.model,
         max_tokens: maxTokens,

--- a/.ferry/iterate-action.js
+++ b/.ferry/iterate-action.js
@@ -7009,6 +7009,21 @@ function isHttpMcpServer(s) {
 }
 
 // src/lib/llm/agent-loop/anthropic.ts
+var KEEP_LAST_TURNS = 6;
+var STUB = "[truncated: tool result elided to save context]";
+function pruneMessageHistory(messages) {
+  const cutoff = messages.length - KEEP_LAST_TURNS * 2;
+  if (cutoff <= 1) return;
+  for (let i = 1; i < cutoff; i++) {
+    const msg = messages[i];
+    if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+    const content = msg.content;
+    if (!content.some((b) => b.type === "tool_result" && b.content !== STUB)) continue;
+    msg.content = content.map(
+      (b) => b.type === "tool_result" && b.content !== STUB ? { ...b, content: STUB } : b
+    );
+  }
+}
 function buildMcpParams(mcpServers) {
   const mcpServerParams = mcpServers.map((s) => ({
     type: "url",
@@ -7121,6 +7136,7 @@ function createAnthropicAgentLoop(opts) {
           consumed: usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens
         });
       }
+      pruneMessageHistory(messages);
       const baseParams = {
         model: opts.model,
         max_tokens: maxTokens,

--- a/.github/actions/ferry-run-developer/dev-action.js
+++ b/.github/actions/ferry-run-developer/dev-action.js
@@ -12014,6 +12014,21 @@ function isHttpMcpServer(s) {
 }
 
 // src/lib/llm/agent-loop/anthropic.ts
+var KEEP_LAST_TURNS = 6;
+var STUB = "[truncated: tool result elided to save context]";
+function pruneMessageHistory(messages) {
+  const cutoff = messages.length - KEEP_LAST_TURNS * 2;
+  if (cutoff <= 1) return;
+  for (let i = 1; i < cutoff; i++) {
+    const msg = messages[i];
+    if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+    const content = msg.content;
+    if (!content.some((b) => b.type === "tool_result" && b.content !== STUB)) continue;
+    msg.content = content.map(
+      (b) => b.type === "tool_result" && b.content !== STUB ? { ...b, content: STUB } : b
+    );
+  }
+}
 function buildMcpParams(mcpServers) {
   const mcpServerParams = mcpServers.map((s) => ({
     type: "url",
@@ -12126,6 +12141,7 @@ function createAnthropicAgentLoop(opts) {
           consumed: usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens
         });
       }
+      pruneMessageHistory(messages);
       const baseParams = {
         model: opts.model,
         max_tokens: maxTokens,

--- a/.github/actions/ferry-run-iterator/iterate-action.js
+++ b/.github/actions/ferry-run-iterator/iterate-action.js
@@ -7009,6 +7009,21 @@ function isHttpMcpServer(s) {
 }
 
 // src/lib/llm/agent-loop/anthropic.ts
+var KEEP_LAST_TURNS = 6;
+var STUB = "[truncated: tool result elided to save context]";
+function pruneMessageHistory(messages) {
+  const cutoff = messages.length - KEEP_LAST_TURNS * 2;
+  if (cutoff <= 1) return;
+  for (let i = 1; i < cutoff; i++) {
+    const msg = messages[i];
+    if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+    const content = msg.content;
+    if (!content.some((b) => b.type === "tool_result" && b.content !== STUB)) continue;
+    msg.content = content.map(
+      (b) => b.type === "tool_result" && b.content !== STUB ? { ...b, content: STUB } : b
+    );
+  }
+}
 function buildMcpParams(mcpServers) {
   const mcpServerParams = mcpServers.map((s) => ({
     type: "url",
@@ -7121,6 +7136,7 @@ function createAnthropicAgentLoop(opts) {
           consumed: usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens
         });
       }
+      pruneMessageHistory(messages);
       const baseParams = {
         model: opts.model,
         max_tokens: maxTokens,

--- a/src/lib/llm/agent-loop/anthropic.test.ts
+++ b/src/lib/llm/agent-loop/anthropic.test.ts
@@ -670,7 +670,12 @@ function makeMultiTurnMock(totalToolCalls: number) {
     return {
       stop_reason: 'tool_use',
       content: [
-        { type: 'tool_use', id: 'tu_done', name: 'done', input: { actionable: true, summary: 'ok' } },
+        {
+          type: 'tool_use',
+          id: 'tu_done',
+          name: 'done',
+          input: { actionable: true, summary: 'ok' },
+        },
       ],
       usage: { input_tokens: 10, output_tokens: 5 },
     };

--- a/src/lib/llm/agent-loop/anthropic.test.ts
+++ b/src/lib/llm/agent-loop/anthropic.test.ts
@@ -637,3 +637,172 @@ describe('createAnthropicAgentLoop — LOG_VERBOSITY=debug structured events', (
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Message history pruning
+// ---------------------------------------------------------------------------
+
+type CapturedMessage = { role: string; content: unknown };
+
+const STUB_VALUE = '[truncated: tool result elided to save context]';
+
+function makeMultiTurnMock(totalToolCalls: number) {
+  const capturedRequests: CapturedMessage[][] = [];
+  let callCount = 0;
+
+  const createFn = vi.fn().mockImplementation(async (params: { messages: CapturedMessage[] }) => {
+    capturedRequests.push(JSON.parse(JSON.stringify(params.messages)) as CapturedMessage[]);
+    callCount++;
+    if (callCount <= totalToolCalls) {
+      return {
+        stop_reason: 'tool_use',
+        content: [
+          {
+            type: 'tool_use',
+            id: `tu_${callCount}`,
+            name: 'read_file',
+            input: { path: `file${callCount}.ts` },
+          },
+        ],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      };
+    }
+    return {
+      stop_reason: 'tool_use',
+      content: [
+        { type: 'tool_use', id: 'tu_done', name: 'done', input: { actionable: true, summary: 'ok' } },
+      ],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    };
+  });
+
+  const mockClient = {
+    messages: { create: createFn },
+    beta: { messages: { create: vi.fn() } },
+  };
+
+  return { capturedRequests, mockClient, createFn };
+}
+
+describe('createAnthropicAgentLoop — message history pruning', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    restorePoolDefaults();
+  });
+
+  it('stubs older tool-result bodies after KEEP_LAST_TURNS threshold and preserves tool_use_id linkage', async () => {
+    // 12 tool-call turns + 1 done turn = 13 API calls total.
+    // KEEP_LAST_TURNS=6 → pruning kicks in when messages.length > 13 (turn 8+).
+    const TOTAL_TOOL_CALLS = 12;
+    const { capturedRequests, mockClient } = makeMultiTurnMock(TOTAL_TOOL_CALLS);
+
+    const execTool = vi.fn().mockResolvedValue('file contents');
+    const loop = createAnthropicAgentLoop({
+      model: 'm',
+      client: mockClient as unknown as Anthropic,
+      executeTool: execTool,
+    });
+
+    await loop.run(baseInput);
+
+    expect(capturedRequests).toHaveLength(TOTAL_TOOL_CALLS + 1);
+
+    // At the last (13th) call: messages had 1 + 12*2 = 25 entries before the call,
+    // cutoff = 25 - 12 = 13 → indices 1..12 are checked.
+    // User-tool-result messages sit at even indices (2, 4, 6, …, 12) — all stubbed.
+    const lastMessages = capturedRequests[capturedRequests.length - 1];
+
+    // index 0: initial prompt must be untouched
+    const initial = lastMessages[0];
+    expect(initial.role).toBe('user');
+    expect((initial.content as Array<{ text: string }>)[0].text).toBe('p');
+
+    // index 2: first tool-result message — should be stubbed
+    const firstToolResultMsg = lastMessages[2];
+    expect(firstToolResultMsg.role).toBe('user');
+    const firstContent = firstToolResultMsg.content as Array<{
+      type: string;
+      tool_use_id: string;
+      content: string;
+    }>;
+    expect(firstContent[0].type).toBe('tool_result');
+    expect(firstContent[0].content).toBe(STUB_VALUE);
+    // tool_use_id linkage must be preserved
+    expect(firstContent[0].tool_use_id).toBe('tu_1');
+
+    // index 4: second tool-result also stubbed, id points to tu_2
+    const secondToolResultMsg = lastMessages[4];
+    const secondContent = secondToolResultMsg.content as Array<{
+      type: string;
+      tool_use_id: string;
+      content: string;
+    }>;
+    expect(secondContent[0].content).toBe(STUB_VALUE);
+    expect(secondContent[0].tool_use_id).toBe('tu_2');
+  });
+
+  it('pruning is idempotent — already-stubbed entries stay stubbed with the same value across turns', async () => {
+    // 14 tool-call turns + 1 done = 15 API calls — ensures multiple prune passes happen.
+    const TOTAL_TOOL_CALLS = 14;
+    const { capturedRequests, mockClient } = makeMultiTurnMock(TOTAL_TOOL_CALLS);
+
+    const execTool = vi.fn().mockResolvedValue('file contents');
+    const loop = createAnthropicAgentLoop({
+      model: 'm',
+      client: mockClient as unknown as Anthropic,
+      executeTool: execTool,
+    });
+
+    await loop.run(baseInput);
+
+    // Find the first captured turn where any tool-result was stubbed.
+    const firstPrunedTurn = capturedRequests.findIndex((msgs) =>
+      msgs.some(
+        (m) =>
+          m.role === 'user' &&
+          Array.isArray(m.content) &&
+          (m.content as Array<{ type: string; content: unknown }>).some(
+            (b) => b.type === 'tool_result' && b.content === STUB_VALUE,
+          ),
+      ),
+    );
+
+    expect(firstPrunedTurn).toBeGreaterThan(-1);
+
+    // In every subsequent turn the same indices must still carry STUB_VALUE.
+    for (let turn = firstPrunedTurn + 1; turn < capturedRequests.length; turn++) {
+      const prev = capturedRequests[firstPrunedTurn];
+      const curr = capturedRequests[turn];
+
+      for (let msgIdx = 1; msgIdx < prev.length; msgIdx++) {
+        const prevMsg = prev[msgIdx];
+        if (prevMsg.role !== 'user' || !Array.isArray(prevMsg.content)) continue;
+
+        const prevContent = prevMsg.content as Array<{
+          type: string;
+          tool_use_id: string;
+          content: unknown;
+        }>;
+        const stubbedBlocks = prevContent.filter(
+          (b) => b.type === 'tool_result' && b.content === STUB_VALUE,
+        );
+        if (stubbedBlocks.length === 0) continue;
+
+        if (msgIdx >= curr.length) continue;
+        const currMsg = curr[msgIdx];
+        const currContent = currMsg.content as Array<{
+          type: string;
+          tool_use_id: string;
+          content: unknown;
+        }>;
+
+        for (const stubbed of stubbedBlocks) {
+          const match = currContent.find(
+            (b) => b.type === 'tool_result' && b.tool_use_id === stubbed.tool_use_id,
+          );
+          expect(match?.content).toBe(STUB_VALUE);
+        }
+      }
+    }
+  });
+});

--- a/src/lib/llm/agent-loop/anthropic.ts
+++ b/src/lib/llm/agent-loop/anthropic.ts
@@ -51,6 +51,24 @@ interface McpToolsetParam {
 
 type ContentLike = { type: string; [key: string]: unknown };
 
+const KEEP_LAST_TURNS = 6;
+const STUB = '[truncated: tool result elided to save context]';
+
+function pruneMessageHistory(messages: MessageParam[]): void {
+  // messages[0] carries the cached seed — never touch it.
+  const cutoff = messages.length - KEEP_LAST_TURNS * 2;
+  if (cutoff <= 1) return;
+  for (let i = 1; i < cutoff; i++) {
+    const msg = messages[i];
+    if (msg.role !== 'user' || !Array.isArray(msg.content)) continue;
+    const content = msg.content as ToolResultBlockParam[];
+    if (!content.some((b) => b.type === 'tool_result' && b.content !== STUB)) continue;
+    msg.content = content.map((b) =>
+      b.type === 'tool_result' && b.content !== STUB ? { ...b, content: STUB } : b,
+    );
+  }
+}
+
 interface ApiResponse {
   stop_reason: string;
   content: ContentLike[];
@@ -245,6 +263,8 @@ export function createAnthropicAgentLoop(opts: {
             usage.input_tokens + usage.cache_read_input_tokens + usage.cache_creation_input_tokens,
         });
       }
+
+      pruneMessageHistory(messages);
 
       const baseParams = {
         model: opts.model,


### PR DESCRIPTION
Implements the message-history pruning described in issue #187.

Adds `pruneMessageHistory()` to the Anthropic agent loop: once history exceeds `KEEP_LAST_TURNS=6` turns, older tool-result bodies are replaced with a stub string. Message structure, `tool_use_id`, and the prefix-cache breakpoint are all preserved. Pruning is idempotent.

Two new tests: 12+-turn loop with stub assertion + idempotency check.

Closes #187

Generated with [Claude Code](https://claude.ai/code)