### PR TITLE
feat: [multi-provider] Phase 1 foundations — isProvider fix, pricing, Refiner e2e tests

### DIFF
--- a/.ferry/refiner-action.js
+++ b/.ferry/refiner-action.js
@@ -187,6 +187,7 @@ var RATES = {
   "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },
   "anthropic/claude-haiku": { inputPer1M: 0.23, outputPer1M: 1.16 },
+  "openai/gpt-4.1-nano": { inputPer1M: 0.09, outputPer1M: 0.37 },
   "openai/gpt-4.1-mini": { inputPer1M: 0.14, outputPer1M: 0.56 },
   "openai/gpt-4.": { inputPer1M: 2.79, outputPer1M: 8.37 },
   "openai/gpt-5.": { inputPer1M: 2.79, outputPer1M: 8.37 },

--- a/.github/actions/ferry-run-refiner/refiner-action.js
+++ b/.github/actions/ferry-run-refiner/refiner-action.js
@@ -187,6 +187,7 @@ var RATES = {
   "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },
   "anthropic/claude-haiku": { inputPer1M: 0.23, outputPer1M: 1.16 },
+  "openai/gpt-4.1-nano": { inputPer1M: 0.09, outputPer1M: 0.37 },
   "openai/gpt-4.1-mini": { inputPer1M: 0.14, outputPer1M: 0.56 },
   "openai/gpt-4.": { inputPer1M: 2.79, outputPer1M: 8.37 },
   "openai/gpt-5.": { inputPer1M: 2.79, outputPer1M: 8.37 },

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -109,47 +109,47 @@ Each composite action (`ferry-run-developer`, `ferry-run-iterator`, `ferry-run-r
 
 These inputs are passed in the `with:` block of your consumer workflow when you call the composite action.
 
-| Input                    | Default | Description                                                                                                                                                  |
-| ------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `pre_agent_command`      | `''`    | Shell command to run **after** checkout + Ferry setup but **before** the agent starts. Skipped when empty. Typical use: `npm ci`, dependency caching, env setup. |
-| `pre_agent_timeout_minutes` | `'3'`| Timeout in minutes for the pre-agent step. Ignored when `pre_agent_command` is empty.                                                                       |
-| `post_agent_command`     | `''`    | Shell command to run **after** the agent finishes. **Always executes** (`if: always()`) — runs on agent success, failure, and cancellation. Typical use: cleanup, artifact upload, notifications. |
+| Input                       | Default | Description                                                                                                                                                                                       |
+| --------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pre_agent_command`         | `''`    | Shell command to run **after** checkout + Ferry setup but **before** the agent starts. Skipped when empty. Typical use: `npm ci`, dependency caching, env setup.                                  |
+| `pre_agent_timeout_minutes` | `'3'`   | Timeout in minutes for the pre-agent step. Ignored when `pre_agent_command` is empty.                                                                                                             |
+| `post_agent_command`        | `''`    | Shell command to run **after** the agent finishes. **Always executes** (`if: always()`) — runs on agent success, failure, and cancellation. Typical use: cleanup, artifact upload, notifications. |
 
 The pre-agent step runs in `GITHUB_WORKSPACE` (your checked-out repo root), after Ferry's own `npm ci` has completed. Use multi-line commands with `|` for scripts longer than one command.
 
 **Example — install consumer dependencies before the Developer agent:**
 
 ```yaml
-      - name: Run Developer agent
-        id: run-developer
-        uses: big-emotion/ferry/.github/actions/ferry-run-developer@v0.8.0
-        with:
-          payload: ${{ toJson(github.event.client_payload) }}
-          # ... required inputs ...
-          pre_agent_command: |
-            npm ci --prefer-offline
-          pre_agent_timeout_minutes: '5'
+- name: Run Developer agent
+  id: run-developer
+  uses: big-emotion/ferry/.github/actions/ferry-run-developer@v0.8.0
+  with:
+    payload: ${{ toJson(github.event.client_payload) }}
+    # ... required inputs ...
+    pre_agent_command: |
+      npm ci --prefer-offline
+    pre_agent_timeout_minutes: '5'
 ```
 
 **Example — combined with `actions/cache@v4` (cache set up in a prior step, populated here):**
 
 ```yaml
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@...
+steps:
+  - name: Checkout repository
+    uses: actions/checkout@...
 
-      - name: Cache node_modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+  - name: Cache node_modules
+    uses: actions/cache@v4
+    with:
+      path: node_modules
+      key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
 
-      - name: Run Developer agent
-        uses: big-emotion/ferry/.github/actions/ferry-run-developer@v0.8.0
-        with:
-          payload: ${{ toJson(github.event.client_payload) }}
-          # ... required inputs ...
-          pre_agent_command: npm ci --prefer-offline
+  - name: Run Developer agent
+    uses: big-emotion/ferry/.github/actions/ferry-run-developer@v0.8.0
+    with:
+      payload: ${{ toJson(github.event.client_payload) }}
+      # ... required inputs ...
+      pre_agent_command: npm ci --prefer-offline
 ```
 
 ---
@@ -220,12 +220,12 @@ Each agent phase can be configured independently. All `models.*` fields are opti
 
 Ferry supports three LLM providers: **`anthropic`**, **`openai`**, and **`google`**. Provider support varies by phase:
 
-| Phase     | Supported providers             | Notes                                                           |
-| --------- | ------------------------------- | --------------------------------------------------------------- |
-| `refiner` | `anthropic`, `openai`, `google` | Uses a single-turn LLM call — all providers work                |
-| `dev`     | `anthropic`                     | Uses an agentic tool-use loop; OpenAI/Google support is planned |
-| `review`  | `anthropic`                     | Uses an agentic tool-use loop; OpenAI/Google support is planned |
-| `iterate` | `anthropic`                     | Uses an agentic tool-use loop; OpenAI/Google support is planned |
+| Phase     | Supported providers             | Notes                                                                       |
+| --------- | ------------------------------- | --------------------------------------------------------------------------- |
+| `refiner` | `anthropic`, `openai`, `google` | Uses a single-turn LLM call — all three providers are supported             |
+| `dev`     | `anthropic`                     | Anthropic only (multi-provider in progress) — uses an agentic tool-use loop |
+| `review`  | `anthropic`                     | Anthropic only (multi-provider in progress) — uses an agentic tool-use loop |
+| `iterate` | `anthropic`                     | Anthropic only (multi-provider in progress) — uses an agentic tool-use loop |
 
 > **MCP:** Model Context Protocol (MCP) server integration is Anthropic-only and is not available when using other providers. MCP availability is also independent of the provider support table above — even with `provider: anthropic`, **only the Developer and Iterator agents consume `AGENT_MCP_SERVERS`**. The Refiner and Reviewer do not load MCP servers regardless of provider or configuration.
 

--- a/src/agents/refiner/refine.providers.test.ts
+++ b/src/agents/refiner/refine.providers.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Refiner × multi-provider end-to-end tests.
+ *
+ * Verifies that the Refiner produces a valid plan when `createLlmCall` is
+ * wired with OpenAI or Google routes, using mocked SDKs so no real API keys
+ * are needed. This exercises the full chain: route config → SDK mock →
+ * LLM response → plan parsing/validation.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// vi.hoisted runs before all imports and const declarations.
+// The plan JSON must be a literal inside the factory.
+const { openaiMockCreate, googleMockGenerateContent, PLAN_JSON } = vi.hoisted(() => {
+  const planJson =
+    '{"actions":[{"type":"create","title":"Add feature X","description":"Implement X"}],"touch_paths":["src/feature-x.ts"],"output_locale":"en","audit_summary":"1 sub-task planned"}';
+  return {
+    PLAN_JSON: planJson,
+    openaiMockCreate: vi.fn().mockResolvedValue({
+      choices: [{ message: { content: planJson } }],
+      usage: { prompt_tokens: 500, completion_tokens: 120 },
+    }),
+    googleMockGenerateContent: vi.fn().mockResolvedValue({
+      text: planJson,
+      usageMetadata: { promptTokenCount: 600, candidatesTokenCount: 150 },
+    }),
+  };
+});
+
+vi.mock('openai', () => {
+  class RateLimitError extends Error {}
+  class APIConnectionError extends Error {
+    constructor(opts: { message: string }) {
+      super(opts.message);
+    }
+  }
+  class APIError extends Error {
+    status = 0;
+  }
+  const fn = vi.fn().mockImplementation(function (this: unknown) {
+    (this as { chat: unknown }).chat = { completions: { create: openaiMockCreate } };
+  } as unknown as () => void);
+  Object.assign(fn, { RateLimitError, APIConnectionError, APIError });
+  return { default: fn };
+});
+
+vi.mock('@google/genai', () => {
+  const fn = vi.fn().mockImplementation(function (this: unknown) {
+    (this as { models: unknown }).models = { generateContent: googleMockGenerateContent };
+  } as unknown as () => void);
+  return { GoogleGenAI: fn };
+});
+
+import { createLlmCall } from '../../lib/llm/call.js';
+import { runRefiner } from './refine.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const validPlan = JSON.parse(PLAN_JSON) as any;
+
+const ticket: Parameters<typeof runRefiner>[0]['ticket'] = {
+  key: 'PROJ-1',
+  title: 'Add feature X',
+  description: 'We need feature X implemented.',
+  comments: [],
+  labels: ['feature'],
+};
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.clearAllMocks();
+});
+
+describe('Refiner with OpenAI provider', () => {
+  it('returns a valid plan when configured with gpt-4.1-mini', async () => {
+    vi.stubEnv('FERRY_OPENAI_KEY', 'test-openai-key');
+    const callLlm = createLlmCall({ provider: 'openai', model: 'gpt-4.1-mini' });
+    const result = await runRefiner({ ticket, callLlm, runLink: 'https://example.com/run/1' });
+
+    expect(result.plan).toEqual(validPlan);
+    expect(result.auditSummary.subtaskCount).toBe(1);
+    expect(result.auditSummary.costEur).toBeGreaterThan(0);
+    expect(openaiMockCreate).toHaveBeenCalledOnce();
+  });
+
+  it('returns a valid plan when configured with gpt-4.1-nano', async () => {
+    vi.stubEnv('FERRY_OPENAI_KEY', 'test-openai-key');
+    const callLlm = createLlmCall({ provider: 'openai', model: 'gpt-4.1-nano' });
+    const result = await runRefiner({ ticket, callLlm, runLink: 'r' });
+
+    expect(result.plan.actions).toHaveLength(1);
+    expect(result.plan.actions[0].type).toBe('create');
+  });
+});
+
+describe('Refiner with Google provider', () => {
+  it('returns a valid plan when configured with gemini-2.5-flash', async () => {
+    vi.stubEnv('FERRY_GOOGLE_AI_KEY', 'test-google-key');
+    const callLlm = createLlmCall({ provider: 'google', model: 'gemini-2.5-flash' });
+    const result = await runRefiner({ ticket, callLlm, runLink: 'https://example.com/run/2' });
+
+    expect(result.plan).toEqual(validPlan);
+    expect(result.auditSummary.subtaskCount).toBe(1);
+    expect(result.auditSummary.costEur).toBeGreaterThan(0);
+    expect(googleMockGenerateContent).toHaveBeenCalledOnce();
+  });
+
+  it('returns a valid plan when configured with gemini-2.5-pro', async () => {
+    vi.stubEnv('FERRY_GOOGLE_AI_KEY', 'test-google-key');
+    const callLlm = createLlmCall({ provider: 'google', model: 'gemini-2.5-pro' });
+    const result = await runRefiner({ ticket, callLlm, runLink: 'r' });
+
+    expect(result.plan.actions).toHaveLength(1);
+    expect(result.plan.touch_paths).toEqual(['src/feature-x.ts']);
+  });
+});

--- a/src/lib/llm/config.test.ts
+++ b/src/lib/llm/config.test.ts
@@ -56,6 +56,23 @@ describe('llm config', () => {
     expect(() => loadFerryLlmConfig()).toThrow(/\[ferry:state-invariant\]/);
   });
 
+  test('accepts google provider in both routes', () => {
+    vi.stubEnv(
+      'FERRY_LLM_CONFIG',
+      JSON.stringify({
+        default: { provider: 'google', model: 'gemini-2.5-flash' },
+        critical: { provider: 'google', model: 'gemini-2.5-pro' },
+      }),
+    );
+
+    const cfg = loadFerryLlmConfig();
+
+    expect(cfg.default.provider).toBe('google');
+    expect(cfg.default.model).toBe('gemini-2.5-flash');
+    expect(cfg.critical.provider).toBe('google');
+    expect(cfg.critical.model).toBe('gemini-2.5-pro');
+  });
+
   test('throws FerryError when config is invalid', () => {
     vi.stubEnv(
       'FERRY_LLM_CONFIG',

--- a/src/lib/llm/config.ts
+++ b/src/lib/llm/config.ts
@@ -23,7 +23,7 @@ function parseJsonEnv(name: string): unknown {
 }
 
 function isProvider(x: unknown): x is LlmProvider {
-  return x === 'openai' || x === 'anthropic';
+  return x === 'openai' || x === 'anthropic' || x === 'google';
 }
 
 function isRoute(x: unknown): x is LlmRoute {

--- a/src/lib/llm/pricing.test.ts
+++ b/src/lib/llm/pricing.test.ts
@@ -29,6 +29,12 @@ describe('computeCostEur', () => {
   });
 
   describe('OpenAI models', () => {
+    it('computes cost for gpt-4.1-nano (exact match)', () => {
+      // 1M input @ 0.09 + 1M output @ 0.37 = 0.46
+      const cost = computeCostEur('openai', 'gpt-4.1-nano', 1_000_000, 1_000_000);
+      expect(cost).toBe(0.46);
+    });
+
     it('computes cost for gpt-4.1-mini (exact match)', () => {
       // 1M input @ 0.14 + 1M output @ 0.56 = 0.7
       const cost = computeCostEur('openai', 'gpt-4.1-mini', 1_000_000, 1_000_000);

--- a/src/lib/llm/pricing.ts
+++ b/src/lib/llm/pricing.ts
@@ -10,6 +10,7 @@ const RATES: Record<string, TokenRates> = {
   'anthropic/claude-sonnet-4-6': { inputPer1M: 2.79, outputPer1M: 13.95 },
   'anthropic/claude-opus': { inputPer1M: 13.95, outputPer1M: 69.75 },
   'anthropic/claude-haiku': { inputPer1M: 0.23, outputPer1M: 1.16 },
+  'openai/gpt-4.1-nano': { inputPer1M: 0.09, outputPer1M: 0.37 },
   'openai/gpt-4.1-mini': { inputPer1M: 0.14, outputPer1M: 0.56 },
   'openai/gpt-4.': { inputPer1M: 2.79, outputPer1M: 8.37 },
   'openai/gpt-5.': { inputPer1M: 2.79, outputPer1M: 8.37 },


### PR DESCRIPTION
Implements issue #217 Phase 1.

## Changes

- **Bug fix:** `isProvider()` in `src/lib/llm/config.ts` was missing `'google'`, silently rejecting `FERRY_LLM_CONFIG` with google routes — now fixed
- **Tests:** added google config acceptance test in `config.test.ts`
- **Pricing:** added `gpt-4.1-nano` entry (was falling to the `gpt-4.` prefix, overestimating cost ~30x)
- **Tests:** new `refine.providers.test.ts` — Refiner e2e with OpenAI + Google mocked SDKs
- **Docs:** `CONFIGURATION.md` provider matrix updated — Developer/Reviewer/Iterator now say "Anthropic only (multi-provider in progress)"
- **Bundle:** `.github/actions/ferry-run-refiner/refiner-action.js` rebuilt

Closes #217

Generated with [Claude Code](https://claude.ai/code)