### PR TITLE
feat: add pre/post-agent command hooks to all composite actions

### DIFF
--- a/.github/actions/ferry-run-developer/action.yml
+++ b/.github/actions/ferry-run-developer/action.yml
@@ -63,6 +63,18 @@ inputs:
     description: Maximum Jira API retry attempts per operation
     required: false
     default: ''
+  pre_agent_command:
+    description: Optional shell command to run after checkout but before the agent (e.g. npm ci, cache restore)
+    required: false
+    default: ''
+  pre_agent_timeout_minutes:
+    description: Timeout in minutes for the pre-agent command (default 3)
+    required: false
+    default: '3'
+  post_agent_command:
+    description: Optional shell command to run after the agent; always executes (e.g. cleanup, reporting)
+    required: false
+    default: ''
 outputs:
   input_tokens:
     description: Number of LLM input tokens consumed
@@ -90,6 +102,11 @@ runs:
         FERRY_JIRA_BASE_URL: ${{ inputs.jira_base_url }}
         FERRY_JIRA_EMAIL: ${{ inputs.jira_email }}
         FERRY_JIRA_API_TOKEN: ${{ inputs.jira_api_token }}
+    - name: Pre-agent setup
+      if: inputs.pre_agent_command != ''
+      shell: bash
+      timeout-minutes: ${{ fromJSON(inputs.pre_agent_timeout_minutes) }}
+      run: ${{ inputs.pre_agent_command }}
     - name: Run Developer agent
       id: run-developer
       shell: bash
@@ -114,3 +131,7 @@ runs:
         FERRY_LLM_RETRY_MAX_ATTEMPTS: ${{ inputs.ferry_llm_retry_max_attempts }}
         FERRY_JIRA_RETRY_MAX_ATTEMPTS: ${{ inputs.ferry_jira_retry_max_attempts }}
         FERRY_BUNDLED_PROMPTS_DIR: ${{ github.action_path }}/prompts
+    - name: Post-agent command
+      if: always() && inputs.post_agent_command != ''
+      shell: bash
+      run: ${{ inputs.post_agent_command }}

--- a/.github/actions/ferry-run-iterator/action.yml
+++ b/.github/actions/ferry-run-iterator/action.yml
@@ -63,6 +63,18 @@ inputs:
     description: Maximum Jira API retry attempts per operation
     required: false
     default: ''
+  pre_agent_command:
+    description: Optional shell command to run after checkout but before the agent (e.g. npm ci, cache restore)
+    required: false
+    default: ''
+  pre_agent_timeout_minutes:
+    description: Timeout in minutes for the pre-agent command (default 3)
+    required: false
+    default: '3'
+  post_agent_command:
+    description: Optional shell command to run after the agent; always executes (e.g. cleanup, reporting)
+    required: false
+    default: ''
 outputs:
   input_tokens:
     description: Number of LLM input tokens consumed
@@ -93,6 +105,11 @@ runs:
         FERRY_JIRA_BASE_URL: ${{ inputs.jira_base_url }}
         FERRY_JIRA_EMAIL: ${{ inputs.jira_email }}
         FERRY_JIRA_API_TOKEN: ${{ inputs.jira_api_token }}
+    - name: Pre-agent setup
+      if: inputs.pre_agent_command != ''
+      shell: bash
+      timeout-minutes: ${{ fromJSON(inputs.pre_agent_timeout_minutes) }}
+      run: ${{ inputs.pre_agent_command }}
     - name: Run Iterator agent
       id: run-iterator
       shell: bash
@@ -117,3 +134,7 @@ runs:
         FERRY_LLM_RETRY_MAX_ATTEMPTS: ${{ inputs.ferry_llm_retry_max_attempts }}
         FERRY_JIRA_RETRY_MAX_ATTEMPTS: ${{ inputs.ferry_jira_retry_max_attempts }}
         FERRY_BUNDLED_PROMPTS_DIR: ${{ github.action_path }}/prompts
+    - name: Post-agent command
+      if: always() && inputs.post_agent_command != ''
+      shell: bash
+      run: ${{ inputs.post_agent_command }}

