### PR TITLE
feat(developer): auto-detect package manager and inject hint into system prompt

### DIFF
--- a/.ferry/dev-action.js
+++ b/.ferry/dev-action.js
@@ -6309,7 +6309,7 @@ function resolveAnthropicAuth(input) {
 }
 
 // src/agents/developer/workspace.ts
-import { readFileSync as readFileSync4 } from "node:fs";
+import { readFileSync as readFileSync4, existsSync as existsSync4 } from "node:fs";
 import { execFileSync as execFileSync3 } from "node:child_process";
 import * as path5 from "node:path";
 function detectTestRunner(packageJsonPath2) {
@@ -6351,6 +6351,53 @@ function repoTree(repoRoot) {
 function packageJsonPath(repoRoot) {
   return path5.join(repoRoot, "package.json");
 }
+function detectPackageManager(repoRoot, _checkExists = existsSync4, _readFile = (p, enc) => readFileSync4(p, enc)) {
+  const join5 = (file) => path5.join(repoRoot, file);
+  if (_checkExists(join5("pnpm-lock.yaml"))) {
+    return "pnpm lockfile detected (`pnpm-lock.yaml`). Use pnpm for all install and script commands.";
+  }
+  if (_checkExists(join5("package.json"))) {
+    try {
+      const pkg = JSON.parse(_readFile(join5("package.json"), "utf8"));
+      const pm = typeof pkg.packageManager === "string" ? pkg.packageManager : "";
+      if (pm.startsWith("pnpm")) {
+        return "pnpm declared in `package.json` (`packageManager` field). Use pnpm for all install and script commands.";
+      }
+      if (pm.startsWith("yarn")) {
+        return "yarn declared in `package.json` (`packageManager` field). Use yarn for all install and script commands.";
+      }
+      if (pm.startsWith("bun")) {
+        return "bun declared in `package.json` (`packageManager` field). Use bun for all install and script commands.";
+      }
+      if (pm.startsWith("npm")) {
+        return "npm declared in `package.json` (`packageManager` field). Use npm for all install and script commands.";
+      }
+    } catch {
+    }
+  }
+  if (_checkExists(join5("yarn.lock"))) {
+    return "yarn lockfile detected (`yarn.lock`). Use yarn for all install and script commands.";
+  }
+  if (_checkExists(join5("bun.lockb"))) {
+    return "bun lockfile detected (`bun.lockb`). Use bun for all install and script commands.";
+  }
+  if (_checkExists(join5("package-lock.json"))) {
+    return "npm lockfile detected (`package-lock.json`). Use npm for all install and script commands.";
+  }
+  const hasPyproject = _checkExists(join5("pyproject.toml"));
+  const hasRequirements = _checkExists(join5("requirements.txt"));
+  if (hasPyproject || hasRequirements) {
+    const marker = hasPyproject ? "pyproject.toml" : "requirements.txt";
+    return `Python project detected (\`${marker}\`). Use pip or the project's configured tool for dependency management.`;
+  }
+  if (_checkExists(join5("Gemfile.lock"))) {
+    return "Ruby project detected (`Gemfile.lock`). Use bundler for dependency management.";
+  }
+  if (_checkExists(join5("Cargo.lock"))) {
+    return "Rust project detected (`Cargo.lock`). Use cargo for dependency management.";
+  }
+  return null;
+}
 
 // src/agents/developer/dev-action.ts
 var REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
@@ -6389,8 +6436,13 @@ async function main(envelope, logger) {
   const ticketBlock = buildTicketBlock(ticketKey, issue, { labels, comments });
   const subtasks = await tracker.getSubtasks(ticketKey);
   const testRunner = detectTestRunner(packageJsonPath(REPO_ROOT));
+  const pkgManagerHint = detectPackageManager(REPO_ROOT);
   const tree = repoTree(REPO_ROOT);
-  const system = buildSystem("dev", REPO_ROOT);
+  const system = buildSystem("dev", REPO_ROOT, {
+    extraParts: pkgManagerHint ? [`## Detected package manager
+
+${pkgManagerHint}`] : []
+  });
   const model = ferryCfg.models.dev.model;
   const branchName = `${workingBranchPrefix}${ticketKey}`;
   configureFerryGitUser(REPO_ROOT);

--- a/.github/actions/ferry-run-developer/dev-action.js
+++ b/.github/actions/ferry-run-developer/dev-action.js
@@ -6309,7 +6309,7 @@ function resolveAnthropicAuth(input) {
 }
 
 // src/agents/developer/workspace.ts
-import { readFileSync as readFileSync4 } from "node:fs";
+import { readFileSync as readFileSync4, existsSync as existsSync4 } from "node:fs";
 import { execFileSync as execFileSync3 } from "node:child_process";
 import * as path5 from "node:path";
 function detectTestRunner(packageJsonPath2) {
@@ -6351,6 +6351,53 @@ function repoTree(repoRoot) {
 function packageJsonPath(repoRoot) {
   return path5.join(repoRoot, "package.json");
 }
+function detectPackageManager(repoRoot, _checkExists = existsSync4, _readFile = (p, enc) => readFileSync4(p, enc)) {
+  const join5 = (file) => path5.join(repoRoot, file);
+  if (_checkExists(join5("pnpm-lock.yaml"))) {
+    return "pnpm lockfile detected (`pnpm-lock.yaml`). Use pnpm for all install and script commands.";
+  }
+  if (_checkExists(join5("package.json"))) {
+    try {
+      const pkg = JSON.parse(_readFile(join5("package.json"), "utf8"));
+      const pm = typeof pkg.packageManager === "string" ? pkg.packageManager : "";
+      if (pm.startsWith("pnpm")) {
+        return "pnpm declared in `package.json` (`packageManager` field). Use pnpm for all install and script commands.";
+      }
+      if (pm.startsWith("yarn")) {
+        return "yarn declared in `package.json` (`packageManager` field). Use yarn for all install and script commands.";
+      }
+      if (pm.startsWith("bun")) {
+        return "bun declared in `package.json` (`packageManager` field). Use bun for all install and script commands.";
+      }
+      if (pm.startsWith("npm")) {
+        return "npm declared in `package.json` (`packageManager` field). Use npm for all install and script commands.";
+      }
+    } catch {
+    }
+  }
+  if (_checkExists(join5("yarn.lock"))) {
+    return "yarn lockfile detected (`yarn.lock`). Use yarn for all install and script commands.";
+  }
+  if (_checkExists(join5("bun.lockb"))) {
+    return "bun lockfile detected (`bun.lockb`). Use bun for all install and script commands.";
+  }
+  if (_checkExists(join5("package-lock.json"))) {
+    return "npm lockfile detected (`package-lock.json`). Use npm for all install and script commands.";
+  }
+  const hasPyproject = _checkExists(join5("pyproject.toml"));
+  const hasRequirements = _checkExists(join5("requirements.txt"));
+  if (hasPyproject || hasRequirements) {
+    const marker = hasPyproject ? "pyproject.toml" : "requirements.txt";
+    return `Python project detected (\`${marker}\`). Use pip or the project's configured tool for dependency management.`;
+  }
+  if (_checkExists(join5("Gemfile.lock"))) {
+    return "Ruby project detected (`Gemfile.lock`). Use bundler for dependency management.";
+  }
+  if (_checkExists(join5("Cargo.lock"))) {
+    return "Rust project detected (`Cargo.lock`). Use cargo for dependency management.";
+  }
+  return null;
+}
 
 // src/agents/developer/dev-action.ts
 var REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
@@ -6389,8 +6436,13 @@ async function main(envelope, logger) {
   const ticketBlock = buildTicketBlock(ticketKey, issue, { labels, comments });
   const subtasks = await tracker.getSubtasks(ticketKey);
   const testRunner = detectTestRunner(packageJsonPath(REPO_ROOT));
+  const pkgManagerHint = detectPackageManager(REPO_ROOT);
   const tree = repoTree(REPO_ROOT);
-  const system = buildSystem("dev", REPO_ROOT);
+  const system = buildSystem("dev", REPO_ROOT, {
+    extraParts: pkgManagerHint ? [`## Detected package manager
+
+${pkgManagerHint}`] : []
+  });
   const model = ferryCfg.models.dev.model;
   const branchName = `${workingBranchPrefix}${ticketKey}`;
   configureFerryGitUser(REPO_ROOT);

--- a/src/agents/developer/dev-action.ts
+++ b/src/agents/developer/dev-action.ts
@@ -31,7 +31,7 @@ import { createAnthropicAgentLoop } from '../../lib/llm/agent-loop/anthropic.js'
 import type { AgentLoop } from '../../lib/llm/agent-loop/types.js';
 import { resolveCapabilities, filterMcpServers } from '../../lib/labels/capabilities.js';
 import { resolveAnthropicAuth } from '../../lib/llm/anthropic-auth.js';
-import { detectTestRunner, repoTree, packageJsonPath } from './workspace.js';
+import { detectTestRunner, repoTree, packageJsonPath, detectPackageManager } from './workspace.js';
 
 const REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 
@@ -84,9 +84,12 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
 
   const subtasks = await tracker.getSubtasks(ticketKey);
   const testRunner = detectTestRunner(packageJsonPath(REPO_ROOT));
+  const pkgManagerHint = detectPackageManager(REPO_ROOT);
   const tree = repoTree(REPO_ROOT);
 
-  const system = buildSystem('dev', REPO_ROOT);
+  const system = buildSystem('dev', REPO_ROOT, {
+    extraParts: pkgManagerHint ? [`## Detected package manager\n\n${pkgManagerHint}`] : [],
+  });
   const model = ferryCfg.models.dev.model;
 
   // Branch is determined upfront from the ticket key so restarts resume the same branch.

--- a/src/agents/developer/workspace.test.ts
+++ b/src/agents/developer/workspace.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { detectTestRunner, repoTree, packageJsonPath } from './workspace.js';
+import { detectTestRunner, repoTree, packageJsonPath, detectPackageManager } from './workspace.js';
 
 let tmpDir: string;
 
@@ -133,5 +133,135 @@ describe('packageJsonPath', () => {
 
   it('returns a path ending in package.json', () => {
     expect(packageJsonPath('/any/path')).toMatch(/package\.json$/);
+  });
+});
+
+describe('detectPackageManager', () => {
+  const readFile = (files: Record<string, string>) => (p: string) => {
+    if (p in files) return files[p];
+    throw new Error(`ENOENT: ${p}`);
+  };
+
+  const checkExists = (present: string[]) => (p: string) => present.includes(p);
+
+  it('detects pnpm via pnpm-lock.yaml', () => {
+    const check = checkExists([`${tmpDir}/pnpm-lock.yaml`]);
+    expect(detectPackageManager(tmpDir, check)).toContain('pnpm');
+  });
+
+  it('detects pnpm via packageManager field in package.json', () => {
+    const check = checkExists([`${tmpDir}/package.json`]);
+    const read = readFile({
+      [`${tmpDir}/package.json`]: JSON.stringify({ packageManager: 'pnpm@9.0.0' }),
+    });
+    expect(detectPackageManager(tmpDir, check, read)).toContain('pnpm');
+  });
+
+  it('detects yarn via packageManager field', () => {
+    const check = checkExists([`${tmpDir}/package.json`]);
+    const read = readFile({
+      [`${tmpDir}/package.json`]: JSON.stringify({ packageManager: 'yarn@4.0.0' }),
+    });
+    expect(detectPackageManager(tmpDir, check, read)).toContain('yarn');
+  });
+
+  it('detects bun via packageManager field', () => {
+    const check = checkExists([`${tmpDir}/package.json`]);
+    const read = readFile({
+      [`${tmpDir}/package.json`]: JSON.stringify({ packageManager: 'bun@1.1.0' }),
+    });
+    expect(detectPackageManager(tmpDir, check, read)).toContain('bun');
+  });
+
+  it('detects npm via packageManager field', () => {
+    const check = checkExists([`${tmpDir}/package.json`]);
+    const read = readFile({
+      [`${tmpDir}/package.json`]: JSON.stringify({ packageManager: 'npm@10.0.0' }),
+    });
+    expect(detectPackageManager(tmpDir, check, read)).toContain('npm');
+  });
+
+  it('detects yarn via yarn.lock', () => {
+    const check = checkExists([`${tmpDir}/yarn.lock`]);
+    expect(detectPackageManager(tmpDir, check)).toContain('yarn');
+  });
+
+  it('detects bun via bun.lockb', () => {
+    const check = checkExists([`${tmpDir}/bun.lockb`]);
+    expect(detectPackageManager(tmpDir, check)).toContain('bun');
+  });
+
+  it('detects npm via package-lock.json', () => {
+    const check = checkExists([`${tmpDir}/package-lock.json`]);
+    expect(detectPackageManager(tmpDir, check)).toContain('npm');
+  });
+
+  it('detects Python via pyproject.toml', () => {
+    const check = checkExists([`${tmpDir}/pyproject.toml`]);
+    expect(detectPackageManager(tmpDir, check)).toContain('Python');
+  });
+
+  it('detects Python via requirements.txt', () => {
+    const check = checkExists([`${tmpDir}/requirements.txt`]);
+    expect(detectPackageManager(tmpDir, check)).toContain('Python');
+  });
+
+  it('prefers pyproject.toml marker text when both Python markers exist', () => {
+    const check = checkExists([`${tmpDir}/pyproject.toml`, `${tmpDir}/requirements.txt`]);
+    expect(detectPackageManager(tmpDir, check)).toContain('pyproject.toml');
+  });
+
+  it('detects Ruby via Gemfile.lock', () => {
+    const check = checkExists([`${tmpDir}/Gemfile.lock`]);
+    expect(detectPackageManager(tmpDir, check)).toContain('Ruby');
+  });
+
+  it('detects Rust via Cargo.lock', () => {
+    const check = checkExists([`${tmpDir}/Cargo.lock`]);
+    expect(detectPackageManager(tmpDir, check)).toContain('Rust');
+  });
+
+  it('returns null when no marker is found', () => {
+    const check = checkExists([]);
+    expect(detectPackageManager(tmpDir, check)).toBeNull();
+  });
+
+  it('pnpm-lock.yaml takes priority over package-lock.json', () => {
+    const check = checkExists([`${tmpDir}/pnpm-lock.yaml`, `${tmpDir}/package-lock.json`]);
+    const result = detectPackageManager(tmpDir, check);
+    expect(result).toContain('pnpm-lock.yaml');
+    expect(result).not.toContain('package-lock.json');
+  });
+
+  it('pnpm-lock.yaml takes priority over packageManager field', () => {
+    const check = checkExists([`${tmpDir}/pnpm-lock.yaml`, `${tmpDir}/package.json`]);
+    const read = readFile({
+      [`${tmpDir}/package.json`]: JSON.stringify({ packageManager: 'yarn@4.0.0' }),
+    });
+    const result = detectPackageManager(tmpDir, check, read);
+    expect(result).toContain('pnpm');
+  });
+
+  it('packageManager field takes priority over yarn.lock', () => {
+    const check = checkExists([`${tmpDir}/package.json`, `${tmpDir}/yarn.lock`]);
+    const read = readFile({
+      [`${tmpDir}/package.json`]: JSON.stringify({ packageManager: 'bun@1.1.0' }),
+    });
+    const result = detectPackageManager(tmpDir, check, read);
+    expect(result).toContain('bun');
+  });
+
+  it('falls back to lockfile when package.json has no packageManager field', () => {
+    const check = checkExists([`${tmpDir}/package.json`, `${tmpDir}/yarn.lock`]);
+    const read = readFile({ [`${tmpDir}/package.json`]: JSON.stringify({ name: 'pkg' }) });
+    const result = detectPackageManager(tmpDir, check, read);
+    expect(result).toContain('yarn');
+  });
+
+  it('falls back to lockfile when package.json contains invalid JSON', () => {
+    const check = checkExists([`${tmpDir}/package.json`, `${tmpDir}/yarn.lock`]);
+    const read = readFile({ [`${tmpDir}/package.json`]: 'not { valid' });
+    const result = detectPackageManager(tmpDir, check, read);
+    expect(result).toContain('yarn');
   });
 });

--- a/src/agents/developer/workspace.ts
+++ b/src/agents/developer/workspace.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import * as path from 'node:path';
 
@@ -48,4 +48,63 @@ export function repoTree(repoRoot: string): string {
 
 export function packageJsonPath(repoRoot: string): string {
   return path.join(repoRoot, 'package.json');
+}
+
+export function detectPackageManager(
+  repoRoot: string,
+  _checkExists: (p: string) => boolean = existsSync,
+  _readFile: (p: string, enc: BufferEncoding) => string = (p, enc) => readFileSync(p, enc),
+): string | null {
+  const join = (file: string) => path.join(repoRoot, file);
+
+  if (_checkExists(join('pnpm-lock.yaml'))) {
+    return 'pnpm lockfile detected (`pnpm-lock.yaml`). Use pnpm for all install and script commands.';
+  }
+
+  if (_checkExists(join('package.json'))) {
+    try {
+      const pkg = JSON.parse(_readFile(join('package.json'), 'utf8')) as Record<string, unknown>;
+      const pm = typeof pkg.packageManager === 'string' ? pkg.packageManager : '';
+      if (pm.startsWith('pnpm')) {
+        return 'pnpm declared in `package.json` (`packageManager` field). Use pnpm for all install and script commands.';
+      }
+      if (pm.startsWith('yarn')) {
+        return 'yarn declared in `package.json` (`packageManager` field). Use yarn for all install and script commands.';
+      }
+      if (pm.startsWith('bun')) {
+        return 'bun declared in `package.json` (`packageManager` field). Use bun for all install and script commands.';
+      }
+      if (pm.startsWith('npm')) {
+        return 'npm declared in `package.json` (`packageManager` field). Use npm for all install and script commands.';
+      }
+    } catch {
+      // ignore parse errors
+    }
+  }
+
+  if (_checkExists(join('yarn.lock'))) {
+    return 'yarn lockfile detected (`yarn.lock`). Use yarn for all install and script commands.';
+  }
+  if (_checkExists(join('bun.lockb'))) {
+    return 'bun lockfile detected (`bun.lockb`). Use bun for all install and script commands.';
+  }
+  if (_checkExists(join('package-lock.json'))) {
+    return 'npm lockfile detected (`package-lock.json`). Use npm for all install and script commands.';
+  }
+
+  const hasPyproject = _checkExists(join('pyproject.toml'));
+  const hasRequirements = _checkExists(join('requirements.txt'));
+  if (hasPyproject || hasRequirements) {
+    const marker = hasPyproject ? 'pyproject.toml' : 'requirements.txt';
+    return `Python project detected (\`${marker}\`). Use pip or the project's configured tool for dependency management.`;
+  }
+
+  if (_checkExists(join('Gemfile.lock'))) {
+    return 'Ruby project detected (`Gemfile.lock`). Use bundler for dependency management.';
+  }
+  if (_checkExists(join('Cargo.lock'))) {
+    return 'Rust project detected (`Cargo.lock`). Use cargo for dependency management.';
+  }
+
+  return null;
 }


### PR DESCRIPTION
Scans the workspace for ecosystem lockfiles and the `packageManager` field in `package.json` before the first agent turn. Injects a concise hint into the developer system prompt via `buildSystem` extraParts so the agent no longer has to guess which tool to use.

Detection priority: pnpm-lock.yaml → packageManager field → yarn.lock → bun.lockb → package-lock.json → Python → Gemfile.lock → Cargo.lock.

Closes #178

Generated with [Claude Code](https://claude.ai/code)