### PR TITLE
feat(developer): commit WIP and post Jira summary on agent failure

### DIFF
--- a/.ferry/dev-action.js
+++ b/.ferry/dev-action.js
@@ -121,7 +121,7 @@ var require_fast_content_type_parse = __commonJS({
 });
 
 // src/agents/developer/dev-action.ts
-import { execFileSync as execFileSync4 } from "node:child_process";
+import { execFileSync as execFileSync5 } from "node:child_process";
 import * as fsp2 from "node:fs/promises";
 import * as path6 from "node:path";
 
@@ -6473,6 +6473,103 @@ function assertDevOutputContract(outcome, outputs) {
   }
 }
 
+// src/agents/developer/wip-finalizer.ts
+import { execFileSync as execFileSync4 } from "node:child_process";
+function classifyError(err) {
+  if (err instanceof FerryError) {
+    const reason = err.context?.reason ?? "unknown";
+    if (err.code === "spend-cap") {
+      const cap = err.context?.cap;
+      const consumed = err.context?.consumed;
+      const detail = cap != null && consumed != null ? `spend cap exceeded (used ${Math.round(Number(consumed)).toLocaleString()} / ${Math.round(Number(cap)).toLocaleString()} tokens)` : "spend cap exceeded";
+      return { code: err.code, detail };
+    }
+    if (err.code === "state-invariant" && reason === "iteration-cap-exceeded") {
+      return {
+        code: err.code,
+        detail: `max iterations reached (cap: ${err.context?.cap ?? "unknown"})`
+      };
+    }
+    return { code: err.code, detail: reason };
+  }
+  const msg = err?.message ?? String(err);
+  return { code: "unknown", detail: msg.slice(0, 200) };
+}
+async function runWipFinalizer(opts) {
+  const {
+    error,
+    ticketKey,
+    eventId,
+    branchName,
+    repoRoot,
+    secretScan,
+    tracker,
+    logger,
+    dryRun,
+    model,
+    provider
+  } = opts;
+  const { code, detail } = classifyError(error);
+  logger.info("wip_finalizer", { code, detail, branch: branchName });
+  let committed = false;
+  try {
+    execFileSync4("git", ["add", "-A"], { cwd: repoRoot });
+    const status = execFileSync4("git", ["status", "--porcelain"], {
+      cwd: repoRoot,
+      encoding: "utf8"
+    });
+    if (status.trim()) {
+      await secretScan();
+      const wipMsg = `wip(${ticketKey}): interrupted \u2014 ${code}
+
+[ferry:dev:${eventId}]`;
+      execFileSync4("git", ["commit", "-m", wipMsg], { cwd: repoRoot });
+      committed = true;
+      logger.info("wip_committed", { branch: branchName });
+    } else {
+      logger.info("wip_nothing_to_commit");
+    }
+  } catch (commitErr) {
+    logger.error("wip_commit_failed", { error: commitErr.message });
+  }
+  let pushed = false;
+  if (!dryRun) {
+    try {
+      execFileSync4("git", ["push", "origin", branchName, "--force-with-lease"], {
+        cwd: repoRoot,
+        stdio: "pipe"
+      });
+      pushed = true;
+    } catch {
+      try {
+        execFileSync4("git", ["push", "origin", branchName], { cwd: repoRoot, stdio: "pipe" });
+        pushed = true;
+      } catch (pushErr) {
+        logger.error("wip_push_failed", { error: pushErr.message });
+      }
+    }
+    if (pushed) {
+      logger.info("wip_pushed", { branch: branchName, committed });
+    }
+  } else {
+    logger.info("DRY_RUN \u2014 wip push skipped");
+  }
+  if (!dryRun) {
+    const wipMarker = `[ferry:dev:wip:${eventId}]`;
+    const branchRef = pushed ? ` WIP pushed to branch \`${branchName}\`.` : "";
+    const comment = `${wipMarker} \u26A0\uFE0F Dev run interrupted \u2014 ${detail}.${branchRef} The next run will resume from this state.`;
+    try {
+      await tracker.postComment(ticketKey, comment);
+      logger.info("wip_jira_comment_posted");
+    } catch (commentErr) {
+      logger.error("wip_jira_comment_failed", { error: commentErr.message });
+    }
+  } else {
+    logger.info("DRY_RUN \u2014 wip Jira comment skipped", { detail });
+  }
+  appendOutput({ input_tokens: 0, output_tokens: 0, model, provider });
+}
+
 // src/agents/developer/dev-action.ts
 var REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main(envelope, logger) {
@@ -6522,13 +6619,13 @@ ${pkgManagerHint}`] : []
   let resumeContext = "";
   let branchHeadSha = "";
   try {
-    execFileSync4("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
+    execFileSync5("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
       cwd: REPO_ROOT,
       stdio: "pipe"
     });
-    execFileSync4("git", ["fetch", "origin", branchName], { cwd: REPO_ROOT });
-    execFileSync4("git", ["checkout", branchName], { cwd: REPO_ROOT });
-    const existingLog = execFileSync4("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
+    execFileSync5("git", ["fetch", "origin", branchName], { cwd: REPO_ROOT });
+    execFileSync5("git", ["checkout", branchName], { cwd: REPO_ROOT });
+    const existingLog = execFileSync5("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
       cwd: REPO_ROOT,
       encoding: "utf8"
     }).trim();
@@ -6541,12 +6638,12 @@ ${existingLog}`;
         prior_commits: existingLog.split("\n").length
       });
     }