--- a/.github/actions/ferry-run-refiner/action.yml
+++ b/.github/actions/ferry-run-refiner/action.yml
@@ -42,6 +42,18 @@ inputs:
     description: Maximum Jira API retry attempts per operation
     required: false
     default: ''
+  pre_agent_command:
+    description: Optional shell command to run after checkout but before the agent (e.g. npm ci, cache restore)
+    required: false
+    default: ''
+  pre_agent_timeout_minutes:
+    description: Timeout in minutes for the pre-agent command (default 3)
+    required: false
+    default: '3'
+  post_agent_command:
+    description: Optional shell command to run after the agent; always executes (e.g. cleanup, reporting)
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
@@ -62,6 +74,11 @@ runs:
         FERRY_JIRA_BASE_URL: ${{ inputs.jira_base_url }}
         FERRY_JIRA_EMAIL: ${{ inputs.jira_email }}
         FERRY_JIRA_API_TOKEN: ${{ inputs.jira_api_token }}
+    - name: Pre-agent setup
+      if: inputs.pre_agent_command != ''
+      shell: bash
+      timeout-minutes: ${{ fromJSON(inputs.pre_agent_timeout_minutes) }}
+      run: ${{ inputs.pre_agent_command }}
     - name: Run Refiner agent
       shell: bash
       run: node ${{ github.action_path }}/refiner-action.js
@@ -78,3 +95,7 @@ runs:
         FERRY_LLM_RETRY_MAX_ATTEMPTS: ${{ inputs.ferry_llm_retry_max_attempts }}
         FERRY_JIRA_RETRY_MAX_ATTEMPTS: ${{ inputs.ferry_jira_retry_max_attempts }}
         FERRY_BUNDLED_PROMPTS_DIR: ${{ github.action_path }}/prompts
+    - name: Post-agent command
+      if: always() && inputs.post_agent_command != ''
+      shell: bash
+      run: ${{ inputs.post_agent_command }}

--- a/.github/actions/ferry-run-reviewer/action.yml
+++ b/.github/actions/ferry-run-reviewer/action.yml
@@ -55,6 +55,18 @@ inputs:
     description: Maximum Jira API retry attempts per operation
     required: false
     default: ''
+  pre_agent_command:
+    description: Optional shell command to run after checkout but before the agent (e.g. npm ci, cache restore)
+    required: false
+    default: ''
+  pre_agent_timeout_minutes:
+    description: Timeout in minutes for the pre-agent command (default 3)
+    required: false
+    default: '3'
+  post_agent_command:
+    description: Optional shell command to run after the agent; always executes (e.g. cleanup, reporting)
+    required: false
+    default: ''
 outputs:
   input_tokens:
     description: Number of LLM input tokens consumed
@@ -85,6 +97,11 @@ runs:
         FERRY_JIRA_BASE_URL: ${{ inputs.jira_base_url }}
         FERRY_JIRA_EMAIL: ${{ inputs.jira_email }}
         FERRY_JIRA_API_TOKEN: ${{ inputs.jira_api_token }}
+    - name: Pre-agent setup
+      if: inputs.pre_agent_command != ''
+      shell: bash
+      timeout-minutes: ${{ fromJSON(inputs.pre_agent_timeout_minutes) }}
+      run: ${{ inputs.pre_agent_command }}
     - name: Run Reviewer agent
       id: run-reviewer
       shell: bash
@@ -107,3 +124,7 @@ runs:
         FERRY_LLM_RETRY_MAX_ATTEMPTS: ${{ inputs.ferry_llm_retry_max_attempts }}
         FERRY_JIRA_RETRY_MAX_ATTEMPTS: ${{ inputs.ferry_jira_retry_max_attempts }}
         FERRY_BUNDLED_PROMPTS_DIR: ${{ github.action_path }}/prompts
+    - name: Post-agent command
+      if: always() && inputs.post_agent_command != ''
+      shell: bash
+      run: ${{ inputs.post_agent_command }}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -103,6 +103,57 @@ All variables marked **wired** below are read directly by the standard consumer 
 
 ---
 
