### PR TITLE
feat: [multi-provider] Phase 2 — Reviewer agent on OpenAI / Google

### DIFF
--- a/.ferry/review-action.js
+++ b/.ferry/review-action.js
@@ -120,7 +120,7 @@ var require_fast_content_type_parse = __commonJS({
   }
 });
 
-// src/agents/reviewer/review-action.ts
+// src/lib/llm/tool-loop/index.ts
 import Anthropic from "@anthropic-ai/sdk";
 
 // src/lib/errors/index.ts
@@ -147,58 +147,6 @@ function resolveAnthropicAuth(input) {
     return { apiKey };
   }
   throw new FerryError("state-invariant", { reason: "missing-env", key: input.apiKeyEnv });
-}
-
-// src/lib/llm/delimit-untrusted.ts
-var OPEN = "<<<UNTRUSTED>>>";
-var CLOSE = "<<<END UNTRUSTED>>>";
-var OPEN_ESCAPE = "<<<UNTRUSTED-LITERAL>>>";
-var CLOSE_ESCAPE = "<<<END UNTRUSTED-LITERAL>>>";
-function delimitUntrusted(value) {
-  const escaped = value.split(OPEN).join(OPEN_ESCAPE).split(CLOSE).join(CLOSE_ESCAPE);
-  return `${OPEN}
-${escaped}
-${CLOSE}`;
-}
-
-// src/lib/io/idempotency.ts
-function checkIdempotencyMarker(marker, items) {
-  for (const item of items) {
-    if (item.includes(marker)) return { skipped: true };
-  }
-  return { skipped: false };
-}
-
-// src/agents/reviewer/ci-gate.ts
-var DEFAULT_RED_MESSAGE = "CI checks failed for this PR. See the failed Actions run for details.";
-function gateCi(input) {
-  if (input.status === "pending") {
-    return {
-      outcome: "pending-ci",
-      proceed: false,
-      findings: [],
-      tokens: { input: 0, output: 0 },
-      cost_eur: 0
-    };
-  }
-  if (input.status === "red") {
-    const message = (input.failure_summary ?? "").trim() || DEFAULT_RED_MESSAGE;
-    return {
-      outcome: "ci-red",
-      proceed: false,
-      findings: [{ rule_id: "ci-failure", message }],
-      next_state: "changes-requested",
-      tokens: { input: 0, output: 0 },
-      cost_eur: 0
-    };
-  }
-  return {
-    outcome: "ci-green",
-    proceed: true,
-    findings: [],
-    tokens: { input: 0, output: 0 },
-    cost_eur: 0
-  };
 }
 
 // src/lib/llm/debug-log.ts
@@ -257,11 +205,523 @@ function createLogger(correlationId, component = "ferry") {
   return makeLogger(correlationId, component);
 }
 
+// src/lib/llm/tool-loop/anthropic.ts
+function createAnthropicToolCallLoop(opts) {
+  return {
+    async run(runOpts) {
+      const {
+        system,
+        initialPrompt,
+        tools,
+        handlers,
+        finishTool,
+        extractDone,
+        maxIterations,
+        maxTokens
+      } = runOpts;
+      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
+      const anthropicTools = tools.map(
+        (t, i) => i === tools.length - 1 ? { ...t, cache_control: { type: "ephemeral" } } : t
+      );
+      const messages = [
+        {
+          role: "user",
+          content: [{ type: "text", text: initialPrompt, cache_control: { type: "ephemeral" } }]
+        }
+      ];
+      let inputTokens = 0;
+      let outputTokens = 0;
+      let done = null;
+      const toolCounts = {};
+      const toolCallRecords = [];
+      function trackTool(name, outputSize) {
+        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+        toolCallRecords.push({ name, outputSize });
+      }
+      const loopStart = Date.now();
+      for (let iter = 0; iter < maxIterations; iter++) {
+        const iterStart = Date.now();
+        const response = await opts.client.messages.create({
+          model: opts.model,
+          max_tokens: maxTokens,
+          system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
+          tools: anthropicTools,
+          messages
+        });
+        inputTokens += response.usage.input_tokens;
+        outputTokens += response.usage.output_tokens;
+        messages.push({ role: "assistant", content: response.content });
+        const toolCount = response.content.filter((b) => b.type === "tool_use").length;
+        logger.info("turn", {
+          iter: iter + 1,
+          stop: response.stop_reason,
+          tools: toolCount,
+          in: response.usage.input_tokens,
+          out: response.usage.output_tokens
+        });
+        emitDebug(
+          {
+            type: "turn",
+            iter: iter + 1,
+            depth: 0,
+            stop_reason: response.stop_reason ?? "unknown",
+            tools: toolCount,
+            mcp_tools: 0,
+            in: response.usage.input_tokens,
+            cache_w: 0,
+            cache_r: 0,
+            out: response.usage.output_tokens,
+            elapsed_ms: Date.now() - iterStart
+          },
+          logger
+        );
+        if (response.stop_reason !== "tool_use") {
+          throw new FerryError("state-invariant", {
+            reason: "tool-loop-stopped-without-finish",
+            stop_reason: response.stop_reason
+          });
+        }
+        const toolResults = [];
+        for (const block of response.content) {
+          if (block.type !== "tool_use") continue;
+          const input = block.input;
+          if (block.name === finishTool) {
+            done = extractDone(input);
+            toolResults.push({ type: "tool_result", tool_use_id: block.id, content: "ok" });
+            continue;
+          }
+          const handler2 = handlers[block.name];
+          if (handler2) {
+            const result = await handler2(input);
+            trackTool(block.name, result.length);
+            toolResults.push({ type: "tool_result", tool_use_id: block.id, content: result });
+          } else {
+            toolResults.push({
+              type: "tool_result",
+              tool_use_id: block.id,
+              content: `unknown tool: ${block.name}`,
+              is_error: true
+            });
+          }
+        }
+        for (let i = messages.length - 1; i >= 0; i--) {
+          const msg = messages[i];
+          if (msg.role === "user" && Array.isArray(msg.content)) {
+            const content = msg.content;
+            if (content.some((b) => b.type === "tool_result")) {
+              const entry = { ...content[content.length - 1] };
+              delete entry.cache_control;
+              content[content.length - 1] = entry;
+              break;
+            }
+          }
+        }
+        if (toolResults.length > 0) {
+          const last = toolResults[toolResults.length - 1];
+          toolResults[toolResults.length - 1] = { ...last, cache_control: { type: "ephemeral" } };
+        }
+        messages.push({ role: "user", content: toolResults });
+        if (done !== null) {
+          emitDebug(
+            {
+              type: "result",
+              subtype: "success",
+              iterations: iter + 1,
+              total_in: inputTokens,
+              total_out: outputTokens,
+              elapsed_ms: Date.now() - loopStart
+            },
+            logger
+          );
+          return {
+            done,
+            usage: { inputTokens, outputTokens },
+            iterations: iter + 1,
+            toolCounts,
+            toolCallRecords
+          };
+        }
+      }
+      throw new FerryError("state-invariant", {
+        reason: "tool-loop-iteration-cap-exceeded",
+        cap: maxIterations
+      });
+    }
+  };
+}
+
+// src/lib/llm/tool-loop/openai.ts
+import OpenAI from "openai";
+function createOpenAIToolCallLoop(opts) {
+  const client = new OpenAI({ apiKey: opts.apiKey });
+  return {
+    async run(runOpts) {
+      const {
+        system,
+        initialPrompt,
+        tools,
+        handlers,
+        finishTool,
+        extractDone,
+        maxIterations,
+        maxTokens
+      } = runOpts;
+      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
+      const openaiTools = tools.map((t) => ({
+        type: "function",
+        function: {
+          name: t.name,
+          description: t.description,
+          parameters: t.input_schema
+        }
+      }));
+      const messages = [
+        { role: "system", content: system },
+        { role: "user", content: initialPrompt }
+      ];
+      let inputTokens = 0;
+      let outputTokens = 0;
+      let done = null;
+      const toolCounts = {};
+      const toolCallRecords = [];
+      function trackTool(name, outputSize) {
+        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+        toolCallRecords.push({ name, outputSize });
+      }
+      const loopStart = Date.now();
+      for (let iter = 0; iter < maxIterations; iter++) {
+        const iterStart = Date.now();
+        const response = await client.chat.completions.create({
+          model: opts.model,
+          max_tokens: maxTokens,
+          messages,
+          tools: openaiTools,
+          tool_choice: "required"
+        });
+        const choice = response.choices[0];
+        if (!choice) {
+          throw new FerryError("state-invariant", { reason: "tool-loop-no-response" });
+        }
+        inputTokens += response.usage?.prompt_tokens ?? 0;
+        outputTokens += response.usage?.completion_tokens ?? 0;
+        const assistantMsg = {
+          role: "assistant",
+          content: choice.message.content ?? null,
+          tool_calls: choice.message.tool_calls
+        };
+        messages.push(assistantMsg);
+        const toolCalls = choice.message.tool_calls ?? [];
+        logger.info("turn", {
+          iter: iter + 1,
+          stop: choice.finish_reason,
+          tools: toolCalls.length,
+          in: response.usage?.prompt_tokens ?? 0,
+          out: response.usage?.completion_tokens ?? 0
+        });
+        emitDebug(
+          {
+            type: "turn",
+            iter: iter + 1,
+            depth: 0,
+            stop_reason: choice.finish_reason ?? "unknown",
+            tools: toolCalls.length,
+            mcp_tools: 0,
+            in: response.usage?.prompt_tokens ?? 0,
+            cache_w: 0,
+            cache_r: 0,
+            out: response.usage?.completion_tokens ?? 0,
+            elapsed_ms: Date.now() - iterStart
+          },
+          logger
+        );
+        if (choice.finish_reason !== "tool_calls") {
+          throw new FerryError("state-invariant", {
+            reason: "tool-loop-stopped-without-finish",
+            stop_reason: choice.finish_reason
+          });
+        }
+        for (const toolCall of toolCalls) {
+          if (toolCall.type !== "function") continue;
+          let input;
+          try {
+            input = JSON.parse(toolCall.function.arguments);
+          } catch {
+            messages.push({
+              role: "tool",
+              tool_call_id: toolCall.id,
+              content: "invalid JSON arguments"
+            });
+            continue;
+          }
+          if (toolCall.function.name === finishTool) {
+            done = extractDone(input);
+            messages.push({ role: "tool", tool_call_id: toolCall.id, content: "ok" });
+            continue;
+          }
+          const handler2 = handlers[toolCall.function.name];
+          if (handler2) {
+            const result = await handler2(input);
+            trackTool(toolCall.function.name, result.length);
+            messages.push({ role: "tool", tool_call_id: toolCall.id, content: result });
+          } else {
+            messages.push({
+              role: "tool",
+              tool_call_id: toolCall.id,
+              content: `unknown tool: ${toolCall.function.name}`
+            });
+          }
+        }
+        if (done !== null) {
+          emitDebug(
+            {
+              type: "result",
+              subtype: "success",
+              iterations: iter + 1,
+              total_in: inputTokens,
+              total_out: outputTokens,
+              elapsed_ms: Date.now() - loopStart
+            },
+            logger
+          );
+          return {
+            done,
+            usage: { inputTokens, outputTokens },
+            iterations: iter + 1,
+            toolCounts,
+            toolCallRecords
+          };
+        }
+      }
+      throw new FerryError("state-invariant", {
+        reason: "tool-loop-iteration-cap-exceeded",
+        cap: maxIterations
+      });
+    }
+  };
+}
+
+// src/lib/llm/tool-loop/google.ts
+import { GoogleGenAI } from "@google/genai";
+function toGoogleTools(tools) {
+  return [
+    {
+      functionDeclarations: tools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        parametersJsonSchema: t.input_schema
+      }))
+    }
+  ];
+}
+function createGoogleToolCallLoop(opts) {
+  const ai = new GoogleGenAI({ apiKey: opts.apiKey });
+  return {
+    async run(runOpts) {
+      const {
+        system,
+        initialPrompt,
+        tools,
+        handlers,
+        finishTool,
+        extractDone,
+        maxIterations,
+        maxTokens
+      } = runOpts;
+      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
+      const googleTools = toGoogleTools(tools);
+      const contents = [{ role: "user", parts: [{ text: initialPrompt }] }];
+      let inputTokens = 0;
+      let outputTokens = 0;
+      let done = null;
+      const toolCounts = {};
+      const toolCallRecords = [];
+      function trackTool(name, outputSize) {
+        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+        toolCallRecords.push({ name, outputSize });
+      }
+      const loopStart = Date.now();
+      for (let iter = 0; iter < maxIterations; iter++) {
+        const iterStart = Date.now();
+        const response = await ai.models.generateContent({
+          model: opts.model,
+          contents,
+          config: {
+            systemInstruction: system,
+            tools: googleTools,
+            maxOutputTokens: maxTokens
+          }
+        });
+        inputTokens += response.usageMetadata?.promptTokenCount ?? 0;
+        outputTokens += response.usageMetadata?.candidatesTokenCount ?? 0;
+        const fnCalls = response.functionCalls ?? [];
+        const modelParts = response.candidates?.[0]?.content?.parts ?? [];
+        if (modelParts.length > 0) {
+          contents.push({ role: "model", parts: modelParts });
+        }
+        logger.info("turn", {
+          iter: iter + 1,
+          tools: fnCalls.length,
+          in: response.usageMetadata?.promptTokenCount ?? 0,
+          out: response.usageMetadata?.candidatesTokenCount ?? 0
+        });
+        emitDebug(
+          {
+            type: "turn",
+            iter: iter + 1,
+            depth: 0,
+            stop_reason: fnCalls.length > 0 ? "tool_use" : "end_turn",
+            tools: fnCalls.length,
+            mcp_tools: 0,
+            in: response.usageMetadata?.promptTokenCount ?? 0,
+            cache_w: 0,
+            cache_r: 0,
+            out: response.usageMetadata?.candidatesTokenCount ?? 0,
+            elapsed_ms: Date.now() - iterStart
+          },
+          logger
+        );
+        if (fnCalls.length === 0) {
+          throw new FerryError("state-invariant", {
+            reason: "tool-loop-stopped-without-finish",
+            stop_reason: "end_turn"
+          });
+        }
+        const responseParts = [];
+        for (const fc of fnCalls) {
+          const name = fc.name ?? "";
+          const input = fc.args ?? {};
+          if (name === finishTool) {
+            done = extractDone(input);
+            responseParts.push({
+              functionResponse: { name, response: { result: "ok" } }
+            });
+            continue;
+          }
+          const handler2 = handlers[name];
+          if (handler2) {
+            const result = await handler2(input);
+            trackTool(name, result.length);
+            responseParts.push({
+              functionResponse: { name, response: { result } }
+            });
+          } else {
+            responseParts.push({
+              functionResponse: { name, response: { error: `unknown tool: ${name}` } }
+            });
+          }
+        }
+        contents.push({ role: "user", parts: responseParts });
+        if (done !== null) {
+          emitDebug(
+            {
+              type: "result",
+              subtype: "success",
+              iterations: iter + 1,
+              total_in: inputTokens,
+              total_out: outputTokens,
+              elapsed_ms: Date.now() - loopStart
+            },
+            logger
+          );
+          return {
+            done,
+            usage: { inputTokens, outputTokens },
+            iterations: iter + 1,
+            toolCounts,
+            toolCallRecords
+          };
+        }
+      }
+      throw new FerryError("state-invariant", {
+        reason: "tool-loop-iteration-cap-exceeded",
+        cap: maxIterations
+      });
+    }
+  };
+}
+
+// src/lib/llm/tool-loop/index.ts
+function requireEnv(key) {
+  const val = process.env[key];
+  if (!val) {
+    throw new FerryError("state-invariant", { reason: "missing-env", key });
+  }
+  return val;
+}
+function createToolCallLoop(opts) {
+  if (opts.provider === "anthropic") {
+    const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
+    const client = new Anthropic(auth2);
+    return createAnthropicToolCallLoop({ client, model: opts.model });
+  }
+  if (opts.provider === "openai") {
+    const apiKey = requireEnv("FERRY_OPENAI_KEY");
+    return createOpenAIToolCallLoop({ apiKey, model: opts.model });
+  }
+  if (opts.provider === "google") {
+    const apiKey = requireEnv("FERRY_GOOGLE_AI_KEY");
+    return createGoogleToolCallLoop({ apiKey, model: opts.model });
+  }
+  throw new FerryError("state-invariant", { reason: "unknown-provider", provider: opts.provider });
+}
+
+// src/lib/llm/delimit-untrusted.ts
+var OPEN = "<<<UNTRUSTED>>>";
+var CLOSE = "<<<END UNTRUSTED>>>";
+var OPEN_ESCAPE = "<<<UNTRUSTED-LITERAL>>>";
+var CLOSE_ESCAPE = "<<<END UNTRUSTED-LITERAL>>>";
+function delimitUntrusted(value) {
+  const escaped = value.split(OPEN).join(OPEN_ESCAPE).split(CLOSE).join(CLOSE_ESCAPE);
+  return `${OPEN}
+${escaped}
+${CLOSE}`;
+}
+
+// src/lib/io/idempotency.ts
+function checkIdempotencyMarker(marker, items) {
+  for (const item of items) {
+    if (item.includes(marker)) return { skipped: true };
+  }
+  return { skipped: false };
+}
+
+// src/agents/reviewer/ci-gate.ts
+var DEFAULT_RED_MESSAGE = "CI checks failed for this PR. See the failed Actions run for details.";
+function gateCi(input) {
+  if (input.status === "pending") {
+    return {
+      outcome: "pending-ci",
+      proceed: false,
+      findings: [],
+      tokens: { input: 0, output: 0 },
+      cost_eur: 0
+    };
+  }
+  if (input.status === "red") {
+    const message = (input.failure_summary ?? "").trim() || DEFAULT_RED_MESSAGE;
+    return {
+      outcome: "ci-red",
+      proceed: false,
+      findings: [{ rule_id: "ci-failure", message }],
+      next_state: "changes-requested",
+      tokens: { input: 0, output: 0 },
+      cost_eur: 0
+    };
+  }
+  return {
+    outcome: "ci-green",
+    proceed: true,
+    findings: [],
+    tokens: { input: 0, output: 0 },
+    cost_eur: 0
+  };
+}
+
 // src/agents/reviewer/review-loop.ts
 var MAX_PATCH_CHARS = 2e4;
 var MAX_CONTENT_CHARS = 4e4;
 var MAX_ITERATIONS = 40;