-    branchHeadSha = execFileSync4("git", ["rev-parse", "HEAD"], {
+    branchHeadSha = execFileSync5("git", ["rev-parse", "HEAD"], {
       cwd: REPO_ROOT,
       encoding: "utf8"
     }).trim();
   } catch {
-    execFileSync4("git", ["checkout", "-B", branchName], { cwd: REPO_ROOT });
+    execFileSync5("git", ["checkout", "-B", branchName], { cwd: REPO_ROOT });
     logger.info("created branch", { branch: branchName });
   }
   let existingPrUrl = "";
@@ -6617,15 +6714,34 @@ ${tree}`,
     }),
     logger
   });
-  const { done, usage, iterations } = await loop.run({
-    system,
-    initialPrompt: initialPrompt + resumeContext + existingPrContext,
-    tools: allToolSchemas,
-    repoRoot: REPO_ROOT,
-    branchName,
-    secretScan,
-    mcpServers
-  });
+  let loopResult;
+  try {
+    loopResult = await loop.run({
+      system,
+      initialPrompt: initialPrompt + resumeContext + existingPrContext,
+      tools: allToolSchemas,
+      repoRoot: REPO_ROOT,
+      branchName,
+      secretScan,
+      mcpServers
+    });
+  } catch (loopErr) {
+    await runWipFinalizer({
+      error: loopErr,
+      ticketKey,
+      eventId,
+      branchName,
+      repoRoot: REPO_ROOT,
+      secretScan,
+      tracker,
+      logger,
+      dryRun,
+      model,
+      provider: devProvider
+    });
+    throw loopErr;
+  }
+  const { done, usage, iterations } = loopResult;
   const resolvedOutcome = done.outcome ?? (done.actionable ? "implemented" : "blocked");
   logger.info("done", {
     iterations,
@@ -6675,20 +6791,20 @@ ${tree}`,
       await fsp2.writeFile(verificationPath, verificationContent, "utf8");
       verificationNoteWritten = true;
     }