+## Pre/Post-Agent Command Hooks
+
+Each composite action (`ferry-run-developer`, `ferry-run-iterator`, `ferry-run-reviewer`, `ferry-run-refiner`) exposes three optional inputs that let consumers inject shell commands around the agent run without modifying Ferry's source.
+
+These inputs are passed in the `with:` block of your consumer workflow when you call the composite action.
+
+| Input                    | Default | Description                                                                                                                                                  |
+| ------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `pre_agent_command`      | `''`    | Shell command to run **after** checkout + Ferry setup but **before** the agent starts. Skipped when empty. Typical use: `npm ci`, dependency caching, env setup. |
+| `pre_agent_timeout_minutes` | `'3'`| Timeout in minutes for the pre-agent step. Ignored when `pre_agent_command` is empty.                                                                       |
+| `post_agent_command`     | `''`    | Shell command to run **after** the agent finishes. **Always executes** (`if: always()`) — runs on agent success, failure, and cancellation. Typical use: cleanup, artifact upload, notifications. |
+
+The pre-agent step runs in `GITHUB_WORKSPACE` (your checked-out repo root), after Ferry's own `npm ci` has completed. Use multi-line commands with `|` for scripts longer than one command.
+
+**Example — install consumer dependencies before the Developer agent:**
+
+```yaml
+      - name: Run Developer agent
+        id: run-developer
+        uses: big-emotion/ferry/.github/actions/ferry-run-developer@v0.8.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          # ... required inputs ...
+          pre_agent_command: |
+            npm ci --prefer-offline
+          pre_agent_timeout_minutes: '5'
+```
+
+**Example — combined with `actions/cache@v4` (cache set up in a prior step, populated here):**
+
+```yaml
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@...
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+
+      - name: Run Developer agent
+        uses: big-emotion/ferry/.github/actions/ferry-run-developer@v0.8.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          # ... required inputs ...
+          pre_agent_command: npm ci --prefer-offline
+```
+
+---
+
 ## `ferry.config.json`
 
 Create `ferry.config.json`, `ferry.config.yaml`, or `ferry.config.yml` at the **root of your repository**. All fields are optional — omit any section to use the defaults.

--- a/examples/consumer-setup/workflows/ferry-dev.yml
+++ b/examples/consumer-setup/workflows/ferry-dev.yml
@@ -12,6 +12,9 @@
 #                     FERRY_MAX_COST_EUR_PER_RUN (default: 10)
 #                     FERRY_LLM_RETRY_MAX_ATTEMPTS (default: 3)
 #                     FERRY_JIRA_RETRY_MAX_ATTEMPTS (default: 3)
+# Action inputs:      pre_agent_command (optional) — shell command to run before the agent (e.g. npm ci)
+#                     pre_agent_timeout_minutes (optional, default: 3)
+#                     post_agent_command (optional) — shell command to run after the agent (always runs)
 
 name: Ferry — Dev
 
@@ -81,6 +84,9 @@ jobs:
           ferry_max_cost_eur_per_run: ${{ vars.FERRY_MAX_COST_EUR_PER_RUN }}
           ferry_llm_retry_max_attempts: ${{ vars.FERRY_LLM_RETRY_MAX_ATTEMPTS }}
           ferry_jira_retry_max_attempts: ${{ vars.FERRY_JIRA_RETRY_MAX_ATTEMPTS }}
+          # pre_agent_command: npm ci  # uncomment to install deps before the agent
+          # pre_agent_timeout_minutes: '3'
+          # post_agent_command: ''  # uncomment to run cleanup after the agent
 
   emit-audit:
     name: Emit audit line

--- a/examples/consumer-setup/workflows/ferry-iterate.yml
+++ b/examples/consumer-setup/workflows/ferry-iterate.yml
@@ -12,6 +12,9 @@
 #                     FERRY_MAX_COST_EUR_PER_RUN (default: 10)
 #                     FERRY_LLM_RETRY_MAX_ATTEMPTS (default: 3)
 #                     FERRY_JIRA_RETRY_MAX_ATTEMPTS (default: 3)
+# Action inputs:      pre_agent_command (optional) — shell command to run before the agent (e.g. npm ci)
+#                     pre_agent_timeout_minutes (optional, default: 3)
+#                     post_agent_command (optional) — shell command to run after the agent (always runs)
 
 name: Ferry — Iterate
 
