### PR TITLE
feat: [multi-provider] Phase 4 — consumer ergonomics (init / doctor / docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ All auto-transitions are configurable via `workflow.agents` in `ferry.config.yam
 npx -p @big-emotion/ferry ferry-init
 ```
 
-The wizard collects your Jira URL, credentials, and column status names (prompts with defaults: **Refinement** / **In Development** / **In Review** / **Changes Requested** / **Ready to Merge**), generates the Jira Automation rules, and copies the 4 consumer workflow stubs into `.github/workflows/`. Custom status names work — enter them when prompted.
+The wizard collects your Jira URL, credentials, column status names (prompts with defaults: **Refinement** / **In Development** / **In Review** / **Changes Requested** / **Ready to Merge**), and LLM provider selection per phase. Ferry supports **Anthropic** (default), **OpenAI**, and **Google AI** — see the [provider × phase matrix](docs/CONFIGURATION.md#provider--phase-matrix) for a full breakdown and caveats. Custom status names work — enter them when prompted.
 
 After the wizard finishes, complete four manual steps:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -27,10 +27,12 @@ Add these under **Settings → Secrets and variables → Actions → Secrets** i
 
 ### Required when using non-Anthropic providers
 
-| Secret                | Provider | Description                                                                       |
-| --------------------- | -------- | --------------------------------------------------------------------------------- |
-| `FERRY_OPENAI_KEY`    | `openai` | OpenAI API key — required when any phase is configured with `provider: openai`    |
-| `FERRY_GOOGLE_AI_KEY` | `google` | Google AI API key — required when any phase is configured with `provider: google` |
+| Secret           | Provider | Description                                                                       |
+| ---------------- | -------- | --------------------------------------------------------------------------------- |
+| `OPENAI_API_KEY` | `openai` | OpenAI API key — required when any phase is configured with `provider: openai`    |
+| `GOOGLE_API_KEY` | `google` | Google AI API key — required when any phase is configured with `provider: google` |
+
+> **Legacy aliases:** `FERRY_OPENAI_KEY` and `FERRY_GOOGLE_AI_KEY` are accepted as fallbacks for backwards compatibility, but `OPENAI_API_KEY` / `GOOGLE_API_KEY` are the canonical names used by the workflow stubs.
 
 ### Required for specific agents
 
@@ -59,16 +61,16 @@ All variables marked **wired** below are read directly by the standard consumer 
 
 #### Model and provider overrides
 
-| Variable                 | Default             | Wired?          | Affects         | Description                                                                                          |
-| ------------------------ | ------------------- | --------------- | --------------- | ---------------------------------------------------------------------------------------------------- |
-| `FERRY_DEV_MODEL`        | `claude-sonnet-4-6` | yes (`dev`)     | Developer agent | Override the model ID for the Developer. Wired via the `ferry_dev_model` composite action input.     |
-| `FERRY_DEV_PROVIDER`     | `anthropic`         | yes (`dev`)     | Developer agent | LLM provider override for the Developer. Currently only `anthropic` is supported for agentic phases. |
-| `FERRY_REVIEW_MODEL`     | `claude-sonnet-4-6` | yes (`review`)  | Reviewer agent  | Override the model ID for the Reviewer. Wired via the `ferry_review_model` composite action input.   |
-| `FERRY_REVIEW_PROVIDER`  | `anthropic`         | yes (`review`)  | Reviewer agent  | LLM provider override for the Reviewer. Currently only `anthropic` is supported for agentic phases.  |
-| `FERRY_ITER_MODEL`       | `claude-sonnet-4-6` | yes (`iterate`) | Iterator agent  | Override the model ID for the Iterator. Wired via the `ferry_iter_model` composite action input.     |
-| `FERRY_ITER_PROVIDER`    | `anthropic`         | yes (`iterate`) | Iterator agent  | LLM provider override for the Iterator. Currently only `anthropic` is supported for agentic phases.  |
-| `FERRY_REFINER_MODEL`    | `claude-sonnet-4-6` | yes (`refine`)  | Refiner agent   | Override the model ID for the Refiner. Wired via the `ferry_refiner_model` composite action input.   |
-| `FERRY_REFINER_PROVIDER` | `anthropic`         | yes (`refine`)  | Refiner agent   | LLM provider override for the Refiner (`anthropic` / `openai` / `google`).                           |
+| Variable                 | Default             | Wired?          | Affects         | Description                                                                                                        |
+| ------------------------ | ------------------- | --------------- | --------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `FERRY_DEV_MODEL`        | `claude-sonnet-4-6` | yes (`dev`)     | Developer agent | Override the model ID for the Developer. Wired via the `ferry_dev_model` composite action input.                   |
+| `FERRY_DEV_PROVIDER`     | `anthropic`         | yes (`dev`)     | Developer agent | LLM provider override for the Developer (`anthropic` / `openai` / `google`). MCP integration requires `anthropic`. |
+| `FERRY_REVIEW_MODEL`     | `claude-sonnet-4-6` | yes (`review`)  | Reviewer agent  | Override the model ID for the Reviewer. Wired via the `ferry_review_model` composite action input.                 |
+| `FERRY_REVIEW_PROVIDER`  | `anthropic`         | yes (`review`)  | Reviewer agent  | LLM provider override for the Reviewer (`anthropic` / `openai` / `google`). MCP integration requires `anthropic`.  |
+| `FERRY_ITER_MODEL`       | `claude-sonnet-4-6` | yes (`iterate`) | Iterator agent  | Override the model ID for the Iterator. Wired via the `ferry_iter_model` composite action input.                   |
+| `FERRY_ITER_PROVIDER`    | `anthropic`         | yes (`iterate`) | Iterator agent  | LLM provider override for the Iterator (`anthropic` / `openai` / `google`). MCP integration requires `anthropic`.  |
+| `FERRY_REFINER_MODEL`    | `claude-sonnet-4-6` | yes (`refine`)  | Refiner agent   | Override the model ID for the Refiner. Wired via the `ferry_refiner_model` composite action input.                 |
+| `FERRY_REFINER_PROVIDER` | `anthropic`         | yes (`refine`)  | Refiner agent   | LLM provider override for the Refiner (`anthropic` / `openai` / `google`).                                         |
 
 #### Token and iteration limits
 
@@ -220,25 +222,50 @@ Each agent phase can be configured independently. All `models.*` fields are opti
 
 Ferry supports three LLM providers: **`anthropic`**, **`openai`**, and **`google`**. Provider support varies by phase:
 
-| Phase     | Supported providers             | Notes                                                                       |
-| --------- | ------------------------------- | --------------------------------------------------------------------------- |
-| `refiner` | `anthropic`, `openai`, `google` | Uses a single-turn LLM call — all three providers are supported             |
-| `dev`     | `anthropic`                     | Anthropic only (multi-provider in progress) — uses an agentic tool-use loop |
-| `review`  | `anthropic`                     | Anthropic only (multi-provider in progress) — uses an agentic tool-use loop |
-| `iterate` | `anthropic`                     | Anthropic only (multi-provider in progress) — uses an agentic tool-use loop |
+### Provider × phase matrix
 
-> **MCP:** Model Context Protocol (MCP) server integration is Anthropic-only and is not available when using other providers. MCP availability is also independent of the provider support table above — even with `provider: anthropic`, **only the Developer and Iterator agents consume `AGENT_MCP_SERVERS`**. The Refiner and Reviewer do not load MCP servers regardless of provider or configuration.
+| Phase     | `anthropic`     | `openai`        | `google`        | Required secret    |
+| --------- | --------------- | --------------- | --------------- | ------------------ |
+| `refiner` | ✅ Full support | ✅ Full support | ✅ Full support | matching key below |
+| `dev`     | ✅ Full support | ✅ Supported    | ✅ Supported    | matching key below |
+| `review`  | ✅ Full support | ✅ Supported    | ✅ Supported    | matching key below |
+| `iterate` | ✅ Full support | ✅ Supported    | ✅ Supported    | matching key below |
 
-| Field                     | Default               | Description                                                                                                                                |
-| ------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `models.refiner.provider` | `"anthropic"`         | LLM provider for the Refiner agent. Accepts `"anthropic"`, `"openai"`, or `"google"`.                                                      |
-| `models.refiner.model`    | `"claude-sonnet-4-6"` | Model ID for the Refiner agent (overridden by `FERRY_REFINER_MODEL` env var)                                                               |
-| `models.dev.provider`     | `"anthropic"`         | LLM provider for the Developer agent. Currently only `"anthropic"` is supported.                                                           |
-| `models.dev.model`        | `"claude-sonnet-4-6"` | Model ID for the Developer agent. The standard `dev.yml` workflow always runs `claude-sonnet-4-6`; override here to use a different model. |
-| `models.review.provider`  | `"anthropic"`         | LLM provider for the Reviewer agent. Currently only `"anthropic"` is supported.                                                            |
-| `models.review.model`     | `"claude-sonnet-4-6"` | Model ID for the Reviewer agent (overridden by `FERRY_REVIEW_MODEL` env var)                                                               |
-| `models.iterate.provider` | `"anthropic"`         | LLM provider for the Iterator agent. Currently only `"anthropic"` is supported.                                                            |
-| `models.iterate.model`    | `"claude-sonnet-4-6"` | Model ID for the Iterator agent (overridden by `FERRY_ITER_MODEL` env var)                                                                 |
+**Provider-specific caveats:**
+
+| Capability                                 | `anthropic` | `openai` | `google` |
+| ------------------------------------------ | :---------: | :------: | :------: |
+| MCP server integration (`labels:`)         |     ✅      |    ❌    |    ❌    |
+| Prompt cache breakpoints                   |     ✅      |    ❌    |    ❌    |
+| Agentic tool-use loop (dev/review/iterate) |     ✅      |    ✅    |    ✅    |
+| Single-turn LLM call (refiner)             |     ✅      |    ✅    |    ✅    |
+
+**Expected cost differential (approximate, relative to `claude-sonnet-4-6`):**
+
+| Provider / model                  | Relative cost | Notes                                                    |
+| --------------------------------- | :-----------: | -------------------------------------------------------- |
+| `anthropic` / `claude-sonnet-4-6` |   baseline    | Recommended; prompt caching reduces repeat costs by ~80% |
+| `openai` / `gpt-4o`               |     ~1–2×     | No caching discount; good for refiner single-turn use    |
+| `openai` / `gpt-4o-mini`          |     ~0.2×     | Cost-effective for light refiner tasks                   |
+| `google` / `gemini-2.5-pro`       |    ~0.5–1×    | Competitive for long-context refiner calls               |
+| `google` / `gemini-2.5-flash`     |    ~0.05×     | Very low cost; good for high-volume refinement           |
+
+> **MCP:** Model Context Protocol (MCP) server integration (`AGENT_MCP_SERVERS`, `labels:` in config) is **Anthropic-only**. If you set `provider: openai` or `provider: google` for the Developer or Iterator, MCP servers are not loaded even if `AGENT_MCP_SERVERS` is set.
+>
+> **Prompt caching:** Explicit cache breakpoints are an Anthropic-specific API feature. With non-Anthropic providers, Ferry omits cache control headers — costs will not be reduced by caching on long system prompts.
+>
+> **Agentic phases:** Even with `provider: anthropic`, **only the Developer and Iterator agents consume `AGENT_MCP_SERVERS`**. The Refiner and Reviewer do not load MCP servers regardless of provider or configuration.
+
+| Field                     | Default               | Description                                                                                                                                      |
+| ------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `models.refiner.provider` | `"anthropic"`         | LLM provider for the Refiner. Accepts `"anthropic"`, `"openai"`, or `"google"`.                                                                  |
+| `models.refiner.model`    | `"claude-sonnet-4-6"` | Model ID for the Refiner (overridden by `FERRY_REFINER_MODEL`). Use a model ID valid for your chosen provider (e.g. `gpt-4o`, `gemini-2.5-pro`). |
+| `models.dev.provider`     | `"anthropic"`         | LLM provider for the Developer. Accepts `"anthropic"`, `"openai"`, or `"google"`. Note: MCP server integration requires `"anthropic"`.           |
+| `models.dev.model`        | `"claude-sonnet-4-6"` | Model ID for the Developer (overridden by `FERRY_DEV_MODEL`). Use a model ID matching your chosen provider.                                      |
+| `models.review.provider`  | `"anthropic"`         | LLM provider for the Reviewer. Accepts `"anthropic"`, `"openai"`, or `"google"`. Note: MCP server integration requires `"anthropic"`.            |
+| `models.review.model`     | `"claude-sonnet-4-6"` | Model ID for the Reviewer (overridden by `FERRY_REVIEW_MODEL`). Use a model ID matching your chosen provider.                                    |
+| `models.iterate.provider` | `"anthropic"`         | LLM provider for the Iterator. Accepts `"anthropic"`, `"openai"`, or `"google"`. Note: MCP server integration requires `"anthropic"`.            |
+| `models.iterate.model`    | `"claude-sonnet-4-6"` | Model ID for the Iterator (overridden by `FERRY_ITER_MODEL`). Use a model ID matching your chosen provider.                                      |
 
 #### `limits`
 

--- a/examples/consumer-setup/workflows/ferry-dev.yml
+++ b/examples/consumer-setup/workflows/ferry-dev.yml
@@ -1,10 +1,15 @@
 # Copy this file to .github/workflows/ferry-dev.yml in your repository.
 # Replace @v0.9.0 with the Ferry release tag you want to pin.
 # Required secrets: FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN,
-#                   ANTHROPIC_API_KEY, FERRY_REVIEW_TRANSITION_ID
+#                   FERRY_REVIEW_TRANSITION_ID
+#                   ANTHROPIC_API_KEY    — required when FERRY_DEV_PROVIDER=anthropic (default)
+#                   OPENAI_API_KEY       — required when FERRY_DEV_PROVIDER=openai
+#                   GOOGLE_API_KEY       — required when FERRY_DEV_PROVIDER=google
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
-# Optional variables: FERRY_DEV_MODEL (default: claude-sonnet-4-6)
-#                     FERRY_DEV_PROVIDER (default: anthropic)
+# Optional variables: FERRY_DEV_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#                     FERRY_DEV_PROVIDER (default: anthropic; also: openai, google)
+#
+# Note: MCP server support is not available for non-Anthropic providers in the Developer agent.
 #                     FERRY_DEV_MAX_INPUT_TOKENS (default: 500000)
 #                     FERRY_DEV_MAX_TOKENS (default: 16384)
 #                     FERRY_DEV_MAX_ITERATIONS (default: 200)
@@ -73,6 +78,8 @@ jobs:
           jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
           ferry_review_transition_id: ${{ secrets.FERRY_REVIEW_TRANSITION_ID }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          google_api_key: ${{ secrets.GOOGLE_API_KEY }}
           github_token: ${{ github.token }}
           github_repo: ${{ github.repository }}
           ferry_dev_model: ${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-4-6' }}

--- a/examples/consumer-setup/workflows/ferry-iterate.yml
+++ b/examples/consumer-setup/workflows/ferry-iterate.yml
@@ -1,10 +1,15 @@
 # Copy this file to .github/workflows/ferry-iterate.yml in your repository.
 # Replace @v0.9.0 with the Ferry release tag you want to pin.
 # Required secrets: FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN,
-#                   ANTHROPIC_API_KEY, FERRY_REVIEW_TRANSITION_ID
+#                   FERRY_REVIEW_TRANSITION_ID
+#                   ANTHROPIC_API_KEY    — required when FERRY_ITER_PROVIDER=anthropic (default)
+#                   OPENAI_API_KEY       — required when FERRY_ITER_PROVIDER=openai
+#                   GOOGLE_API_KEY       — required when FERRY_ITER_PROVIDER=google
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
-# Optional variables: FERRY_ITER_MODEL (default: claude-sonnet-4-6)
-#                     FERRY_ITER_PROVIDER (default: anthropic)
+# Optional variables: FERRY_ITER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#                     FERRY_ITER_PROVIDER (default: anthropic; also: openai, google)
+#
+# Note: MCP server support is not available for non-Anthropic providers in the Iterator agent.
 #                     FERRY_ITER_MAX_INPUT_TOKENS (default: 500000)
 #                     FERRY_DEV_MAX_TOKENS (default: 16384)
 #                     FERRY_DEV_MAX_ITERATIONS (default: 200)
@@ -76,6 +81,8 @@ jobs:
           jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
           ferry_review_transition_id: ${{ secrets.FERRY_REVIEW_TRANSITION_ID }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          google_api_key: ${{ secrets.GOOGLE_API_KEY }}
           github_token: ${{ github.token }}
           github_repo: ${{ github.repository }}
           ferry_iter_model: ${{ vars.FERRY_ITER_MODEL || 'claude-sonnet-4-6' }}

--- a/examples/consumer-setup/workflows/ferry-refine.yml
+++ b/examples/consumer-setup/workflows/ferry-refine.yml
@@ -1,9 +1,12 @@
 # Copy this file to .github/workflows/ferry-refine.yml in your repository.
 # Replace @v0.9.0 with the Ferry release tag you want to pin.
-# Required secrets: FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN, ANTHROPIC_API_KEY
+# Required secrets: FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN
+#                   ANTHROPIC_API_KEY    — required when FERRY_REFINER_PROVIDER=anthropic (default)
+#                   OPENAI_API_KEY       — required when FERRY_REFINER_PROVIDER=openai
+#                   GOOGLE_API_KEY       — required when FERRY_REFINER_PROVIDER=google
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
-# Optional variables: FERRY_REFINER_MODEL (default: claude-sonnet-4-6)
-#                     FERRY_REFINER_PROVIDER (default: anthropic)
+# Optional variables: FERRY_REFINER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#                     FERRY_REFINER_PROVIDER (default: anthropic; also: openai, google)
 #                     FERRY_REFINER_SUBTASK_CAP (default: 12)
 #                     FERRY_MAX_COST_EUR_PER_RUN (default: 10)
 #                     FERRY_LLM_RETRY_MAX_ATTEMPTS (default: 3)
@@ -62,6 +65,8 @@ jobs:
           jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
           jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          google_api_key: ${{ secrets.GOOGLE_API_KEY }}
           ferry_refiner_model: ${{ vars.FERRY_REFINER_MODEL || 'claude-sonnet-4-6' }}
           ferry_refiner_provider: ${{ vars.FERRY_REFINER_PROVIDER }}
           ferry_refiner_subtask_cap: ${{ vars.FERRY_REFINER_SUBTASK_CAP }}

--- a/src/cli/doctor/checks/llm.test.ts
+++ b/src/cli/doctor/checks/llm.test.ts
@@ -1,10 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockHttpsPost = vi.hoisted(() => vi.fn());
+const mockListRepoSecrets = vi.hoisted(() => vi.fn<() => string[]>(() => []));
+const mockLoadFerryConfig = vi.hoisted(() => vi.fn());
 
 vi.mock('../../http.js', () => ({
   httpsPost: mockHttpsPost,
   httpsGet: vi.fn(),
+}));
+
+vi.mock('./secrets.js', () => ({
+  listRepoSecrets: mockListRepoSecrets,
+  checkSecrets: vi.fn(),
+}));
+
+vi.mock('../../../lib/config.js', () => ({
+  loadFerryConfig: mockLoadFerryConfig,
 }));
 
 import { checkLlmKeys } from './llm.js';
@@ -12,6 +23,7 @@ import { checkLlmKeys } from './llm.js';
 describe('checkLlmKeys', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    mockListRepoSecrets.mockReturnValue([]);
   });
 
   it('returns skip when anthropicApiKey is empty', async () => {
@@ -72,5 +84,130 @@ describe('checkLlmKeys', () => {
     mockHttpsPost.mockResolvedValue({ statusCode: 401, body: '' });
     const result = await checkLlmKeys({ anthropicApiKey: 'sk-ant-bad' });
     expect(result.remedy).toBeTruthy();
+  });
+
+  describe('openai provider configured via repoRoot', () => {
+    beforeEach(() => {
+      mockHttpsPost.mockResolvedValue({ statusCode: 200, body: '{}' });
+      mockLoadFerryConfig.mockReturnValue({
+        models: {
+          refiner: { provider: 'openai', model: 'gpt-4o' },
+          dev: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          review: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          iterate: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+        },
+      });
+    });
+
+    it('returns yellow when openai provider is configured but OPENAI_API_KEY is missing from repo and env', async () => {
+      mockListRepoSecrets.mockReturnValue([]);
+      const result = await checkLlmKeys({
+        anthropicApiKey: 'sk-ant-valid',
+        repoRoot: '/some/repo',
+        repo: 'owner/repo',
+      });
+      expect(result.status).toBe('yellow');
+      expect(result.detail).toContain('OPENAI_API_KEY');
+    });
+
+    it('returns green when OPENAI_API_KEY is present in env', async () => {
+      const result = await checkLlmKeys({
+        anthropicApiKey: 'sk-ant-valid',
+        openaiApiKey: 'sk-openai-valid',
+        repoRoot: '/some/repo',
+      });
+      expect(result.status).toBe('green');
+      expect(result.detail).toContain('OpenAI key present');
+    });
+
+    it('returns green (with note) when OPENAI_API_KEY is in repo secrets but not env', async () => {
+      mockListRepoSecrets.mockReturnValue(['OPENAI_API_KEY']);
+      const result = await checkLlmKeys({
+        anthropicApiKey: 'sk-ant-valid',
+        repoRoot: '/some/repo',
+        repo: 'owner/repo',
+      });
+      expect(result.status).toBe('green');
+      expect(result.detail).toContain('repo secrets');
+    });
+
+    it('accepts legacy FERRY_OPENAI_KEY in repo secrets', async () => {
+      mockListRepoSecrets.mockReturnValue(['FERRY_OPENAI_KEY']);
+      const result = await checkLlmKeys({
+        anthropicApiKey: 'sk-ant-valid',
+        repoRoot: '/some/repo',
+        repo: 'owner/repo',
+      });
+      expect(result.status).toBe('green');
+      expect(result.detail).toContain('repo secrets');
+    });
+
+    it('names the missing secret in the warning', async () => {
+      mockListRepoSecrets.mockReturnValue([]);
+      const result = await checkLlmKeys({
+        anthropicApiKey: 'sk-ant-valid',
+        repoRoot: '/some/repo',
+        repo: 'owner/repo',
+      });
+      expect(result.detail).toContain('OPENAI_API_KEY');
+      expect(result.remedy).toContain('OPENAI_API_KEY');
+    });
+  });
+
+  describe('google provider configured via repoRoot', () => {
+    beforeEach(() => {
+      mockHttpsPost.mockResolvedValue({ statusCode: 200, body: '{}' });
+      mockLoadFerryConfig.mockReturnValue({
+        models: {
+          refiner: { provider: 'google', model: 'gemini-2.5-pro' },
+          dev: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          review: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+          iterate: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+        },
+      });
+    });
+
+    it('returns yellow when google provider is configured and GOOGLE_API_KEY is missing', async () => {
+      mockListRepoSecrets.mockReturnValue([]);
+      const result = await checkLlmKeys({
+        anthropicApiKey: 'sk-ant-valid',
+        repoRoot: '/some/repo',
+        repo: 'owner/repo',
+      });
+      expect(result.status).toBe('yellow');
+      expect(result.detail).toContain('GOOGLE_API_KEY');
+    });
+
+    it('returns green when GOOGLE_API_KEY is present in env', async () => {
+      const result = await checkLlmKeys({
+        anthropicApiKey: 'sk-ant-valid',
+        googleApiKey: 'gai-key-valid',
+        repoRoot: '/some/repo',
+      });
+      expect(result.status).toBe('green');
+      expect(result.detail).toContain('Google AI key present');
+    });
+
+    it('returns green (with note) when GOOGLE_API_KEY is in repo secrets but not env', async () => {
+      mockListRepoSecrets.mockReturnValue(['GOOGLE_API_KEY']);
+      const result = await checkLlmKeys({
+        anthropicApiKey: 'sk-ant-valid',
+        repoRoot: '/some/repo',
+        repo: 'owner/repo',
+      });
+      expect(result.status).toBe('green');
+      expect(result.detail).toContain('repo secrets');
+    });
+
+    it('accepts legacy FERRY_GOOGLE_AI_KEY in repo secrets', async () => {
+      mockListRepoSecrets.mockReturnValue(['FERRY_GOOGLE_AI_KEY']);
+      const result = await checkLlmKeys({
+        anthropicApiKey: 'sk-ant-valid',
+        repoRoot: '/some/repo',
+        repo: 'owner/repo',
+      });
+      expect(result.status).toBe('green');
+      expect(result.detail).toContain('repo secrets');
+    });
   });
 });

--- a/src/cli/doctor/checks/llm.ts
+++ b/src/cli/doctor/checks/llm.ts
@@ -1,5 +1,6 @@
 import { httpsPost } from '../../http.js';
 import { loadFerryConfig } from '../../../lib/config.js';
+import { listRepoSecrets } from './secrets.js';
 import type { CheckResult } from '../types.js';
 
 async function probeAnthropic(apiKey: string): Promise<{ ok: boolean; detail: string }> {
@@ -45,8 +46,9 @@ export async function checkLlmKeys(opts: {
   openaiApiKey?: string;
   googleApiKey?: string;
   repoRoot?: string;
+  repo?: string;
 }): Promise<CheckResult> {
-  const { anthropicApiKey, openaiApiKey = '', googleApiKey = '', repoRoot } = opts;
+  const { anthropicApiKey, openaiApiKey = '', googleApiKey = '', repoRoot, repo } = opts;
 
   // Determine which providers are required by the ferry config.
   const requiredProviders = new Set<string>(['anthropic']);
@@ -59,6 +61,15 @@ export async function checkLlmKeys(opts: {
     } catch {
       // Config may not exist in doctor context; fall back to Anthropic-only check.
     }
+  }
+
+  // Lazily fetch repo secrets once if we need to cross-check missing keys.
+  let repoSecrets: string[] | null = null;
+  function getRepoSecrets(): string[] {
+    if (repoSecrets === null) {
+      repoSecrets = repo ? listRepoSecrets(repo) : [];
+    }
+    return repoSecrets;
   }
 
   const missing: string[] = [];
@@ -85,7 +96,15 @@ export async function checkLlmKeys(opts: {
 
   if (requiredProviders.has('openai')) {
     if (!openaiApiKey) {
-      missing.push('FERRY_OPENAI_KEY (required for openai provider)');
+      // Cross-check repo secrets: workflows use OPENAI_API_KEY; legacy env uses FERRY_OPENAI_KEY.
+      const secrets = getRepoSecrets();
+      if (secrets.includes('OPENAI_API_KEY') || secrets.includes('FERRY_OPENAI_KEY')) {
+        details.push('OpenAI key present in repo secrets (not verifiable locally)');
+      } else {
+        missing.push(
+          'OPENAI_API_KEY (required for openai provider — set via `gh secret set OPENAI_API_KEY`)',
+        );
+      }
     } else {
       details.push('OpenAI key present');
     }
@@ -93,7 +112,15 @@ export async function checkLlmKeys(opts: {
 
   if (requiredProviders.has('google')) {
     if (!googleApiKey) {
-      missing.push('FERRY_GOOGLE_AI_KEY (required for google provider)');
+      // Cross-check repo secrets: workflows use GOOGLE_API_KEY; legacy env uses FERRY_GOOGLE_AI_KEY.
+      const secrets = getRepoSecrets();
+      if (secrets.includes('GOOGLE_API_KEY') || secrets.includes('FERRY_GOOGLE_AI_KEY')) {
+        details.push('Google AI key present in repo secrets (not verifiable locally)');
+      } else {
+        missing.push(
+          'GOOGLE_API_KEY (required for google provider — set via `gh secret set GOOGLE_API_KEY`)',
+        );
+      }
     } else {
       details.push('Google AI key present');
     }

--- a/src/cli/doctor/index.ts
+++ b/src/cli/doctor/index.ts
@@ -72,8 +72,16 @@ function parseConfig(argv: string[]): DoctorConfig {
     jiraApiToken: getArg(argv, '--jira-token') ?? process.env['FERRY_JIRA_API_TOKEN'] ?? '',
     jiraProjectKey: getArg(argv, '--jira-project') ?? process.env['FERRY_JIRA_PROJECT_KEY'] ?? '',
     anthropicApiKey: getArg(argv, '--anthropic-key') ?? process.env['ANTHROPIC_API_KEY'] ?? '',
-    openaiApiKey: getArg(argv, '--openai-key') ?? process.env['FERRY_OPENAI_KEY'] ?? '',
-    googleApiKey: getArg(argv, '--google-key') ?? process.env['FERRY_GOOGLE_AI_KEY'] ?? '',
+    openaiApiKey:
+      getArg(argv, '--openai-key') ??
+      process.env['OPENAI_API_KEY'] ??
+      process.env['FERRY_OPENAI_KEY'] ??
+      '',
+    googleApiKey:
+      getArg(argv, '--google-key') ??
+      process.env['GOOGLE_API_KEY'] ??
+      process.env['FERRY_GOOGLE_AI_KEY'] ??
+      '',
     ferryVersion: getArg(argv, '--version') ?? 'v1',
     repoRoot: getArg(argv, '--repo-root') ?? process.cwd(),
     noDispatch: hasFlag(argv, '--no-dispatch'),
@@ -156,6 +164,7 @@ Exit code: 0 if all checks green/yellow, 1 if any check red.
       openaiApiKey: config.openaiApiKey,
       googleApiKey: config.googleApiKey,
       repoRoot: config.repoRoot,
+      repo: config.repo,
     }),
     checkSyntheticDispatch({ repo: config.repo, noDispatch: config.noDispatch }),
     checkWorkflowDrift({ repoRoot: config.repoRoot, ferryVersion: config.ferryVersion }),

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -20,7 +20,7 @@ import { installWorkflows, scaffoldCodeowners } from './steps/workflows.js';
 import { stepJiraBundle, DEFAULT_STATUS_NAMES } from './steps/jira-bundle.js';
 import { resolveJiraWorkspaceId, resolveJiraProjectId } from './steps/jira-resolve.js';
 import { stepVerify } from './steps/verify.js';
-import type { FerryConfig } from './types.js';
+import type { FerryConfig, LlmProvider } from './types.js';
 
 const FERRY_VERSION_DEFAULT = 'v1';
 
@@ -154,8 +154,45 @@ async function main(): Promise<void> {
   const iteratorAutoTransition = await ask('Iterator → after iteration (moves to)', 'In Review');
 
   print('');
-  print('LLM provider:');
+  print('LLM provider per phase (anthropic / openai / google, default: anthropic):');
+  print('  Note: MCP server support (labels, context7, etc.) requires Anthropic.');
+
+  function validateProvider(input: string): LlmProvider {
+    const lower = input.toLowerCase().trim();
+    if (lower === 'openai' || lower === 'google' || lower === 'anthropic') return lower;
+    return 'anthropic';
+  }
+
+  const refinerProviderRaw = await ask('Refiner provider', 'anthropic');
+  const devProviderRaw = await ask('Developer provider', 'anthropic');
+  const reviewProviderRaw = await ask('Reviewer provider', 'anthropic');
+  const iterateProviderRaw = await ask('Iterator provider', 'anthropic');
+
+  const refinerProvider = validateProvider(refinerProviderRaw);
+  const devProvider = validateProvider(devProviderRaw);
+  const reviewProvider = validateProvider(reviewProviderRaw);
+  const iterateProvider = validateProvider(iterateProviderRaw);
+
+  const needsOpenAI = [refinerProvider, devProvider, reviewProvider, iterateProvider].includes(
+    'openai',
+  );
+  const needsGoogle = [refinerProvider, devProvider, reviewProvider, iterateProvider].includes(
+    'google',
+  );
+
+  print('');
+  print('API keys:');
   const anthropicApiKey = await askSecret('Anthropic API key (sk-ant-...)');
+
+  let openaiApiKey = '';
+  if (needsOpenAI) {
+    openaiApiKey = await askSecret('OpenAI API key (sk-...)');
+  }
+
+  let googleApiKey = '';
+  if (needsGoogle) {
+    googleApiKey = await askSecret('Google AI API key');
+  }
 
   closePrompt();
 
@@ -172,6 +209,12 @@ async function main(): Promise<void> {
     jiraWorkspaceId: workspaceId,
     jiraProjectId: projectId,
     anthropicApiKey,
+    openaiApiKey: openaiApiKey || undefined,
+    googleApiKey: googleApiKey || undefined,
+    refinerProvider,
+    devProvider,
+    reviewProvider,
+    iterateProvider,
   };
 
   // ── Step 2: Secrets ───────────────────────────────────────────────────────
@@ -193,7 +236,36 @@ async function main(): Promise<void> {
   const configPath = join(repoRoot, 'ferry.config.yaml');
   if (!existsSync(configPath) || overwrite) {
     const nullable = (val: string): string => (val.trim() ? `"${val.trim()}"` : 'null');
+
+    const DEFAULT_MODELS: Record<string, string> = {
+      anthropic: 'claude-sonnet-4-6',
+      openai: 'gpt-4o',
+      google: 'gemini-2.5-pro',
+    };
+
+    const phaseProviders: Array<[string, string]> = [
+      ['refiner', refinerProvider],
+      ['dev', devProvider],
+      ['review', reviewProvider],
+      ['iterate', iterateProvider],
+    ];
+    const nonDefaultPhases = phaseProviders.filter(([, p]) => p !== 'anthropic');
+
+    const modelsBlock =
+      nonDefaultPhases.length > 0
+        ? [
+            'models:',
+            ...nonDefaultPhases.flatMap(([phase, provider]) => [
+              `  ${phase}:`,
+              `    provider: ${provider}`,
+              `    model: ${DEFAULT_MODELS[provider] ?? 'gpt-4o'}`,
+            ]),
+            '',
+          ]
+        : [];
+
     const workflowYaml = [
+      ...modelsBlock,
       'workflow:',
       '  agents:',
       '    refiner:',
@@ -213,6 +285,11 @@ async function main(): Promise<void> {
     ].join('\n');
     writeFileSync(configPath, workflowYaml, 'utf8');
     printSuccess('Generated ferry.config.yaml with workflow.agents settings');
+    if (nonDefaultPhases.length > 0) {
+      printSuccess(
+        `Added models block for non-default providers: ${nonDefaultPhases.map(([p]) => p).join(', ')}`,
+      );
+    }
   } else {
     printSkip('ferry.config.yaml already exists — skipping (use --overwrite to replace)');
   }
@@ -245,7 +322,18 @@ async function main(): Promise<void> {
   print('  3. Set spend caps on provider billing pages (see links above)');
   print('  4. Set FERRY_AUDIT_ISSUE repository variable to a GitHub Issue number');
   print('     for the audit log (create a blank issue and use its number)');
-  print('  5. Move a Jira ticket to "Refinement" — watch the Actions tab!');
+  let nextStep = 5;
+  if (needsOpenAI) {
+    print(`  ${nextStep++}. OpenAI key was set as OPENAI_API_KEY secret.`);
+    print(
+      '     Set spend limits: https://platform.openai.com/settings/organization/billing/limits',
+    );
+  }
+  if (needsGoogle) {
+    print(`  ${nextStep++}. Google AI key was set as GOOGLE_API_KEY secret.`);
+    print('     Enable budget alerts: https://console.cloud.google.com/billing');
+  }
+  print(`  ${nextStep}. Move a Jira ticket to "Refinement" — watch the Actions tab!`);
   print('');
 
   if (!secretsResult.ok || !verifyResult.ok) {

--- a/src/cli/init/steps/secrets.ts
+++ b/src/cli/init/steps/secrets.ts
@@ -9,8 +9,10 @@ export function buildSecrets(config: {
   jiraEmail: string;
   jiraApiToken: string;
   anthropicApiKey: string;
+  openaiApiKey?: string;
+  googleApiKey?: string;
 }): SecretEntry[] {
-  return [
+  const secrets: SecretEntry[] = [
     { name: 'FERRY_APP_ID', value: config.appId, description: 'GitHub App numeric ID' },
     {
       name: 'FERRY_PRIVATE_KEY',
@@ -30,6 +32,23 @@ export function buildSecrets(config: {
       description: 'Anthropic API key',
     },
   ];
+
+  if (config.openaiApiKey) {
+    secrets.push({
+      name: 'OPENAI_API_KEY',
+      value: config.openaiApiKey,
+      description: 'OpenAI API key',
+    });
+  }
+  if (config.googleApiKey) {
+    secrets.push({
+      name: 'GOOGLE_API_KEY',
+      value: config.googleApiKey,
+      description: 'Google AI API key',
+    });
+  }
+
+  return secrets;
 }
 
 export function listExistingSecrets(repo: string): string[] {

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -5,8 +5,13 @@ export function workflowTemplates(version: string): WorkflowEntry[] {
     {
       filename: 'ferry-refine.yml',
       content: `# Managed by ferry-init. Re-run \`npx -p @big-emotion/ferry ferry-init\` to update.
-# Required secrets: FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN, ANTHROPIC_API_KEY
+# Required secrets: FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN
+#                   ANTHROPIC_API_KEY  — required when FERRY_REFINER_PROVIDER=anthropic (default)
+#                   OPENAI_API_KEY     — required when FERRY_REFINER_PROVIDER=openai
+#                   GOOGLE_API_KEY     — required when FERRY_REFINER_PROVIDER=google
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
+# Optional variables: FERRY_REFINER_PROVIDER (default: anthropic; also: openai, google)
+#                     FERRY_REFINER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
 
 name: Ferry — Refine
 
@@ -58,6 +63,8 @@ jobs:
           jira_email: \${{ secrets.FERRY_JIRA_EMAIL }}
           jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
           anthropic_api_key: \${{ secrets.ANTHROPIC_API_KEY }}
+          openai_api_key: \${{ secrets.OPENAI_API_KEY }}
+          google_api_key: \${{ secrets.GOOGLE_API_KEY }}
           ferry_refiner_model: claude-sonnet-4-6
 
   emit-audit:
@@ -88,8 +95,15 @@ jobs:
       filename: 'ferry-dev.yml',
       content: `# Managed by ferry-init. Re-run \`npx -p @big-emotion/ferry ferry-init\` to update.
 # Required secrets: FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN,
-#                   ANTHROPIC_API_KEY, FERRY_REVIEW_TRANSITION_ID
+#                   FERRY_REVIEW_TRANSITION_ID
+#                   ANTHROPIC_API_KEY  — required when FERRY_DEV_PROVIDER=anthropic (default)
+#                   OPENAI_API_KEY     — required when FERRY_DEV_PROVIDER=openai
+#                   GOOGLE_API_KEY     — required when FERRY_DEV_PROVIDER=google
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
+# Optional variables: FERRY_DEV_PROVIDER (default: anthropic; also: openai, google)
+#                     FERRY_DEV_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#
+# Note: MCP server support is not available for non-Anthropic providers in the Developer agent.
 
 name: Ferry — Dev
 
@@ -148,6 +162,8 @@ jobs:
           jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
           ferry_review_transition_id: \${{ secrets.FERRY_REVIEW_TRANSITION_ID }}
           anthropic_api_key: \${{ secrets.ANTHROPIC_API_KEY }}
+          openai_api_key: \${{ secrets.OPENAI_API_KEY }}
+          google_api_key: \${{ secrets.GOOGLE_API_KEY }}
           github_token: \${{ github.token }}
           github_repo: \${{ github.repository }}
           ferry_dev_model: claude-sonnet-4-6
@@ -182,9 +198,15 @@ jobs:
       filename: 'ferry-review.yml',
       content: `# Managed by ferry-init. Re-run \`npx -p @big-emotion/ferry ferry-init\` to update.
 # Required secrets: FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN,
-#                   ANTHROPIC_API_KEY, FERRY_ITER_TRANSITION_ID
+#                   FERRY_ITER_TRANSITION_ID
+#                   ANTHROPIC_API_KEY  — required when FERRY_REVIEW_PROVIDER=anthropic (default)
+#                   OPENAI_API_KEY     — required when FERRY_REVIEW_PROVIDER=openai
+#                   GOOGLE_API_KEY     — required when FERRY_REVIEW_PROVIDER=google
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
-# Optional variables: FERRY_REVIEW_MODEL (default: claude-sonnet-4-6)
+# Optional variables: FERRY_REVIEW_PROVIDER (default: anthropic; also: openai, google)
+#                     FERRY_REVIEW_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#
+# Note: MCP server support is not available for non-Anthropic providers in the Reviewer agent.
 
 name: Ferry — Review
 
@@ -245,6 +267,8 @@ jobs:
           jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
           ferry_iter_transition_id: \${{ secrets.FERRY_ITER_TRANSITION_ID }}
           anthropic_api_key: \${{ secrets.ANTHROPIC_API_KEY }}
+          openai_api_key: \${{ secrets.OPENAI_API_KEY }}
+          google_api_key: \${{ secrets.GOOGLE_API_KEY }}
           github_token: \${{ github.token }}
           github_repo: \${{ github.repository }}
           ferry_review_model: \${{ vars.FERRY_REVIEW_MODEL || 'claude-sonnet-4-6' }}
@@ -279,10 +303,16 @@ jobs:
       filename: 'ferry-iterate.yml',
       content: `# Managed by ferry-init. Re-run \`npx -p @big-emotion/ferry ferry-init\` to update.
 # Required secrets: FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN,
-#                   ANTHROPIC_API_KEY, FERRY_REVIEW_TRANSITION_ID
+#                   FERRY_REVIEW_TRANSITION_ID
+#                   ANTHROPIC_API_KEY  — required when FERRY_ITER_PROVIDER=anthropic (default)
+#                   OPENAI_API_KEY     — required when FERRY_ITER_PROVIDER=openai
+#                   GOOGLE_API_KEY     — required when FERRY_ITER_PROVIDER=google
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
-# Optional variables: FERRY_ITER_MODEL (default: claude-sonnet-4-6)
+# Optional variables: FERRY_ITER_PROVIDER (default: anthropic; also: openai, google)
+#                     FERRY_ITER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
 #                     FERRY_ITER_MAX_INPUT_TOKENS (default: 500000)
+#
+# Note: MCP server support is not available for non-Anthropic providers in the Iterator agent.
 
 name: Ferry — Iterate
 
@@ -344,6 +374,8 @@ jobs:
           jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
           ferry_review_transition_id: \${{ secrets.FERRY_REVIEW_TRANSITION_ID }}
           anthropic_api_key: \${{ secrets.ANTHROPIC_API_KEY }}
+          openai_api_key: \${{ secrets.OPENAI_API_KEY }}
+          google_api_key: \${{ secrets.GOOGLE_API_KEY }}
           github_token: \${{ github.token }}
           github_repo: \${{ github.repository }}
           ferry_iter_model: \${{ vars.FERRY_ITER_MODEL || 'claude-sonnet-4-6' }}

--- a/src/cli/init/types.ts
+++ b/src/cli/init/types.ts
@@ -1,3 +1,5 @@
+export type LlmProvider = 'anthropic' | 'openai' | 'google';
+
 export interface FerryConfig {
   owner: string;
   repo: string;
@@ -11,6 +13,12 @@ export interface FerryConfig {
   jiraWorkspaceId: string;
   jiraProjectId: string;
   anthropicApiKey: string;
+  openaiApiKey?: string;
+  googleApiKey?: string;
+  refinerProvider: LlmProvider;
+  devProvider: LlmProvider;
+  reviewProvider: LlmProvider;
+  iterateProvider: LlmProvider;
 }
 
 export interface SecretEntry {


### PR DESCRIPTION
Implements all tasks from issue #220:

- Example workflows (refine/dev/iterate): add OPENAI_API_KEY, GOOGLE_API_KEY alongside ANTHROPIC_API_KEY; document FERRY_{PHASE}_PROVIDER variables
- ferry-doctor llm check: cross-check repo secrets via GitHub API, accept both OPENAI_API_KEY/FERRY_OPENAI_KEY (and Google equivalent)
- ferry-init: per-phase provider prompts, emit models block in ferry.config.yaml, secret-setup hints
- docs/CONFIGURATION.md: full provider × phase matrix with caveats (MCP, caching, cost)
- README.md: multi-provider note with link to config matrix

Closes #220

Generated with [Claude Code](https://claude.ai/code)