-    execFileSync4("git", ["add", "-A"], { cwd: REPO_ROOT });
-    const finalStatus = execFileSync4("git", ["status", "--porcelain"], {
+    execFileSync5("git", ["add", "-A"], { cwd: REPO_ROOT });
+    const finalStatus = execFileSync5("git", ["status", "--porcelain"], {
       cwd: REPO_ROOT,
       encoding: "utf8"
     });
     if (finalStatus.trim()) {
       await secretScan();
       const msg = resolvedOutcome === "already_satisfied" ? `chore(${ticketKey}): add verification note \u2014 spec already satisfied` : done.commit_message ?? commitMessage;
-      execFileSync4("git", ["commit", "-m", msg], { cwd: REPO_ROOT });
+      execFileSync5("git", ["commit", "-m", msg], { cwd: REPO_ROOT });
     }
     if (dryRun) {
       let diffOutput = "(no local changes)";
       try {
-        diffOutput = execFileSync4(
+        diffOutput = execFileSync5(
           "sh",
           [
             "-c",
@@ -6707,7 +6823,7 @@ ${tree}`,
       appendOutput({ ...usage, model, provider: devProvider });
       process.exit(0);
     }
-    execFileSync4("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT });
+    execFileSync5("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT });
     const branchPushed = true;
     const prTitle = resolvedOutcome === "already_satisfied" ? `verify(${ticketKey}): existing implementation satisfies spec` : formatPullRequestTitle({ ticketKey, summary: done.summary });
     const prBody = formatPullRequestBody({

--- a/.github/actions/ferry-run-developer/dev-action.js
+++ b/.github/actions/ferry-run-developer/dev-action.js
@@ -121,7 +121,7 @@ var require_fast_content_type_parse = __commonJS({
 });
 
 // src/agents/developer/dev-action.ts
-import { execFileSync as execFileSync4 } from "node:child_process";
+import { execFileSync as execFileSync5 } from "node:child_process";
 import * as fsp2 from "node:fs/promises";
 import * as path6 from "node:path";
 
@@ -6473,6 +6473,103 @@ function assertDevOutputContract(outcome, outputs) {
   }
 }
 
+// src/agents/developer/wip-finalizer.ts
+import { execFileSync as execFileSync4 } from "node:child_process";
+function classifyError(err) {
+  if (err instanceof FerryError) {
+    const reason = err.context?.reason ?? "unknown";
+    if (err.code === "spend-cap") {
+      const cap = err.context?.cap;
+      const consumed = err.context?.consumed;
+      const detail = cap != null && consumed != null ? `spend cap exceeded (used ${Math.round(Number(consumed)).toLocaleString()} / ${Math.round(Number(cap)).toLocaleString()} tokens)` : "spend cap exceeded";
+      return { code: err.code, detail };
+    }
+    if (err.code === "state-invariant" && reason === "iteration-cap-exceeded") {
+      return {
+        code: err.code,
+        detail: `max iterations reached (cap: ${err.context?.cap ?? "unknown"})`
+      };
+    }
+    return { code: err.code, detail: reason };
+  }
+  const msg = err?.message ?? String(err);
+  return { code: "unknown", detail: msg.slice(0, 200) };
+}
+async function runWipFinalizer(opts) {
+  const {
+    error,
+    ticketKey,
+    eventId,
+    branchName,
+    repoRoot,
+    secretScan,
+    tracker,
+    logger,
+    dryRun,
+    model,
+    provider
+  } = opts;
+  const { code, detail } = classifyError(error);
+  logger.info("wip_finalizer", { code, detail, branch: branchName });
+  let committed = false;
+  try {
+    execFileSync4("git", ["add", "-A"], { cwd: repoRoot });
+    const status = execFileSync4("git", ["status", "--porcelain"], {
+      cwd: repoRoot,
+      encoding: "utf8"
+    });
+    if (status.trim()) {
+      await secretScan();
+      const wipMsg = `wip(${ticketKey}): interrupted \u2014 ${code}
+
+[ferry:dev:${eventId}]`;
+      execFileSync4("git", ["commit", "-m", wipMsg], { cwd: repoRoot });
+      committed = true;
+      logger.info("wip_committed", { branch: branchName });
+    } else {
+      logger.info("wip_nothing_to_commit");
+    }
+  } catch (commitErr) {
+    logger.error("wip_commit_failed", { error: commitErr.message });
+  }
+  let pushed = false;
+  if (!dryRun) {
+    try {
+      execFileSync4("git", ["push", "origin", branchName, "--force-with-lease"], {
+        cwd: repoRoot,
+        stdio: "pipe"
+      });
+      pushed = true;
+    } catch {
+      try {
+        execFileSync4("git", ["push", "origin", branchName], { cwd: repoRoot, stdio: "pipe" });
+        pushed = true;
+      } catch (pushErr) {
+        logger.error("wip_push_failed", { error: pushErr.message });
+      }
+    }
+    if (pushed) {
+      logger.info("wip_pushed", { branch: branchName, committed });
+    }
+  } else {
+    logger.info("DRY_RUN \u2014 wip push skipped");
+  }
+  if (!dryRun) {
+    const wipMarker = `[ferry:dev:wip:${eventId}]`;
+    const branchRef = pushed ? ` WIP pushed to branch \`${branchName}\`.` : "";
+    const comment = `${wipMarker} \u26A0\uFE0F Dev run interrupted \u2014 ${detail}.${branchRef} The next run will resume from this state.`;
+    try {
+      await tracker.postComment(ticketKey, comment);
+      logger.info("wip_jira_comment_posted");
+    } catch (commentErr) {
+      logger.error("wip_jira_comment_failed", { error: commentErr.message });
+    }
+  } else {
+    logger.info("DRY_RUN \u2014 wip Jira comment skipped", { detail });
+  }
+  appendOutput({ input_tokens: 0, output_tokens: 0, model, provider });
+}
+
 // src/agents/developer/dev-action.ts
 var REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main(envelope, logger) {
@@ -6522,13 +6619,13 @@ ${pkgManagerHint}`] : []
   let resumeContext = "";
   let branchHeadSha = "";
   try {
-    execFileSync4("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
+    execFileSync5("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
       cwd: REPO_ROOT,
       stdio: "pipe"
     });
-    execFileSync4("git", ["fetch", "origin", branchName], { cwd: REPO_ROOT });
-    execFileSync4("git", ["checkout", branchName], { cwd: REPO_ROOT });
-    const existingLog = execFileSync4("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
+    execFileSync5("git", ["fetch", "origin", branchName], { cwd: REPO_ROOT });
+    execFileSync5("git", ["checkout", branchName], { cwd: REPO_ROOT });
+    const existingLog = execFileSync5("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
       cwd: REPO_ROOT,
       encoding: "utf8"
     }).trim();
@@ -6541,12 +6638,12 @@ ${existingLog}`;
         prior_commits: existingLog.split("\n").length
       });
     }
-    branchHeadSha = execFileSync4("git", ["rev-parse", "HEAD"], {
+    branchHeadSha = execFileSync5("git", ["rev-parse", "HEAD"], {
       cwd: REPO_ROOT,
       encoding: "utf8"
     }).trim();
   } catch {
-    execFileSync4("git", ["checkout", "-B", branchName], { cwd: REPO_ROOT });
+    execFileSync5("git", ["checkout", "-B", branchName], { cwd: REPO_ROOT });
     logger.info("created branch", { branch: branchName });
   }
   let existingPrUrl = "";
@@ -6617,15 +6714,34 @@ ${tree}`,
     }),
     logger
   });
-  const { done, usage, iterations } = await loop.run({
-    system,
-    initialPrompt: initialPrompt + resumeContext + existingPrContext,
-    tools: allToolSchemas,
-    repoRoot: REPO_ROOT,
-    branchName,
-    secretScan,
-    mcpServers
-  });
+  let loopResult;
+  try {
+    loopResult = await loop.run({
+      system,
+      initialPrompt: initialPrompt + resumeContext + existingPrContext,
+      tools: allToolSchemas,
+      repoRoot: REPO_ROOT,
+      branchName,
+      secretScan,
+      mcpServers
+    });
+  } catch (loopErr) {
+    await runWipFinalizer({
+      error: loopErr,
+      ticketKey,
+      eventId,
+      branchName,
+      repoRoot: REPO_ROOT,
+      secretScan,
+      tracker,
+      logger,
+      dryRun,
+      model,
+      provider: devProvider
+    });
+    throw loopErr;
+  }
+  const { done, usage, iterations } = loopResult;
   const resolvedOutcome = done.outcome ?? (done.actionable ? "implemented" : "blocked");
   logger.info("done", {
     iterations,
@@ -6675,20 +6791,20 @@ ${tree}`,
       await fsp2.writeFile(verificationPath, verificationContent, "utf8");
       verificationNoteWritten = true;
     }
-    execFileSync4("git", ["add", "-A"], { cwd: REPO_ROOT });
-    const finalStatus = execFileSync4("git", ["status", "--porcelain"], {
+    execFileSync5("git", ["add", "-A"], { cwd: REPO_ROOT });
+    const finalStatus = execFileSync5("git", ["status", "--porcelain"], {
       cwd: REPO_ROOT,
       encoding: "utf8"
     });
     if (finalStatus.trim()) {
       await secretScan();
       const msg = resolvedOutcome === "already_satisfied" ? `chore(${ticketKey}): add verification note \u2014 spec already satisfied` : done.commit_message ?? commitMessage;
-      execFileSync4("git", ["commit", "-m", msg], { cwd: REPO_ROOT });
+      execFileSync5("git", ["commit", "-m", msg], { cwd: REPO_ROOT });
     }
     if (dryRun) {
       let diffOutput = "(no local changes)";
       try {
-        diffOutput = execFileSync4(
+        diffOutput = execFileSync5(
           "sh",
           [
             "-c",
@@ -6707,7 +6823,7 @@ ${tree}`,
       appendOutput({ ...usage, model, provider: devProvider });
       process.exit(0);
     }
-    execFileSync4("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT });
+    execFileSync5("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT });
     const branchPushed = true;
     const prTitle = resolvedOutcome === "already_satisfied" ? `verify(${ticketKey}): existing implementation satisfies spec` : formatPullRequestTitle({ ticketKey, summary: done.summary });
     const prBody = formatPullRequestBody({

--- a/src/agents/developer/dev-action.ts
+++ b/src/agents/developer/dev-action.ts
@@ -35,6 +35,7 @@ import { resolveCapabilities, filterMcpServers } from '../../lib/labels/capabili
 import { resolveAnthropicAuth } from '../../lib/llm/anthropic-auth.js';
 import { detectTestRunner, repoTree, packageJsonPath, detectPackageManager } from './workspace.js';
 import { assertDevOutputContract } from './outcome-guard.js';
+import { runWipFinalizer } from './wip-finalizer.js';
 
 const REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 
@@ -204,15 +205,35 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
     logger,
   });
 
-  const { done, usage, iterations } = await loop.run({
-    system,
-    initialPrompt: initialPrompt + resumeContext + existingPrContext,
-    tools: allToolSchemas,
-    repoRoot: REPO_ROOT,
-    branchName,
-    secretScan,
-    mcpServers,
-  });
+  let loopResult: Awaited<ReturnType<typeof loop.run>>;
+  try {
+    loopResult = await loop.run({
+      system,
+      initialPrompt: initialPrompt + resumeContext + existingPrContext,
+      tools: allToolSchemas,
+      repoRoot: REPO_ROOT,
+      branchName,
+      secretScan,
+      mcpServers,
+    });
+  } catch (loopErr) {
+    await runWipFinalizer({
+      error: loopErr,
+      ticketKey,
+      eventId,
+      branchName,
+      repoRoot: REPO_ROOT,
+      secretScan,
+      tracker,
+      logger,
+      dryRun,
+      model,
+      provider: devProvider,
+    });
+    throw loopErr;
+  }
+
+  const { done, usage, iterations } = loopResult;
 
   const resolvedOutcome = done.outcome ?? (done.actionable ? 'implemented' : 'blocked');
 

--- a/src/agents/developer/wip-finalizer.test.ts
+++ b/src/agents/developer/wip-finalizer.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FerryError } from '../../lib/errors/index.js';
+import { InMemoryTracker } from '../../lib/io/tracker/in-memory.js';
+import { createTestLogger } from '../../lib/logger/index.js';
+
+const { mockExecFileSync, mockAppendFileSync } = vi.hoisted(() => ({
+  mockExecFileSync: vi.fn<(cmd: string, args: string[], opts?: unknown) => Buffer | string>(),
+  mockAppendFileSync: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  execFileSync: mockExecFileSync,
+}));
+
+vi.mock('node:fs', () => ({
+  appendFileSync: mockAppendFileSync,
+}));
+
+import { classifyError, runWipFinalizer } from './wip-finalizer.js';
+
+function makeTracker(ticketKey: string): InMemoryTracker {
+  const tracker = new InMemoryTracker();
+  tracker.seed({
+    key: ticketKey,
+    summary: 'Test ticket',
+    description: 'desc',
+    comments: [],
+    labels: [],
+    issueType: 'Story',
+  });
+  return tracker;
+}
+
+function baseOpts(tracker: InMemoryTracker) {
+  return {
+    ticketKey: 'PROJ-1',
+    eventId: 'ev-123',
+    branchName: 'ferry/PROJ-1',
+    repoRoot: '/repo',
+    secretScan: async () => {},
+    tracker,
+    logger: createTestLogger('test', 'wip-test').logger,
+    dryRun: false,
+    model: 'claude-test',
+    provider: 'anthropic',
+  };
+}
+
+describe('classifyError', () => {
+  it('classifies spend-cap with token counts', () => {
+    const err = new FerryError('spend-cap', {
+      reason: 'input-token-budget-exceeded',
+      cap: 500_000,
+      consumed: 520_000,
+    });
+    const { code, detail } = classifyError(err);
+    expect(code).toBe('spend-cap');
+    expect(detail).toContain('520,000');
+    expect(detail).toContain('500,000');
+  });
+
+  it('classifies spend-cap without counts when context is missing', () => {
+    const err = new FerryError('spend-cap', {});
+    const { code, detail } = classifyError(err);
+    expect(code).toBe('spend-cap');
+    expect(detail).toBe('spend cap exceeded');
+  });
+
+  it('classifies iteration-cap-exceeded with cap value', () => {
+    const err = new FerryError('state-invariant', {
+      reason: 'iteration-cap-exceeded',
+      cap: 200,
+    });
+    const { code, detail } = classifyError(err);
+    expect(code).toBe('state-invariant');
+    expect(detail).toContain('200');
+    expect(detail).toMatch(/max iterations/i);
+  });
+
+  it('classifies other FerryErrors by reason', () => {
+    const err = new FerryError('state-invariant', { reason: 'agent-stopped-without-done' });
+    const { code, detail } = classifyError(err);
+    expect(code).toBe('state-invariant');
+    expect(detail).toBe('agent-stopped-without-done');
+  });
+
+  it('classifies non-FerryError by message', () => {
+    const err = new Error('network timeout');
+    const { code, detail } = classifyError(err);
+    expect(code).toBe('unknown');
+    expect(detail).toBe('network timeout');
+  });
+
+  it('truncates long non-FerryError messages to 200 chars', () => {
+    const err = new Error('x'.repeat(300));
+    const { detail } = classifyError(err);
+    expect(detail).toHaveLength(200);
+  });
+});
+
+describe('runWipFinalizer', () => {
+  beforeEach(() => {
+    mockExecFileSync.mockReset();
+    mockAppendFileSync.mockReset();
+    delete process.env.GITHUB_OUTPUT;
+  });
+
+  it('commits, pushes, and posts Jira comment on spend-cap failure', async () => {
+    const tracker = makeTracker('PROJ-1');
+    const error = new FerryError('spend-cap', {
+      reason: 'input-token-budget-exceeded',
+      cap: 500_000,
+      consumed: 520_000,
+    });
+
+    mockExecFileSync.mockReturnValueOnce(''); // git add -A
+    mockExecFileSync.mockReturnValueOnce('M foo'); // git status (has changes)
+    mockExecFileSync.mockReturnValueOnce(''); // git commit
+    mockExecFileSync.mockReturnValueOnce(''); // git push --force-with-lease
+
+    await runWipFinalizer({ ...baseOpts(tracker), error });
+
+    expect(tracker.postedComments).toHaveLength(1);
+    const { key, body } = tracker.postedComments[0];
+    expect(key).toBe('PROJ-1');
+    expect(body).toContain('[ferry:dev:wip:ev-123]');
+    expect(body).toContain('ferry/PROJ-1');
+    expect(body).toContain('spend cap exceeded');
+    expect(body).toContain('520,000');
+  });
+
+  it('skips commit when nothing to commit but still posts Jira comment', async () => {
+    const tracker = makeTracker('PROJ-1');
+    const error = new FerryError('state-invariant', {
+      reason: 'iteration-cap-exceeded',
+      cap: 200,
+    });
+
+    mockExecFileSync.mockReturnValueOnce(''); // git add -A
+    mockExecFileSync.mockReturnValueOnce(''); // git status (empty)
+    mockExecFileSync.mockReturnValueOnce(''); // git push --force-with-lease
+
+    await runWipFinalizer({ ...baseOpts(tracker), error });
+
+    const calls = mockExecFileSync.mock.calls as Array<[string, string[], unknown]>;
+    const commitCall = calls.find(([, args]) => Array.isArray(args) && args[0] === 'commit');
+    expect(commitCall).toBeUndefined();
+
+    expect(tracker.postedComments).toHaveLength(1);
+    expect(tracker.postedComments[0].body).toContain('max iterations reached');
+    expect(tracker.postedComments[0].body).toContain('200');
+  });
+
+  it('skips push and Jira comment in dryRun mode', async () => {
+    const tracker = makeTracker('PROJ-1');
+    const error = new FerryError('spend-cap', { reason: 'budget', cap: 1, consumed: 2 });
+
+    mockExecFileSync.mockReturnValueOnce(''); // git add -A
+    mockExecFileSync.mockReturnValueOnce('M foo.ts'); // git status
+    mockExecFileSync.mockReturnValueOnce(''); // git commit
+
+    await runWipFinalizer({ ...baseOpts(tracker), error, dryRun: true });
+
+    const calls = mockExecFileSync.mock.calls as Array<[string, string[], unknown]>;
+    const pushCall = calls.find(([, args]) => Array.isArray(args) && args[0] === 'push');
+    expect(pushCall).toBeUndefined();
+    expect(tracker.postedComments).toHaveLength(0);
+  });
+
+  it('falls back to plain push when force-with-lease fails', async () => {
+    const tracker = makeTracker('PROJ-1');
+    const error = new FerryError('spend-cap', { cap: 1, consumed: 2 });
+
+    mockExecFileSync.mockReturnValueOnce(''); // git add -A
+    mockExecFileSync.mockReturnValueOnce(''); // git status (nothing to commit)
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw new Error('no upstream tracking reference');
+    }); // git push --force-with-lease
+    mockExecFileSync.mockReturnValueOnce(''); // git push (fallback)
+
+    await runWipFinalizer({ ...baseOpts(tracker), error });
+
+    const calls = mockExecFileSync.mock.calls as Array<[string, string[], unknown]>;
+    const plainPush = calls.find(
+      ([, args]) =>
+        Array.isArray(args) && args[0] === 'push' && !args.includes('--force-with-lease'),
+    );
+    expect(plainPush).toBeDefined();
+    expect(tracker.postedComments).toHaveLength(1);
+    expect(tracker.postedComments[0].body).toContain('ferry/PROJ-1');
+  });
+
+  it('swallows Jira comment failure without rethrowing', async () => {
+    const tracker = makeTracker('PROJ-1');
+    vi.spyOn(tracker, 'postComment').mockRejectedValueOnce(new Error('Jira unreachable'));
+    const error = new FerryError('spend-cap', { cap: 1, consumed: 2 });
+
+    mockExecFileSync.mockReturnValueOnce(''); // git add -A
+    mockExecFileSync.mockReturnValueOnce(''); // git status
+    mockExecFileSync.mockReturnValueOnce(''); // git push --force-with-lease
+
+    await expect(runWipFinalizer({ ...baseOpts(tracker), error })).resolves.toBeUndefined();
+  });
+
+  it('swallows git commit failure without rethrowing', async () => {
+    const tracker = makeTracker('PROJ-1');
+    const error = new FerryError('spend-cap', { cap: 1, consumed: 2 });
+
+    mockExecFileSync.mockReturnValueOnce(''); // git add -A
+    mockExecFileSync.mockReturnValueOnce('M foo'); // git status (has changes)
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw new Error('git commit failed: pre-commit hook rejected');
+    }); // git commit fails
+    // push is still attempted after commit failure
+    mockExecFileSync.mockReturnValueOnce(''); // git push --force-with-lease
+
+    await expect(runWipFinalizer({ ...baseOpts(tracker), error })).resolves.toBeUndefined();
+    expect(tracker.postedComments).toHaveLength(1);
+  });
+
+  it('emits zeroed audit output via appendOutput', async () => {
+    process.env.GITHUB_OUTPUT = '/tmp/ferry-test-output';
+    const tracker = makeTracker('PROJ-1');
+    const error = new FerryError('spend-cap', { cap: 1, consumed: 2 });
+
+    mockExecFileSync.mockReturnValueOnce(''); // git add -A
+    mockExecFileSync.mockReturnValueOnce(''); // git status
+    mockExecFileSync.mockReturnValueOnce(''); // git push
+
+    await runWipFinalizer({ ...baseOpts(tracker), error });
+
+    expect(mockAppendFileSync).toHaveBeenCalledWith(
+      '/tmp/ferry-test-output',
+      expect.stringContaining('input_tokens=0'),
+    );
+    expect(mockAppendFileSync).toHaveBeenCalledWith(
+      '/tmp/ferry-test-output',
+      expect.stringContaining('output_tokens=0'),
+    );
+  });
+
+  it('calls secretScan before committing', async () => {
+    const tracker = makeTracker('PROJ-1');
+    const secretScan = vi.fn().mockResolvedValue(undefined);
+    const error = new FerryError('spend-cap', { cap: 1, consumed: 2 });
+
+    mockExecFileSync.mockReturnValueOnce(''); // git add -A
+    mockExecFileSync.mockReturnValueOnce('M foo'); // git status
+    mockExecFileSync.mockReturnValueOnce(''); // git commit
+    mockExecFileSync.mockReturnValueOnce(''); // git push
+
+    await runWipFinalizer({ ...baseOpts(tracker), error, secretScan });
+
+    expect(secretScan).toHaveBeenCalledOnce();
+  });
+
+  it('does not call secretScan when nothing to commit', async () => {
+    const tracker = makeTracker('PROJ-1');
+    const secretScan = vi.fn().mockResolvedValue(undefined);
+    const error = new FerryError('spend-cap', { cap: 1, consumed: 2 });
+
+    mockExecFileSync.mockReturnValueOnce(''); // git add -A
+    mockExecFileSync.mockReturnValueOnce(''); // git status (empty)
+    mockExecFileSync.mockReturnValueOnce(''); // git push
+
+    await runWipFinalizer({ ...baseOpts(tracker), error, secretScan });
+
+    expect(secretScan).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/developer/wip-finalizer.ts
+++ b/src/agents/developer/wip-finalizer.ts
@@ -1,0 +1,128 @@
+import { execFileSync } from 'node:child_process';
+import type { IssueTracker } from '../../lib/io/tracker/types.js';
+import type { Logger } from '../../lib/logger/index.js';
+import { FerryError } from '../../lib/errors/index.js';
+import { appendOutput } from '../../lib/agent-runtime/output.js';
+
+export interface WipFinalizerOptions {
+  error: unknown;
+  ticketKey: string;
+  eventId: string;
+  branchName: string;
+  repoRoot: string;
+  secretScan: () => Promise<void>;
+  tracker: IssueTracker;
+  logger: Logger;
+  dryRun: boolean;
+  model: string;
+  provider: string;
+}
+
+export function classifyError(err: unknown): { code: string; detail: string } {
+  if (err instanceof FerryError) {
+    const reason = (err.context?.reason as string | undefined) ?? 'unknown';
+    if (err.code === 'spend-cap') {
+      const cap = err.context?.cap;
+      const consumed = err.context?.consumed;
+      const detail =
+        cap != null && consumed != null
+          ? `spend cap exceeded (used ${Math.round(Number(consumed)).toLocaleString()} / ${Math.round(Number(cap)).toLocaleString()} tokens)`
+          : 'spend cap exceeded';
+      return { code: err.code, detail };
+    }
+    if (err.code === 'state-invariant' && reason === 'iteration-cap-exceeded') {
+      return {
+        code: err.code,
+        detail: `max iterations reached (cap: ${err.context?.cap ?? 'unknown'})`,
+      };
+    }
+    return { code: err.code, detail: reason };
+  }
+  const msg = (err as Error)?.message ?? String(err);
+  return { code: 'unknown', detail: msg.slice(0, 200) };
+}
+
+export async function runWipFinalizer(opts: WipFinalizerOptions): Promise<void> {
+  const {
+    error,
+    ticketKey,
+    eventId,
+    branchName,
+    repoRoot,
+    secretScan,
+    tracker,
+    logger,
+    dryRun,
+    model,
+    provider,
+  } = opts;
+
+  const { code, detail } = classifyError(error);
+  logger.info('wip_finalizer', { code, detail, branch: branchName });
+
+  // 1. Commit any staged/unstaged changes (best-effort).
+  let committed = false;
+  try {
+    execFileSync('git', ['add', '-A'], { cwd: repoRoot });
+    const status = execFileSync('git', ['status', '--porcelain'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    if (status.trim()) {
+      await secretScan();
+      const wipMsg = `wip(${ticketKey}): interrupted — ${code}\n\n[ferry:dev:${eventId}]`;
+      execFileSync('git', ['commit', '-m', wipMsg], { cwd: repoRoot });
+      committed = true;
+      logger.info('wip_committed', { branch: branchName });
+    } else {
+      logger.info('wip_nothing_to_commit');
+    }
+  } catch (commitErr) {
+    logger.error('wip_commit_failed', { error: (commitErr as Error).message });
+  }
+
+  // 2. Push the branch (best-effort; skipped in dryRun).
+  let pushed = false;
+  if (!dryRun) {
+    try {
+      execFileSync('git', ['push', 'origin', branchName, '--force-with-lease'], {
+        cwd: repoRoot,
+        stdio: 'pipe',
+      });
+      pushed = true;
+    } catch {
+      // --force-with-lease requires an upstream tracking ref; fall back for first-time pushes.
+      try {
+        execFileSync('git', ['push', 'origin', branchName], { cwd: repoRoot, stdio: 'pipe' });
+        pushed = true;
+      } catch (pushErr) {
+        logger.error('wip_push_failed', { error: (pushErr as Error).message });
+      }
+    }
+    if (pushed) {
+      logger.info('wip_pushed', { branch: branchName, committed });
+    }
+  } else {
+    logger.info('DRY_RUN — wip push skipped');
+  }
+
+  // 3. Post Jira comment (best-effort; skipped in dryRun).
+  if (!dryRun) {
+    const wipMarker = `[ferry:dev:wip:${eventId}]`;
+    const branchRef = pushed ? ` WIP pushed to branch \`${branchName}\`.` : '';
+    const comment =
+      `${wipMarker} ⚠️ Dev run interrupted — ${detail}.${branchRef} ` +
+      `The next run will resume from this state.`;
+    try {
+      await tracker.postComment(ticketKey, comment);
+      logger.info('wip_jira_comment_posted');
+    } catch (commentErr) {
+      logger.error('wip_jira_comment_failed', { error: (commentErr as Error).message });
+    }
+  } else {
+    logger.info('DRY_RUN — wip Jira comment skipped', { detail });
+  }
+
+  // 4. Emit zeroed audit tokens so the run-developer step output is always populated after failure.
+  appendOutput({ input_tokens: 0, output_tokens: 0, model, provider });
+}


### PR DESCRIPTION
Closes #177

## Summary

- Add `wip-finalizer.ts` with `classifyError` and `runWipFinalizer`: on any `loop.run()` throw, commits WIP, pushes the branch, and posts a Jira comment before re-throwing
- All finalizer steps are best-effort (swallows individual failures); the process still exits 1
- 11 new unit tests; all existing tests pass

Generated with [Claude Code](https://claude.ai/code)