-var REVIEW_TOOLS = [
+var REVIEW_TOOL_DEFS = [
   {
     name: "get_file_patch",
     description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
@@ -316,160 +776,55 @@ function buildFileList(files) {
   return files.map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`).join("\n");
 }
 async function runReviewLoop(opts) {
-  const { anthropic, model, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
+  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
   const logger = opts.logger ?? createLogger("", "ferry:review-loop");
   const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
   const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
-  const tools = REVIEW_TOOLS.map(
-    (t, i) => i === REVIEW_TOOLS.length - 1 ? { ...t, cache_control: { type: "ephemeral" } } : t
-  );
-  const messages = [
-    {
-      role: "user",
-      content: [{ type: "text", text: initialPrompt, cache_control: { type: "ephemeral" } }]
-    }
-  ];
-  let inputTokens = 0;
-  let outputTokens = 0;
-  let result = null;
-  const toolCounts = {};
-  const toolCallRecords = [];
-  function trackTool(name, outputSize) {
-    toolCounts[name] = (toolCounts[name] ?? 0) + 1;
-    toolCallRecords.push({ name, outputSize });
-  }
-  const loopStart = Date.now();
-  for (let iter = 0; iter < maxIterations; iter++) {
-    const iterStart = Date.now();
-    const response = await anthropic.messages.create({
-      model,
-      max_tokens: maxTokens,
-      system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
-      tools,
-      messages
-    });
-    inputTokens += response.usage.input_tokens;
-    outputTokens += response.usage.output_tokens;
-    messages.push({ role: "assistant", content: response.content });
-    const toolCount = response.content.filter((b) => b.type === "tool_use").length;
-    logger.info("turn", {
-      iter: iter + 1,
-      stop: response.stop_reason,
-      tools: toolCount,
-      in: response.usage.input_tokens,
-      out: response.usage.output_tokens
-    });
-    emitDebug(
-      {
-        type: "turn",
-        iter: iter + 1,
-        depth: 0,
-        stop_reason: response.stop_reason ?? "unknown",
-        tools: toolCount,
-        mcp_tools: 0,
-        in: response.usage.input_tokens,
-        cache_w: 0,
-        cache_r: 0,
-        out: response.usage.output_tokens,
-        elapsed_ms: Date.now() - iterStart
-      },
-      logger
-    );
-    if (response.stop_reason !== "tool_use") {
-      throw new FerryError("state-invariant", {
-        reason: "reviewer-stopped-without-finish",
-        stop_reason: response.stop_reason
-      });
-    }
-    const toolResults = [];
-    for (const block of response.content) {
-      if (block.type !== "tool_use") continue;
-      const input = block.input;
-      if (block.name === "finish_review") {
-        result = {
-          approved: input.approved,
-          comment: input.comment
-        };
-        toolResults.push({ type: "tool_result", tool_use_id: block.id, content: "ok" });
-        continue;
-      }
-      if (block.name === "get_file_patch") {
+  const {
+    done: result,
+    usage,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  } = await loop.run({
+    system,
+    initialPrompt,
+    tools: REVIEW_TOOL_DEFS,
+    finishTool: "finish_review",
+    extractDone: (input) => ({
+      approved: input.approved,
+      comment: input.comment
+    }),
+    handlers: {
+      get_file_patch: (input) => {
         const filename = input.filename;
-        logger.info("tool", { iter: iter + 1, tool: "get_file_patch", file: filename });
+        logger.info("tool", { tool: "get_file_patch", file: filename });
         const patch = fileMap.get(filename);
-        let content;
-        if (patch === void 0) {
-          content = `(file not found in PR: ${filename})`;
-        } else if (!patch) {
-          content = "(no patch \u2014 binary, empty, or content unchanged)";
-        } else {
-          const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
-          content = patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
-        }
-        trackTool("get_file_patch", content.length);
-        toolResults.push({ type: "tool_result", tool_use_id: block.id, content });
-        continue;
-      }
-      if (block.name === "get_file_content") {
+        if (patch === void 0) return `(file not found in PR: ${filename})`;
+        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
+        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
+        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
+      },
+      get_file_content: async (input) => {
         const filename = input.filename;
-        logger.info("tool", { iter: iter + 1, tool: "get_file_content", file: filename });
+        logger.info("tool", { tool: "get_file_content", file: filename });
         const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
         const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
-        const content = rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
-        trackTool("get_file_content", content.length);
-        toolResults.push({ type: "tool_result", tool_use_id: block.id, content });
-        continue;
+        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
       }
-      toolResults.push({
-        type: "tool_result",
-        tool_use_id: block.id,
-        content: `unknown tool: ${block.name}`,
-        is_error: true
-      });
-    }
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const msg = messages[i];
-      if (msg.role === "user" && Array.isArray(msg.content)) {
-        const content = msg.content;
-        if (content.some((b) => b.type === "tool_result")) {
-          const entry = { ...content[content.length - 1] };
-          delete entry.cache_control;
-          content[content.length - 1] = entry;
-          break;
-        }
-      }
-    }
-    if (toolResults.length > 0) {
-      const last = toolResults[toolResults.length - 1];
-      toolResults[toolResults.length - 1] = { ...last, cache_control: { type: "ephemeral" } };
-    }
-    messages.push({ role: "user", content: toolResults });
-    if (result) {
-      emitDebug(
-        {
-          type: "result",
-          subtype: "success",
-          iterations: iter + 1,
-          total_in: inputTokens,
-          total_out: outputTokens,
-          elapsed_ms: Date.now() - loopStart
-        },
-        logger
-      );
-      return {
-        result,
-        inputTokens,
-        outputTokens,
-        iterations: iter + 1,
-        toolCounts,
-        toolCallRecords
-      };
-    }
-  }
-  throw new FerryError("state-invariant", {
-    reason: "review-iteration-cap-exceeded",
-    cap: MAX_ITERATIONS
+    },
+    maxIterations,
+    maxTokens,
+    logger
   });
+  return {
+    result,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  };
 }
 
 // src/lib/labels/capabilities.ts
@@ -518,7 +873,7 @@ function resolveCapabilities(ticketLabels, configLabels, logger) {
 }
 
 // src/lib/agent-runtime/env.ts
-function requireEnv(key) {
+function requireEnv2(key) {
   const val = process.env[key];
   if (!val) throw new FerryError("state-invariant", { reason: "missing-env", key });
   return val;
@@ -556,7 +911,7 @@ async function runAgent(role, handler2) {
   const component = COMPONENT[role];
   const bootstrapLogger = createLogger("", component);
   try {
-    const rawPayload = requireEnv("FERRY_ENVELOPE_PAYLOAD");
+    const rawPayload = requireEnv2("FERRY_ENVELOPE_PAYLOAD");
     const envelope = validateEnvelope(JSON.parse(rawPayload));
     const logger = createLogger(envelope.event_id, component);
     await handler2(envelope, logger);
@@ -5498,8 +5853,8 @@ function createTrackerFromEnv() {
 
 // src/lib/agent-runtime/context.ts
 function createGitHubContext(repoRoot) {
-  const githubToken = requireEnv("GITHUB_TOKEN");
-  const githubRepo = requireEnv("GITHUB_REPO");
+  const githubToken = requireEnv2("GITHUB_TOKEN");
+  const githubRepo = requireEnv2("GITHUB_REPO");
   const [owner, repo] = githubRepo.split("/");
   if (!owner || !repo) {
     throw new FerryError("state-invariant", { reason: "invalid-github-repo", githubRepo });
@@ -5533,19 +5888,11 @@ async function main(envelope, logger) {
   const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
   const { provider, model } = ferryCfg.models.review;
-  if (provider !== "anthropic") {
-    throw new FerryError("state-invariant", {
-      reason: "unsupported-provider",
-      provider,
-      phase: "reviewer",
-      detail: "The reviewer phase requires provider 'anthropic'. OpenAI and Google support for agentic phases is planned for a future release."
-    });
-  }
   const reviewerWorkflow = ferryCfg.workflow.agents.reviewer;
   const shouldTransitionChanges = reviewerWorkflow.auto_transition_changes !== null;
   const shouldTransitionApprove = reviewerWorkflow.auto_transition_approve !== null;
-  const iterTransitionId = shouldTransitionChanges ? requireEnv("FERRY_ITER_TRANSITION_ID") : "";
-  const approveTransitionId = shouldTransitionApprove ? requireEnv("FERRY_APPROVE_TRANSITION_ID") : "";
+  const iterTransitionId = shouldTransitionChanges ? requireEnv2("FERRY_ITER_TRANSITION_ID") : "";
+  const approveTransitionId = shouldTransitionApprove ? requireEnv2("FERRY_APPROVE_TRANSITION_ID") : "";
   const issue = await tracker.getIssue(ticketKey);
   const existingComments = issue.comments;
   const capabilities = resolveCapabilities(issue.labels, ferryCfg.labels, logger);
@@ -5636,7 +5983,7 @@ async function main(envelope, logger) {
     extraParts: [loadOptionalPrompt("review-comment", REPO_ROOT)],
     separator: "\n\n---\n\n"
   });
-  const anthropic = new Anthropic(resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" }));
+  const loop = createToolCallLoop({ provider, model });
   const {
     result: review,
     inputTokens,
@@ -5645,8 +5992,7 @@ async function main(envelope, logger) {
     toolCounts: reviewToolCounts,
     toolCallRecords: reviewToolCallRecords
   } = await runReviewLoop({
-    anthropic,
-    model,
+    loop,
     system,
     initialPrompt,
     fileMap,

--- a/.github/actions/ferry-run-reviewer/action.yml
+++ b/.github/actions/ferry-run-reviewer/action.yml
@@ -19,8 +19,17 @@ inputs:
     description: Jira transition ID to move ticket to Iterating
     required: true
   anthropic_api_key:
-    description: Anthropic API key
-    required: true
+    description: Anthropic API key (required when ferry_review_provider=anthropic)
+    required: false
+    default: ''
+  openai_api_key:
+    description: OpenAI API key (required when ferry_review_provider=openai)
+    required: false
+    default: ''
+  google_api_key:
+    description: Google AI API key (required when ferry_review_provider=google)
+    required: false
+    default: ''
   github_token:
     description: GitHub token with pull-requests:write and checks:read
     required: true
@@ -113,6 +122,8 @@ runs:
         FERRY_JIRA_API_TOKEN: ${{ inputs.jira_api_token }}
         FERRY_ITER_TRANSITION_ID: ${{ inputs.ferry_iter_transition_id }}
         ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        FERRY_OPENAI_KEY: ${{ inputs.openai_api_key }}
+        FERRY_GOOGLE_AI_KEY: ${{ inputs.google_api_key }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
         GH_TOKEN: ${{ inputs.github_token }}
         GITHUB_REPO: ${{ inputs.github_repo }}

--- a/.github/actions/ferry-run-reviewer/review-action.js
+++ b/.github/actions/ferry-run-reviewer/review-action.js
@@ -120,7 +120,7 @@ var require_fast_content_type_parse = __commonJS({
   }
 });
 
-// src/agents/reviewer/review-action.ts
+// src/lib/llm/tool-loop/index.ts
 import Anthropic from "@anthropic-ai/sdk";
 
 // src/lib/errors/index.ts
@@ -147,58 +147,6 @@ function resolveAnthropicAuth(input) {
     return { apiKey };
   }
   throw new FerryError("state-invariant", { reason: "missing-env", key: input.apiKeyEnv });
-}
-
-// src/lib/llm/delimit-untrusted.ts
-var OPEN = "<<<UNTRUSTED>>>";
-var CLOSE = "<<<END UNTRUSTED>>>";
-var OPEN_ESCAPE = "<<<UNTRUSTED-LITERAL>>>";
-var CLOSE_ESCAPE = "<<<END UNTRUSTED-LITERAL>>>";
-function delimitUntrusted(value) {
-  const escaped = value.split(OPEN).join(OPEN_ESCAPE).split(CLOSE).join(CLOSE_ESCAPE);
-  return `${OPEN}
-${escaped}
-${CLOSE}`;
-}
-
-// src/lib/io/idempotency.ts
-function checkIdempotencyMarker(marker, items) {
-  for (const item of items) {
-    if (item.includes(marker)) return { skipped: true };
-  }
-  return { skipped: false };
-}
-
-// src/agents/reviewer/ci-gate.ts
-var DEFAULT_RED_MESSAGE = "CI checks failed for this PR. See the failed Actions run for details.";
-function gateCi(input) {
-  if (input.status === "pending") {
-    return {
-      outcome: "pending-ci",
-      proceed: false,
-      findings: [],
-      tokens: { input: 0, output: 0 },
-      cost_eur: 0
-    };
-  }
-  if (input.status === "red") {
-    const message = (input.failure_summary ?? "").trim() || DEFAULT_RED_MESSAGE;
-    return {
-      outcome: "ci-red",
-      proceed: false,
-      findings: [{ rule_id: "ci-failure", message }],
-      next_state: "changes-requested",
-      tokens: { input: 0, output: 0 },
-      cost_eur: 0
-    };
-  }
-  return {
-    outcome: "ci-green",
-    proceed: true,
-    findings: [],
-    tokens: { input: 0, output: 0 },
-    cost_eur: 0
-  };
 }
 
 // src/lib/llm/debug-log.ts
@@ -257,11 +205,523 @@ function createLogger(correlationId, component = "ferry") {
   return makeLogger(correlationId, component);
 }
 
+// src/lib/llm/tool-loop/anthropic.ts
+function createAnthropicToolCallLoop(opts) {
+  return {
+    async run(runOpts) {
+      const {
+        system,
+        initialPrompt,
+        tools,
+        handlers,
+        finishTool,
+        extractDone,
+        maxIterations,
+        maxTokens
+      } = runOpts;
+      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
+      const anthropicTools = tools.map(
+        (t, i) => i === tools.length - 1 ? { ...t, cache_control: { type: "ephemeral" } } : t
+      );
+      const messages = [
+        {
+          role: "user",
+          content: [{ type: "text", text: initialPrompt, cache_control: { type: "ephemeral" } }]
+        }
+      ];
+      let inputTokens = 0;
+      let outputTokens = 0;
+      let done = null;
+      const toolCounts = {};
+      const toolCallRecords = [];
+      function trackTool(name, outputSize) {
+        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+        toolCallRecords.push({ name, outputSize });
+      }
+      const loopStart = Date.now();
+      for (let iter = 0; iter < maxIterations; iter++) {
+        const iterStart = Date.now();
+        const response = await opts.client.messages.create({
+          model: opts.model,
+          max_tokens: maxTokens,
+          system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
+          tools: anthropicTools,
+          messages
+        });
+        inputTokens += response.usage.input_tokens;
+        outputTokens += response.usage.output_tokens;
+        messages.push({ role: "assistant", content: response.content });
+        const toolCount = response.content.filter((b) => b.type === "tool_use").length;
+        logger.info("turn", {
+          iter: iter + 1,
+          stop: response.stop_reason,
+          tools: toolCount,
+          in: response.usage.input_tokens,
+          out: response.usage.output_tokens
+        });
+        emitDebug(
+          {
+            type: "turn",
+            iter: iter + 1,
+            depth: 0,
+            stop_reason: response.stop_reason ?? "unknown",
+            tools: toolCount,
+            mcp_tools: 0,
+            in: response.usage.input_tokens,
+            cache_w: 0,
+            cache_r: 0,
+            out: response.usage.output_tokens,
+            elapsed_ms: Date.now() - iterStart
+          },
+          logger
+        );
+        if (response.stop_reason !== "tool_use") {
+          throw new FerryError("state-invariant", {
+            reason: "tool-loop-stopped-without-finish",
+            stop_reason: response.stop_reason
+          });
+        }
+        const toolResults = [];
+        for (const block of response.content) {
+          if (block.type !== "tool_use") continue;
+          const input = block.input;
+          if (block.name === finishTool) {
+            done = extractDone(input);
+            toolResults.push({ type: "tool_result", tool_use_id: block.id, content: "ok" });
+            continue;
+          }
+          const handler2 = handlers[block.name];
+          if (handler2) {
+            const result = await handler2(input);
+            trackTool(block.name, result.length);
+            toolResults.push({ type: "tool_result", tool_use_id: block.id, content: result });
+          } else {
+            toolResults.push({
+              type: "tool_result",
+              tool_use_id: block.id,
+              content: `unknown tool: ${block.name}`,
+              is_error: true
+            });
+          }
+        }
+        for (let i = messages.length - 1; i >= 0; i--) {
+          const msg = messages[i];
+          if (msg.role === "user" && Array.isArray(msg.content)) {
+            const content = msg.content;
+            if (content.some((b) => b.type === "tool_result")) {
+              const entry = { ...content[content.length - 1] };
+              delete entry.cache_control;
+              content[content.length - 1] = entry;
+              break;
+            }
+          }
+        }
+        if (toolResults.length > 0) {
+          const last = toolResults[toolResults.length - 1];
+          toolResults[toolResults.length - 1] = { ...last, cache_control: { type: "ephemeral" } };
+        }
+        messages.push({ role: "user", content: toolResults });
+        if (done !== null) {
+          emitDebug(
+            {
+              type: "result",
+              subtype: "success",
+              iterations: iter + 1,
+              total_in: inputTokens,
+              total_out: outputTokens,
+              elapsed_ms: Date.now() - loopStart
+            },
+            logger
+          );
+          return {
+            done,
+            usage: { inputTokens, outputTokens },
+            iterations: iter + 1,
+            toolCounts,
+            toolCallRecords
+          };
+        }
+      }
+      throw new FerryError("state-invariant", {
+        reason: "tool-loop-iteration-cap-exceeded",
+        cap: maxIterations
+      });
+    }
+  };
+}
+
+// src/lib/llm/tool-loop/openai.ts
+import OpenAI from "openai";
+function createOpenAIToolCallLoop(opts) {
+  const client = new OpenAI({ apiKey: opts.apiKey });
+  return {
+    async run(runOpts) {
+      const {
+        system,
+        initialPrompt,
+        tools,
+        handlers,
+        finishTool,
+        extractDone,
+        maxIterations,
+        maxTokens
+      } = runOpts;
+      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
+      const openaiTools = tools.map((t) => ({
+        type: "function",
+        function: {
+          name: t.name,
+          description: t.description,
+          parameters: t.input_schema
+        }
+      }));
+      const messages = [
+        { role: "system", content: system },
+        { role: "user", content: initialPrompt }
+      ];
+      let inputTokens = 0;
+      let outputTokens = 0;
+      let done = null;
+      const toolCounts = {};
+      const toolCallRecords = [];
+      function trackTool(name, outputSize) {
+        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+        toolCallRecords.push({ name, outputSize });
+      }
+      const loopStart = Date.now();
+      for (let iter = 0; iter < maxIterations; iter++) {
+        const iterStart = Date.now();
+        const response = await client.chat.completions.create({
+          model: opts.model,
+          max_tokens: maxTokens,
+          messages,
+          tools: openaiTools,
+          tool_choice: "required"
+        });
+        const choice = response.choices[0];
+        if (!choice) {
+          throw new FerryError("state-invariant", { reason: "tool-loop-no-response" });
+        }
+        inputTokens += response.usage?.prompt_tokens ?? 0;
+        outputTokens += response.usage?.completion_tokens ?? 0;
+        const assistantMsg = {
+          role: "assistant",
+          content: choice.message.content ?? null,
+          tool_calls: choice.message.tool_calls
+        };
+        messages.push(assistantMsg);
+        const toolCalls = choice.message.tool_calls ?? [];
+        logger.info("turn", {
+          iter: iter + 1,
+          stop: choice.finish_reason,
+          tools: toolCalls.length,
+          in: response.usage?.prompt_tokens ?? 0,
+          out: response.usage?.completion_tokens ?? 0
+        });
+        emitDebug(
+          {
+            type: "turn",
+            iter: iter + 1,
+            depth: 0,
+            stop_reason: choice.finish_reason ?? "unknown",
+            tools: toolCalls.length,
+            mcp_tools: 0,
+            in: response.usage?.prompt_tokens ?? 0,
+            cache_w: 0,
+            cache_r: 0,
+            out: response.usage?.completion_tokens ?? 0,
+            elapsed_ms: Date.now() - iterStart
+          },
+          logger
+        );
+        if (choice.finish_reason !== "tool_calls") {
+          throw new FerryError("state-invariant", {
+            reason: "tool-loop-stopped-without-finish",
+            stop_reason: choice.finish_reason
+          });
+        }
+        for (const toolCall of toolCalls) {
+          if (toolCall.type !== "function") continue;
+          let input;
+          try {
+            input = JSON.parse(toolCall.function.arguments);
+          } catch {
+            messages.push({
+              role: "tool",
+              tool_call_id: toolCall.id,
+              content: "invalid JSON arguments"
+            });
+            continue;
+          }
+          if (toolCall.function.name === finishTool) {
+            done = extractDone(input);
+            messages.push({ role: "tool", tool_call_id: toolCall.id, content: "ok" });
+            continue;
+          }
+          const handler2 = handlers[toolCall.function.name];
+          if (handler2) {
+            const result = await handler2(input);
+            trackTool(toolCall.function.name, result.length);
+            messages.push({ role: "tool", tool_call_id: toolCall.id, content: result });
+          } else {
+            messages.push({
+              role: "tool",
+              tool_call_id: toolCall.id,
+              content: `unknown tool: ${toolCall.function.name}`
+            });
+          }
+        }
+        if (done !== null) {
+          emitDebug(
+            {
+              type: "result",
+              subtype: "success",
+              iterations: iter + 1,
+              total_in: inputTokens,
+              total_out: outputTokens,
+              elapsed_ms: Date.now() - loopStart
+            },
+            logger
+          );
+          return {
+            done,
+            usage: { inputTokens, outputTokens },
+            iterations: iter + 1,
+            toolCounts,
+            toolCallRecords
+          };
+        }
+      }
+      throw new FerryError("state-invariant", {
+        reason: "tool-loop-iteration-cap-exceeded",
+        cap: maxIterations
+      });
+    }
+  };
+}
+
+// src/lib/llm/tool-loop/google.ts
+import { GoogleGenAI } from "@google/genai";
+function toGoogleTools(tools) {
+  return [
+    {
+      functionDeclarations: tools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        parametersJsonSchema: t.input_schema
+      }))
+    }
+  ];
+}
+function createGoogleToolCallLoop(opts) {
+  const ai = new GoogleGenAI({ apiKey: opts.apiKey });
+  return {
+    async run(runOpts) {
+      const {
+        system,
+        initialPrompt,
+        tools,
+        handlers,
+        finishTool,
+        extractDone,
+        maxIterations,
+        maxTokens
+      } = runOpts;
+      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
+      const googleTools = toGoogleTools(tools);
+      const contents = [{ role: "user", parts: [{ text: initialPrompt }] }];
+      let inputTokens = 0;
+      let outputTokens = 0;
+      let done = null;
+      const toolCounts = {};
+      const toolCallRecords = [];
+      function trackTool(name, outputSize) {
+        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+        toolCallRecords.push({ name, outputSize });
+      }
+      const loopStart = Date.now();
+      for (let iter = 0; iter < maxIterations; iter++) {
+        const iterStart = Date.now();
+        const response = await ai.models.generateContent({
+          model: opts.model,
+          contents,
+          config: {
+            systemInstruction: system,
+            tools: googleTools,
+            maxOutputTokens: maxTokens
+          }
+        });
+        inputTokens += response.usageMetadata?.promptTokenCount ?? 0;
+        outputTokens += response.usageMetadata?.candidatesTokenCount ?? 0;
+        const fnCalls = response.functionCalls ?? [];
+        const modelParts = response.candidates?.[0]?.content?.parts ?? [];
+        if (modelParts.length > 0) {
+          contents.push({ role: "model", parts: modelParts });
+        }
+        logger.info("turn", {
+          iter: iter + 1,
+          tools: fnCalls.length,
+          in: response.usageMetadata?.promptTokenCount ?? 0,
+          out: response.usageMetadata?.candidatesTokenCount ?? 0
+        });
+        emitDebug(
+          {
+            type: "turn",
+            iter: iter + 1,
+            depth: 0,
+            stop_reason: fnCalls.length > 0 ? "tool_use" : "end_turn",
+            tools: fnCalls.length,
+            mcp_tools: 0,
+            in: response.usageMetadata?.promptTokenCount ?? 0,
+            cache_w: 0,
+            cache_r: 0,
+            out: response.usageMetadata?.candidatesTokenCount ?? 0,
+            elapsed_ms: Date.now() - iterStart
+          },
+          logger
+        );
+        if (fnCalls.length === 0) {
+          throw new FerryError("state-invariant", {
+            reason: "tool-loop-stopped-without-finish",
+            stop_reason: "end_turn"
+          });
+        }
+        const responseParts = [];
+        for (const fc of fnCalls) {
+          const name = fc.name ?? "";
+          const input = fc.args ?? {};
+          if (name === finishTool) {
+            done = extractDone(input);
+            responseParts.push({
+              functionResponse: { name, response: { result: "ok" } }
+            });
+            continue;
+          }
+          const handler2 = handlers[name];
+          if (handler2) {
+            const result = await handler2(input);
+            trackTool(name, result.length);
+            responseParts.push({
+              functionResponse: { name, response: { result } }
+            });
+          } else {
+            responseParts.push({
+              functionResponse: { name, response: { error: `unknown tool: ${name}` } }
+            });
+          }
+        }
+        contents.push({ role: "user", parts: responseParts });
+        if (done !== null) {
+          emitDebug(
+            {
+              type: "result",
+              subtype: "success",
+              iterations: iter + 1,
+              total_in: inputTokens,
+              total_out: outputTokens,
+              elapsed_ms: Date.now() - loopStart
+            },
+            logger
+          );
+          return {
+            done,
+            usage: { inputTokens, outputTokens },
+            iterations: iter + 1,
+            toolCounts,
+            toolCallRecords
+          };
+        }
+      }
+      throw new FerryError("state-invariant", {
+        reason: "tool-loop-iteration-cap-exceeded",
+        cap: maxIterations
+      });
+    }
+  };
+}
+
+// src/lib/llm/tool-loop/index.ts
+function requireEnv(key) {
+  const val = process.env[key];
+  if (!val) {
+    throw new FerryError("state-invariant", { reason: "missing-env", key });
+  }
+  return val;
+}
+function createToolCallLoop(opts) {
+  if (opts.provider === "anthropic") {
+    const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
+    const client = new Anthropic(auth2);
+    return createAnthropicToolCallLoop({ client, model: opts.model });
+  }
+  if (opts.provider === "openai") {
+    const apiKey = requireEnv("FERRY_OPENAI_KEY");
+    return createOpenAIToolCallLoop({ apiKey, model: opts.model });
+  }
+  if (opts.provider === "google") {
+    const apiKey = requireEnv("FERRY_GOOGLE_AI_KEY");
+    return createGoogleToolCallLoop({ apiKey, model: opts.model });
+  }
+  throw new FerryError("state-invariant", { reason: "unknown-provider", provider: opts.provider });
+}
+
+// src/lib/llm/delimit-untrusted.ts
+var OPEN = "<<<UNTRUSTED>>>";
+var CLOSE = "<<<END UNTRUSTED>>>";
+var OPEN_ESCAPE = "<<<UNTRUSTED-LITERAL>>>";
+var CLOSE_ESCAPE = "<<<END UNTRUSTED-LITERAL>>>";
+function delimitUntrusted(value) {
+  const escaped = value.split(OPEN).join(OPEN_ESCAPE).split(CLOSE).join(CLOSE_ESCAPE);
+  return `${OPEN}
+${escaped}
+${CLOSE}`;
+}
+
+// src/lib/io/idempotency.ts
+function checkIdempotencyMarker(marker, items) {
+  for (const item of items) {
+    if (item.includes(marker)) return { skipped: true };
+  }
+  return { skipped: false };
+}
+
+// src/agents/reviewer/ci-gate.ts
+var DEFAULT_RED_MESSAGE = "CI checks failed for this PR. See the failed Actions run for details.";
+function gateCi(input) {
+  if (input.status === "pending") {
+    return {
+      outcome: "pending-ci",
+      proceed: false,
+      findings: [],
+      tokens: { input: 0, output: 0 },
+      cost_eur: 0
+    };
+  }
+  if (input.status === "red") {
+    const message = (input.failure_summary ?? "").trim() || DEFAULT_RED_MESSAGE;
+    return {
+      outcome: "ci-red",
+      proceed: false,
+      findings: [{ rule_id: "ci-failure", message }],
+      next_state: "changes-requested",
+      tokens: { input: 0, output: 0 },
+      cost_eur: 0
+    };
+  }
+  return {
+    outcome: "ci-green",
+    proceed: true,
+    findings: [],
+    tokens: { input: 0, output: 0 },
+    cost_eur: 0
+  };
+}
+
 // src/agents/reviewer/review-loop.ts
 var MAX_PATCH_CHARS = 2e4;
 var MAX_CONTENT_CHARS = 4e4;
 var MAX_ITERATIONS = 40;
-var REVIEW_TOOLS = [
+var REVIEW_TOOL_DEFS = [
   {
     name: "get_file_patch",
     description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
@@ -316,160 +776,55 @@ function buildFileList(files) {
   return files.map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`).join("\n");
 }
 async function runReviewLoop(opts) {
-  const { anthropic, model, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
+  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
   const logger = opts.logger ?? createLogger("", "ferry:review-loop");
   const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
   const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
-  const tools = REVIEW_TOOLS.map(
-    (t, i) => i === REVIEW_TOOLS.length - 1 ? { ...t, cache_control: { type: "ephemeral" } } : t
-  );
-  const messages = [
-    {
-      role: "user",
-      content: [{ type: "text", text: initialPrompt, cache_control: { type: "ephemeral" } }]
-    }
-  ];
-  let inputTokens = 0;
-  let outputTokens = 0;
-  let result = null;
-  const toolCounts = {};
-  const toolCallRecords = [];
-  function trackTool(name, outputSize) {
-    toolCounts[name] = (toolCounts[name] ?? 0) + 1;
-    toolCallRecords.push({ name, outputSize });
-  }
-  const loopStart = Date.now();
-  for (let iter = 0; iter < maxIterations; iter++) {
-    const iterStart = Date.now();
-    const response = await anthropic.messages.create({
-      model,
-      max_tokens: maxTokens,
-      system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
-      tools,
-      messages
-    });
-    inputTokens += response.usage.input_tokens;
-    outputTokens += response.usage.output_tokens;
-    messages.push({ role: "assistant", content: response.content });
-    const toolCount = response.content.filter((b) => b.type === "tool_use").length;
-    logger.info("turn", {
-      iter: iter + 1,
-      stop: response.stop_reason,
-      tools: toolCount,
-      in: response.usage.input_tokens,
-      out: response.usage.output_tokens
-    });
-    emitDebug(
-      {
-        type: "turn",
-        iter: iter + 1,
-        depth: 0,
-        stop_reason: response.stop_reason ?? "unknown",
-        tools: toolCount,
-        mcp_tools: 0,
-        in: response.usage.input_tokens,
-        cache_w: 0,
-        cache_r: 0,
-        out: response.usage.output_tokens,
-        elapsed_ms: Date.now() - iterStart
-      },
-      logger
-    );
-    if (response.stop_reason !== "tool_use") {
-      throw new FerryError("state-invariant", {
-        reason: "reviewer-stopped-without-finish",
-        stop_reason: response.stop_reason
-      });
-    }
-    const toolResults = [];
-    for (const block of response.content) {
-      if (block.type !== "tool_use") continue;
-      const input = block.input;
-      if (block.name === "finish_review") {
-        result = {
-          approved: input.approved,
-          comment: input.comment
-        };
-        toolResults.push({ type: "tool_result", tool_use_id: block.id, content: "ok" });
-        continue;
-      }
-      if (block.name === "get_file_patch") {
+  const {
+    done: result,
+    usage,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  } = await loop.run({
+    system,
+    initialPrompt,
+    tools: REVIEW_TOOL_DEFS,
+    finishTool: "finish_review",
+    extractDone: (input) => ({
+      approved: input.approved,
+      comment: input.comment
+    }),
+    handlers: {
+      get_file_patch: (input) => {
         const filename = input.filename;
-        logger.info("tool", { iter: iter + 1, tool: "get_file_patch", file: filename });
+        logger.info("tool", { tool: "get_file_patch", file: filename });
         const patch = fileMap.get(filename);
-        let content;
-        if (patch === void 0) {
-          content = `(file not found in PR: ${filename})`;
-        } else if (!patch) {
-          content = "(no patch \u2014 binary, empty, or content unchanged)";
-        } else {
-          const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
-          content = patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
-        }
-        trackTool("get_file_patch", content.length);
-        toolResults.push({ type: "tool_result", tool_use_id: block.id, content });
-        continue;
-      }
-      if (block.name === "get_file_content") {
+        if (patch === void 0) return `(file not found in PR: ${filename})`;
+        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
+        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
+        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
+      },
+      get_file_content: async (input) => {
         const filename = input.filename;
-        logger.info("tool", { iter: iter + 1, tool: "get_file_content", file: filename });
+        logger.info("tool", { tool: "get_file_content", file: filename });
         const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
         const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
-        const content = rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
-        trackTool("get_file_content", content.length);
-        toolResults.push({ type: "tool_result", tool_use_id: block.id, content });
-        continue;
+        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
       }
-      toolResults.push({
-        type: "tool_result",
-        tool_use_id: block.id,
-        content: `unknown tool: ${block.name}`,
-        is_error: true
-      });
-    }
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const msg = messages[i];
-      if (msg.role === "user" && Array.isArray(msg.content)) {
-        const content = msg.content;
-        if (content.some((b) => b.type === "tool_result")) {
-          const entry = { ...content[content.length - 1] };
-          delete entry.cache_control;
-          content[content.length - 1] = entry;
-          break;
-        }
-      }
-    }
-    if (toolResults.length > 0) {
-      const last = toolResults[toolResults.length - 1];
-      toolResults[toolResults.length - 1] = { ...last, cache_control: { type: "ephemeral" } };
-    }
-    messages.push({ role: "user", content: toolResults });
-    if (result) {
-      emitDebug(
-        {
-          type: "result",
-          subtype: "success",
-          iterations: iter + 1,
-          total_in: inputTokens,
-          total_out: outputTokens,
-          elapsed_ms: Date.now() - loopStart
-        },
-        logger
-      );
-      return {
-        result,
-        inputTokens,
-        outputTokens,
-        iterations: iter + 1,
-        toolCounts,
-        toolCallRecords
-      };
-    }
-  }
-  throw new FerryError("state-invariant", {
-    reason: "review-iteration-cap-exceeded",
-    cap: MAX_ITERATIONS
+    },
+    maxIterations,
+    maxTokens,
+    logger
   });
+  return {
+    result,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  };
 }
 
 // src/lib/labels/capabilities.ts
@@ -518,7 +873,7 @@ function resolveCapabilities(ticketLabels, configLabels, logger) {
 }
 
 // src/lib/agent-runtime/env.ts
-function requireEnv(key) {
+function requireEnv2(key) {
   const val = process.env[key];
   if (!val) throw new FerryError("state-invariant", { reason: "missing-env", key });
   return val;
@@ -556,7 +911,7 @@ async function runAgent(role, handler2) {
   const component = COMPONENT[role];
   const bootstrapLogger = createLogger("", component);
   try {
-    const rawPayload = requireEnv("FERRY_ENVELOPE_PAYLOAD");
+    const rawPayload = requireEnv2("FERRY_ENVELOPE_PAYLOAD");
     const envelope = validateEnvelope(JSON.parse(rawPayload));
     const logger = createLogger(envelope.event_id, component);
     await handler2(envelope, logger);
@@ -5498,8 +5853,8 @@ function createTrackerFromEnv() {
 
 // src/lib/agent-runtime/context.ts
 function createGitHubContext(repoRoot) {
-  const githubToken = requireEnv("GITHUB_TOKEN");
-  const githubRepo = requireEnv("GITHUB_REPO");
+  const githubToken = requireEnv2("GITHUB_TOKEN");
+  const githubRepo = requireEnv2("GITHUB_REPO");
   const [owner, repo] = githubRepo.split("/");
   if (!owner || !repo) {
     throw new FerryError("state-invariant", { reason: "invalid-github-repo", githubRepo });
@@ -5533,19 +5888,11 @@ async function main(envelope, logger) {
   const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
   const { provider, model } = ferryCfg.models.review;
-  if (provider !== "anthropic") {
-    throw new FerryError("state-invariant", {
-      reason: "unsupported-provider",
-      provider,
-      phase: "reviewer",
-      detail: "The reviewer phase requires provider 'anthropic'. OpenAI and Google support for agentic phases is planned for a future release."
-    });
-  }
   const reviewerWorkflow = ferryCfg.workflow.agents.reviewer;
   const shouldTransitionChanges = reviewerWorkflow.auto_transition_changes !== null;
   const shouldTransitionApprove = reviewerWorkflow.auto_transition_approve !== null;
-  const iterTransitionId = shouldTransitionChanges ? requireEnv("FERRY_ITER_TRANSITION_ID") : "";
-  const approveTransitionId = shouldTransitionApprove ? requireEnv("FERRY_APPROVE_TRANSITION_ID") : "";
+  const iterTransitionId = shouldTransitionChanges ? requireEnv2("FERRY_ITER_TRANSITION_ID") : "";
+  const approveTransitionId = shouldTransitionApprove ? requireEnv2("FERRY_APPROVE_TRANSITION_ID") : "";
   const issue = await tracker.getIssue(ticketKey);
   const existingComments = issue.comments;
   const capabilities = resolveCapabilities(issue.labels, ferryCfg.labels, logger);
@@ -5636,7 +5983,7 @@ async function main(envelope, logger) {
     extraParts: [loadOptionalPrompt("review-comment", REPO_ROOT)],
     separator: "\n\n---\n\n"
   });
-  const anthropic = new Anthropic(resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" }));
+  const loop = createToolCallLoop({ provider, model });
   const {
     result: review,
     inputTokens,
@@ -5645,8 +5992,7 @@ async function main(envelope, logger) {
     toolCounts: reviewToolCounts,
     toolCallRecords: reviewToolCallRecords
   } = await runReviewLoop({
-    anthropic,
-    model,
+    loop,
     system,
     initialPrompt,
     fileMap,

--- a/examples/consumer-setup/workflows/ferry-review.yml
+++ b/examples/consumer-setup/workflows/ferry-review.yml
@@ -1,10 +1,13 @@
 # Copy this file to .github/workflows/ferry-review.yml in your repository.
 # Replace @v0.8.0 with the Ferry release tag you want to pin.
 # Required secrets: FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN,
-#                   ANTHROPIC_API_KEY, FERRY_ITER_TRANSITION_ID
+#                   FERRY_ITER_TRANSITION_ID
+#                   ANTHROPIC_API_KEY    — required when FERRY_REVIEW_PROVIDER=anthropic (default)
+#                   OPENAI_API_KEY       — required when FERRY_REVIEW_PROVIDER=openai
+#                   GOOGLE_API_KEY       — required when FERRY_REVIEW_PROVIDER=google
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_REVIEW_MODEL (default: claude-sonnet-4-6)
-#                     FERRY_REVIEW_PROVIDER (default: anthropic)
+#                     FERRY_REVIEW_PROVIDER (default: anthropic; also: openai, google)
 #                     FERRY_REVIEWER_MAX_ITERATIONS (default: 40)
 #                     FERRY_REVIEWER_MAX_TOKENS (default: 16384)
 #                     FERRY_MAX_COST_EUR_PER_RUN (default: 10)
@@ -13,6 +16,8 @@
 # Action inputs:      pre_agent_command (optional) — shell command to run before the agent (e.g. npm ci)
 #                     pre_agent_timeout_minutes (optional, default: 3)
 #                     post_agent_command (optional) — shell command to run after the agent (always runs)
+#
+# Note: MCP server support is not available for non-Anthropic providers in the Reviewer agent.
 
 name: Ferry — Review
 
@@ -73,6 +78,8 @@ jobs:
           jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
           ferry_iter_transition_id: ${{ secrets.FERRY_ITER_TRANSITION_ID }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          google_api_key: ${{ secrets.GOOGLE_API_KEY }}
           github_token: ${{ github.token }}
           github_repo: ${{ github.repository }}
           ferry_review_model: ${{ vars.FERRY_REVIEW_MODEL || 'claude-sonnet-4-6' }}

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -1,11 +1,9 @@
-import Anthropic from '@anthropic-ai/sdk';
-import { resolveAnthropicAuth } from '../../lib/llm/anthropic-auth.js';
+import { createToolCallLoop } from '../../lib/llm/tool-loop/index.js';
 import { delimitUntrusted } from '../../lib/llm/delimit-untrusted.js';
 import { checkIdempotencyMarker } from '../../lib/io/idempotency.js';
 import { gateCi } from './ci-gate.js';
 import { detectMergeConflicts, buildFileList, runReviewLoop } from './review-loop.js';
 import { resolveCapabilities } from '../../lib/labels/capabilities.js';
-import { FerryError } from '../../lib/errors/index.js';
 import {
   requireEnv,
   appendOutput,
@@ -35,15 +33,6 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
   const { provider, model } = ferryCfg.models.review;
-  if (provider !== 'anthropic') {
-    throw new FerryError('state-invariant', {
-      reason: 'unsupported-provider',
-      provider,
-      phase: 'reviewer',
-      detail:
-        "The reviewer phase requires provider 'anthropic'. OpenAI and Google support for agentic phases is planned for a future release.",
-    });
-  }
   const reviewerWorkflow = ferryCfg.workflow.agents.reviewer;
   const shouldTransitionChanges = reviewerWorkflow.auto_transition_changes !== null;
   const shouldTransitionApprove = reviewerWorkflow.auto_transition_approve !== null;
@@ -169,7 +158,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
     extraParts: [loadOptionalPrompt('review-comment', REPO_ROOT)],
     separator: '\n\n---\n\n',
   });
-  const anthropic = new Anthropic(resolveAnthropicAuth({ apiKeyEnv: 'ANTHROPIC_API_KEY' }));
+  const loop = createToolCallLoop({ provider, model });
 
   const {
     result: review,
@@ -179,8 +168,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
     toolCounts: reviewToolCounts,
     toolCallRecords: reviewToolCallRecords,
   } = await runReviewLoop({
-    anthropic,
-    model,
+    loop,
     system,
     initialPrompt,
     fileMap,

--- a/src/agents/reviewer/review-loop.test.ts
+++ b/src/agents/reviewer/review-loop.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import Anthropic from '@anthropic-ai/sdk';
 import {
   runReviewLoop,
   detectMergeConflicts,
@@ -7,47 +6,60 @@ import {
   MAX_PATCH_CHARS,
 } from './review-loop.js';
 import type { PrFile } from './review-loop.js';
-import { createTestLogger } from '../../lib/logger/index.js';
 import type { CIRunner } from '../../lib/dispatch/runner/types.js';
-import { FerryError } from '../../lib/errors/index.js';
+import type {
+  ToolCallLoop,
+  ToolLoopRunOpts,
+  ToolLoopResult,
+} from '../../lib/llm/tool-loop/index.js';
 
-type FakeMessage = {
-  stop_reason: string;
-  content: Array<{ type: string; id?: string; name?: string; input?: unknown; text?: string }>;
-  usage: { input_tokens: number; output_tokens: number };
-};
-
-function makeAnthropicMock(responses: FakeMessage[]) {
-  let idx = 0;
-  const create = vi.fn().mockImplementation(async () => {
-    const r = responses[idx++];
-    return {
-      stop_reason: r.stop_reason,
-      content: r.content,
-      usage: r.usage,
-    };
-  });
+/** Creates a mock ToolCallLoop that invokes handlers to simulate an LLM run. */
+function makeMockLoop(
+  scenario: (
+    opts: ToolLoopRunOpts<unknown>,
+  ) => Promise<ToolLoopResult<unknown>> | ToolLoopResult<unknown>,
+): ToolCallLoop {
   return {
-    messages: { create },
-    create,
+    run: vi.fn().mockImplementation(scenario),
   };
 }
 
-const finishReviewResponse: FakeMessage = {
-  stop_reason: 'tool_use',
-  content: [
-    {
-      type: 'tool_use',
-      id: 'tu_finish',
-      name: 'finish_review',
-      input: { approved: true, comment: 'LGTM' },
-    },
-  ],
-  usage: { input_tokens: 100, output_tokens: 50 },
-};
+/** Simulates a single-turn finish_review call. */
+function makeFinishLoop(approved: boolean, comment: string): ToolCallLoop {
+  return makeMockLoop(async (opts) => {
+    const done = opts.extractDone({ approved, comment });
+    return {
+      done,
+      usage: { inputTokens: 100, outputTokens: 50 },
+      iterations: 1,
+      toolCounts: {},
+      toolCallRecords: [],
+    };
+  });
+}
+
+/** Simulates: call handler once → finish_review. */
+function makeToolThenFinishLoop(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  approved: boolean,
+  comment: string,
+): ToolCallLoop {
+  return makeMockLoop(async (opts) => {
+    const handler = opts.handlers[toolName];
+    if (handler) await handler(toolInput);
+    const done = opts.extractDone({ approved, comment });
+    return {
+      done,
+      usage: { inputTokens: 200, outputTokens: 80 },
+      iterations: 2,
+      toolCounts: { [toolName]: 1 },
+      toolCallRecords: [{ name: toolName, outputSize: 10 }],
+    };
+  });
+}
 
 const baseOpts = {
-  model: 'm',
   system: 'sys',
   initialPrompt: 'review this',
   fileMap: new Map<string, string | undefined>(),
@@ -64,436 +76,127 @@ describe('runReviewLoop', () => {
   });
 
   it('completes when finish_review is called', async () => {
-    const mock = makeAnthropicMock([finishReviewResponse]);
-    const result = await runReviewLoop({
-      ...baseOpts,
-      anthropic: mock as unknown as Anthropic,
-    });
+    const loop = makeFinishLoop(true, 'LGTM');
+    const result = await runReviewLoop({ ...baseOpts, loop });
     expect(result.result.approved).toBe(true);
     expect(result.result.comment).toBe('LGTM');
     expect(result.inputTokens).toBe(100);
     expect(result.outputTokens).toBe(50);
   });
 
-  it('throws FerryError on unexpected stop_reason', async () => {
-    const mock = makeAnthropicMock([
-      {
-        stop_reason: 'end_turn',
-        content: [{ type: 'text', text: 'done' }],
-        usage: { input_tokens: 10, output_tokens: 5 },
-      },
-    ]);
-    await expect(
-      runReviewLoop({ ...baseOpts, anthropic: mock as unknown as Anthropic }),
-    ).rejects.toThrow(FerryError);
+  it('returns correct iteration count', async () => {
+    const loop = makeFinishLoop(false, 'needs work');
+    const result = await runReviewLoop({ ...baseOpts, loop });
+    expect(result.iterations).toBe(1);
   });
 
-  it('emits debug "turn" record when LOG_VERBOSITY=debug', async () => {
-    vi.stubEnv('LOG_VERBOSITY', 'debug');
-    const { logger, records } = createTestLogger('evt-review', 'ferry:review-loop');
-    const mock = makeAnthropicMock([finishReviewResponse]);
-
-    await runReviewLoop({ ...baseOpts, anthropic: mock as unknown as Anthropic, logger });
-
-    const turnRecord = records.find((r) => r.level === 'debug' && r.message === 'turn');
-    expect(turnRecord).toBeDefined();
-    expect(turnRecord).toMatchObject({
-      type: 'turn',
-      iter: 1,
-      depth: 0,
-      stop_reason: 'tool_use',
-    });
-    expect(typeof turnRecord?.['elapsed_ms']).toBe('number');
-  });
-
-  it('emits debug "result" record on success when LOG_VERBOSITY=debug', async () => {
-    vi.stubEnv('LOG_VERBOSITY', 'debug');
-    const { logger, records } = createTestLogger('evt-review', 'ferry:review-loop');
-    const mock = makeAnthropicMock([finishReviewResponse]);
-
-    await runReviewLoop({ ...baseOpts, anthropic: mock as unknown as Anthropic, logger });
-
-    const resultRecord = records.find((r) => r.level === 'debug' && r.message === 'result');
-    expect(resultRecord).toBeDefined();
-    expect(resultRecord).toMatchObject({
-      type: 'result',
-      subtype: 'success',
-      iterations: 1,
-    });
-    expect(typeof resultRecord?.['elapsed_ms']).toBe('number');
-  });
-
-  it('does not emit debug records when LOG_VERBOSITY is unset', async () => {
-    vi.stubEnv('LOG_VERBOSITY', '');
-    const { logger, records } = createTestLogger('evt-review', 'ferry:review-loop');
-    const mock = makeAnthropicMock([finishReviewResponse]);
-
-    await runReviewLoop({ ...baseOpts, anthropic: mock as unknown as Anthropic, logger });
-
-    expect(records.filter((r) => r.level === 'debug')).toHaveLength(0);
-  });
-
-  it('emits structured "turn" info records per iteration', async () => {
-    const { logger, records } = createTestLogger('evt-review', 'ferry:review-loop');
-    const mock = makeAnthropicMock([finishReviewResponse]);
-
-    await runReviewLoop({ ...baseOpts, anthropic: mock as unknown as Anthropic, logger });
-
-    const turnInfoRecords = records.filter((r) => r.level === 'info' && r.message === 'turn');
-    expect(turnInfoRecords.length).toBeGreaterThanOrEqual(1);
-    expect(turnInfoRecords[0]).toMatchObject({
-      level: 'info',
-      correlation_id: 'evt-review',
-      iter: 1,
-    });
-  });
-
-  it('handles get_file_patch for a file in the fileMap', async () => {
+  it('passes get_file_patch handler that returns patch from fileMap', async () => {
     const fileMap = new Map<string, string | undefined>([
       ['src/auth.ts', '+export function login() {}'],
     ]);
-    const mock = makeAnthropicMock([
-      {
-        stop_reason: 'tool_use',
-        content: [
-          {
-            type: 'tool_use',
-            id: 'tu_gfp',
-            name: 'get_file_patch',
-            input: { filename: 'src/auth.ts' },
-          },
-        ],
-        usage: { input_tokens: 20, output_tokens: 10 },
-      },
-      finishReviewResponse,
-    ]);
+    let capturedContent: string | undefined;
 
-    const result = await runReviewLoop({
-      ...baseOpts,
-      fileMap,
-      anthropic: mock as unknown as Anthropic,
+    const loop = makeMockLoop(async (opts) => {
+      const handler = opts.handlers['get_file_patch'];
+      capturedContent = await handler!({ filename: 'src/auth.ts' });
+      const done = opts.extractDone({ approved: true, comment: 'ok' });
+      return {
+        done,
+        usage: { inputTokens: 20, outputTokens: 10 },
+        iterations: 2,
+        toolCounts: {},
+        toolCallRecords: [],
+      };
     });
 
-    expect(result.result.approved).toBe(true);
-    expect(mock.create).toHaveBeenCalledTimes(2);
+    await runReviewLoop({ ...baseOpts, fileMap, loop });
+    expect(capturedContent).toBe('+export function login() {}');
   });
 
-  it('returns not-found message for get_file_patch when file is absent from fileMap', async () => {
-    const fileMap = new Map<string, string | undefined>();
-    let capturedToolContent: string | undefined;
-
-    const captureCreate = vi
-      .fn()
-      .mockImplementation(
-        async (params: { messages: Array<{ role: string; content: unknown }> }) => {
-          if (params.messages.length >= 3) {
-            const lastMsg = params.messages[params.messages.length - 1];
-            if (Array.isArray(lastMsg.content)) {
-              const toolResult = (lastMsg.content as Array<{ content?: string }>)[0];
-              capturedToolContent = toolResult?.content;
-            }
-          }
-          if (params.messages.length <= 2) {
-            return {
-              stop_reason: 'tool_use',
-              content: [
-                {
-                  type: 'tool_use',
-                  id: 'tu_gfp',
-                  name: 'get_file_patch',
-                  input: { filename: 'missing.ts' },
-                },
-              ],
-              usage: { input_tokens: 10, output_tokens: 5 },
-            };
-          }
-          return {
-            stop_reason: 'tool_use',
-            content: [
-              {
-                type: 'tool_use',
-                id: 'tu_finish',
-                name: 'finish_review',
-                input: { approved: false, comment: 'cannot find file' },
-              },
-            ],
-            usage: { input_tokens: 10, output_tokens: 5 },
-          };
-        },
-      );
-
-    await runReviewLoop({
-      ...baseOpts,
-      fileMap,
-      anthropic: { messages: { create: captureCreate } } as unknown as Anthropic,
+  it('get_file_patch returns not-found message for missing file', async () => {
+    let capturedContent: string | undefined;
+    const loop = makeMockLoop(async (opts) => {
+      capturedContent = await opts.handlers['get_file_patch']!({ filename: 'missing.ts' });
+      const done = opts.extractDone({ approved: false, comment: 'cannot find file' });
+      return {
+        done,
+        usage: { inputTokens: 10, outputTokens: 5 },
+        iterations: 2,
+        toolCounts: {},
+        toolCallRecords: [],
+      };
     });
 
-    expect(capturedToolContent).toContain('(file not found in PR: missing.ts)');
+    await runReviewLoop({ ...baseOpts, loop });
+    expect(capturedContent).toContain('(file not found in PR: missing.ts)');
   });
 
-  it('returns no-patch message for get_file_patch when patch is empty string', async () => {
+  it('get_file_patch returns no-patch message for empty string', async () => {
     const fileMap = new Map<string, string | undefined>([['binary.png', '']]);
-    let capturedToolContent: string | undefined;
-
-    const captureCreate = vi
-      .fn()
-      .mockImplementation(
-        async (params: { messages: Array<{ role: string; content: unknown }> }) => {
-          if (params.messages.length >= 3) {
-            const lastMsg = params.messages[params.messages.length - 1];
-            if (Array.isArray(lastMsg.content)) {
-              const toolResult = (lastMsg.content as Array<{ content?: string }>)[0];
-              capturedToolContent = toolResult?.content;
-            }
-          }
-          if (params.messages.length <= 2) {
-            return {
-              stop_reason: 'tool_use',
-              content: [
-                {
-                  type: 'tool_use',
-                  id: 'tu_gfp',
-                  name: 'get_file_patch',
-                  input: { filename: 'binary.png' },
-                },
-              ],
-              usage: { input_tokens: 10, output_tokens: 5 },
-            };
-          }
-          return {
-            stop_reason: 'tool_use',
-            content: [
-              {
-                type: 'tool_use',
-                id: 'tu_finish',
-                name: 'finish_review',
-                input: { approved: true, comment: 'ok' },
-              },
-            ],
-            usage: { input_tokens: 10, output_tokens: 5 },
-          };
-        },
-      );
-
-    await runReviewLoop({
-      ...baseOpts,
-      fileMap,
-      anthropic: { messages: { create: captureCreate } } as unknown as Anthropic,
+    let capturedContent: string | undefined;
+    const loop = makeMockLoop(async (opts) => {
+      capturedContent = await opts.handlers['get_file_patch']!({ filename: 'binary.png' });
+      const done = opts.extractDone({ approved: true, comment: 'ok' });
+      return {
+        done,
+        usage: { inputTokens: 10, outputTokens: 5 },
+        iterations: 2,
+        toolCounts: {},
+        toolCallRecords: [],
+      };
     });
 
-    expect(capturedToolContent).toBe('(no patch — binary, empty, or content unchanged)');
+    await runReviewLoop({ ...baseOpts, fileMap, loop });
+    expect(capturedContent).toBe('(no patch — binary, empty, or content unchanged)');
   });
 
-  it('truncates get_file_patch content when patch exceeds MAX_PATCH_CHARS', async () => {
+  it('truncates patch when it exceeds MAX_PATCH_CHARS', async () => {
     const longPatch = '+' + 'x'.repeat(MAX_PATCH_CHARS + 100);
     const fileMap = new Map<string, string | undefined>([['big.ts', longPatch]]);
-    let capturedToolContent: string | undefined;
-
-    const captureCreate = vi
-      .fn()
-      .mockImplementation(
-        async (params: { messages: Array<{ role: string; content: unknown }> }) => {
-          if (params.messages.length >= 3) {
-            const lastMsg = params.messages[params.messages.length - 1];
-            if (Array.isArray(lastMsg.content)) {
-              const toolResult = (lastMsg.content as Array<{ content?: string }>)[0];
-              capturedToolContent = toolResult?.content;
-            }
-          }
-          if (params.messages.length <= 2) {
-            return {
-              stop_reason: 'tool_use',
-              content: [
-                {
-                  type: 'tool_use',
-                  id: 'tu_gfp',
-                  name: 'get_file_patch',
-                  input: { filename: 'big.ts' },
-                },
-              ],
-              usage: { input_tokens: 10, output_tokens: 5 },
-            };
-          }
-          return {
-            stop_reason: 'tool_use',
-            content: [
-              {
-                type: 'tool_use',
-                id: 'tu_finish',
-                name: 'finish_review',
-                input: { approved: true, comment: 'truncated' },
-              },
-            ],
-            usage: { input_tokens: 10, output_tokens: 5 },
-          };
-        },
-      );
-
-    await runReviewLoop({
-      ...baseOpts,
-      fileMap,
-      anthropic: { messages: { create: captureCreate } } as unknown as Anthropic,
+    let capturedContent: string | undefined;
+    const loop = makeMockLoop(async (opts) => {
+      capturedContent = await opts.handlers['get_file_patch']!({ filename: 'big.ts' });
+      const done = opts.extractDone({ approved: true, comment: 'truncated' });
+      return {
+        done,
+        usage: { inputTokens: 10, outputTokens: 5 },
+        iterations: 2,
+        toolCounts: {},
+        toolCallRecords: [],
+      };
     });
 
-    expect(capturedToolContent).toContain('... (truncated)');
-    expect(capturedToolContent!.length).toBeLessThan(longPatch.length);
+    await runReviewLoop({ ...baseOpts, fileMap, loop });
+    expect(capturedContent).toContain('... (truncated)');
+    expect(capturedContent!.length).toBeLessThan(longPatch.length);
   });
 
-  it('handles get_file_content by calling runner.getFileContent', async () => {
+  it('get_file_content calls runner.getFileContent', async () => {
     const getFileContent = vi.fn().mockResolvedValue('function foo() { return 42; }');
     const runner = { getFileContent } as unknown as CIRunner;
-
-    const mock = makeAnthropicMock([
-      {
-        stop_reason: 'tool_use',
-        content: [
-          {
-            type: 'tool_use',
-            id: 'tu_gfc',
-            name: 'get_file_content',
-            input: { filename: 'src/foo.ts' },
-          },
-        ],
-        usage: { input_tokens: 15, output_tokens: 8 },
-      },
-      finishReviewResponse,
-    ]);
-
-    const result = await runReviewLoop({
-      ...baseOpts,
-      runner,
-      anthropic: mock as unknown as Anthropic,
+    let capturedContent: string | undefined;
+    const loop = makeMockLoop(async (opts) => {
+      capturedContent = await opts.handlers['get_file_content']!({ filename: 'src/foo.ts' });
+      const done = opts.extractDone({ approved: true, comment: 'ok' });
+      return {
+        done,
+        usage: { inputTokens: 15, outputTokens: 8 },
+        iterations: 2,
+        toolCounts: {},
+        toolCallRecords: [],
+      };
     });
 
-    expect(result.result.approved).toBe(true);
-    expect(getFileContent).toHaveBeenCalledWith(
-      baseOpts.owner,
-      baseOpts.repo,
-      'src/foo.ts',
-      baseOpts.headSha,
-    );
+    await runReviewLoop({ ...baseOpts, runner, loop });
+    expect(capturedContent).toBe('function foo() { return 42; }');
+    expect(getFileContent).toHaveBeenCalledWith('org', 'repo', 'src/foo.ts', 'abc123');
   });
 
-  it('returns is_error tool result for unknown tool names', async () => {
-    let capturedToolResult: Array<{ is_error?: boolean; content?: string }> | undefined;
-
-    const captureCreate = vi
-      .fn()
-      .mockImplementation(
-        async (params: { messages: Array<{ role: string; content: unknown }> }) => {
-          if (params.messages.length >= 3) {
-            const lastMsg = params.messages[params.messages.length - 1];
-            if (Array.isArray(lastMsg.content)) {
-              capturedToolResult = lastMsg.content as Array<{
-                is_error?: boolean;
-                content?: string;
-              }>;
-            }
-          }
-          if (params.messages.length <= 2) {
-            return {
-              stop_reason: 'tool_use',
-              content: [
-                {
-                  type: 'tool_use',
-                  id: 'tu_bad',
-                  name: 'totally_unknown_tool',
-                  input: {},
-                },
-              ],
-              usage: { input_tokens: 10, output_tokens: 5 },
-            };
-          }
-          return {
-            stop_reason: 'tool_use',
-            content: [
-              {
-                type: 'tool_use',
-                id: 'tu_finish',
-                name: 'finish_review',
-                input: { approved: true, comment: 'done' },
-              },
-            ],
-            usage: { input_tokens: 10, output_tokens: 5 },
-          };
-        },
-      );
-
-    await runReviewLoop({
-      ...baseOpts,
-      anthropic: { messages: { create: captureCreate } } as unknown as Anthropic,
-    });
-
-    expect(capturedToolResult).toBeDefined();
-    expect(capturedToolResult).toContainEqual(
-      expect.objectContaining({
-        is_error: true,
-        content: expect.stringContaining('unknown tool: totally_unknown_tool'),
-      }),
-    );
-  });
-
-  it('throws FerryError when maxIterations is reached without finish_review', async () => {
-    const create = vi.fn().mockResolvedValue({
-      stop_reason: 'tool_use',
-      content: [
-        {
-          type: 'tool_use',
-          id: 'tu_gfp',
-          name: 'get_file_patch',
-          input: { filename: 'x.ts' },
-        },
-      ],
-      usage: { input_tokens: 5, output_tokens: 3 },
-    });
-
-    await expect(
-      runReviewLoop({
-        ...baseOpts,
-        anthropic: { messages: { create } } as unknown as Anthropic,
-        maxIterations: 1,
-      }),
-    ).rejects.toMatchObject({ code: 'state-invariant' });
-  });
-
-  it('accumulates token counts across multiple iterations', async () => {
-    const mock = makeAnthropicMock([
-      {
-        stop_reason: 'tool_use',
-        content: [
-          {
-            type: 'tool_use',
-            id: 'tu_gfp',
-            name: 'get_file_patch',
-            input: { filename: 'src/a.ts' },
-          },
-        ],
-        usage: { input_tokens: 100, output_tokens: 40 },
-      },
-      {
-        stop_reason: 'tool_use',
-        content: [
-          {
-            type: 'tool_use',
-            id: 'tu_finish',
-            name: 'finish_review',
-            input: { approved: false, comment: 'needs work' },
-          },
-        ],
-        usage: { input_tokens: 200, output_tokens: 60 },
-      },
-    ]);
-
-    const fileMap = new Map<string, string | undefined>([['src/a.ts', '+code']]);
-    const result = await runReviewLoop({
-      ...baseOpts,
-      fileMap,
-      anthropic: mock as unknown as Anthropic,
-    });
-
-    expect(result.inputTokens).toBe(300);
-    expect(result.outputTokens).toBe(100);
-    expect(result.result.approved).toBe(false);
+  it('passes through toolCounts and toolCallRecords from the loop', async () => {
+    const loop = makeToolThenFinishLoop('get_file_patch', { filename: 'x.ts' }, true, 'ok');
+    const result = await runReviewLoop({ ...baseOpts, loop });
+    expect(result.toolCounts).toEqual({ get_file_patch: 1 });
+    expect(result.toolCallRecords).toEqual([{ name: 'get_file_patch', outputSize: 10 }]);
   });
 });
 

--- a/src/agents/reviewer/review-loop.ts
+++ b/src/agents/reviewer/review-loop.ts
@@ -1,15 +1,8 @@
-import Anthropic from '@anthropic-ai/sdk';
-import type {
-  MessageParam,
-  ToolResultBlockParam,
-  ContentBlock,
-} from '@anthropic-ai/sdk/resources/messages.js';
 import type { CIRunner, PRFile } from '../../lib/dispatch/runner/types.js';
-import { FerryError } from '../../lib/errors/index.js';
-import { emitDebug } from '../../lib/llm/debug-log.js';
 import { createLogger } from '../../lib/logger/index.js';
 import type { Logger } from '../../lib/logger/index.js';
 import type { CiStatus } from './ci-gate.js';
+import type { ToolCallLoop, ToolDef } from '../../lib/llm/tool-loop/index.js';
 
 export const MAX_PATCH_CHARS = 20_000;
 export const MAX_CONTENT_CHARS = 40_000;
@@ -17,7 +10,7 @@ const MAX_ITERATIONS = 40;
 
 export type { CiStatus, PRFile as PrFile };
 
-export const REVIEW_TOOLS: Anthropic.Tool[] = [
+export const REVIEW_TOOL_DEFS: ToolDef[] = [
   {
     name: 'get_file_patch',
     description:
@@ -88,8 +81,7 @@ export function buildFileList(files: PRFile[]): string {
 }
 
 export async function runReviewLoop(opts: {
-  anthropic: Anthropic;
-  model: string;
+  loop: ToolCallLoop;
   system: string;
   initialPrompt: string;
   fileMap: Map<string, string | undefined>;
@@ -108,7 +100,7 @@ export async function runReviewLoop(opts: {
   toolCounts: Record<string, number>;
   toolCallRecords: Array<{ name: string; outputSize: number }>;
 }> {
-  const { anthropic, model, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
+  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
   const logger = opts.logger ?? createLogger('', 'ferry:review-loop');
   const maxIterations =
     opts.maxIterations ??
@@ -116,179 +108,54 @@ export async function runReviewLoop(opts: {
   const maxTokens =
     opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? '', 10) || 16384);
 
-  const tools = REVIEW_TOOLS.map((t, i) =>
-    i === REVIEW_TOOLS.length - 1 ? { ...t, cache_control: { type: 'ephemeral' as const } } : t,
-  );
-
-  const messages: MessageParam[] = [
-    {
-      role: 'user',
-      content: [{ type: 'text', text: initialPrompt, cache_control: { type: 'ephemeral' } }],
-    },
-  ];
-
-  let inputTokens = 0;
-  let outputTokens = 0;
-  let result: ReviewResult | null = null;
-  const toolCounts: Record<string, number> = {};
-  const toolCallRecords: Array<{ name: string; outputSize: number }> = [];
-  function trackTool(name: string, outputSize: number): void {
-    toolCounts[name] = (toolCounts[name] ?? 0) + 1;
-    toolCallRecords.push({ name, outputSize });
-  }
-  const loopStart = Date.now();
-
-  for (let iter = 0; iter < maxIterations; iter++) {
-    const iterStart = Date.now();
-    const response = await anthropic.messages.create({
-      model,
-      max_tokens: maxTokens,
-      system: [{ type: 'text', text: system, cache_control: { type: 'ephemeral' } }],
-      tools,
-      messages,
-    });
-
-    inputTokens += response.usage.input_tokens;
-    outputTokens += response.usage.output_tokens;
-    messages.push({ role: 'assistant', content: response.content as ContentBlock[] });
-
-    const toolCount = response.content.filter((b) => b.type === 'tool_use').length;
-    logger.info('turn', {
-      iter: iter + 1,
-      stop: response.stop_reason,
-      tools: toolCount,
-      in: response.usage.input_tokens,
-      out: response.usage.output_tokens,
-    });
-    emitDebug(
-      {
-        type: 'turn',
-        iter: iter + 1,
-        depth: 0,
-        stop_reason: response.stop_reason ?? 'unknown',
-        tools: toolCount,
-        mcp_tools: 0,
-        in: response.usage.input_tokens,
-        cache_w: 0,
-        cache_r: 0,
-        out: response.usage.output_tokens,
-        elapsed_ms: Date.now() - iterStart,
-      },
-      logger,
-    );
-
-    if (response.stop_reason !== 'tool_use') {
-      throw new FerryError('state-invariant', {
-        reason: 'reviewer-stopped-without-finish',
-        stop_reason: response.stop_reason,
-      });
-    }
-
-    const toolResults: ToolResultBlockParam[] = [];
-
-    for (const block of response.content) {
-      if (block.type !== 'tool_use') continue;
-      const input = block.input as Record<string, unknown>;
-
-      if (block.name === 'finish_review') {
-        result = {
-          approved: input.approved as boolean,
-          comment: input.comment as string,
-        };
-        toolResults.push({ type: 'tool_result', tool_use_id: block.id, content: 'ok' });
-        continue;
-      }
-
-      if (block.name === 'get_file_patch') {
+  const {
+    done: result,
+    usage,
+    iterations,
+    toolCounts,
+    toolCallRecords,
+  } = await loop.run<ReviewResult>({
+    system,
+    initialPrompt,
+    tools: REVIEW_TOOL_DEFS,
+    finishTool: 'finish_review',
+    extractDone: (input) => ({
+      approved: input.approved as boolean,
+      comment: input.comment as string,
+    }),
+    handlers: {
+      get_file_patch: (input) => {
         const filename = input.filename as string;
-        logger.info('tool', { iter: iter + 1, tool: 'get_file_patch', file: filename });
+        logger.info('tool', { tool: 'get_file_patch', file: filename });
         const patch = fileMap.get(filename);
-        let content: string;
-        if (patch === undefined) {
-          content = `(file not found in PR: ${filename})`;
-        } else if (!patch) {
-          content = '(no patch — binary, empty, or content unchanged)';
-        } else {
-          const patchLimit =
-            parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? '', 10) || MAX_PATCH_CHARS;
-          content =
-            patch.length > patchLimit ? patch.slice(0, patchLimit) + '\n... (truncated)' : patch;
-        }
-        trackTool('get_file_patch', content.length);
-        toolResults.push({ type: 'tool_result', tool_use_id: block.id, content });
-        continue;
-      }
-
-      if (block.name === 'get_file_content') {
+        if (patch === undefined) return `(file not found in PR: ${filename})`;
+        if (!patch) return '(no patch — binary, empty, or content unchanged)';
+        const patchLimit =
+          parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? '', 10) || MAX_PATCH_CHARS;
+        return patch.length > patchLimit ? patch.slice(0, patchLimit) + '\n... (truncated)' : patch;
+      },
+      get_file_content: async (input) => {
         const filename = input.filename as string;
-        logger.info('tool', { iter: iter + 1, tool: 'get_file_content', file: filename });
+        logger.info('tool', { tool: 'get_file_content', file: filename });
         const fileLimit =
           parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? '', 10) || MAX_CONTENT_CHARS;
         const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
-        const content =
-          rawContent.length > fileLimit
-            ? rawContent.slice(0, fileLimit) + '\n... (truncated)'
-            : rawContent;
-        trackTool('get_file_content', content.length);
-        toolResults.push({ type: 'tool_result', tool_use_id: block.id, content });
-        continue;
-      }
-
-      toolResults.push({
-        type: 'tool_result',
-        tool_use_id: block.id,
-        content: `unknown tool: ${block.name}`,
-        is_error: true,
-      });
-    }
-
-    // Roll cache breakpoint forward to the latest tool results
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const msg = messages[i];
-      if (msg.role === 'user' && Array.isArray(msg.content)) {
-        const content = msg.content as ToolResultBlockParam[];
-        if (content.some((b) => b.type === 'tool_result')) {
-          const entry = { ...content[content.length - 1] } as ToolResultBlockParam & {
-            cache_control?: unknown;
-          };
-          delete entry.cache_control;
-          content[content.length - 1] = entry as ToolResultBlockParam;
-          break;
-        }
-      }
-    }
-    if (toolResults.length > 0) {
-      const last = toolResults[toolResults.length - 1];
-      toolResults[toolResults.length - 1] = { ...last, cache_control: { type: 'ephemeral' } };
-    }
-
-    messages.push({ role: 'user', content: toolResults });
-
-    if (result) {
-      emitDebug(
-        {
-          type: 'result',
-          subtype: 'success',
-          iterations: iter + 1,
-          total_in: inputTokens,
-          total_out: outputTokens,
-          elapsed_ms: Date.now() - loopStart,
-        },
-        logger,
-      );
-      return {
-        result,
-        inputTokens,
-        outputTokens,
-        iterations: iter + 1,
-        toolCounts,
-        toolCallRecords,
-      };
-    }
-  }
-
-  throw new FerryError('state-invariant', {
-    reason: 'review-iteration-cap-exceeded',
-    cap: MAX_ITERATIONS,
+        return rawContent.length > fileLimit
+          ? rawContent.slice(0, fileLimit) + '\n... (truncated)'
+          : rawContent;
+      },
+    },
+    maxIterations,
+    maxTokens,
+    logger,
   });
+
+  return {
+    result,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    iterations,
+    toolCounts,
+    toolCallRecords,
+  };
 }

--- a/src/labels/allowlist.ts
+++ b/src/labels/allowlist.ts
@@ -31,4 +31,5 @@ export const LABELS_ALLOWLIST = [
   'ferry:envelope',
   'ferry:dev-loop',
   'ferry:review-loop',
+  'ferry:tool-loop',
 ] as const;

--- a/src/lib/llm/tool-loop/anthropic.test.ts
+++ b/src/lib/llm/tool-loop/anthropic.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import Anthropic from '@anthropic-ai/sdk';
+import { createAnthropicToolCallLoop } from './anthropic.js';
+import { FerryError } from '../../errors/index.js';
+import { createTestLogger } from '../../logger/index.js';
+import type { ToolDef } from './types.js';
+
+const TOOLS: ToolDef[] = [
+  {
+    name: 'echo',
+    description: 'Echoes input',
+    input_schema: { type: 'object', properties: { text: { type: 'string' } }, required: ['text'] },
+  },
+  {
+    name: 'finish',
+    description: 'Finishes the loop',
+    input_schema: {
+      type: 'object',
+      properties: { result: { type: 'string' } },
+      required: ['result'],
+    },
+  },
+];
+
+type FakeResponse = {
+  stop_reason: string;
+  content: Array<{ type: string; id?: string; name?: string; input?: unknown; text?: string }>;
+  usage: { input_tokens: number; output_tokens: number };
+};
+
+function makeClient(responses: FakeResponse[]): Anthropic {
+  let idx = 0;
+  const create = vi.fn().mockImplementation(async () => {
+    const r = responses[idx++];
+    return { stop_reason: r.stop_reason, content: r.content, usage: r.usage };
+  });
+  return { messages: { create } } as unknown as Anthropic;
+}
+
+const baseRunOpts = {
+  system: 'system prompt',
+  initialPrompt: 'do something',
+  tools: TOOLS,
+  handlers: {
+    echo: (input: Record<string, unknown>) => String(input.text ?? ''),
+  },
+  finishTool: 'finish',
+  extractDone: (input: Record<string, unknown>) => input.result as string,
+  maxIterations: 10,
+  maxTokens: 1024,
+  logger: createTestLogger('test', 'tool-loop:anthropic').logger,
+};
+
+describe('createAnthropicToolCallLoop', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns done result on single finish_review turn', async () => {
+    const client = makeClient([
+      {
+        stop_reason: 'tool_use',
+        content: [{ type: 'tool_use', id: 'tu1', name: 'finish', input: { result: 'done!' } }],
+        usage: { input_tokens: 100, output_tokens: 50 },
+      },
+    ]);
+    const loop = createAnthropicToolCallLoop({ client, model: 'claude-test' });
+    const out = await loop.run(baseRunOpts);
+    expect(out.done).toBe('done!');
+    expect(out.usage.inputTokens).toBe(100);
+    expect(out.usage.outputTokens).toBe(50);
+    expect(out.iterations).toBe(1);
+  });
+
+  it('calls handler and then finishes on second turn', async () => {
+    const echoSpy = vi.fn().mockReturnValue('hello back');
+    const client = makeClient([
+      {
+        stop_reason: 'tool_use',
+        content: [{ type: 'tool_use', id: 'tu1', name: 'echo', input: { text: 'hello' } }],
+        usage: { input_tokens: 50, output_tokens: 20 },
+      },
+      {
+        stop_reason: 'tool_use',
+        content: [{ type: 'tool_use', id: 'tu2', name: 'finish', input: { result: 'all done' } }],
+        usage: { input_tokens: 80, output_tokens: 30 },
+      },
+    ]);
+    const loop = createAnthropicToolCallLoop({ client, model: 'claude-test' });
+    const out = await loop.run({ ...baseRunOpts, handlers: { echo: echoSpy } });
+
+    expect(echoSpy).toHaveBeenCalledWith({ text: 'hello' });
+    expect(out.done).toBe('all done');
+    expect(out.usage.inputTokens).toBe(130);
+    expect(out.usage.outputTokens).toBe(50);
+    expect(out.iterations).toBe(2);
+    expect(out.toolCounts.echo).toBe(1);
+  });
+
+  it('returns is_error for unknown tool names', async () => {
+    let capturedMessages: unknown[] = [];
+    const create = vi.fn().mockImplementation(async (params: { messages: unknown[] }) => {
+      capturedMessages = params.messages;
+      if (params.messages.length <= 1) {
+        return {
+          stop_reason: 'tool_use',
+          content: [{ type: 'tool_use', id: 'tu_bad', name: 'unknown_tool', input: {} }],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        };
+      }
+      return {
+        stop_reason: 'tool_use',
+        content: [{ type: 'tool_use', id: 'tu_finish', name: 'finish', input: { result: 'ok' } }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      };
+    });
+    const client = { messages: { create } } as unknown as Anthropic;
+    const loop = createAnthropicToolCallLoop({ client, model: 'claude-test' });
+    await loop.run(baseRunOpts);
+
+    // The third message (index 2) should be the tool result with is_error
+    const toolResultMsg = capturedMessages[2] as {
+      role: string;
+      content: Array<{ is_error?: boolean; content?: string }>;
+    };
+    expect(toolResultMsg.content).toContainEqual(
+      expect.objectContaining({
+        is_error: true,
+        content: expect.stringContaining('unknown tool: unknown_tool'),
+      }),
+    );
+  });
+
+  it('throws FerryError when stop_reason is not tool_use', async () => {
+    const client = makeClient([
+      {
+        stop_reason: 'end_turn',
+        content: [{ type: 'text', text: 'no tool called' }],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+    ]);
+    const loop = createAnthropicToolCallLoop({ client, model: 'claude-test' });
+    await expect(loop.run(baseRunOpts)).rejects.toThrow(FerryError);
+  });
+
+  it('throws FerryError when maxIterations is exceeded', async () => {
+    const create = vi.fn().mockResolvedValue({
+      stop_reason: 'tool_use',
+      content: [{ type: 'tool_use', id: 'tu1', name: 'echo', input: { text: 'x' } }],
+      usage: { input_tokens: 5, output_tokens: 3 },
+    });
+    const client = { messages: { create } } as unknown as Anthropic;
+    const loop = createAnthropicToolCallLoop({ client, model: 'claude-test' });
+    await expect(loop.run({ ...baseRunOpts, maxIterations: 2 })).rejects.toMatchObject({
+      code: 'state-invariant',
+    });
+  });
+
+  it('accumulates token counts across multiple iterations', async () => {
+    const client = makeClient([
+      {
+        stop_reason: 'tool_use',
+        content: [{ type: 'tool_use', id: 'tu1', name: 'echo', input: { text: 'a' } }],
+        usage: { input_tokens: 100, output_tokens: 40 },
+      },
+      {
+        stop_reason: 'tool_use',
+        content: [{ type: 'tool_use', id: 'tu2', name: 'finish', input: { result: 'final' } }],
+        usage: { input_tokens: 200, output_tokens: 60 },
+      },
+    ]);
+    const loop = createAnthropicToolCallLoop({ client, model: 'claude-test' });
+    const out = await loop.run(baseRunOpts);
+    expect(out.usage.inputTokens).toBe(300);
+    expect(out.usage.outputTokens).toBe(100);
+  });
+});

--- a/src/lib/llm/tool-loop/anthropic.ts
+++ b/src/lib/llm/tool-loop/anthropic.ts
@@ -1,0 +1,180 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type {
+  MessageParam,
+  ToolResultBlockParam,
+  ContentBlock,
+} from '@anthropic-ai/sdk/resources/messages.js';
+import { FerryError } from '../../errors/index.js';
+import { emitDebug } from '../debug-log.js';
+import { createLogger } from '../../logger/index.js';
+import type { ToolCallLoop, ToolLoopRunOpts, ToolLoopResult } from './types.js';
+
+export function createAnthropicToolCallLoop(opts: {
+  client: Anthropic;
+  model: string;
+}): ToolCallLoop {
+  return {
+    async run<T>(runOpts: ToolLoopRunOpts<T>): Promise<ToolLoopResult<T>> {
+      const {
+        system,
+        initialPrompt,
+        tools,
+        handlers,
+        finishTool,
+        extractDone,
+        maxIterations,
+        maxTokens,
+      } = runOpts;
+      const logger = runOpts.logger ?? createLogger('', 'ferry:tool-loop');
+
+      // Add cache_control to the last tool for Anthropic prompt-caching.
+      const anthropicTools = tools.map((t, i) =>
+        i === tools.length - 1
+          ? ({ ...t, cache_control: { type: 'ephemeral' } } as Anthropic.Tool)
+          : (t as Anthropic.Tool),
+      );
+
+      const messages: MessageParam[] = [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: initialPrompt, cache_control: { type: 'ephemeral' } }],
+        },
+      ];
+
+      let inputTokens = 0;
+      let outputTokens = 0;
+      let done: T | null = null;
+      const toolCounts: Record<string, number> = {};
+      const toolCallRecords: Array<{ name: string; outputSize: number }> = [];
+
+      function trackTool(name: string, outputSize: number): void {
+        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+        toolCallRecords.push({ name, outputSize });
+      }
+
+      const loopStart = Date.now();
+
+      for (let iter = 0; iter < maxIterations; iter++) {
+        const iterStart = Date.now();
+        const response = await opts.client.messages.create({
+          model: opts.model,
+          max_tokens: maxTokens,
+          system: [{ type: 'text', text: system, cache_control: { type: 'ephemeral' } }],
+          tools: anthropicTools,
+          messages,
+        });
+
+        inputTokens += response.usage.input_tokens;
+        outputTokens += response.usage.output_tokens;
+        messages.push({ role: 'assistant', content: response.content as ContentBlock[] });
+
+        const toolCount = response.content.filter((b) => b.type === 'tool_use').length;
+        logger.info('turn', {
+          iter: iter + 1,
+          stop: response.stop_reason,
+          tools: toolCount,
+          in: response.usage.input_tokens,
+          out: response.usage.output_tokens,
+        });
+        emitDebug(
+          {
+            type: 'turn',
+            iter: iter + 1,
+            depth: 0,
+            stop_reason: response.stop_reason ?? 'unknown',
+            tools: toolCount,
+            mcp_tools: 0,
+            in: response.usage.input_tokens,
+            cache_w: 0,
+            cache_r: 0,
+            out: response.usage.output_tokens,
+            elapsed_ms: Date.now() - iterStart,
+          },
+          logger,
+        );
+
+        if (response.stop_reason !== 'tool_use') {
+          throw new FerryError('state-invariant', {
+            reason: 'tool-loop-stopped-without-finish',
+            stop_reason: response.stop_reason,
+          });
+        }
+
+        const toolResults: ToolResultBlockParam[] = [];
+
+        for (const block of response.content) {
+          if (block.type !== 'tool_use') continue;
+          const input = block.input as Record<string, unknown>;
+
+          if (block.name === finishTool) {
+            done = extractDone(input);
+            toolResults.push({ type: 'tool_result', tool_use_id: block.id, content: 'ok' });
+            continue;
+          }
+
+          const handler = handlers[block.name];
+          if (handler) {
+            const result = await handler(input);
+            trackTool(block.name, result.length);
+            toolResults.push({ type: 'tool_result', tool_use_id: block.id, content: result });
+          } else {
+            toolResults.push({
+              type: 'tool_result',
+              tool_use_id: block.id,
+              content: `unknown tool: ${block.name}`,
+              is_error: true,
+            });
+          }
+        }
+
+        // Roll cache breakpoint forward to the most recent tool results.
+        for (let i = messages.length - 1; i >= 0; i--) {
+          const msg = messages[i];
+          if (msg.role === 'user' && Array.isArray(msg.content)) {
+            const content = msg.content as ToolResultBlockParam[];
+            if (content.some((b) => b.type === 'tool_result')) {
+              const entry = { ...content[content.length - 1] } as ToolResultBlockParam & {
+                cache_control?: unknown;
+              };
+              delete entry.cache_control;
+              content[content.length - 1] = entry as ToolResultBlockParam;
+              break;
+            }
+          }
+        }
+        if (toolResults.length > 0) {
+          const last = toolResults[toolResults.length - 1];
+          toolResults[toolResults.length - 1] = { ...last, cache_control: { type: 'ephemeral' } };
+        }
+
+        messages.push({ role: 'user', content: toolResults });
+
+        if (done !== null) {
+          emitDebug(
+            {
+              type: 'result',
+              subtype: 'success',
+              iterations: iter + 1,
+              total_in: inputTokens,
+              total_out: outputTokens,
+              elapsed_ms: Date.now() - loopStart,
+            },
+            logger,
+          );
+          return {
+            done,
+            usage: { inputTokens, outputTokens },
+            iterations: iter + 1,
+            toolCounts,
+            toolCallRecords,
+          };
+        }
+      }
+
+      throw new FerryError('state-invariant', {
+        reason: 'tool-loop-iteration-cap-exceeded',
+        cap: maxIterations,
+      });
+    },
+  };
+}

--- a/src/lib/llm/tool-loop/google.test.ts
+++ b/src/lib/llm/tool-loop/google.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { FerryError } from '../../errors/index.js';
+import { createTestLogger } from '../../logger/index.js';
+import type { ToolDef } from './types.js';
+
+// vi.hoisted so mockGenerateContent is defined when the vi.mock factory runs.
+const { mockGenerateContent } = vi.hoisted(() => ({
+  mockGenerateContent: vi.fn(),
+}));
+
+vi.mock('@google/genai', () => {
+  const fn = vi.fn().mockImplementation(function (this: unknown) {
+    (this as { models: unknown }).models = { generateContent: mockGenerateContent };
+  } as unknown as () => void);
+  return { GoogleGenAI: fn };
+});
+
+import { createGoogleToolCallLoop } from './google.js';
+
+const TOOLS: ToolDef[] = [
+  {
+    name: 'echo',
+    description: 'Echoes input',
+    input_schema: { type: 'object', properties: { text: { type: 'string' } }, required: ['text'] },
+  },
+  {
+    name: 'finish',
+    description: 'Finishes the loop',
+    input_schema: {
+      type: 'object',
+      properties: { result: { type: 'string' } },
+      required: ['result'],
+    },
+  },
+];
+
+const baseRunOpts = {
+  system: 'system prompt',
+  initialPrompt: 'do something',
+  tools: TOOLS,
+  handlers: {
+    echo: (input: Record<string, unknown>) => String(input.text ?? ''),
+  },
+  finishTool: 'finish',
+  extractDone: (input: Record<string, unknown>) => input.result as string,
+  maxIterations: 10,
+  maxTokens: 1024,
+  logger: createTestLogger('test', 'tool-loop:google').logger,
+};
+
+function makeGoogleResponse(
+  fnCalls: Array<{ name: string; args: Record<string, unknown> }>,
+  usage = { promptTokenCount: 100, candidatesTokenCount: 40 },
+) {
+  return {
+    functionCalls: fnCalls,
+    candidates: [
+      {
+        content: {
+          parts: fnCalls.map((fc) => ({ functionCall: { name: fc.name, args: fc.args } })),
+        },
+      },
+    ],
+    usageMetadata: usage,
+  };
+}
+
+function makeEmptyResponse(usage = { promptTokenCount: 10, candidatesTokenCount: 5 }) {
+  return {
+    functionCalls: [],
+    candidates: [{ content: { parts: [{ text: 'no tool' }] } }],
+    usageMetadata: usage,
+    text: 'no tool',
+  };
+}
+
+describe('createGoogleToolCallLoop', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns done result on a single finish turn', async () => {
+    mockGenerateContent.mockResolvedValueOnce(
+      makeGoogleResponse([{ name: 'finish', args: { result: 'done!' } }]),
+    );
+    const loop = createGoogleToolCallLoop({ apiKey: 'test-key', model: 'gemini-2.5-flash' });
+    const out = await loop.run(baseRunOpts);
+    expect(out.done).toBe('done!');
+    expect(out.usage.inputTokens).toBe(100);
+    expect(out.usage.outputTokens).toBe(40);
+    expect(out.iterations).toBe(1);
+  });
+
+  it('calls handler then finishes on second turn', async () => {
+    const echoSpy = vi.fn().mockReturnValue('echo result');
+    mockGenerateContent
+      .mockResolvedValueOnce(
+        makeGoogleResponse([{ name: 'echo', args: { text: 'hello' } }], {
+          promptTokenCount: 50,
+          candidatesTokenCount: 20,
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeGoogleResponse([{ name: 'finish', args: { result: 'all done' } }], {
+          promptTokenCount: 80,
+          candidatesTokenCount: 30,
+        }),
+      );
+
+    const loop = createGoogleToolCallLoop({ apiKey: 'test-key', model: 'gemini-2.5-flash' });
+    const out = await loop.run({ ...baseRunOpts, handlers: { echo: echoSpy } });
+
+    expect(echoSpy).toHaveBeenCalledWith({ text: 'hello' });
+    expect(out.done).toBe('all done');
+    expect(out.usage.inputTokens).toBe(130);
+    expect(out.usage.outputTokens).toBe(50);
+    expect(out.iterations).toBe(2);
+    expect(out.toolCounts.echo).toBe(1);
+    expect(out.toolCallRecords).toContainEqual(expect.objectContaining({ name: 'echo' }));
+  });
+
+  it('throws FerryError when no function calls are returned', async () => {
+    mockGenerateContent.mockResolvedValueOnce(makeEmptyResponse());
+    const loop = createGoogleToolCallLoop({ apiKey: 'test-key', model: 'gemini-2.5-flash' });
+    await expect(loop.run(baseRunOpts)).rejects.toThrow(FerryError);
+  });
+
+  it('throws FerryError when maxIterations is exceeded', async () => {
+    mockGenerateContent.mockResolvedValue(
+      makeGoogleResponse([{ name: 'echo', args: { text: 'x' } }]),
+    );
+    const loop = createGoogleToolCallLoop({ apiKey: 'test-key', model: 'gemini-2.5-flash' });
+    await expect(loop.run({ ...baseRunOpts, maxIterations: 2 })).rejects.toMatchObject({
+      code: 'state-invariant',
+    });
+  });
+
+  it('accumulates token counts across turns', async () => {
+    mockGenerateContent
+      .mockResolvedValueOnce(
+        makeGoogleResponse([{ name: 'echo', args: { text: 'a' } }], {
+          promptTokenCount: 100,
+          candidatesTokenCount: 40,
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeGoogleResponse([{ name: 'finish', args: { result: 'final' } }], {
+          promptTokenCount: 200,
+          candidatesTokenCount: 60,
+        }),
+      );
+
+    const loop = createGoogleToolCallLoop({ apiKey: 'test-key', model: 'gemini-2.5-flash' });
+    const out = await loop.run(baseRunOpts);
+    expect(out.usage.inputTokens).toBe(300);
+    expect(out.usage.outputTokens).toBe(100);
+  });
+});

--- a/src/lib/llm/tool-loop/google.ts
+++ b/src/lib/llm/tool-loop/google.ts
@@ -1,0 +1,164 @@
+import { GoogleGenAI } from '@google/genai';
+import type { Content, Part, Tool } from '@google/genai';
+import { FerryError } from '../../errors/index.js';
+import { emitDebug } from '../debug-log.js';
+import { createLogger } from '../../logger/index.js';
+import type { ToolCallLoop, ToolLoopRunOpts, ToolLoopResult, ToolDef } from './types.js';
+
+function toGoogleTools(tools: ToolDef[]): Tool[] {
+  return [
+    {
+      functionDeclarations: tools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        parametersJsonSchema: t.input_schema,
+      })),
+    },
+  ];
+}
+
+export function createGoogleToolCallLoop(opts: { apiKey: string; model: string }): ToolCallLoop {
+  const ai = new GoogleGenAI({ apiKey: opts.apiKey });
+
+  return {
+    async run<T>(runOpts: ToolLoopRunOpts<T>): Promise<ToolLoopResult<T>> {
+      const {
+        system,
+        initialPrompt,
+        tools,
+        handlers,
+        finishTool,
+        extractDone,
+        maxIterations,
+        maxTokens,
+      } = runOpts;
+      const logger = runOpts.logger ?? createLogger('', 'ferry:tool-loop');
+
+      const googleTools = toGoogleTools(tools);
+      const contents: Content[] = [{ role: 'user', parts: [{ text: initialPrompt }] }];
+
+      let inputTokens = 0;
+      let outputTokens = 0;
+      let done: T | null = null;
+      const toolCounts: Record<string, number> = {};
+      const toolCallRecords: Array<{ name: string; outputSize: number }> = [];
+
+      function trackTool(name: string, outputSize: number): void {
+        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+        toolCallRecords.push({ name, outputSize });
+      }
+
+      const loopStart = Date.now();
+
+      for (let iter = 0; iter < maxIterations; iter++) {
+        const iterStart = Date.now();
+        const response = await ai.models.generateContent({
+          model: opts.model,
+          contents,
+          config: {
+            systemInstruction: system,
+            tools: googleTools,
+            maxOutputTokens: maxTokens,
+          },
+        });
+
+        inputTokens += response.usageMetadata?.promptTokenCount ?? 0;
+        outputTokens += response.usageMetadata?.candidatesTokenCount ?? 0;
+
+        const fnCalls = response.functionCalls ?? [];
+
+        // Append the model's turn to history using the raw candidate content.
+        const modelParts = response.candidates?.[0]?.content?.parts ?? [];
+        if (modelParts.length > 0) {
+          contents.push({ role: 'model', parts: modelParts });
+        }
+
+        logger.info('turn', {
+          iter: iter + 1,
+          tools: fnCalls.length,
+          in: response.usageMetadata?.promptTokenCount ?? 0,
+          out: response.usageMetadata?.candidatesTokenCount ?? 0,
+        });
+        emitDebug(
+          {
+            type: 'turn',
+            iter: iter + 1,
+            depth: 0,
+            stop_reason: fnCalls.length > 0 ? 'tool_use' : 'end_turn',
+            tools: fnCalls.length,
+            mcp_tools: 0,
+            in: response.usageMetadata?.promptTokenCount ?? 0,
+            cache_w: 0,
+            cache_r: 0,
+            out: response.usageMetadata?.candidatesTokenCount ?? 0,
+            elapsed_ms: Date.now() - iterStart,
+          },
+          logger,
+        );
+
+        if (fnCalls.length === 0) {
+          throw new FerryError('state-invariant', {
+            reason: 'tool-loop-stopped-without-finish',
+            stop_reason: 'end_turn',
+          });
+        }
+
+        const responseParts: Part[] = [];
+
+        for (const fc of fnCalls) {
+          const name = fc.name ?? '';
+          const input = (fc.args ?? {}) as Record<string, unknown>;
+
+          if (name === finishTool) {
+            done = extractDone(input);
+            responseParts.push({
+              functionResponse: { name, response: { result: 'ok' } },
+            });
+            continue;
+          }
+
+          const handler = handlers[name];
+          if (handler) {
+            const result = await handler(input);
+            trackTool(name, result.length);
+            responseParts.push({
+              functionResponse: { name, response: { result } },
+            });
+          } else {
+            responseParts.push({
+              functionResponse: { name, response: { error: `unknown tool: ${name}` } },
+            });
+          }
+        }
+
+        contents.push({ role: 'user', parts: responseParts });
+
+        if (done !== null) {
+          emitDebug(
+            {
+              type: 'result',
+              subtype: 'success',
+              iterations: iter + 1,
+              total_in: inputTokens,
+              total_out: outputTokens,
+              elapsed_ms: Date.now() - loopStart,
+            },
+            logger,
+          );
+          return {
+            done,
+            usage: { inputTokens, outputTokens },
+            iterations: iter + 1,
+            toolCounts,
+            toolCallRecords,
+          };
+        }
+      }
+
+      throw new FerryError('state-invariant', {
+        reason: 'tool-loop-iteration-cap-exceeded',
+        cap: maxIterations,
+      });
+    },
+  };
+}

--- a/src/lib/llm/tool-loop/index.ts
+++ b/src/lib/llm/tool-loop/index.ts
@@ -1,0 +1,43 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { FerryError } from '../../errors/index.js';
+import { resolveAnthropicAuth } from '../anthropic-auth.js';
+import { createAnthropicToolCallLoop } from './anthropic.js';
+import { createOpenAIToolCallLoop } from './openai.js';
+import { createGoogleToolCallLoop } from './google.js';
+import type { ToolCallLoop } from './types.js';
+
+function requireEnv(key: string): string {
+  const val = process.env[key];
+  if (!val) {
+    throw new FerryError('state-invariant', { reason: 'missing-env', key });
+  }
+  return val;
+}
+
+export function createToolCallLoop(opts: { provider: string; model: string }): ToolCallLoop {
+  if (opts.provider === 'anthropic') {
+    const auth = resolveAnthropicAuth({ apiKeyEnv: 'ANTHROPIC_API_KEY' });
+    const client = new Anthropic(auth);
+    return createAnthropicToolCallLoop({ client, model: opts.model });
+  }
+
+  if (opts.provider === 'openai') {
+    const apiKey = requireEnv('FERRY_OPENAI_KEY');
+    return createOpenAIToolCallLoop({ apiKey, model: opts.model });
+  }
+
+  if (opts.provider === 'google') {
+    const apiKey = requireEnv('FERRY_GOOGLE_AI_KEY');
+    return createGoogleToolCallLoop({ apiKey, model: opts.model });
+  }
+
+  throw new FerryError('state-invariant', { reason: 'unknown-provider', provider: opts.provider });
+}
+
+export type {
+  ToolCallLoop,
+  ToolDef,
+  ToolHandler,
+  ToolLoopResult,
+  ToolLoopRunOpts,
+} from './types.js';

--- a/src/lib/llm/tool-loop/openai.test.ts
+++ b/src/lib/llm/tool-loop/openai.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { FerryError } from '../../errors/index.js';
+import { createTestLogger } from '../../logger/index.js';
+import type { ToolDef } from './types.js';
+
+// vi.hoisted so mockCreate is defined when the vi.mock factory runs (ESM hoisting).
+const { mockCreate } = vi.hoisted(() => ({
+  mockCreate: vi.fn(),
+}));
+
+vi.mock('openai', () => {
+  const fn = vi.fn().mockImplementation(function (this: unknown) {
+    (this as { chat: unknown }).chat = { completions: { create: mockCreate } };
+  } as unknown as () => void);
+  class RateLimitError extends Error {}
+  class APIConnectionError extends Error {
+    constructor(opts: { message: string }) {
+      super(opts.message);
+    }
+  }
+  class APIError extends Error {
+    status = 0;
+  }
+  Object.assign(fn, { RateLimitError, APIConnectionError, APIError });
+  return { default: fn };
+});
+
+import { createOpenAIToolCallLoop } from './openai.js';
+
+const TOOLS: ToolDef[] = [
+  {
+    name: 'echo',
+    description: 'Echoes input',
+    input_schema: { type: 'object', properties: { text: { type: 'string' } }, required: ['text'] },
+  },
+  {
+    name: 'finish',
+    description: 'Finishes the loop',
+    input_schema: {
+      type: 'object',
+      properties: { result: { type: 'string' } },
+      required: ['result'],
+    },
+  },
+];
+
+const baseRunOpts = {
+  system: 'system prompt',
+  initialPrompt: 'do something',
+  tools: TOOLS,
+  handlers: {
+    echo: (input: Record<string, unknown>) => String(input.text ?? ''),
+  },
+  finishTool: 'finish',
+  extractDone: (input: Record<string, unknown>) => input.result as string,
+  maxIterations: 10,
+  maxTokens: 1024,
+  logger: createTestLogger('test', 'tool-loop:openai').logger,
+};
+
+function makeFinishResponse(result: string, usage = { prompt_tokens: 100, completion_tokens: 40 }) {
+  return {
+    choices: [
+      {
+        finish_reason: 'tool_calls',
+        message: {
+          content: null,
+          tool_calls: [
+            {
+              id: 'tc_finish',
+              type: 'function' as const,
+              function: { name: 'finish', arguments: JSON.stringify({ result }) },
+            },
+          ],
+        },
+      },
+    ],
+    usage,
+  };
+}
+
+function makeToolResponse(
+  name: string,
+  args: Record<string, unknown>,
+  usage = { prompt_tokens: 50, completion_tokens: 20 },
+) {
+  return {
+    choices: [
+      {
+        finish_reason: 'tool_calls',
+        message: {
+          content: null,
+          tool_calls: [
+            {
+              id: `tc_${name}`,
+              type: 'function' as const,
+              function: { name, arguments: JSON.stringify(args) },
+            },
+          ],
+        },
+      },
+    ],
+    usage,
+  };
+}
+
+describe('createOpenAIToolCallLoop', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns done result on a single finish turn', async () => {
+    mockCreate.mockResolvedValueOnce(makeFinishResponse('done!'));
+    const loop = createOpenAIToolCallLoop({ apiKey: 'test-key', model: 'gpt-4.1-mini' });
+    const out = await loop.run(baseRunOpts);
+    expect(out.done).toBe('done!');
+    expect(out.usage.inputTokens).toBe(100);
+    expect(out.usage.outputTokens).toBe(40);
+    expect(out.iterations).toBe(1);
+  });
+
+  it('calls handler then finishes on second turn', async () => {
+    const echoSpy = vi.fn().mockReturnValue('echo result');
+    mockCreate
+      .mockResolvedValueOnce(
+        makeToolResponse('echo', { text: 'hello' }, { prompt_tokens: 50, completion_tokens: 20 }),
+      )
+      .mockResolvedValueOnce(
+        makeFinishResponse('all done', { prompt_tokens: 80, completion_tokens: 30 }),
+      );
+
+    const loop = createOpenAIToolCallLoop({ apiKey: 'test-key', model: 'gpt-4.1-mini' });
+    const out = await loop.run({ ...baseRunOpts, handlers: { echo: echoSpy } });
+
+    expect(echoSpy).toHaveBeenCalledWith({ text: 'hello' });
+    expect(out.done).toBe('all done');
+    expect(out.usage.inputTokens).toBe(130);
+    expect(out.usage.outputTokens).toBe(50);
+    expect(out.iterations).toBe(2);
+    expect(out.toolCounts.echo).toBe(1);
+    expect(out.toolCallRecords).toContainEqual(expect.objectContaining({ name: 'echo' }));
+  });
+
+  it('throws FerryError when finish_reason is not tool_calls', async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [{ finish_reason: 'stop', message: { content: 'no tool', tool_calls: undefined } }],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    });
+    const loop = createOpenAIToolCallLoop({ apiKey: 'test-key', model: 'gpt-4.1-mini' });
+    await expect(loop.run(baseRunOpts)).rejects.toThrow(FerryError);
+  });
+
+  it('throws FerryError when maxIterations is exceeded', async () => {
+    mockCreate.mockResolvedValue(makeToolResponse('echo', { text: 'x' }));
+    const loop = createOpenAIToolCallLoop({ apiKey: 'test-key', model: 'gpt-4.1-mini' });
+    await expect(loop.run({ ...baseRunOpts, maxIterations: 2 })).rejects.toMatchObject({
+      code: 'state-invariant',
+    });
+  });
+
+  it('accumulates token counts across turns', async () => {
+    mockCreate
+      .mockResolvedValueOnce(
+        makeToolResponse('echo', { text: 'a' }, { prompt_tokens: 100, completion_tokens: 40 }),
+      )
+      .mockResolvedValueOnce(
+        makeFinishResponse('final', { prompt_tokens: 200, completion_tokens: 60 }),
+      );
+
+    const loop = createOpenAIToolCallLoop({ apiKey: 'test-key', model: 'gpt-4.1-mini' });
+    const out = await loop.run(baseRunOpts);
+    expect(out.usage.inputTokens).toBe(300);
+    expect(out.usage.outputTokens).toBe(100);
+  });
+});

--- a/src/lib/llm/tool-loop/openai.ts
+++ b/src/lib/llm/tool-loop/openai.ts
@@ -1,0 +1,171 @@
+import OpenAI from 'openai';
+import { FerryError } from '../../errors/index.js';
+import { emitDebug } from '../debug-log.js';
+import { createLogger } from '../../logger/index.js';
+import type { ToolCallLoop, ToolLoopRunOpts, ToolLoopResult } from './types.js';
+
+export function createOpenAIToolCallLoop(opts: { apiKey: string; model: string }): ToolCallLoop {
+  const client = new OpenAI({ apiKey: opts.apiKey });
+
+  return {
+    async run<T>(runOpts: ToolLoopRunOpts<T>): Promise<ToolLoopResult<T>> {
+      const {
+        system,
+        initialPrompt,
+        tools,
+        handlers,
+        finishTool,
+        extractDone,
+        maxIterations,
+        maxTokens,
+      } = runOpts;
+      const logger = runOpts.logger ?? createLogger('', 'ferry:tool-loop');
+
+      const openaiTools: OpenAI.ChatCompletionTool[] = tools.map((t) => ({
+        type: 'function',
+        function: {
+          name: t.name,
+          description: t.description,
+          parameters: t.input_schema as Record<string, unknown>,
+        },
+      }));
+
+      const messages: OpenAI.ChatCompletionMessageParam[] = [
+        { role: 'system', content: system },
+        { role: 'user', content: initialPrompt },
+      ];
+
+      let inputTokens = 0;
+      let outputTokens = 0;
+      let done: T | null = null;
+      const toolCounts: Record<string, number> = {};
+      const toolCallRecords: Array<{ name: string; outputSize: number }> = [];
+
+      function trackTool(name: string, outputSize: number): void {
+        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+        toolCallRecords.push({ name, outputSize });
+      }
+
+      const loopStart = Date.now();
+
+      for (let iter = 0; iter < maxIterations; iter++) {
+        const iterStart = Date.now();
+        const response = await client.chat.completions.create({
+          model: opts.model,
+          max_tokens: maxTokens,
+          messages,
+          tools: openaiTools,
+          tool_choice: 'required',
+        });
+
+        const choice = response.choices[0];
+        if (!choice) {
+          throw new FerryError('state-invariant', { reason: 'tool-loop-no-response' });
+        }
+
+        inputTokens += response.usage?.prompt_tokens ?? 0;
+        outputTokens += response.usage?.completion_tokens ?? 0;
+
+        const assistantMsg: OpenAI.ChatCompletionMessageParam = {
+          role: 'assistant',
+          content: choice.message.content ?? null,
+          tool_calls: choice.message.tool_calls,
+        };
+        messages.push(assistantMsg);
+
+        const toolCalls = choice.message.tool_calls ?? [];
+        logger.info('turn', {
+          iter: iter + 1,
+          stop: choice.finish_reason,
+          tools: toolCalls.length,
+          in: response.usage?.prompt_tokens ?? 0,
+          out: response.usage?.completion_tokens ?? 0,
+        });
+        emitDebug(
+          {
+            type: 'turn',
+            iter: iter + 1,
+            depth: 0,
+            stop_reason: choice.finish_reason ?? 'unknown',
+            tools: toolCalls.length,
+            mcp_tools: 0,
+            in: response.usage?.prompt_tokens ?? 0,
+            cache_w: 0,
+            cache_r: 0,
+            out: response.usage?.completion_tokens ?? 0,
+            elapsed_ms: Date.now() - iterStart,
+          },
+          logger,
+        );
+
+        if (choice.finish_reason !== 'tool_calls') {
+          throw new FerryError('state-invariant', {
+            reason: 'tool-loop-stopped-without-finish',
+            stop_reason: choice.finish_reason,
+          });
+        }
+
+        for (const toolCall of toolCalls) {
+          if (toolCall.type !== 'function') continue;
+
+          let input: Record<string, unknown>;
+          try {
+            input = JSON.parse(toolCall.function.arguments) as Record<string, unknown>;
+          } catch {
+            messages.push({
+              role: 'tool',
+              tool_call_id: toolCall.id,
+              content: 'invalid JSON arguments',
+            });
+            continue;
+          }
+
+          if (toolCall.function.name === finishTool) {
+            done = extractDone(input);
+            messages.push({ role: 'tool', tool_call_id: toolCall.id, content: 'ok' });
+            continue;
+          }
+
+          const handler = handlers[toolCall.function.name];
+          if (handler) {
+            const result = await handler(input);
+            trackTool(toolCall.function.name, result.length);
+            messages.push({ role: 'tool', tool_call_id: toolCall.id, content: result });
+          } else {
+            messages.push({
+              role: 'tool',
+              tool_call_id: toolCall.id,
+              content: `unknown tool: ${toolCall.function.name}`,
+            });
+          }
+        }
+
+        if (done !== null) {
+          emitDebug(
+            {
+              type: 'result',
+              subtype: 'success',
+              iterations: iter + 1,
+              total_in: inputTokens,
+              total_out: outputTokens,
+              elapsed_ms: Date.now() - loopStart,
+            },
+            logger,
+          );
+          return {
+            done,
+            usage: { inputTokens, outputTokens },
+            iterations: iter + 1,
+            toolCounts,
+            toolCallRecords,
+          };
+        }
+      }
+
+      throw new FerryError('state-invariant', {
+        reason: 'tool-loop-iteration-cap-exceeded',
+        cap: maxIterations,
+      });
+    },
+  };
+}

--- a/src/lib/llm/tool-loop/types.ts
+++ b/src/lib/llm/tool-loop/types.ts
@@ -1,0 +1,50 @@
+import type { Logger } from '../../logger/index.js';
+
+export interface ToolDef {
+  name: string;
+  description: string;
+  input_schema: {
+    type: 'object';
+    properties: Record<string, unknown>;
+    required?: string[];
+  };
+}
+
+export type ToolHandler = (input: Record<string, unknown>) => Promise<string> | string;
+
+export interface ToolLoopUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface ToolCallRecord {
+  name: string;
+  outputSize: number;
+}
+
+export interface ToolLoopResult<T> {
+  done: T;
+  usage: ToolLoopUsage;
+  iterations: number;
+  toolCounts: Record<string, number>;
+  toolCallRecords: ToolCallRecord[];
+}
+
+export interface ToolLoopRunOpts<T> {
+  system: string;
+  initialPrompt: string;
+  tools: ToolDef[];
+  /** Keyed by tool name; called when LLM invokes that tool. */
+  handlers: Record<string, ToolHandler>;
+  /** Name of the tool that terminates the loop. */
+  finishTool: string;
+  /** Extracts the typed result from the finish tool's input. */
+  extractDone: (input: Record<string, unknown>) => T;
+  maxIterations: number;
+  maxTokens: number;
+  logger: Logger;
+}
+
+export interface ToolCallLoop {
+  run<T>(opts: ToolLoopRunOpts<T>): Promise<ToolLoopResult<T>>;
+}


### PR DESCRIPTION
Closes #218

## Summary

- Introduces a provider-neutral `ToolCallLoop` abstraction (`types.ts`, `anthropic.ts`, `openai.ts`, `google.ts`, `index.ts`) under `src/lib/llm/tool-loop/`
- `review-loop.ts` becomes a thin adapter; `review-action.ts` removes the `provider !== 'anthropic'` guard
- `ferry-run-reviewer` action and consumer workflow updated with OpenAI/Google API key inputs

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (1192 tests, 99 files)
- [x] Per-provider unit tests with mocked SDKs: `anthropic.test.ts`, `openai.test.ts`, `google.test.ts`

Generated with [Claude Code](https://claude.ai/code)