@@ -84,6 +87,9 @@ jobs:
           ferry_max_cost_eur_per_run: ${{ vars.FERRY_MAX_COST_EUR_PER_RUN }}
           ferry_llm_retry_max_attempts: ${{ vars.FERRY_LLM_RETRY_MAX_ATTEMPTS }}
           ferry_jira_retry_max_attempts: ${{ vars.FERRY_JIRA_RETRY_MAX_ATTEMPTS }}
+          # pre_agent_command: npm ci  # uncomment to install deps before the agent
+          # pre_agent_timeout_minutes: '3'
+          # post_agent_command: ''  # uncomment to run cleanup after the agent
 
   emit-audit:
     name: Emit audit line

--- a/examples/consumer-setup/workflows/ferry-refine.yml
+++ b/examples/consumer-setup/workflows/ferry-refine.yml
@@ -8,6 +8,9 @@
 #                     FERRY_MAX_COST_EUR_PER_RUN (default: 10)
 #                     FERRY_LLM_RETRY_MAX_ATTEMPTS (default: 3)
 #                     FERRY_JIRA_RETRY_MAX_ATTEMPTS (default: 3)
+# Action inputs:      pre_agent_command (optional) — shell command to run before the agent (e.g. npm ci)
+#                     pre_agent_timeout_minutes (optional, default: 3)
+#                     post_agent_command (optional) — shell command to run after the agent (always runs)
 
 name: Ferry — Refine
 
@@ -65,6 +68,9 @@ jobs:
           ferry_max_cost_eur_per_run: ${{ vars.FERRY_MAX_COST_EUR_PER_RUN }}
           ferry_llm_retry_max_attempts: ${{ vars.FERRY_LLM_RETRY_MAX_ATTEMPTS }}
           ferry_jira_retry_max_attempts: ${{ vars.FERRY_JIRA_RETRY_MAX_ATTEMPTS }}
+          # pre_agent_command: npm ci  # uncomment to install deps before the agent
+          # pre_agent_timeout_minutes: '3'
+          # post_agent_command: ''  # uncomment to run cleanup after the agent
 
   emit-audit:
     name: Emit audit line

--- a/examples/consumer-setup/workflows/ferry-review.yml
+++ b/examples/consumer-setup/workflows/ferry-review.yml
@@ -10,6 +10,9 @@
 #                     FERRY_MAX_COST_EUR_PER_RUN (default: 10)
 #                     FERRY_LLM_RETRY_MAX_ATTEMPTS (default: 3)
 #                     FERRY_JIRA_RETRY_MAX_ATTEMPTS (default: 3)
+# Action inputs:      pre_agent_command (optional) — shell command to run before the agent (e.g. npm ci)
+#                     pre_agent_timeout_minutes (optional, default: 3)
+#                     post_agent_command (optional) — shell command to run after the agent (always runs)
 
 name: Ferry — Review
 
@@ -79,6 +82,9 @@ jobs:
           ferry_max_cost_eur_per_run: ${{ vars.FERRY_MAX_COST_EUR_PER_RUN }}
           ferry_llm_retry_max_attempts: ${{ vars.FERRY_LLM_RETRY_MAX_ATTEMPTS }}
           ferry_jira_retry_max_attempts: ${{ vars.FERRY_JIRA_RETRY_MAX_ATTEMPTS }}
+          # pre_agent_command: npm ci  # uncomment to install deps before the agent
+          # pre_agent_timeout_minutes: '3'
+          # post_agent_command: ''  # uncomment to run cleanup after the agent
 
   emit-audit:
     name: Emit audit line


### PR DESCRIPTION
Adds `pre_agent_command`, `pre_agent_timeout_minutes`, and `post_agent_command` inputs to all four Ferry composite actions (developer, iterator, reviewer, refiner).

This gives consumers a clean seam to run `npm ci`, restore caches, or prime the environment before the agent starts — avoiding the pattern of running `npm install` inside the agent loop which wastes an iteration and pumps verbose output into the conversation history.

Closes #180

Generated with [Claude Code](https://claude.ai/code)