### PR TITLE
feat: port agentic loop to OpenAI and Google providers (#219)

### DIFF
--- a/.ferry/dev-action.js
+++ b/.ferry/dev-action.js
@@ -5765,6 +5765,20 @@ function runProcess(cmd, args, cwd, timeoutMs) {
   });
 }
 
+// src/lib/llm/anthropic-auth.ts
+function resolveAnthropicAuth(input) {
+  const env = input.env ?? process.env;
+  const oauthToken = env["CLAUDE_CODE_OAUTH_TOKEN"];
+  if (oauthToken) {
+    return { authToken: oauthToken };
+  }
+  const apiKey = env[input.apiKeyEnv];
+  if (apiKey) {
+    return { apiKey };
+  }
+  throw new FerryError("state-invariant", { reason: "missing-env", key: input.apiKeyEnv });
+}
+
 // src/lib/llm/agent-loop/anthropic.ts
 import Anthropic from "@anthropic-ai/sdk";
 
@@ -6413,6 +6427,714 @@ function createAnthropicAgentLoop(opts) {
   };
 }
 
+// src/lib/llm/agent-loop/openai.ts
+import OpenAI from "openai";
+var COMMIT_AND_STOP_TOOL_NAMES2 = /* @__PURE__ */ new Set([
+  "bash",
+  "write_file",
+  "str_replace",
+  "commit_progress",
+  "done"
+]);
+var KEEP_LAST_TURNS2 = 6;
+var STUB2 = "[truncated: tool result elided to save context]";
+function agentToolToOpenAI(t) {
+  return {
+    type: "function",
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: t.input_schema
+    }
+  };
+}
+function pruneMessageHistory2(messages) {
+  const toolResultIndices = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i].role === "tool") {
+      toolResultIndices.push(i);
+    }
+  }
+  const cutoff = messages.length - KEEP_LAST_TURNS2 * 2;
+  if (cutoff <= 1) return;
+  for (let i = 0; i < toolResultIndices.length; i++) {
+    const idx = toolResultIndices[i];
+    if (idx >= cutoff) break;
+    const msg = messages[idx];
+    if (msg.role === "tool" && typeof msg.content === "string" && msg.content !== STUB2) {
+      messages[idx].content = STUB2;
+    }
+  }
+}
+function injectBudgetWarning2(messages, text) {
+  const last = messages[messages.length - 1];
+  if (!last) return;
+  if (last.role === "user") {
+    if (typeof last.content === "string") {
+      messages[messages.length - 1].content = last.content + "\n\n" + text;
+    } else if (Array.isArray(last.content)) {
+      last.content.push({ type: "text", text });
+    }
+  } else {
+    messages.push({ role: "user", content: text });
+  }
+}
+function compactOldToolResults2(messages, windowTurns) {
+  const toolResultIndices = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i].role === "tool") {
+      toolResultIndices.push(i);
+    }
+  }
+  if (toolResultIndices.length <= windowTurns) return;
+  const compactCount = toolResultIndices.length - windowTurns;
+  for (let k = 0; k < compactCount; k++) {
+    const idx = toolResultIndices[k];
+    const msg = messages[idx];
+    if (msg.role !== "tool" || typeof msg.content !== "string") continue;
+    if (msg.content.startsWith("[compacted")) continue;
+    const tokens = Math.ceil(msg.content.length / 4);
+    messages[idx].content = `[compacted \u2014 ~${tokens} tokens elided]`;
+  }
+}
+function createOpenAIAgentLoop(opts) {
+  const openai = opts.client ?? new OpenAI({ apiKey: opts.apiKey });
+  const logger = opts.logger ?? createLogger("", "ferry:dev-loop");
+  async function runLoop(input) {
+    const { system, initialPrompt, tools, repoRoot, branchName, secretScan } = input;
+    const maxIterations = opts.maxIterations ?? parseInt(process.env.FERRY_DEV_MAX_ITERATIONS ?? "200", 10);
+    const maxInputTokens = opts.maxInputTokens ?? parseInt(process.env.FERRY_DEV_MAX_INPUT_TOKENS ?? "500000", 10);
+    const maxTokens = opts.maxTokens ?? parseInt(process.env.FERRY_DEV_MAX_TOKENS ?? "16384", 10);
+    const compactWindow = opts.compactWindow ?? parseInt(process.env.FERRY_DEV_COMPACT_WINDOW ?? "8", 10);
+    const allServers = input.mcpServers ?? [];
+    const httpServers = allServers.filter((s) => isHttpMcpServer(s) && "url" in s);
+    if (httpServers.length > 0) {
+      throw new FerryError("state-invariant", {
+        reason: "http-mcp-unsupported",
+        provider: "openai",
+        detail: "HTTP MCP servers are only supported with the Anthropic provider. Configure stdio MCP servers or switch to provider: anthropic."
+      });
+    }
+    const stdioServers = allServers.filter((s) => isStdioMcpServer(s));
+    const pool = new McpClientPool();
+    try {
+      let trackTool2 = function(name, outputSize) {
+        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+        toolCallRecords.push({ name, outputSize });
+      };
+      var trackTool = trackTool2;
+      if (stdioServers.length > 0) {
+        await pool.connect(stdioServers);
+        if (pool.getTools().length > 0) {
+          logger.info("stdio_mcp_tools", {
+            count: pool.getTools().length,
+            servers: stdioServers.map((s) => s.name).join(",")
+          });
+        }
+      }
+      const nativeAndStdioTools = [...tools, ...pool.getTools()];
+      const openaiTools = nativeAndStdioTools.map(agentToolToOpenAI);
+      const messages = [
+        { role: "system", content: system },
+        { role: "user", content: initialPrompt }
+      ];
+      const usage = {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0
+      };
+      const toolCounts = {};
+      const toolCallRecords = [];
+      let done = null;
+      let iter = 0;
+      const loopStart = Date.now();
+      let warned70 = false;
+      let warned85 = false;
+      while (iter < maxIterations) {
+        iter++;
+        const iterStart = Date.now();
+        const billableEquiv = usage.input_tokens + usage.output_tokens;
+        if (billableEquiv > maxInputTokens) {
+          throw new FerryError("spend-cap", {
+            reason: "input-token-budget-exceeded",
+            cap: maxInputTokens,
+            consumed: billableEquiv
+          });
+        }
+        const budgetFraction = maxInputTokens > 0 ? billableEquiv / maxInputTokens : 0;
+        if (!warned70 && budgetFraction >= 0.7) {
+          warned70 = true;
+          const remaining = Math.round((1 - budgetFraction) * 100);
+          logger.info("budget_warning", { iter, threshold: 70, remaining_pct: remaining });
+          injectBudgetWarning2(
+            messages,
+            `[ferry] You have used ~${Math.round(budgetFraction * 100)}% of your input budget (${remaining}% remaining). Wrap up now: stop exploration, finish the current change, commit, and push.`
+          );
+        }
+        if (!warned85 && budgetFraction >= 0.85) {
+          warned85 = true;
+          logger.info("budget_warning", { iter, threshold: 85, mode: "commit-and-stop" });
+          injectBudgetWarning2(
+            messages,
+            `[ferry] BUDGET CRITICAL: ~${Math.round(budgetFraction * 100)}% of your input budget is consumed. You are now in commit-and-stop mode. Only use: bash (git operations), write_file, str_replace, commit_progress, or done. No exploration, no new reads \u2014 commit all work and call done immediately.`
+          );
+        }
+        const effectiveTools = warned85 ? openaiTools.filter((t) => COMMIT_AND_STOP_TOOL_NAMES2.has(t.function.name)) : openaiTools;
+        pruneMessageHistory2(messages);
+        const response = await openai.chat.completions.create({
+          model: opts.model,
+          max_tokens: maxTokens,
+          tools: effectiveTools,
+          tool_choice: effectiveTools.length > 0 ? "required" : "none",
+          messages
+        });
+        usage.input_tokens += response.usage?.prompt_tokens ?? 0;
+        usage.output_tokens += response.usage?.completion_tokens ?? 0;
+        const choice = response.choices[0];
+        if (!choice) {
+          throw new FerryError("state-invariant", {
+            reason: "agent-stopped-without-done",
+            stop_reason: "no-choices"
+          });
+        }
+        const assistantMsg = choice.message;
+        messages.push(assistantMsg);
+        const allToolCalls = assistantMsg.tool_calls ?? [];
+        const toolCalls = allToolCalls.filter(
+          (tc) => tc.type === "function"
+        );
+        logger.info("turn", {
+          iter,
+          stop_reason: choice.finish_reason,
+          tools: toolCalls.length,
+          in: response.usage?.prompt_tokens ?? 0,
+          out: response.usage?.completion_tokens ?? 0
+        });
+        emitDebug(
+          {
+            type: "turn",
+            iter,
+            depth: 0,
+            stop_reason: choice.finish_reason,
+            tools: toolCalls.length,
+            mcp_tools: 0,
+            in: response.usage?.prompt_tokens ?? 0,
+            cache_w: 0,
+            cache_r: 0,
+            out: response.usage?.completion_tokens ?? 0,
+            elapsed_ms: Date.now() - iterStart
+          },
+          logger
+        );
+        if (choice.finish_reason !== "tool_calls" && toolCalls.length === 0) {
+          throw new FerryError("state-invariant", {
+            reason: "agent-stopped-without-done",
+            stop_reason: choice.finish_reason
+          });
+        }
+        for (const toolCall of toolCalls) {
+          const name = toolCall.function.name;
+          let blockInput;
+          try {
+            blockInput = JSON.parse(toolCall.function.arguments);
+          } catch {
+            blockInput = {};
+          }
+          if (name === "done") {
+            const outcome = blockInput.outcome;
+            const actionable = outcome !== void 0 ? outcome !== "blocked" : blockInput.actionable;
+            done = { ...blockInput, actionable, outcome };
+            messages.push({ role: "tool", tool_call_id: toolCall.id, content: "ok" });
+            continue;
+          }
+          if (name === "commit_progress" && opts.commitProgress) {
+            const { message } = blockInput;
+            logger.info("tool", { iter, tool: "commit_progress", arg: message.slice(0, 120) });
+            try {
+              const result = await opts.commitProgress(repoRoot, branchName, message, secretScan);
+              trackTool2("commit_progress", result.length);
+              messages.push({ role: "tool", tool_call_id: toolCall.id, content: result });
+            } catch (e) {
+              trackTool2("commit_progress", 0);
+              messages.push({
+                role: "tool",
+                tool_call_id: toolCall.id,
+                content: e.message
+              });
+            }
+            continue;
+          }
+          if (pool.hasTool(name)) {
+            const serverName = pool.getServerName(name) ?? "unknown";
+            logger.info("mcp_stdio_tool", { iter, tool: name, server: serverName });
+            try {
+              const result = await pool.callTool(name, blockInput);
+              trackTool2(name, result.length);
+              messages.push({ role: "tool", tool_call_id: toolCall.id, content: result });
+            } catch (e) {
+              trackTool2(name, 0);
+              messages.push({
+                role: "tool",
+                tool_call_id: toolCall.id,
+                content: e.message
+              });
+            }
+            continue;
+          }
+          const argHint = blockInput.path ?? blockInput.source ?? blockInput.command ?? blockInput.pattern ?? "";
+          logger.info("tool", {
+            iter,
+            tool: name,
+            ...argHint ? { arg: String(argHint).slice(0, 120) } : {}
+          });
+          try {
+            const result = await opts.executeTool(repoRoot, name, blockInput);
+            trackTool2(name, result.length);
+            messages.push({ role: "tool", tool_call_id: toolCall.id, content: result });
+          } catch (e) {
+            trackTool2(name, 0);
+            messages.push({
+              role: "tool",
+              tool_call_id: toolCall.id,
+              content: e.message
+            });
+          }
+        }
+        compactOldToolResults2(messages, compactWindow);
+        if (done) {
+          emitDebug(
+            {
+              type: "result",
+              subtype: "success",
+              iterations: iter,
+              total_in: usage.input_tokens,
+              total_out: usage.output_tokens,
+              elapsed_ms: Date.now() - loopStart
+            },
+            logger
+          );
+          return { done, usage, iterations: iter, toolCounts, toolCallRecords };
+        }
+      }
+      throw new FerryError("state-invariant", {
+        reason: "iteration-cap-exceeded",
+        cap: maxIterations
+      });
+    } finally {
+      await pool.close();
+    }
+  }
+  return {
+    run(input) {
+      return runLoop(input);
+    }
+  };
+}
+
+// src/lib/llm/agent-loop/google.ts
+import { GoogleGenAI, FunctionCallingConfigMode } from "@google/genai";
+var COMMIT_AND_STOP_TOOL_NAMES3 = /* @__PURE__ */ new Set([
+  "bash",
+  "write_file",
+  "str_replace",
+  "commit_progress",
+  "done"
+]);
+var KEEP_LAST_TURNS3 = 6;
+var STUB3 = "[truncated: tool result elided to save context]";
+function pruneMessageHistory3(messages) {
+  const toolResultIndices = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role === "user" && msg.parts?.some((p) => p.functionResponse !== void 0)) {
+      toolResultIndices.push(i);
+    }
+  }
+  const cutoff = messages.length - KEEP_LAST_TURNS3 * 2;
+  if (cutoff <= 1) return;
+  for (const idx of toolResultIndices) {
+    if (idx >= cutoff) break;
+    const msg = messages[idx];
+    if (!msg.parts) continue;
+    for (let j = 0; j < msg.parts.length; j++) {
+      const part = msg.parts[j];
+      if (part.functionResponse === void 0) continue;
+      const output = part.functionResponse.response?.["output"];
+      if (typeof output === "string" && output !== STUB3) {
+        msg.parts[j] = {
+          functionResponse: {
+            name: part.functionResponse.name,
+            id: part.functionResponse.id,
+            response: { output: STUB3 }
+          }
+        };
+      }
+    }
+  }
+}
+function injectBudgetWarning3(messages, text) {
+  const last = messages[messages.length - 1];
+  if (last?.role === "user") {
+    last.parts = [...last.parts ?? [], { text }];
+  } else {
+    messages.push({ role: "user", parts: [{ text }] });
+  }
+}
+function compactOldToolResults3(messages, windowTurns) {
+  const toolResultIndices = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role === "user" && msg.parts?.some((p) => p.functionResponse !== void 0)) {
+      toolResultIndices.push(i);
+    }
+  }
+  if (toolResultIndices.length <= windowTurns) return;
+  const compactCount = toolResultIndices.length - windowTurns;
+  for (let k = 0; k < compactCount; k++) {
+    const idx = toolResultIndices[k];
+    const msg = messages[idx];
+    if (!msg.parts) continue;
+    for (let j = 0; j < msg.parts.length; j++) {
+      const part = msg.parts[j];
+      if (part.functionResponse === void 0) continue;
+      const output = part.functionResponse.response?.["output"];
+      if (typeof output !== "string" || output.startsWith("[compacted")) continue;
+      const tokens = Math.ceil(output.length / 4);
+      msg.parts[j] = {
+        functionResponse: {
+          name: part.functionResponse.name,
+          id: part.functionResponse.id,
+          response: { output: `[compacted \u2014 ~${tokens} tokens elided]` }
+        }
+      };
+    }
+  }
+}
+function createGoogleAgentLoop(opts) {
+  const ai = opts.ai ?? new GoogleGenAI({ apiKey: opts.apiKey });
+  const logger = opts.logger ?? createLogger("", "ferry:dev-loop");
+  async function runLoop(input) {
+    const { system, initialPrompt, tools, repoRoot, branchName, secretScan } = input;
+    const maxIterations = opts.maxIterations ?? parseInt(process.env.FERRY_DEV_MAX_ITERATIONS ?? "200", 10);
+    const maxInputTokens = opts.maxInputTokens ?? parseInt(process.env.FERRY_DEV_MAX_INPUT_TOKENS ?? "500000", 10);
+    const maxTokens = opts.maxTokens ?? parseInt(process.env.FERRY_DEV_MAX_TOKENS ?? "16384", 10);
+    const compactWindow = opts.compactWindow ?? parseInt(process.env.FERRY_DEV_COMPACT_WINDOW ?? "8", 10);
+    const allServers = input.mcpServers ?? [];
+    const httpServers = allServers.filter((s) => isHttpMcpServer(s) && "url" in s);
+    if (httpServers.length > 0) {
+      throw new FerryError("state-invariant", {
+        reason: "http-mcp-unsupported",
+        provider: "google",
+        detail: "HTTP MCP servers are only supported with the Anthropic provider. Configure stdio MCP servers or switch to provider: anthropic."
+      });
+    }
+    const stdioServers = allServers.filter((s) => isStdioMcpServer(s));
+    const pool = new McpClientPool();
+    try {
+      let trackTool2 = function(name, outputSize) {
+        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+        toolCallRecords.push({ name, outputSize });
+      };
+      var trackTool = trackTool2;
+      if (stdioServers.length > 0) {
+        await pool.connect(stdioServers);
+        if (pool.getTools().length > 0) {
+          logger.info("stdio_mcp_tools", {
+            count: pool.getTools().length,
+            servers: stdioServers.map((s) => s.name).join(",")
+          });
+        }
+      }
+      const nativeAndStdioTools = [...tools, ...pool.getTools()];
+      const allToolDeclarations = nativeAndStdioTools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        parametersJsonSchema: t.input_schema
+      }));
+      const messages = [{ role: "user", parts: [{ text: initialPrompt }] }];
+      const usage = {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0
+      };
+      const toolCounts = {};
+      const toolCallRecords = [];
+      let done = null;
+      let iter = 0;
+      const loopStart = Date.now();
+      let warned70 = false;
+      let warned85 = false;
+      while (iter < maxIterations) {
+        iter++;
+        const iterStart = Date.now();
+        const billableEquiv = usage.input_tokens + usage.output_tokens;
+        if (billableEquiv > maxInputTokens) {
+          throw new FerryError("spend-cap", {
+            reason: "input-token-budget-exceeded",
+            cap: maxInputTokens,
+            consumed: billableEquiv
+          });
+        }
+        const budgetFraction = maxInputTokens > 0 ? billableEquiv / maxInputTokens : 0;
+        if (!warned70 && budgetFraction >= 0.7) {
+          warned70 = true;
+          const remaining = Math.round((1 - budgetFraction) * 100);
+          logger.info("budget_warning", { iter, threshold: 70, remaining_pct: remaining });
+          injectBudgetWarning3(
+            messages,
+            `[ferry] You have used ~${Math.round(budgetFraction * 100)}% of your input budget (${remaining}% remaining). Wrap up now: stop exploration, finish the current change, commit, and push.`
+          );
+        }
+        if (!warned85 && budgetFraction >= 0.85) {
+          warned85 = true;
+          logger.info("budget_warning", { iter, threshold: 85, mode: "commit-and-stop" });
+          injectBudgetWarning3(
+            messages,
+            `[ferry] BUDGET CRITICAL: ~${Math.round(budgetFraction * 100)}% of your input budget is consumed. You are now in commit-and-stop mode. Only use: bash (git operations), write_file, str_replace, commit_progress, or done. No exploration, no new reads \u2014 commit all work and call done immediately.`
+          );
+        }
+        const effectiveToolDeclarations = warned85 ? allToolDeclarations.filter((t) => COMMIT_AND_STOP_TOOL_NAMES3.has(t.name ?? "")) : allToolDeclarations;
+        pruneMessageHistory3(messages);
+        const response = await ai.models.generateContent({
+          model: opts.model,
+          contents: messages,
+          config: {
+            systemInstruction: system,
+            maxOutputTokens: maxTokens,
+            tools: effectiveToolDeclarations.length > 0 ? [{ functionDeclarations: effectiveToolDeclarations }] : void 0,
+            toolConfig: effectiveToolDeclarations.length > 0 ? {
+              functionCallingConfig: {
+                mode: FunctionCallingConfigMode.ANY
+              }
+            } : void 0,
+            automaticFunctionCalling: { disable: true }
+          }
+        });
+        usage.input_tokens += response.usageMetadata?.promptTokenCount ?? 0;
+        usage.output_tokens += response.usageMetadata?.candidatesTokenCount ?? 0;
+        const candidate = response.candidates?.[0];
+        const finishReason = candidate?.finishReason ?? "STOP";
+        const modelContent = candidate?.content;
+        const parts = modelContent?.parts ?? [];
+        const functionCallParts = parts.filter((p) => p.functionCall !== void 0);
+        logger.info("turn", {
+          iter,
+          stop_reason: finishReason,
+          tools: functionCallParts.length,
+          in: response.usageMetadata?.promptTokenCount ?? 0,
+          out: response.usageMetadata?.candidatesTokenCount ?? 0
+        });
+        emitDebug(
+          {
+            type: "turn",
+            iter,
+            depth: 0,
+            stop_reason: finishReason,
+            tools: functionCallParts.length,
+            mcp_tools: 0,
+            in: response.usageMetadata?.promptTokenCount ?? 0,
+            cache_w: 0,
+            cache_r: 0,
+            out: response.usageMetadata?.candidatesTokenCount ?? 0,
+            elapsed_ms: Date.now() - iterStart
+          },
+          logger
+        );
+        if (functionCallParts.length === 0) {
+          throw new FerryError("state-invariant", {
+            reason: "agent-stopped-without-done",
+            stop_reason: finishReason
+          });
+        }
+        messages.push({ role: "model", parts });
+        const toolResultParts = [];
+        for (const part of functionCallParts) {
+          const fc = part.functionCall;
+          const name = fc.name ?? "";
+          const blockInput = fc.args ?? {};
+          const callId = fc.id;
+          if (name === "done") {
+            const outcome = blockInput.outcome;
+            const actionable = outcome !== void 0 ? outcome !== "blocked" : blockInput.actionable;
+            done = { ...blockInput, actionable, outcome };
+            toolResultParts.push({
+              functionResponse: {
+                name,
+                ...callId !== void 0 ? { id: callId } : {},
+                response: { output: "ok" }
+              }
+            });
+            continue;
+          }
+          if (name === "commit_progress" && opts.commitProgress) {
+            const { message } = blockInput;
+            logger.info("tool", { iter, tool: "commit_progress", arg: message.slice(0, 120) });
+            try {
+              const result = await opts.commitProgress(repoRoot, branchName, message, secretScan);
+              trackTool2("commit_progress", result.length);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...callId !== void 0 ? { id: callId } : {},
+                  response: { output: result }
+                }
+              });
+            } catch (e) {
+              trackTool2("commit_progress", 0);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...callId !== void 0 ? { id: callId } : {},
+                  response: { output: e.message, error: true }
+                }
+              });
+            }
+            continue;
+          }
+          if (pool.hasTool(name)) {
+            const serverName = pool.getServerName(name) ?? "unknown";
+            logger.info("mcp_stdio_tool", { iter, tool: name, server: serverName });
+            try {
+              const result = await pool.callTool(name, blockInput);
+              trackTool2(name, result.length);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...callId !== void 0 ? { id: callId } : {},
+                  response: { output: result }
+                }
+              });
+            } catch (e) {
+              trackTool2(name, 0);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...callId !== void 0 ? { id: callId } : {},
+                  response: { output: e.message, error: true }
+                }
+              });
+            }
+            continue;
+          }
+          const argHint = blockInput.path ?? blockInput.source ?? blockInput.command ?? blockInput.pattern ?? "";
+          logger.info("tool", {
+            iter,
+            tool: name,
+            ...argHint ? { arg: String(argHint).slice(0, 120) } : {}
+          });
+          try {
+            const result = await opts.executeTool(repoRoot, name, blockInput);
+            trackTool2(name, result.length);
+            toolResultParts.push({
+              functionResponse: {
+                name,
+                ...callId !== void 0 ? { id: callId } : {},
+                response: { output: result }
+              }
+            });
+          } catch (e) {
+            trackTool2(name, 0);
+            toolResultParts.push({
+              functionResponse: {
+                name,
+                ...callId !== void 0 ? { id: callId } : {},
+                response: { output: e.message, error: true }
+              }
+            });
+          }
+        }
+        messages.push({ role: "user", parts: toolResultParts });
+        compactOldToolResults3(messages, compactWindow);
+        if (done) {
+          emitDebug(
+            {
+              type: "result",
+              subtype: "success",
+              iterations: iter,
+              total_in: usage.input_tokens,
+              total_out: usage.output_tokens,
+              elapsed_ms: Date.now() - loopStart
+            },
+            logger
+          );
+          return { done, usage, iterations: iter, toolCounts, toolCallRecords };
+        }
+      }
+      throw new FerryError("state-invariant", {
+        reason: "iteration-cap-exceeded",
+        cap: maxIterations
+      });
+    } finally {
+      await pool.close();
+    }
+  }
+  return {
+    run(input) {
+      return runLoop(input);
+    }
+  };
+}
+
+// src/lib/llm/agent-loop/index.ts
+function requireEnv2(key) {
+  const val = process.env[key];
+  if (!val) {
+    throw new FerryError("state-invariant", { reason: "missing-env", key });
+  }
+  return val;
+}
+function createAgentLoop(opts) {
+  if (opts.provider === "anthropic") {
+    const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
+    return createAnthropicAgentLoop({
+      ...auth2,
+      model: opts.model,
+      executeTool: opts.executeTool,
+      commitProgress: opts.commitProgress,
+      spawnSubagent: opts.spawnSubagent,
+      maxIterations: opts.maxIterations,
+      maxInputTokens: opts.maxInputTokens,
+      maxTokens: opts.maxTokens,
+      compactWindow: opts.compactWindow,
+      logger: opts.logger
+    });
+  }
+  if (opts.provider === "openai") {
+    const apiKey = requireEnv2("FERRY_OPENAI_KEY");
+    return createOpenAIAgentLoop({
+      apiKey,
+      model: opts.model,
+      executeTool: opts.executeTool,
+      commitProgress: opts.commitProgress,
+      maxIterations: opts.maxIterations,
+      maxInputTokens: opts.maxInputTokens,
+      maxTokens: opts.maxTokens,
+      compactWindow: opts.compactWindow,
+      logger: opts.logger
+    });
+  }
+  if (opts.provider === "google") {
+    const apiKey = requireEnv2("FERRY_GOOGLE_AI_KEY");
+    return createGoogleAgentLoop({
+      apiKey,
+      model: opts.model,
+      executeTool: opts.executeTool,
+      commitProgress: opts.commitProgress,
+      maxIterations: opts.maxIterations,
+      maxInputTokens: opts.maxInputTokens,
+      maxTokens: opts.maxTokens,
+      compactWindow: opts.compactWindow,
+      logger: opts.logger
+    });
+  }
+  throw new FerryError("state-invariant", {
+    reason: "unknown-provider",
+    provider: opts.provider
+  });
+}
+
 // src/lib/labels/capabilities.ts
 function resolveCapabilities(ticketLabels, configLabels, logger) {
   if (!configLabels) {
@@ -6466,20 +7188,6 @@ function filterMcpServers(pool, capabilities, hasLabelsConfig) {
     }
     return s;
   });
-}
-
-// src/lib/llm/anthropic-auth.ts
-function resolveAnthropicAuth(input) {
-  const env = input.env ?? process.env;
-  const oauthToken = env["CLAUDE_CODE_OAUTH_TOKEN"];
-  if (oauthToken) {
-    return { authToken: oauthToken };
-  }
-  const apiKey = env[input.apiKeyEnv];
-  if (apiKey) {
-    return { apiKey };
-  }
-  throw new FerryError("state-invariant", { reason: "missing-env", key: input.apiKeyEnv });
 }
 
 // src/agents/developer/workspace.ts
@@ -6699,7 +7407,6 @@ async function main(envelope, logger) {
   if (dryRun) {
     logger.info("DRY_RUN mode \u2014 no branch push, no PR, no Jira writes");
   }
-  const anthropicAuth = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT);
   const { baseBranch, targetBranch, workingBranchPrefix } = await resolveGitConfig(
     initialCfg,
@@ -6709,14 +7416,6 @@ async function main(envelope, logger) {
   );
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
   const { provider: devProvider } = ferryCfg.models.dev;
-  if (devProvider !== "anthropic") {
-    throw new FerryError("state-invariant", {
-      reason: "unsupported-provider",
-      provider: devProvider,
-      phase: "developer",
-      detail: "The developer phase requires provider 'anthropic'. OpenAI and Google support for agentic phases is planned for a future release."
-    });
-  }
   const devWorkflow = ferryCfg.workflow.agents.developer;
   const shouldAutoTransition = devWorkflow.auto_transition !== null;
   const reviewTransitionId = dryRun || !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
@@ -6816,8 +7515,8 @@ ${tree}`,
   }
   const allToolSchemas = [...TOOL_SCHEMAS, COMMIT_PROGRESS_SCHEMA, SPAWN_SUBAGENT_SCHEMA];
   let loop;
-  loop = createAnthropicAgentLoop({
-    ...anthropicAuth,
+  loop = createAgentLoop({
+    provider: devProvider,
     model,
     maxIterations: ferryCfg.limits.max_agent_iterations,
     maxInputTokens: ferryCfg.limits.max_tokens_per_run,

--- a/.ferry/iterate-action.js
+++ b/.ferry/iterate-action.js
@@ -539,9 +539,6 @@ function runProcess(cmd, args, cwd, timeoutMs) {
   });
 }
 
-// src/lib/llm/agent-loop/anthropic.ts
-import Anthropic from "@anthropic-ai/sdk";
-
 // src/lib/errors/index.ts
 var FerryError = class extends Error {
   constructor(code, context) {
@@ -553,6 +550,23 @@ var FerryError = class extends Error {
   code;
   context;
 };
+
+// src/lib/llm/anthropic-auth.ts
+function resolveAnthropicAuth(input) {
+  const env = input.env ?? process.env;
+  const oauthToken = env["CLAUDE_CODE_OAUTH_TOKEN"];
+  if (oauthToken) {
+    return { authToken: oauthToken };
+  }
+  const apiKey = env[input.apiKeyEnv];
+  if (apiKey) {
+    return { apiKey };
+  }
+  throw new FerryError("state-invariant", { reason: "missing-env", key: input.apiKeyEnv });
+}
+
+// src/lib/llm/agent-loop/anthropic.ts
+import Anthropic from "@anthropic-ai/sdk";
 
 // src/lib/llm/debug-log.ts
 function isDebugEnabled(env) {
@@ -1246,18 +1260,712 @@ function createAnthropicAgentLoop(opts) {
   };
 }
 
-// src/lib/llm/anthropic-auth.ts
-function resolveAnthropicAuth(input) {
-  const env = input.env ?? process.env;
-  const oauthToken = env["CLAUDE_CODE_OAUTH_TOKEN"];
-  if (oauthToken) {
-    return { authToken: oauthToken };
+// src/lib/llm/agent-loop/openai.ts
+import OpenAI from "openai";
+var COMMIT_AND_STOP_TOOL_NAMES2 = /* @__PURE__ */ new Set([
+  "bash",
+  "write_file",
+  "str_replace",
+  "commit_progress",
+  "done"
+]);
+var KEEP_LAST_TURNS2 = 6;
+var STUB2 = "[truncated: tool result elided to save context]";
+function agentToolToOpenAI(t) {
+  return {
+    type: "function",
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: t.input_schema
+    }
+  };
+}
+function pruneMessageHistory2(messages) {
+  const toolResultIndices = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i].role === "tool") {
+      toolResultIndices.push(i);
+    }
   }
-  const apiKey = env[input.apiKeyEnv];
-  if (apiKey) {
-    return { apiKey };
+  const cutoff = messages.length - KEEP_LAST_TURNS2 * 2;
+  if (cutoff <= 1) return;
+  for (let i = 0; i < toolResultIndices.length; i++) {
+    const idx = toolResultIndices[i];
+    if (idx >= cutoff) break;
+    const msg = messages[idx];
+    if (msg.role === "tool" && typeof msg.content === "string" && msg.content !== STUB2) {
+      messages[idx].content = STUB2;
+    }
   }
-  throw new FerryError("state-invariant", { reason: "missing-env", key: input.apiKeyEnv });
+}
+function injectBudgetWarning2(messages, text) {
+  const last = messages[messages.length - 1];
+  if (!last) return;
+  if (last.role === "user") {
+    if (typeof last.content === "string") {
+      messages[messages.length - 1].content = last.content + "\n\n" + text;
+    } else if (Array.isArray(last.content)) {
+      last.content.push({ type: "text", text });
+    }
+  } else {
+    messages.push({ role: "user", content: text });
+  }
+}
+function compactOldToolResults2(messages, windowTurns) {
+  const toolResultIndices = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i].role === "tool") {
+      toolResultIndices.push(i);
+    }
+  }
+  if (toolResultIndices.length <= windowTurns) return;
+  const compactCount = toolResultIndices.length - windowTurns;
+  for (let k = 0; k < compactCount; k++) {
+    const idx = toolResultIndices[k];
+    const msg = messages[idx];
+    if (msg.role !== "tool" || typeof msg.content !== "string") continue;
+    if (msg.content.startsWith("[compacted")) continue;
+    const tokens = Math.ceil(msg.content.length / 4);
+    messages[idx].content = `[compacted \u2014 ~${tokens} tokens elided]`;
+  }
+}
+function createOpenAIAgentLoop(opts) {
+  const openai = opts.client ?? new OpenAI({ apiKey: opts.apiKey });
+  const logger = opts.logger ?? createLogger("", "ferry:dev-loop");
+  async function runLoop(input) {
+    const { system, initialPrompt, tools, repoRoot, branchName, secretScan } = input;
+    const maxIterations = opts.maxIterations ?? parseInt(process.env.FERRY_DEV_MAX_ITERATIONS ?? "200", 10);
+    const maxInputTokens = opts.maxInputTokens ?? parseInt(process.env.FERRY_DEV_MAX_INPUT_TOKENS ?? "500000", 10);
+    const maxTokens = opts.maxTokens ?? parseInt(process.env.FERRY_DEV_MAX_TOKENS ?? "16384", 10);
+    const compactWindow = opts.compactWindow ?? parseInt(process.env.FERRY_DEV_COMPACT_WINDOW ?? "8", 10);
+    const allServers = input.mcpServers ?? [];
+    const httpServers = allServers.filter((s) => isHttpMcpServer(s) && "url" in s);
+    if (httpServers.length > 0) {
+      throw new FerryError("state-invariant", {
+        reason: "http-mcp-unsupported",
+        provider: "openai",
+        detail: "HTTP MCP servers are only supported with the Anthropic provider. Configure stdio MCP servers or switch to provider: anthropic."
+      });
+    }
+    const stdioServers = allServers.filter((s) => isStdioMcpServer(s));
+    const pool = new McpClientPool();
+    try {
+      let trackTool2 = function(name, outputSize) {
+        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+        toolCallRecords.push({ name, outputSize });
+      };
+      var trackTool = trackTool2;
+      if (stdioServers.length > 0) {
+        await pool.connect(stdioServers);
+        if (pool.getTools().length > 0) {
+          logger.info("stdio_mcp_tools", {
+            count: pool.getTools().length,
+            servers: stdioServers.map((s) => s.name).join(",")
+          });
+        }
+      }
+      const nativeAndStdioTools = [...tools, ...pool.getTools()];
+      const openaiTools = nativeAndStdioTools.map(agentToolToOpenAI);
+      const messages = [
+        { role: "system", content: system },
+        { role: "user", content: initialPrompt }
+      ];
+      const usage = {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0
+      };
+      const toolCounts = {};
+      const toolCallRecords = [];
+      let done = null;
+      let iter = 0;
+      const loopStart = Date.now();
+      let warned70 = false;
+      let warned85 = false;
+      while (iter < maxIterations) {
+        iter++;
+        const iterStart = Date.now();
+        const billableEquiv = usage.input_tokens + usage.output_tokens;
+        if (billableEquiv > maxInputTokens) {
+          throw new FerryError("spend-cap", {
+            reason: "input-token-budget-exceeded",
+            cap: maxInputTokens,
+            consumed: billableEquiv
+          });
+        }
+        const budgetFraction = maxInputTokens > 0 ? billableEquiv / maxInputTokens : 0;
+        if (!warned70 && budgetFraction >= 0.7) {
+          warned70 = true;
+          const remaining = Math.round((1 - budgetFraction) * 100);
+          logger.info("budget_warning", { iter, threshold: 70, remaining_pct: remaining });
+          injectBudgetWarning2(
+            messages,
+            `[ferry] You have used ~${Math.round(budgetFraction * 100)}% of your input budget (${remaining}% remaining). Wrap up now: stop exploration, finish the current change, commit, and push.`
+          );
+        }
+        if (!warned85 && budgetFraction >= 0.85) {
+          warned85 = true;
+          logger.info("budget_warning", { iter, threshold: 85, mode: "commit-and-stop" });
+          injectBudgetWarning2(
+            messages,
+            `[ferry] BUDGET CRITICAL: ~${Math.round(budgetFraction * 100)}% of your input budget is consumed. You are now in commit-and-stop mode. Only use: bash (git operations), write_file, str_replace, commit_progress, or done. No exploration, no new reads \u2014 commit all work and call done immediately.`
+          );
+        }
+        const effectiveTools = warned85 ? openaiTools.filter((t) => COMMIT_AND_STOP_TOOL_NAMES2.has(t.function.name)) : openaiTools;
+        pruneMessageHistory2(messages);
+        const response = await openai.chat.completions.create({
+          model: opts.model,
+          max_tokens: maxTokens,
+          tools: effectiveTools,
+          tool_choice: effectiveTools.length > 0 ? "required" : "none",
+          messages
+        });
+        usage.input_tokens += response.usage?.prompt_tokens ?? 0;
+        usage.output_tokens += response.usage?.completion_tokens ?? 0;
+        const choice = response.choices[0];
+        if (!choice) {
+          throw new FerryError("state-invariant", {
+            reason: "agent-stopped-without-done",
+            stop_reason: "no-choices"
+          });
+        }
+        const assistantMsg = choice.message;
+        messages.push(assistantMsg);
+        const allToolCalls = assistantMsg.tool_calls ?? [];
+        const toolCalls = allToolCalls.filter(
+          (tc) => tc.type === "function"
+        );
+        logger.info("turn", {
+          iter,
+          stop_reason: choice.finish_reason,
+          tools: toolCalls.length,
+          in: response.usage?.prompt_tokens ?? 0,
+          out: response.usage?.completion_tokens ?? 0
+        });
+        emitDebug(
+          {
+            type: "turn",
+            iter,
+            depth: 0,
+            stop_reason: choice.finish_reason,
+            tools: toolCalls.length,
+            mcp_tools: 0,
+            in: response.usage?.prompt_tokens ?? 0,
+            cache_w: 0,
+            cache_r: 0,
+            out: response.usage?.completion_tokens ?? 0,
+            elapsed_ms: Date.now() - iterStart
+          },
+          logger
+        );
+        if (choice.finish_reason !== "tool_calls" && toolCalls.length === 0) {
+          throw new FerryError("state-invariant", {
+            reason: "agent-stopped-without-done",
+            stop_reason: choice.finish_reason
+          });
+        }
+        for (const toolCall of toolCalls) {
+          const name = toolCall.function.name;
+          let blockInput;
+          try {
+            blockInput = JSON.parse(toolCall.function.arguments);
+          } catch {
+            blockInput = {};
+          }
+          if (name === "done") {
+            const outcome = blockInput.outcome;
+            const actionable = outcome !== void 0 ? outcome !== "blocked" : blockInput.actionable;
+            done = { ...blockInput, actionable, outcome };
+            messages.push({ role: "tool", tool_call_id: toolCall.id, content: "ok" });
+            continue;
+          }
+          if (name === "commit_progress" && opts.commitProgress) {
+            const { message } = blockInput;
+            logger.info("tool", { iter, tool: "commit_progress", arg: message.slice(0, 120) });
+            try {
+              const result = await opts.commitProgress(repoRoot, branchName, message, secretScan);
+              trackTool2("commit_progress", result.length);
+              messages.push({ role: "tool", tool_call_id: toolCall.id, content: result });
+            } catch (e) {
+              trackTool2("commit_progress", 0);
+              messages.push({
+                role: "tool",
+                tool_call_id: toolCall.id,
+                content: e.message
+              });
+            }
+            continue;
+          }
+          if (pool.hasTool(name)) {
+            const serverName = pool.getServerName(name) ?? "unknown";
+            logger.info("mcp_stdio_tool", { iter, tool: name, server: serverName });
+            try {
+              const result = await pool.callTool(name, blockInput);
+              trackTool2(name, result.length);
+              messages.push({ role: "tool", tool_call_id: toolCall.id, content: result });
+            } catch (e) {
+              trackTool2(name, 0);
+              messages.push({
+                role: "tool",
+                tool_call_id: toolCall.id,
+                content: e.message
+              });
+            }
+            continue;
+          }
+          const argHint = blockInput.path ?? blockInput.source ?? blockInput.command ?? blockInput.pattern ?? "";
+          logger.info("tool", {
+            iter,
+            tool: name,
+            ...argHint ? { arg: String(argHint).slice(0, 120) } : {}
+          });
+          try {
+            const result = await opts.executeTool(repoRoot, name, blockInput);
+            trackTool2(name, result.length);
+            messages.push({ role: "tool", tool_call_id: toolCall.id, content: result });
+          } catch (e) {
+            trackTool2(name, 0);
+            messages.push({
+              role: "tool",
+              tool_call_id: toolCall.id,
+              content: e.message
+            });
+          }
+        }
+        compactOldToolResults2(messages, compactWindow);
+        if (done) {
+          emitDebug(
+            {
+              type: "result",
+              subtype: "success",
+              iterations: iter,
+              total_in: usage.input_tokens,
+              total_out: usage.output_tokens,
+              elapsed_ms: Date.now() - loopStart
+            },
+            logger
+          );
+          return { done, usage, iterations: iter, toolCounts, toolCallRecords };
+        }
+      }
+      throw new FerryError("state-invariant", {
+        reason: "iteration-cap-exceeded",
+        cap: maxIterations
+      });
+    } finally {
+      await pool.close();
+    }
+  }
+  return {
+    run(input) {
+      return runLoop(input);
+    }
+  };
+}
+
+// src/lib/llm/agent-loop/google.ts
+import { GoogleGenAI, FunctionCallingConfigMode } from "@google/genai";
+var COMMIT_AND_STOP_TOOL_NAMES3 = /* @__PURE__ */ new Set([
+  "bash",
+  "write_file",
+  "str_replace",
+  "commit_progress",
+  "done"
+]);
+var KEEP_LAST_TURNS3 = 6;
+var STUB3 = "[truncated: tool result elided to save context]";
+function pruneMessageHistory3(messages) {
+  const toolResultIndices = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role === "user" && msg.parts?.some((p) => p.functionResponse !== void 0)) {
+      toolResultIndices.push(i);
+    }
+  }
+  const cutoff = messages.length - KEEP_LAST_TURNS3 * 2;
+  if (cutoff <= 1) return;
+  for (const idx of toolResultIndices) {
+    if (idx >= cutoff) break;
+    const msg = messages[idx];
+    if (!msg.parts) continue;
+    for (let j = 0; j < msg.parts.length; j++) {
+      const part = msg.parts[j];
+      if (part.functionResponse === void 0) continue;
+      const output = part.functionResponse.response?.["output"];
+      if (typeof output === "string" && output !== STUB3) {
+        msg.parts[j] = {
+          functionResponse: {
+            name: part.functionResponse.name,
+            id: part.functionResponse.id,
+            response: { output: STUB3 }
+          }
+        };
+      }
+    }
+  }
+}
+function injectBudgetWarning3(messages, text) {
+  const last = messages[messages.length - 1];
+  if (last?.role === "user") {
+    last.parts = [...last.parts ?? [], { text }];
+  } else {
+    messages.push({ role: "user", parts: [{ text }] });
+  }
+}
+function compactOldToolResults3(messages, windowTurns) {
+  const toolResultIndices = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role === "user" && msg.parts?.some((p) => p.functionResponse !== void 0)) {
+      toolResultIndices.push(i);
+    }
+  }
+  if (toolResultIndices.length <= windowTurns) return;
+  const compactCount = toolResultIndices.length - windowTurns;
+  for (let k = 0; k < compactCount; k++) {
+    const idx = toolResultIndices[k];
+    const msg = messages[idx];
+    if (!msg.parts) continue;
+    for (let j = 0; j < msg.parts.length; j++) {
+      const part = msg.parts[j];
+      if (part.functionResponse === void 0) continue;
+      const output = part.functionResponse.response?.["output"];
+      if (typeof output !== "string" || output.startsWith("[compacted")) continue;
+      const tokens = Math.ceil(output.length / 4);
+      msg.parts[j] = {
+        functionResponse: {
+          name: part.functionResponse.name,
+          id: part.functionResponse.id,
+          response: { output: `[compacted \u2014 ~${tokens} tokens elided]` }
+        }
+      };
+    }
+  }
+}
+function createGoogleAgentLoop(opts) {
+  const ai = opts.ai ?? new GoogleGenAI({ apiKey: opts.apiKey });
+  const logger = opts.logger ?? createLogger("", "ferry:dev-loop");
+  async function runLoop(input) {
+    const { system, initialPrompt, tools, repoRoot, branchName, secretScan } = input;
+    const maxIterations = opts.maxIterations ?? parseInt(process.env.FERRY_DEV_MAX_ITERATIONS ?? "200", 10);
+    const maxInputTokens = opts.maxInputTokens ?? parseInt(process.env.FERRY_DEV_MAX_INPUT_TOKENS ?? "500000", 10);
+    const maxTokens = opts.maxTokens ?? parseInt(process.env.FERRY_DEV_MAX_TOKENS ?? "16384", 10);
+    const compactWindow = opts.compactWindow ?? parseInt(process.env.FERRY_DEV_COMPACT_WINDOW ?? "8", 10);
+    const allServers = input.mcpServers ?? [];
+    const httpServers = allServers.filter((s) => isHttpMcpServer(s) && "url" in s);
+    if (httpServers.length > 0) {
+      throw new FerryError("state-invariant", {
+        reason: "http-mcp-unsupported",
+        provider: "google",
+        detail: "HTTP MCP servers are only supported with the Anthropic provider. Configure stdio MCP servers or switch to provider: anthropic."
+      });
+    }
+    const stdioServers = allServers.filter((s) => isStdioMcpServer(s));
+    const pool = new McpClientPool();
+    try {
+      let trackTool2 = function(name, outputSize) {
+        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+        toolCallRecords.push({ name, outputSize });
+      };
+      var trackTool = trackTool2;
+      if (stdioServers.length > 0) {
+        await pool.connect(stdioServers);
+        if (pool.getTools().length > 0) {
+          logger.info("stdio_mcp_tools", {
+            count: pool.getTools().length,
+            servers: stdioServers.map((s) => s.name).join(",")
+          });
+        }
+      }
+      const nativeAndStdioTools = [...tools, ...pool.getTools()];
+      const allToolDeclarations = nativeAndStdioTools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        parametersJsonSchema: t.input_schema
+      }));
+      const messages = [{ role: "user", parts: [{ text: initialPrompt }] }];
+      const usage = {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0
+      };
+      const toolCounts = {};
+      const toolCallRecords = [];
+      let done = null;
+      let iter = 0;
+      const loopStart = Date.now();
+      let warned70 = false;
+      let warned85 = false;
+      while (iter < maxIterations) {
+        iter++;
+        const iterStart = Date.now();
+        const billableEquiv = usage.input_tokens + usage.output_tokens;
+        if (billableEquiv > maxInputTokens) {
+          throw new FerryError("spend-cap", {
+            reason: "input-token-budget-exceeded",
+            cap: maxInputTokens,
+            consumed: billableEquiv
+          });
+        }
+        const budgetFraction = maxInputTokens > 0 ? billableEquiv / maxInputTokens : 0;
+        if (!warned70 && budgetFraction >= 0.7) {
+          warned70 = true;
+          const remaining = Math.round((1 - budgetFraction) * 100);
+          logger.info("budget_warning", { iter, threshold: 70, remaining_pct: remaining });
+          injectBudgetWarning3(
+            messages,
+            `[ferry] You have used ~${Math.round(budgetFraction * 100)}% of your input budget (${remaining}% remaining). Wrap up now: stop exploration, finish the current change, commit, and push.`
+          );
+        }
+        if (!warned85 && budgetFraction >= 0.85) {
+          warned85 = true;
+          logger.info("budget_warning", { iter, threshold: 85, mode: "commit-and-stop" });
+          injectBudgetWarning3(
+            messages,
+            `[ferry] BUDGET CRITICAL: ~${Math.round(budgetFraction * 100)}% of your input budget is consumed. You are now in commit-and-stop mode. Only use: bash (git operations), write_file, str_replace, commit_progress, or done. No exploration, no new reads \u2014 commit all work and call done immediately.`
+          );
+        }
+        const effectiveToolDeclarations = warned85 ? allToolDeclarations.filter((t) => COMMIT_AND_STOP_TOOL_NAMES3.has(t.name ?? "")) : allToolDeclarations;
+        pruneMessageHistory3(messages);
+        const response = await ai.models.generateContent({
+          model: opts.model,
+          contents: messages,
+          config: {
+            systemInstruction: system,
+            maxOutputTokens: maxTokens,
+            tools: effectiveToolDeclarations.length > 0 ? [{ functionDeclarations: effectiveToolDeclarations }] : void 0,
+            toolConfig: effectiveToolDeclarations.length > 0 ? {
+              functionCallingConfig: {
+                mode: FunctionCallingConfigMode.ANY
+              }
+            } : void 0,
+            automaticFunctionCalling: { disable: true }
+          }
+        });
+        usage.input_tokens += response.usageMetadata?.promptTokenCount ?? 0;
+        usage.output_tokens += response.usageMetadata?.candidatesTokenCount ?? 0;
+        const candidate = response.candidates?.[0];
+        const finishReason = candidate?.finishReason ?? "STOP";
+        const modelContent = candidate?.content;
+        const parts = modelContent?.parts ?? [];
+        const functionCallParts = parts.filter((p) => p.functionCall !== void 0);
+        logger.info("turn", {
+          iter,
+          stop_reason: finishReason,
+          tools: functionCallParts.length,
+          in: response.usageMetadata?.promptTokenCount ?? 0,
+          out: response.usageMetadata?.candidatesTokenCount ?? 0
+        });
+        emitDebug(
+          {
+            type: "turn",
+            iter,
+            depth: 0,
+            stop_reason: finishReason,
+            tools: functionCallParts.length,
+            mcp_tools: 0,
+            in: response.usageMetadata?.promptTokenCount ?? 0,
+            cache_w: 0,
+            cache_r: 0,
+            out: response.usageMetadata?.candidatesTokenCount ?? 0,
+            elapsed_ms: Date.now() - iterStart
+          },
+          logger
+        );
+        if (functionCallParts.length === 0) {
+          throw new FerryError("state-invariant", {
+            reason: "agent-stopped-without-done",
+            stop_reason: finishReason
+          });
+        }
+        messages.push({ role: "model", parts });
+        const toolResultParts = [];
+        for (const part of functionCallParts) {
+          const fc = part.functionCall;
+          const name = fc.name ?? "";
+          const blockInput = fc.args ?? {};
+          const callId = fc.id;
+          if (name === "done") {
+            const outcome = blockInput.outcome;
+            const actionable = outcome !== void 0 ? outcome !== "blocked" : blockInput.actionable;
+            done = { ...blockInput, actionable, outcome };
+            toolResultParts.push({
+              functionResponse: {
+                name,
+                ...callId !== void 0 ? { id: callId } : {},
+                response: { output: "ok" }
+              }
+            });
+            continue;
+          }
+          if (name === "commit_progress" && opts.commitProgress) {
+            const { message } = blockInput;
+            logger.info("tool", { iter, tool: "commit_progress", arg: message.slice(0, 120) });
+            try {
+              const result = await opts.commitProgress(repoRoot, branchName, message, secretScan);
+              trackTool2("commit_progress", result.length);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...callId !== void 0 ? { id: callId } : {},
+                  response: { output: result }
+                }
+              });
+            } catch (e) {
+              trackTool2("commit_progress", 0);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...callId !== void 0 ? { id: callId } : {},
+                  response: { output: e.message, error: true }
+                }
+              });
+            }
+            continue;
+          }
+          if (pool.hasTool(name)) {
+            const serverName = pool.getServerName(name) ?? "unknown";
+            logger.info("mcp_stdio_tool", { iter, tool: name, server: serverName });
+            try {
+              const result = await pool.callTool(name, blockInput);
+              trackTool2(name, result.length);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...callId !== void 0 ? { id: callId } : {},
+                  response: { output: result }
+                }
+              });
+            } catch (e) {
+              trackTool2(name, 0);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...callId !== void 0 ? { id: callId } : {},
+                  response: { output: e.message, error: true }
+                }
+              });
+            }
+            continue;
+          }
+          const argHint = blockInput.path ?? blockInput.source ?? blockInput.command ?? blockInput.pattern ?? "";
+          logger.info("tool", {
+            iter,
+            tool: name,
+            ...argHint ? { arg: String(argHint).slice(0, 120) } : {}
+          });
+          try {
+            const result = await opts.executeTool(repoRoot, name, blockInput);
+            trackTool2(name, result.length);
+            toolResultParts.push({
+              functionResponse: {
+                name,
+                ...callId !== void 0 ? { id: callId } : {},
+                response: { output: result }
+              }
+            });
+          } catch (e) {
+            trackTool2(name, 0);
+            toolResultParts.push({
+              functionResponse: {
+                name,
+                ...callId !== void 0 ? { id: callId } : {},
+                response: { output: e.message, error: true }
+              }
+            });
+          }
+        }
+        messages.push({ role: "user", parts: toolResultParts });
+        compactOldToolResults3(messages, compactWindow);
+        if (done) {
+          emitDebug(
+            {
+              type: "result",
+              subtype: "success",
+              iterations: iter,
+              total_in: usage.input_tokens,
+              total_out: usage.output_tokens,
+              elapsed_ms: Date.now() - loopStart
+            },
+            logger
+          );
+          return { done, usage, iterations: iter, toolCounts, toolCallRecords };
+        }
+      }
+      throw new FerryError("state-invariant", {
+        reason: "iteration-cap-exceeded",
+        cap: maxIterations
+      });
+    } finally {
+      await pool.close();
+    }
+  }
+  return {
+    run(input) {
+      return runLoop(input);
+    }
+  };
+}
+
+// src/lib/llm/agent-loop/index.ts
+function requireEnv(key) {
+  const val = process.env[key];
+  if (!val) {
+    throw new FerryError("state-invariant", { reason: "missing-env", key });
+  }
+  return val;
+}
+function createAgentLoop(opts) {
+  if (opts.provider === "anthropic") {
+    const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
+    return createAnthropicAgentLoop({
+      ...auth2,
+      model: opts.model,
+      executeTool: opts.executeTool,
+      commitProgress: opts.commitProgress,
+      spawnSubagent: opts.spawnSubagent,
+      maxIterations: opts.maxIterations,
+      maxInputTokens: opts.maxInputTokens,
+      maxTokens: opts.maxTokens,
+      compactWindow: opts.compactWindow,
+      logger: opts.logger
+    });
+  }
+  if (opts.provider === "openai") {
+    const apiKey = requireEnv("FERRY_OPENAI_KEY");
+    return createOpenAIAgentLoop({
+      apiKey,
+      model: opts.model,
+      executeTool: opts.executeTool,
+      commitProgress: opts.commitProgress,
+      maxIterations: opts.maxIterations,
+      maxInputTokens: opts.maxInputTokens,
+      maxTokens: opts.maxTokens,
+      compactWindow: opts.compactWindow,
+      logger: opts.logger
+    });
+  }
+  if (opts.provider === "google") {
+    const apiKey = requireEnv("FERRY_GOOGLE_AI_KEY");
+    return createGoogleAgentLoop({
+      apiKey,
+      model: opts.model,
+      executeTool: opts.executeTool,
+      commitProgress: opts.commitProgress,
+      maxIterations: opts.maxIterations,
+      maxInputTokens: opts.maxInputTokens,
+      maxTokens: opts.maxTokens,
+      compactWindow: opts.compactWindow,
+      logger: opts.logger
+    });
+  }
+  throw new FerryError("state-invariant", {
+    reason: "unknown-provider",
+    provider: opts.provider
+  });
 }
 
 // src/agents/iterator/outcome-guard.ts
@@ -1367,7 +2075,7 @@ function filterMcpServers(pool, capabilities, hasLabelsConfig) {
 }
 
 // src/lib/agent-runtime/env.ts
-function requireEnv(key) {
+function requireEnv2(key) {
   const val = process.env[key];
   if (!val) throw new FerryError("state-invariant", { reason: "missing-env", key });
   return val;
@@ -1425,7 +2133,7 @@ async function runAgent(role, handler2) {
   const component = COMPONENT[role];
   const bootstrapLogger = createLogger("", component);
   try {
-    const rawPayload = requireEnv("FERRY_ENVELOPE_PAYLOAD");
+    const rawPayload = requireEnv2("FERRY_ENVELOPE_PAYLOAD");
     const envelope = validateEnvelope(JSON.parse(rawPayload));
     const logger = createLogger(envelope.event_id, component);
     await handler2(envelope, logger);
@@ -6492,8 +7200,8 @@ function createTrackerFromEnv() {
 
 // src/lib/agent-runtime/context.ts
 function createGitHubContext(repoRoot) {
-  const githubToken = requireEnv("GITHUB_TOKEN");
-  const githubRepo = requireEnv("GITHUB_REPO");
+  const githubToken = requireEnv2("GITHUB_TOKEN");
+  const githubRepo = requireEnv2("GITHUB_REPO");
   const [owner, repo] = githubRepo.split("/");
   if (!owner || !repo) {
     throw new FerryError("state-invariant", { reason: "invalid-github-repo", githubRepo });
@@ -6516,7 +7224,6 @@ async function resolveGitConfig(ferryCfg, runner, owner, repo) {
 var REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
-  const anthropicAuth = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT);
   const { baseBranch, workingBranchPrefix } = await resolveGitConfig(
     initialCfg,
@@ -6526,17 +7233,9 @@ async function main(envelope, logger) {
   );
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
   const { provider: iterProvider, model } = ferryCfg.models.iterate;
-  if (iterProvider !== "anthropic") {
-    throw new FerryError("state-invariant", {
-      reason: "unsupported-provider",
-      provider: iterProvider,
-      phase: "iterator",
-      detail: "The iterator phase requires provider 'anthropic'. OpenAI and Google support for agentic phases is planned for a future release."
-    });
-  }
   const iteratorWorkflow = ferryCfg.workflow.agents.iterator;
   const shouldAutoTransition = iteratorWorkflow.auto_transition !== null;
-  const reviewTransitionId = shouldAutoTransition ? requireEnv("FERRY_REVIEW_TRANSITION_ID") : "";
+  const reviewTransitionId = shouldAutoTransition ? requireEnv2("FERRY_REVIEW_TRANSITION_ID") : "";
   const issue = await tracker.getIssue(ticketKey);
   const existingComments = issue.comments;
   const mcpPool = loadMcpServers();
@@ -6628,8 +7327,8 @@ ${existingLog}` : "",
     "When you have fixed all findings, call the `done` tool."
   ].filter(Boolean).join("\n");
   const secretScan = makeSecretScan(REPO_ROOT);
-  const loop = createAnthropicAgentLoop({
-    ...anthropicAuth,
+  const loop = createAgentLoop({
+    provider: iterProvider,
     model,
     maxIterations: ferryCfg.limits.max_agent_iterations,
     maxInputTokens: ferryCfg.limits.max_tokens_per_run,

--- a/.github/actions/ferry-run-developer/dev-action.js
+++ b/.github/actions/ferry-run-developer/dev-action.js
@@ -5765,6 +5765,20 @@ function runProcess(cmd, args, cwd, timeoutMs) {
   });
 }
 
+// src/lib/llm/anthropic-auth.ts
+function resolveAnthropicAuth(input) {
+  const env = input.env ?? process.env;
+  const oauthToken = env["CLAUDE_CODE_OAUTH_TOKEN"];
+  if (oauthToken) {
+    return { authToken: oauthToken };
+  }
+  const apiKey = env[input.apiKeyEnv];
+  if (apiKey) {
+    return { apiKey };
+  }
+  throw new FerryError("state-invariant", { reason: "missing-env", key: input.apiKeyEnv });
+}
+
 // src/lib/llm/agent-loop/anthropic.ts
 import Anthropic from "@anthropic-ai/sdk";
 
@@ -6413,6 +6427,714 @@ function createAnthropicAgentLoop(opts) {
   };
 }
 
+// src/lib/llm/agent-loop/openai.ts
+import OpenAI from "openai";
+var COMMIT_AND_STOP_TOOL_NAMES2 = /* @__PURE__ */ new Set([
+  "bash",
+  "write_file",
+  "str_replace",
+  "commit_progress",
+  "done"
+]);
+var KEEP_LAST_TURNS2 = 6;
+var STUB2 = "[truncated: tool result elided to save context]";
+function agentToolToOpenAI(t) {
+  return {
+    type: "function",
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: t.input_schema
+    }
+  };
+}
+function pruneMessageHistory2(messages) {
+  const toolResultIndices = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i].role === "tool") {
+      toolResultIndices.push(i);
+    }
+  }
+  const cutoff = messages.length - KEEP_LAST_TURNS2 * 2;
+  if (cutoff <= 1) return;
+  for (let i = 0; i < toolResultIndices.length; i++) {
+    const idx = toolResultIndices[i];
+    if (idx >= cutoff) break;
+    const msg = messages[idx];
+    if (msg.role === "tool" && typeof msg.content === "string" && msg.content !== STUB2) {
+      messages[idx].content = STUB2;
+    }
+  }
+}
+function injectBudgetWarning2(messages, text) {
+  const last = messages[messages.length - 1];
+  if (!last) return;
+  if (last.role === "user") {
+    if (typeof last.content === "string") {
+      messages[messages.length - 1].content = last.content + "\n\n" + text;
+    } else if (Array.isArray(last.content)) {
+      last.content.push({ type: "text", text });
+    }
+  } else {
+    messages.push({ role: "user", content: text });
+  }
+}
+function compactOldToolResults2(messages, windowTurns) {
+  const toolResultIndices = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i].role === "tool") {
+      toolResultIndices.push(i);
+    }
+  }
+  if (toolResultIndices.length <= windowTurns) return;
+  const compactCount = toolResultIndices.length - windowTurns;
+  for (let k = 0; k < compactCount; k++) {
+    const idx = toolResultIndices[k];
+    const msg = messages[idx];
+    if (msg.role !== "tool" || typeof msg.content !== "string") continue;
+    if (msg.content.startsWith("[compacted")) continue;
+    const tokens = Math.ceil(msg.content.length / 4);
+    messages[idx].content = `[compacted \u2014 ~${tokens} tokens elided]`;
+  }
+}
+function createOpenAIAgentLoop(opts) {
+  const openai = opts.client ?? new OpenAI({ apiKey: opts.apiKey });
+  const logger = opts.logger ?? createLogger("", "ferry:dev-loop");
+  async function runLoop(input) {
+    const { system, initialPrompt, tools, repoRoot, branchName, secretScan } = input;
+    const maxIterations = opts.maxIterations ?? parseInt(process.env.FERRY_DEV_MAX_ITERATIONS ?? "200", 10);
+    const maxInputTokens = opts.maxInputTokens ?? parseInt(process.env.FERRY_DEV_MAX_INPUT_TOKENS ?? "500000", 10);
+    const maxTokens = opts.maxTokens ?? parseInt(process.env.FERRY_DEV_MAX_TOKENS ?? "16384", 10);
+    const compactWindow = opts.compactWindow ?? parseInt(process.env.FERRY_DEV_COMPACT_WINDOW ?? "8", 10);
+    const allServers = input.mcpServers ?? [];
+    const httpServers = allServers.filter((s) => isHttpMcpServer(s) && "url" in s);
+    if (httpServers.length > 0) {
+      throw new FerryError("state-invariant", {
+        reason: "http-mcp-unsupported",
+        provider: "openai",
+        detail: "HTTP MCP servers are only supported with the Anthropic provider. Configure stdio MCP servers or switch to provider: anthropic."
+      });
+    }
+    const stdioServers = allServers.filter((s) => isStdioMcpServer(s));
+    const pool = new McpClientPool();
+    try {
+      let trackTool2 = function(name, outputSize) {
+        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+        toolCallRecords.push({ name, outputSize });
+      };
+      var trackTool = trackTool2;
+      if (stdioServers.length > 0) {
+        await pool.connect(stdioServers);
+        if (pool.getTools().length > 0) {
+          logger.info("stdio_mcp_tools", {
+            count: pool.getTools().length,
+            servers: stdioServers.map((s) => s.name).join(",")
+          });
+        }
+      }
+      const nativeAndStdioTools = [...tools, ...pool.getTools()];
+      const openaiTools = nativeAndStdioTools.map(agentToolToOpenAI);
+      const messages = [
+        { role: "system", content: system },
+        { role: "user", content: initialPrompt }
+      ];
+      const usage = {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0
+      };
+      const toolCounts = {};
+      const toolCallRecords = [];
+      let done = null;
+      let iter = 0;
+      const loopStart = Date.now();
+      let warned70 = false;
+      let warned85 = false;
+      while (iter < maxIterations) {
+        iter++;
+        const iterStart = Date.now();
+        const billableEquiv = usage.input_tokens + usage.output_tokens;
+        if (billableEquiv > maxInputTokens) {
+          throw new FerryError("spend-cap", {
+            reason: "input-token-budget-exceeded",
+            cap: maxInputTokens,
+            consumed: billableEquiv
+          });
+        }
+        const budgetFraction = maxInputTokens > 0 ? billableEquiv / maxInputTokens : 0;
+        if (!warned70 && budgetFraction >= 0.7) {
+          warned70 = true;
+          const remaining = Math.round((1 - budgetFraction) * 100);
+          logger.info("budget_warning", { iter, threshold: 70, remaining_pct: remaining });
+          injectBudgetWarning2(
+            messages,
+            `[ferry] You have used ~${Math.round(budgetFraction * 100)}% of your input budget (${remaining}% remaining). Wrap up now: stop exploration, finish the current change, commit, and push.`
+          );
+        }
+        if (!warned85 && budgetFraction >= 0.85) {
+          warned85 = true;
+          logger.info("budget_warning", { iter, threshold: 85, mode: "commit-and-stop" });
+          injectBudgetWarning2(
+            messages,
+            `[ferry] BUDGET CRITICAL: ~${Math.round(budgetFraction * 100)}% of your input budget is consumed. You are now in commit-and-stop mode. Only use: bash (git operations), write_file, str_replace, commit_progress, or done. No exploration, no new reads \u2014 commit all work and call done immediately.`
+          );
+        }
+        const effectiveTools = warned85 ? openaiTools.filter((t) => COMMIT_AND_STOP_TOOL_NAMES2.has(t.function.name)) : openaiTools;
+        pruneMessageHistory2(messages);
+        const response = await openai.chat.completions.create({
+          model: opts.model,
+          max_tokens: maxTokens,
+          tools: effectiveTools,
+          tool_choice: effectiveTools.length > 0 ? "required" : "none",
+          messages
+        });
+        usage.input_tokens += response.usage?.prompt_tokens ?? 0;
+        usage.output_tokens += response.usage?.completion_tokens ?? 0;
+        const choice = response.choices[0];
+        if (!choice) {
+          throw new FerryError("state-invariant", {
+            reason: "agent-stopped-without-done",
+            stop_reason: "no-choices"
+          });
+        }
+        const assistantMsg = choice.message;
+        messages.push(assistantMsg);
+        const allToolCalls = assistantMsg.tool_calls ?? [];
+        const toolCalls = allToolCalls.filter(
+          (tc) => tc.type === "function"
+        );
+        logger.info("turn", {
+          iter,
+          stop_reason: choice.finish_reason,
+          tools: toolCalls.length,
+          in: response.usage?.prompt_tokens ?? 0,
+          out: response.usage?.completion_tokens ?? 0
+        });
+        emitDebug(
+          {
+            type: "turn",
+            iter,
+            depth: 0,
+            stop_reason: choice.finish_reason,
+            tools: toolCalls.length,
+            mcp_tools: 0,
+            in: response.usage?.prompt_tokens ?? 0,
+            cache_w: 0,
+            cache_r: 0,
+            out: response.usage?.completion_tokens ?? 0,
+            elapsed_ms: Date.now() - iterStart
+          },
+          logger
+        );
+        if (choice.finish_reason !== "tool_calls" && toolCalls.length === 0) {
+          throw new FerryError("state-invariant", {
+            reason: "agent-stopped-without-done",
+            stop_reason: choice.finish_reason
+          });
+        }
+        for (const toolCall of toolCalls) {
+          const name = toolCall.function.name;
+          let blockInput;
+          try {
+            blockInput = JSON.parse(toolCall.function.arguments);
+          } catch {
+            blockInput = {};
+          }
+          if (name === "done") {
+            const outcome = blockInput.outcome;
+            const actionable = outcome !== void 0 ? outcome !== "blocked" : blockInput.actionable;
+            done = { ...blockInput, actionable, outcome };
+            messages.push({ role: "tool", tool_call_id: toolCall.id, content: "ok" });
+            continue;
+          }
+          if (name === "commit_progress" && opts.commitProgress) {
+            const { message } = blockInput;
+            logger.info("tool", { iter, tool: "commit_progress", arg: message.slice(0, 120) });
+            try {
+              const result = await opts.commitProgress(repoRoot, branchName, message, secretScan);
+              trackTool2("commit_progress", result.length);
+              messages.push({ role: "tool", tool_call_id: toolCall.id, content: result });
+            } catch (e) {
+              trackTool2("commit_progress", 0);
+              messages.push({
+                role: "tool",
+                tool_call_id: toolCall.id,
+                content: e.message
+              });
+            }
+            continue;
+          }
+          if (pool.hasTool(name)) {
+            const serverName = pool.getServerName(name) ?? "unknown";
+            logger.info("mcp_stdio_tool", { iter, tool: name, server: serverName });
+            try {
+              const result = await pool.callTool(name, blockInput);
+              trackTool2(name, result.length);
+              messages.push({ role: "tool", tool_call_id: toolCall.id, content: result });
+            } catch (e) {
+              trackTool2(name, 0);
+              messages.push({
+                role: "tool",
+                tool_call_id: toolCall.id,
+                content: e.message
+              });
+            }
+            continue;
+          }
+          const argHint = blockInput.path ?? blockInput.source ?? blockInput.command ?? blockInput.pattern ?? "";
+          logger.info("tool", {
+            iter,
+            tool: name,
+            ...argHint ? { arg: String(argHint).slice(0, 120) } : {}
+          });
+          try {
+            const result = await opts.executeTool(repoRoot, name, blockInput);
+            trackTool2(name, result.length);
+            messages.push({ role: "tool", tool_call_id: toolCall.id, content: result });
+          } catch (e) {
+            trackTool2(name, 0);
+            messages.push({
+              role: "tool",
+              tool_call_id: toolCall.id,
+              content: e.message
+            });
+          }
+        }
+        compactOldToolResults2(messages, compactWindow);
+        if (done) {
+          emitDebug(
+            {
+              type: "result",
+              subtype: "success",
+              iterations: iter,
+              total_in: usage.input_tokens,
+              total_out: usage.output_tokens,
+              elapsed_ms: Date.now() - loopStart
+            },
+            logger
+          );
+          return { done, usage, iterations: iter, toolCounts, toolCallRecords };
+        }
+      }
+      throw new FerryError("state-invariant", {
+        reason: "iteration-cap-exceeded",
+        cap: maxIterations
+      });
+    } finally {
+      await pool.close();
+    }
+  }
+  return {
+    run(input) {
+      return runLoop(input);
+    }
+  };
+}
+
+// src/lib/llm/agent-loop/google.ts
+import { GoogleGenAI, FunctionCallingConfigMode } from "@google/genai";
+var COMMIT_AND_STOP_TOOL_NAMES3 = /* @__PURE__ */ new Set([
+  "bash",
+  "write_file",
+  "str_replace",
+  "commit_progress",
+  "done"
+]);
+var KEEP_LAST_TURNS3 = 6;
+var STUB3 = "[truncated: tool result elided to save context]";
+function pruneMessageHistory3(messages) {
+  const toolResultIndices = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role === "user" && msg.parts?.some((p) => p.functionResponse !== void 0)) {
+      toolResultIndices.push(i);
+    }
+  }
+  const cutoff = messages.length - KEEP_LAST_TURNS3 * 2;
+  if (cutoff <= 1) return;
+  for (const idx of toolResultIndices) {
+    if (idx >= cutoff) break;
+    const msg = messages[idx];
+    if (!msg.parts) continue;
+    for (let j = 0; j < msg.parts.length; j++) {
+      const part = msg.parts[j];
+      if (part.functionResponse === void 0) continue;
+      const output = part.functionResponse.response?.["output"];
+      if (typeof output === "string" && output !== STUB3) {
+        msg.parts[j] = {
+          functionResponse: {
+            name: part.functionResponse.name,
+            id: part.functionResponse.id,
+            response: { output: STUB3 }
+          }
+        };
+      }
+    }
+  }
+}
+function injectBudgetWarning3(messages, text) {
+  const last = messages[messages.length - 1];
+  if (last?.role === "user") {
+    last.parts = [...last.parts ?? [], { text }];
+  } else {
+    messages.push({ role: "user", parts: [{ text }] });
+  }
+}
+function compactOldToolResults3(messages, windowTurns) {
+  const toolResultIndices = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role === "user" && msg.parts?.some((p) => p.functionResponse !== void 0)) {
+      toolResultIndices.push(i);
+    }
+  }
+  if (toolResultIndices.length <= windowTurns) return;
+  const compactCount = toolResultIndices.length - windowTurns;
+  for (let k = 0; k < compactCount; k++) {
+    const idx = toolResultIndices[k];
+    const msg = messages[idx];
+    if (!msg.parts) continue;
+    for (let j = 0; j < msg.parts.length; j++) {
+      const part = msg.parts[j];
+      if (part.functionResponse === void 0) continue;
+      const output = part.functionResponse.response?.["output"];
+      if (typeof output !== "string" || output.startsWith("[compacted")) continue;
+      const tokens = Math.ceil(output.length / 4);
+      msg.parts[j] = {
+        functionResponse: {
+          name: part.functionResponse.name,
+          id: part.functionResponse.id,
+          response: { output: `[compacted \u2014 ~${tokens} tokens elided]` }
+        }
+      };
+    }
+  }
+}
+function createGoogleAgentLoop(opts) {
+  const ai = opts.ai ?? new GoogleGenAI({ apiKey: opts.apiKey });
+  const logger = opts.logger ?? createLogger("", "ferry:dev-loop");
+  async function runLoop(input) {
+    const { system, initialPrompt, tools, repoRoot, branchName, secretScan } = input;
+    const maxIterations = opts.maxIterations ?? parseInt(process.env.FERRY_DEV_MAX_ITERATIONS ?? "200", 10);
+    const maxInputTokens = opts.maxInputTokens ?? parseInt(process.env.FERRY_DEV_MAX_INPUT_TOKENS ?? "500000", 10);
+    const maxTokens = opts.maxTokens ?? parseInt(process.env.FERRY_DEV_MAX_TOKENS ?? "16384", 10);
+    const compactWindow = opts.compactWindow ?? parseInt(process.env.FERRY_DEV_COMPACT_WINDOW ?? "8", 10);
+    const allServers = input.mcpServers ?? [];
+    const httpServers = allServers.filter((s) => isHttpMcpServer(s) && "url" in s);
+    if (httpServers.length > 0) {
+      throw new FerryError("state-invariant", {
+        reason: "http-mcp-unsupported",
+        provider: "google",
+        detail: "HTTP MCP servers are only supported with the Anthropic provider. Configure stdio MCP servers or switch to provider: anthropic."
+      });
+    }
+    const stdioServers = allServers.filter((s) => isStdioMcpServer(s));
+    const pool = new McpClientPool();
+    try {
+      let trackTool2 = function(name, outputSize) {
+        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+        toolCallRecords.push({ name, outputSize });
+      };
+      var trackTool = trackTool2;
+      if (stdioServers.length > 0) {
+        await pool.connect(stdioServers);
+        if (pool.getTools().length > 0) {
+          logger.info("stdio_mcp_tools", {
+            count: pool.getTools().length,
+            servers: stdioServers.map((s) => s.name).join(",")
+          });
+        }
+      }
+      const nativeAndStdioTools = [...tools, ...pool.getTools()];
+      const allToolDeclarations = nativeAndStdioTools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        parametersJsonSchema: t.input_schema
+      }));
+      const messages = [{ role: "user", parts: [{ text: initialPrompt }] }];
+      const usage = {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0
+      };
+      const toolCounts = {};
+      const toolCallRecords = [];
+      let done = null;
+      let iter = 0;
+      const loopStart = Date.now();
+      let warned70 = false;
+      let warned85 = false;
+      while (iter < maxIterations) {
+        iter++;
+        const iterStart = Date.now();
+        const billableEquiv = usage.input_tokens + usage.output_tokens;
+        if (billableEquiv > maxInputTokens) {
+          throw new FerryError("spend-cap", {
+            reason: "input-token-budget-exceeded",
+            cap: maxInputTokens,
+            consumed: billableEquiv
+          });
+        }
+        const budgetFraction = maxInputTokens > 0 ? billableEquiv / maxInputTokens : 0;
+        if (!warned70 && budgetFraction >= 0.7) {
+          warned70 = true;
+          const remaining = Math.round((1 - budgetFraction) * 100);
+          logger.info("budget_warning", { iter, threshold: 70, remaining_pct: remaining });
+          injectBudgetWarning3(
+            messages,
+            `[ferry] You have used ~${Math.round(budgetFraction * 100)}% of your input budget (${remaining}% remaining). Wrap up now: stop exploration, finish the current change, commit, and push.`
+          );
+        }
+        if (!warned85 && budgetFraction >= 0.85) {
+          warned85 = true;
+          logger.info("budget_warning", { iter, threshold: 85, mode: "commit-and-stop" });
+          injectBudgetWarning3(
+            messages,
+            `[ferry] BUDGET CRITICAL: ~${Math.round(budgetFraction * 100)}% of your input budget is consumed. You are now in commit-and-stop mode. Only use: bash (git operations), write_file, str_replace, commit_progress, or done. No exploration, no new reads \u2014 commit all work and call done immediately.`
+          );
+        }
+        const effectiveToolDeclarations = warned85 ? allToolDeclarations.filter((t) => COMMIT_AND_STOP_TOOL_NAMES3.has(t.name ?? "")) : allToolDeclarations;
+        pruneMessageHistory3(messages);
+        const response = await ai.models.generateContent({
+          model: opts.model,
+          contents: messages,
+          config: {
+            systemInstruction: system,
+            maxOutputTokens: maxTokens,
+            tools: effectiveToolDeclarations.length > 0 ? [{ functionDeclarations: effectiveToolDeclarations }] : void 0,
+            toolConfig: effectiveToolDeclarations.length > 0 ? {
+              functionCallingConfig: {
+                mode: FunctionCallingConfigMode.ANY
+              }
+            } : void 0,
+            automaticFunctionCalling: { disable: true }
+          }
+        });
+        usage.input_tokens += response.usageMetadata?.promptTokenCount ?? 0;
+        usage.output_tokens += response.usageMetadata?.candidatesTokenCount ?? 0;
+        const candidate = response.candidates?.[0];
+        const finishReason = candidate?.finishReason ?? "STOP";
+        const modelContent = candidate?.content;
+        const parts = modelContent?.parts ?? [];
+        const functionCallParts = parts.filter((p) => p.functionCall !== void 0);
+        logger.info("turn", {
+          iter,
+          stop_reason: finishReason,
+          tools: functionCallParts.length,
+          in: response.usageMetadata?.promptTokenCount ?? 0,
+          out: response.usageMetadata?.candidatesTokenCount ?? 0
+        });
+        emitDebug(
+          {
+            type: "turn",
+            iter,
+            depth: 0,
+            stop_reason: finishReason,
+            tools: functionCallParts.length,
+            mcp_tools: 0,
+            in: response.usageMetadata?.promptTokenCount ?? 0,
+            cache_w: 0,
+            cache_r: 0,
+            out: response.usageMetadata?.candidatesTokenCount ?? 0,
+            elapsed_ms: Date.now() - iterStart
+          },
+          logger
+        );
+        if (functionCallParts.length === 0) {
+          throw new FerryError("state-invariant", {
+            reason: "agent-stopped-without-done",
+            stop_reason: finishReason
+          });
+        }
+        messages.push({ role: "model", parts });
+        const toolResultParts = [];
+        for (const part of functionCallParts) {
+          const fc = part.functionCall;
+          const name = fc.name ?? "";
+          const blockInput = fc.args ?? {};
+          const callId = fc.id;
+          if (name === "done") {
+            const outcome = blockInput.outcome;
+            const actionable = outcome !== void 0 ? outcome !== "blocked" : blockInput.actionable;
+            done = { ...blockInput, actionable, outcome };
+            toolResultParts.push({
+              functionResponse: {
+                name,
+                ...callId !== void 0 ? { id: callId } : {},
+                response: { output: "ok" }
+              }
+            });
+            continue;
+          }
+          if (name === "commit_progress" && opts.commitProgress) {
+            const { message } = blockInput;
+            logger.info("tool", { iter, tool: "commit_progress", arg: message.slice(0, 120) });
+            try {
+              const result = await opts.commitProgress(repoRoot, branchName, message, secretScan);
+              trackTool2("commit_progress", result.length);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...callId !== void 0 ? { id: callId } : {},
+                  response: { output: result }
+                }
+              });
+            } catch (e) {
+              trackTool2("commit_progress", 0);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...callId !== void 0 ? { id: callId } : {},
+                  response: { output: e.message, error: true }
+                }
+              });
+            }
+            continue;
+          }
+          if (pool.hasTool(name)) {
+            const serverName = pool.getServerName(name) ?? "unknown";
+            logger.info("mcp_stdio_tool", { iter, tool: name, server: serverName });
+            try {
+              const result = await pool.callTool(name, blockInput);
+              trackTool2(name, result.length);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...callId !== void 0 ? { id: callId } : {},
+                  response: { output: result }
+                }
+              });
+            } catch (e) {
+              trackTool2(name, 0);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...callId !== void 0 ? { id: callId } : {},
+                  response: { output: e.message, error: true }
+                }
+              });
+            }
+            continue;
+          }
+          const argHint = blockInput.path ?? blockInput.source ?? blockInput.command ?? blockInput.pattern ?? "";
+          logger.info("tool", {
+            iter,
+            tool: name,
+            ...argHint ? { arg: String(argHint).slice(0, 120) } : {}
+          });
+          try {
+            const result = await opts.executeTool(repoRoot, name, blockInput);
+            trackTool2(name, result.length);
+            toolResultParts.push({
+              functionResponse: {
+                name,
+                ...callId !== void 0 ? { id: callId } : {},
+                response: { output: result }
+              }
+            });
+          } catch (e) {
+            trackTool2(name, 0);
+            toolResultParts.push({
+              functionResponse: {
+                name,
+                ...callId !== void 0 ? { id: callId } : {},
+                response: { output: e.message, error: true }
+              }
+            });
+          }
+        }
+        messages.push({ role: "user", parts: toolResultParts });
+        compactOldToolResults3(messages, compactWindow);
+        if (done) {
+          emitDebug(
+            {
+              type: "result",
+              subtype: "success",
+              iterations: iter,
+              total_in: usage.input_tokens,
+              total_out: usage.output_tokens,
+              elapsed_ms: Date.now() - loopStart
+            },
+            logger
+          );
+          return { done, usage, iterations: iter, toolCounts, toolCallRecords };
+        }
+      }
+      throw new FerryError("state-invariant", {
+        reason: "iteration-cap-exceeded",
+        cap: maxIterations
+      });
+    } finally {
+      await pool.close();
+    }
+  }
+  return {
+    run(input) {
+      return runLoop(input);
+    }
+  };
+}
+
+// src/lib/llm/agent-loop/index.ts
+function requireEnv2(key) {
+  const val = process.env[key];
+  if (!val) {
+    throw new FerryError("state-invariant", { reason: "missing-env", key });
+  }
+  return val;
+}
+function createAgentLoop(opts) {
+  if (opts.provider === "anthropic") {
+    const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
+    return createAnthropicAgentLoop({
+      ...auth2,
+      model: opts.model,
+      executeTool: opts.executeTool,
+      commitProgress: opts.commitProgress,
+      spawnSubagent: opts.spawnSubagent,
+      maxIterations: opts.maxIterations,
+      maxInputTokens: opts.maxInputTokens,
+      maxTokens: opts.maxTokens,
+      compactWindow: opts.compactWindow,
+      logger: opts.logger
+    });
+  }
+  if (opts.provider === "openai") {
+    const apiKey = requireEnv2("FERRY_OPENAI_KEY");
+    return createOpenAIAgentLoop({
+      apiKey,
+      model: opts.model,
+      executeTool: opts.executeTool,
+      commitProgress: opts.commitProgress,
+      maxIterations: opts.maxIterations,
+      maxInputTokens: opts.maxInputTokens,
+      maxTokens: opts.maxTokens,
+      compactWindow: opts.compactWindow,
+      logger: opts.logger
+    });
+  }
+  if (opts.provider === "google") {
+    const apiKey = requireEnv2("FERRY_GOOGLE_AI_KEY");
+    return createGoogleAgentLoop({
+      apiKey,
+      model: opts.model,
+      executeTool: opts.executeTool,
+      commitProgress: opts.commitProgress,
+      maxIterations: opts.maxIterations,
+      maxInputTokens: opts.maxInputTokens,
+      maxTokens: opts.maxTokens,
+      compactWindow: opts.compactWindow,
+      logger: opts.logger
+    });
+  }
+  throw new FerryError("state-invariant", {
+    reason: "unknown-provider",
+    provider: opts.provider
+  });
+}
+
 // src/lib/labels/capabilities.ts
 function resolveCapabilities(ticketLabels, configLabels, logger) {
   if (!configLabels) {
@@ -6466,20 +7188,6 @@ function filterMcpServers(pool, capabilities, hasLabelsConfig) {
     }
     return s;
   });
-}
-
-// src/lib/llm/anthropic-auth.ts
-function resolveAnthropicAuth(input) {
-  const env = input.env ?? process.env;
-  const oauthToken = env["CLAUDE_CODE_OAUTH_TOKEN"];
-  if (oauthToken) {
-    return { authToken: oauthToken };
-  }
-  const apiKey = env[input.apiKeyEnv];
-  if (apiKey) {
-    return { apiKey };
-  }
-  throw new FerryError("state-invariant", { reason: "missing-env", key: input.apiKeyEnv });
 }
 
 // src/agents/developer/workspace.ts
@@ -6699,7 +7407,6 @@ async function main(envelope, logger) {
   if (dryRun) {
     logger.info("DRY_RUN mode \u2014 no branch push, no PR, no Jira writes");
   }
-  const anthropicAuth = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT);
   const { baseBranch, targetBranch, workingBranchPrefix } = await resolveGitConfig(
     initialCfg,
@@ -6709,14 +7416,6 @@ async function main(envelope, logger) {
   );
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
   const { provider: devProvider } = ferryCfg.models.dev;
-  if (devProvider !== "anthropic") {
-    throw new FerryError("state-invariant", {
-      reason: "unsupported-provider",
-      provider: devProvider,
-      phase: "developer",
-      detail: "The developer phase requires provider 'anthropic'. OpenAI and Google support for agentic phases is planned for a future release."
-    });
-  }
   const devWorkflow = ferryCfg.workflow.agents.developer;
   const shouldAutoTransition = devWorkflow.auto_transition !== null;
   const reviewTransitionId = dryRun || !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
@@ -6816,8 +7515,8 @@ ${tree}`,
   }
   const allToolSchemas = [...TOOL_SCHEMAS, COMMIT_PROGRESS_SCHEMA, SPAWN_SUBAGENT_SCHEMA];
   let loop;
-  loop = createAnthropicAgentLoop({
-    ...anthropicAuth,
+  loop = createAgentLoop({
+    provider: devProvider,
     model,
     maxIterations: ferryCfg.limits.max_agent_iterations,
     maxInputTokens: ferryCfg.limits.max_tokens_per_run,

--- a/.github/actions/ferry-run-iterator/iterate-action.js
+++ b/.github/actions/ferry-run-iterator/iterate-action.js
@@ -539,9 +539,6 @@ function runProcess(cmd, args, cwd, timeoutMs) {
   });
 }
 
-// src/lib/llm/agent-loop/anthropic.ts
-import Anthropic from "@anthropic-ai/sdk";
-
 // src/lib/errors/index.ts
 var FerryError = class extends Error {
   constructor(code, context) {
@@ -553,6 +550,23 @@ var FerryError = class extends Error {
   code;
   context;
 };
+
+// src/lib/llm/anthropic-auth.ts
+function resolveAnthropicAuth(input) {
+  const env = input.env ?? process.env;
+  const oauthToken = env["CLAUDE_CODE_OAUTH_TOKEN"];
+  if (oauthToken) {
+    return { authToken: oauthToken };
+  }
+  const apiKey = env[input.apiKeyEnv];
+  if (apiKey) {
+    return { apiKey };
+  }
+  throw new FerryError("state-invariant", { reason: "missing-env", key: input.apiKeyEnv });
+}
+
+// src/lib/llm/agent-loop/anthropic.ts
+import Anthropic from "@anthropic-ai/sdk";
 
 // src/lib/llm/debug-log.ts
 function isDebugEnabled(env) {
@@ -1246,18 +1260,712 @@ function createAnthropicAgentLoop(opts) {
   };
 }
 
-// src/lib/llm/anthropic-auth.ts
-function resolveAnthropicAuth(input) {
-  const env = input.env ?? process.env;
-  const oauthToken = env["CLAUDE_CODE_OAUTH_TOKEN"];
-  if (oauthToken) {
-    return { authToken: oauthToken };
+// src/lib/llm/agent-loop/openai.ts
+import OpenAI from "openai";
+var COMMIT_AND_STOP_TOOL_NAMES2 = /* @__PURE__ */ new Set([
+  "bash",
+  "write_file",
+  "str_replace",
+  "commit_progress",
+  "done"
+]);
+var KEEP_LAST_TURNS2 = 6;
+var STUB2 = "[truncated: tool result elided to save context]";
+function agentToolToOpenAI(t) {
+  return {
+    type: "function",
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: t.input_schema
+    }
+  };
+}
+function pruneMessageHistory2(messages) {
+  const toolResultIndices = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i].role === "tool") {
+      toolResultIndices.push(i);
+    }
   }
-  const apiKey = env[input.apiKeyEnv];
-  if (apiKey) {
-    return { apiKey };
+  const cutoff = messages.length - KEEP_LAST_TURNS2 * 2;
+  if (cutoff <= 1) return;
+  for (let i = 0; i < toolResultIndices.length; i++) {
+    const idx = toolResultIndices[i];
+    if (idx >= cutoff) break;
+    const msg = messages[idx];
+    if (msg.role === "tool" && typeof msg.content === "string" && msg.content !== STUB2) {
+      messages[idx].content = STUB2;
+    }
   }
-  throw new FerryError("state-invariant", { reason: "missing-env", key: input.apiKeyEnv });
+}
+function injectBudgetWarning2(messages, text) {
+  const last = messages[messages.length - 1];
+  if (!last) return;
+  if (last.role === "user") {
+    if (typeof last.content === "string") {
+      messages[messages.length - 1].content = last.content + "\n\n" + text;
+    } else if (Array.isArray(last.content)) {
+      last.content.push({ type: "text", text });
+    }
+  } else {
+    messages.push({ role: "user", content: text });
+  }
+}
+function compactOldToolResults2(messages, windowTurns) {
+  const toolResultIndices = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i].role === "tool") {
+      toolResultIndices.push(i);
+    }
+  }
+  if (toolResultIndices.length <= windowTurns) return;
+  const compactCount = toolResultIndices.length - windowTurns;
+  for (let k = 0; k < compactCount; k++) {
+    const idx = toolResultIndices[k];
+    const msg = messages[idx];
+    if (msg.role !== "tool" || typeof msg.content !== "string") continue;
+    if (msg.content.startsWith("[compacted")) continue;
+    const tokens = Math.ceil(msg.content.length / 4);
+    messages[idx].content = `[compacted \u2014 ~${tokens} tokens elided]`;
+  }
+}
+function createOpenAIAgentLoop(opts) {
+  const openai = opts.client ?? new OpenAI({ apiKey: opts.apiKey });
+  const logger = opts.logger ?? createLogger("", "ferry:dev-loop");
+  async function runLoop(input) {
+    const { system, initialPrompt, tools, repoRoot, branchName, secretScan } = input;
+    const maxIterations = opts.maxIterations ?? parseInt(process.env.FERRY_DEV_MAX_ITERATIONS ?? "200", 10);
+    const maxInputTokens = opts.maxInputTokens ?? parseInt(process.env.FERRY_DEV_MAX_INPUT_TOKENS ?? "500000", 10);
+    const maxTokens = opts.maxTokens ?? parseInt(process.env.FERRY_DEV_MAX_TOKENS ?? "16384", 10);
+    const compactWindow = opts.compactWindow ?? parseInt(process.env.FERRY_DEV_COMPACT_WINDOW ?? "8", 10);
+    const allServers = input.mcpServers ?? [];
+    const httpServers = allServers.filter((s) => isHttpMcpServer(s) && "url" in s);
+    if (httpServers.length > 0) {
+      throw new FerryError("state-invariant", {
+        reason: "http-mcp-unsupported",
+        provider: "openai",
+        detail: "HTTP MCP servers are only supported with the Anthropic provider. Configure stdio MCP servers or switch to provider: anthropic."
+      });
+    }
+    const stdioServers = allServers.filter((s) => isStdioMcpServer(s));
+    const pool = new McpClientPool();
+    try {
+      let trackTool2 = function(name, outputSize) {
+        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+        toolCallRecords.push({ name, outputSize });
+      };
+      var trackTool = trackTool2;
+      if (stdioServers.length > 0) {
+        await pool.connect(stdioServers);
+        if (pool.getTools().length > 0) {
+          logger.info("stdio_mcp_tools", {
+            count: pool.getTools().length,
+            servers: stdioServers.map((s) => s.name).join(",")
+          });
+        }
+      }
+      const nativeAndStdioTools = [...tools, ...pool.getTools()];
+      const openaiTools = nativeAndStdioTools.map(agentToolToOpenAI);
+      const messages = [
+        { role: "system", content: system },
+        { role: "user", content: initialPrompt }
+      ];
+      const usage = {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0
+      };
+      const toolCounts = {};
+      const toolCallRecords = [];
+      let done = null;
+      let iter = 0;
+      const loopStart = Date.now();
+      let warned70 = false;
+      let warned85 = false;
+      while (iter < maxIterations) {
+        iter++;
+        const iterStart = Date.now();
+        const billableEquiv = usage.input_tokens + usage.output_tokens;
+        if (billableEquiv > maxInputTokens) {
+          throw new FerryError("spend-cap", {
+            reason: "input-token-budget-exceeded",
+            cap: maxInputTokens,
+            consumed: billableEquiv
+          });
+        }
+        const budgetFraction = maxInputTokens > 0 ? billableEquiv / maxInputTokens : 0;
+        if (!warned70 && budgetFraction >= 0.7) {
+          warned70 = true;
+          const remaining = Math.round((1 - budgetFraction) * 100);
+          logger.info("budget_warning", { iter, threshold: 70, remaining_pct: remaining });
+          injectBudgetWarning2(
+            messages,
+            `[ferry] You have used ~${Math.round(budgetFraction * 100)}% of your input budget (${remaining}% remaining). Wrap up now: stop exploration, finish the current change, commit, and push.`
+          );
+        }
+        if (!warned85 && budgetFraction >= 0.85) {
+          warned85 = true;
+          logger.info("budget_warning", { iter, threshold: 85, mode: "commit-and-stop" });
+          injectBudgetWarning2(
+            messages,
+            `[ferry] BUDGET CRITICAL: ~${Math.round(budgetFraction * 100)}% of your input budget is consumed. You are now in commit-and-stop mode. Only use: bash (git operations), write_file, str_replace, commit_progress, or done. No exploration, no new reads \u2014 commit all work and call done immediately.`
+          );
+        }
+        const effectiveTools = warned85 ? openaiTools.filter((t) => COMMIT_AND_STOP_TOOL_NAMES2.has(t.function.name)) : openaiTools;
+        pruneMessageHistory2(messages);
+        const response = await openai.chat.completions.create({
+          model: opts.model,
+          max_tokens: maxTokens,
+          tools: effectiveTools,
+          tool_choice: effectiveTools.length > 0 ? "required" : "none",
+          messages
+        });
+        usage.input_tokens += response.usage?.prompt_tokens ?? 0;
+        usage.output_tokens += response.usage?.completion_tokens ?? 0;
+        const choice = response.choices[0];
+        if (!choice) {
+          throw new FerryError("state-invariant", {
+            reason: "agent-stopped-without-done",
+            stop_reason: "no-choices"
+          });
+        }
+        const assistantMsg = choice.message;
+        messages.push(assistantMsg);
+        const allToolCalls = assistantMsg.tool_calls ?? [];
+        const toolCalls = allToolCalls.filter(
+          (tc) => tc.type === "function"
+        );
+        logger.info("turn", {
+          iter,
+          stop_reason: choice.finish_reason,
+          tools: toolCalls.length,
+          in: response.usage?.prompt_tokens ?? 0,
+          out: response.usage?.completion_tokens ?? 0
+        });
+        emitDebug(
+          {
+            type: "turn",
+            iter,
+            depth: 0,
+            stop_reason: choice.finish_reason,
+            tools: toolCalls.length,
+            mcp_tools: 0,
+            in: response.usage?.prompt_tokens ?? 0,
+            cache_w: 0,
+            cache_r: 0,
+            out: response.usage?.completion_tokens ?? 0,
+            elapsed_ms: Date.now() - iterStart
+          },
+          logger
+        );
+        if (choice.finish_reason !== "tool_calls" && toolCalls.length === 0) {
+          throw new FerryError("state-invariant", {
+            reason: "agent-stopped-without-done",
+            stop_reason: choice.finish_reason
+          });
+        }
+        for (const toolCall of toolCalls) {
+          const name = toolCall.function.name;
+          let blockInput;
+          try {
+            blockInput = JSON.parse(toolCall.function.arguments);
+          } catch {
+            blockInput = {};
+          }
+          if (name === "done") {
+            const outcome = blockInput.outcome;
+            const actionable = outcome !== void 0 ? outcome !== "blocked" : blockInput.actionable;
+            done = { ...blockInput, actionable, outcome };
+            messages.push({ role: "tool", tool_call_id: toolCall.id, content: "ok" });
+            continue;
+          }
+          if (name === "commit_progress" && opts.commitProgress) {
+            const { message } = blockInput;
+            logger.info("tool", { iter, tool: "commit_progress", arg: message.slice(0, 120) });
+            try {
+              const result = await opts.commitProgress(repoRoot, branchName, message, secretScan);
+              trackTool2("commit_progress", result.length);
+              messages.push({ role: "tool", tool_call_id: toolCall.id, content: result });
+            } catch (e) {
+              trackTool2("commit_progress", 0);
+              messages.push({
+                role: "tool",
+                tool_call_id: toolCall.id,
+                content: e.message
+              });
+            }
+            continue;
+          }
+          if (pool.hasTool(name)) {
+            const serverName = pool.getServerName(name) ?? "unknown";
+            logger.info("mcp_stdio_tool", { iter, tool: name, server: serverName });
+            try {
+              const result = await pool.callTool(name, blockInput);
+              trackTool2(name, result.length);
+              messages.push({ role: "tool", tool_call_id: toolCall.id, content: result });
+            } catch (e) {
+              trackTool2(name, 0);
+              messages.push({
+                role: "tool",
+                tool_call_id: toolCall.id,
+                content: e.message
+              });
+            }
+            continue;
+          }
+          const argHint = blockInput.path ?? blockInput.source ?? blockInput.command ?? blockInput.pattern ?? "";
+          logger.info("tool", {
+            iter,
+            tool: name,
+            ...argHint ? { arg: String(argHint).slice(0, 120) } : {}
+          });
+          try {
+            const result = await opts.executeTool(repoRoot, name, blockInput);
+            trackTool2(name, result.length);
+            messages.push({ role: "tool", tool_call_id: toolCall.id, content: result });
+          } catch (e) {
+            trackTool2(name, 0);
+            messages.push({
+              role: "tool",
+              tool_call_id: toolCall.id,
+              content: e.message
+            });
+          }
+        }
+        compactOldToolResults2(messages, compactWindow);
+        if (done) {
+          emitDebug(
+            {
+              type: "result",
+              subtype: "success",
+              iterations: iter,
+              total_in: usage.input_tokens,
+              total_out: usage.output_tokens,
+              elapsed_ms: Date.now() - loopStart
+            },
+            logger
+          );
+          return { done, usage, iterations: iter, toolCounts, toolCallRecords };
+        }
+      }
+      throw new FerryError("state-invariant", {
+        reason: "iteration-cap-exceeded",
+        cap: maxIterations
+      });
+    } finally {
+      await pool.close();
+    }
+  }
+  return {
+    run(input) {
+      return runLoop(input);
+    }
+  };
+}
+
+// src/lib/llm/agent-loop/google.ts
+import { GoogleGenAI, FunctionCallingConfigMode } from "@google/genai";
+var COMMIT_AND_STOP_TOOL_NAMES3 = /* @__PURE__ */ new Set([
+  "bash",
+  "write_file",
+  "str_replace",
+  "commit_progress",
+  "done"
+]);
+var KEEP_LAST_TURNS3 = 6;
+var STUB3 = "[truncated: tool result elided to save context]";
+function pruneMessageHistory3(messages) {
+  const toolResultIndices = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role === "user" && msg.parts?.some((p) => p.functionResponse !== void 0)) {
+      toolResultIndices.push(i);
+    }
+  }
+  const cutoff = messages.length - KEEP_LAST_TURNS3 * 2;
+  if (cutoff <= 1) return;
+  for (const idx of toolResultIndices) {
+    if (idx >= cutoff) break;
+    const msg = messages[idx];
+    if (!msg.parts) continue;
+    for (let j = 0; j < msg.parts.length; j++) {
+      const part = msg.parts[j];
+      if (part.functionResponse === void 0) continue;
+      const output = part.functionResponse.response?.["output"];
+      if (typeof output === "string" && output !== STUB3) {
+        msg.parts[j] = {
+          functionResponse: {
+            name: part.functionResponse.name,
+            id: part.functionResponse.id,
+            response: { output: STUB3 }
+          }
+        };
+      }
+    }
+  }
+}
+function injectBudgetWarning3(messages, text) {
+  const last = messages[messages.length - 1];
+  if (last?.role === "user") {
+    last.parts = [...last.parts ?? [], { text }];
+  } else {
+    messages.push({ role: "user", parts: [{ text }] });
+  }
+}
+function compactOldToolResults3(messages, windowTurns) {
+  const toolResultIndices = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role === "user" && msg.parts?.some((p) => p.functionResponse !== void 0)) {
+      toolResultIndices.push(i);
+    }
+  }
+  if (toolResultIndices.length <= windowTurns) return;
+  const compactCount = toolResultIndices.length - windowTurns;
+  for (let k = 0; k < compactCount; k++) {
+    const idx = toolResultIndices[k];
+    const msg = messages[idx];
+    if (!msg.parts) continue;
+    for (let j = 0; j < msg.parts.length; j++) {
+      const part = msg.parts[j];
+      if (part.functionResponse === void 0) continue;
+      const output = part.functionResponse.response?.["output"];
+      if (typeof output !== "string" || output.startsWith("[compacted")) continue;
+      const tokens = Math.ceil(output.length / 4);
+      msg.parts[j] = {
+        functionResponse: {
+          name: part.functionResponse.name,
+          id: part.functionResponse.id,
+          response: { output: `[compacted \u2014 ~${tokens} tokens elided]` }
+        }
+      };
+    }
+  }
+}
+function createGoogleAgentLoop(opts) {
+  const ai = opts.ai ?? new GoogleGenAI({ apiKey: opts.apiKey });
+  const logger = opts.logger ?? createLogger("", "ferry:dev-loop");
+  async function runLoop(input) {
+    const { system, initialPrompt, tools, repoRoot, branchName, secretScan } = input;
+    const maxIterations = opts.maxIterations ?? parseInt(process.env.FERRY_DEV_MAX_ITERATIONS ?? "200", 10);
+    const maxInputTokens = opts.maxInputTokens ?? parseInt(process.env.FERRY_DEV_MAX_INPUT_TOKENS ?? "500000", 10);
+    const maxTokens = opts.maxTokens ?? parseInt(process.env.FERRY_DEV_MAX_TOKENS ?? "16384", 10);
+    const compactWindow = opts.compactWindow ?? parseInt(process.env.FERRY_DEV_COMPACT_WINDOW ?? "8", 10);
+    const allServers = input.mcpServers ?? [];
+    const httpServers = allServers.filter((s) => isHttpMcpServer(s) && "url" in s);
+    if (httpServers.length > 0) {
+      throw new FerryError("state-invariant", {
+        reason: "http-mcp-unsupported",
+        provider: "google",
+        detail: "HTTP MCP servers are only supported with the Anthropic provider. Configure stdio MCP servers or switch to provider: anthropic."
+      });
+    }
+    const stdioServers = allServers.filter((s) => isStdioMcpServer(s));
+    const pool = new McpClientPool();
+    try {
+      let trackTool2 = function(name, outputSize) {
+        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+        toolCallRecords.push({ name, outputSize });
+      };
+      var trackTool = trackTool2;
+      if (stdioServers.length > 0) {
+        await pool.connect(stdioServers);
+        if (pool.getTools().length > 0) {
+          logger.info("stdio_mcp_tools", {
+            count: pool.getTools().length,
+            servers: stdioServers.map((s) => s.name).join(",")
+          });
+        }
+      }
+      const nativeAndStdioTools = [...tools, ...pool.getTools()];
+      const allToolDeclarations = nativeAndStdioTools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        parametersJsonSchema: t.input_schema
+      }));
+      const messages = [{ role: "user", parts: [{ text: initialPrompt }] }];
+      const usage = {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0
+      };
+      const toolCounts = {};
+      const toolCallRecords = [];
+      let done = null;
+      let iter = 0;
+      const loopStart = Date.now();
+      let warned70 = false;
+      let warned85 = false;
+      while (iter < maxIterations) {
+        iter++;
+        const iterStart = Date.now();
+        const billableEquiv = usage.input_tokens + usage.output_tokens;
+        if (billableEquiv > maxInputTokens) {
+          throw new FerryError("spend-cap", {
+            reason: "input-token-budget-exceeded",
+            cap: maxInputTokens,
+            consumed: billableEquiv
+          });
+        }
+        const budgetFraction = maxInputTokens > 0 ? billableEquiv / maxInputTokens : 0;
+        if (!warned70 && budgetFraction >= 0.7) {
+          warned70 = true;
+          const remaining = Math.round((1 - budgetFraction) * 100);
+          logger.info("budget_warning", { iter, threshold: 70, remaining_pct: remaining });
+          injectBudgetWarning3(
+            messages,
+            `[ferry] You have used ~${Math.round(budgetFraction * 100)}% of your input budget (${remaining}% remaining). Wrap up now: stop exploration, finish the current change, commit, and push.`
+          );
+        }
+        if (!warned85 && budgetFraction >= 0.85) {
+          warned85 = true;
+          logger.info("budget_warning", { iter, threshold: 85, mode: "commit-and-stop" });
+          injectBudgetWarning3(
+            messages,
+            `[ferry] BUDGET CRITICAL: ~${Math.round(budgetFraction * 100)}% of your input budget is consumed. You are now in commit-and-stop mode. Only use: bash (git operations), write_file, str_replace, commit_progress, or done. No exploration, no new reads \u2014 commit all work and call done immediately.`
+          );
+        }
+        const effectiveToolDeclarations = warned85 ? allToolDeclarations.filter((t) => COMMIT_AND_STOP_TOOL_NAMES3.has(t.name ?? "")) : allToolDeclarations;
+        pruneMessageHistory3(messages);
+        const response = await ai.models.generateContent({
+          model: opts.model,
+          contents: messages,
+          config: {
+            systemInstruction: system,
+            maxOutputTokens: maxTokens,
+            tools: effectiveToolDeclarations.length > 0 ? [{ functionDeclarations: effectiveToolDeclarations }] : void 0,
+            toolConfig: effectiveToolDeclarations.length > 0 ? {
+              functionCallingConfig: {
+                mode: FunctionCallingConfigMode.ANY
+              }
+            } : void 0,
+            automaticFunctionCalling: { disable: true }
+          }
+        });
+        usage.input_tokens += response.usageMetadata?.promptTokenCount ?? 0;
+        usage.output_tokens += response.usageMetadata?.candidatesTokenCount ?? 0;
+        const candidate = response.candidates?.[0];
+        const finishReason = candidate?.finishReason ?? "STOP";
+        const modelContent = candidate?.content;
+        const parts = modelContent?.parts ?? [];
+        const functionCallParts = parts.filter((p) => p.functionCall !== void 0);
+        logger.info("turn", {
+          iter,
+          stop_reason: finishReason,
+          tools: functionCallParts.length,
+          in: response.usageMetadata?.promptTokenCount ?? 0,
+          out: response.usageMetadata?.candidatesTokenCount ?? 0
+        });
+        emitDebug(
+          {
+            type: "turn",
+            iter,
+            depth: 0,
+            stop_reason: finishReason,
+            tools: functionCallParts.length,
+            mcp_tools: 0,
+            in: response.usageMetadata?.promptTokenCount ?? 0,
+            cache_w: 0,
+            cache_r: 0,
+            out: response.usageMetadata?.candidatesTokenCount ?? 0,
+            elapsed_ms: Date.now() - iterStart
+          },
+          logger
+        );
+        if (functionCallParts.length === 0) {
+          throw new FerryError("state-invariant", {
+            reason: "agent-stopped-without-done",
+            stop_reason: finishReason
+          });
+        }
+        messages.push({ role: "model", parts });
+        const toolResultParts = [];
+        for (const part of functionCallParts) {
+          const fc = part.functionCall;
+          const name = fc.name ?? "";
+          const blockInput = fc.args ?? {};
+          const callId = fc.id;
+          if (name === "done") {
+            const outcome = blockInput.outcome;
+            const actionable = outcome !== void 0 ? outcome !== "blocked" : blockInput.actionable;
+            done = { ...blockInput, actionable, outcome };
+            toolResultParts.push({
+              functionResponse: {
+                name,
+                ...callId !== void 0 ? { id: callId } : {},
+                response: { output: "ok" }
+              }
+            });
+            continue;
+          }
+          if (name === "commit_progress" && opts.commitProgress) {
+            const { message } = blockInput;
+            logger.info("tool", { iter, tool: "commit_progress", arg: message.slice(0, 120) });
+            try {
+              const result = await opts.commitProgress(repoRoot, branchName, message, secretScan);
+              trackTool2("commit_progress", result.length);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...callId !== void 0 ? { id: callId } : {},
+                  response: { output: result }
+                }
+              });
+            } catch (e) {
+              trackTool2("commit_progress", 0);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...callId !== void 0 ? { id: callId } : {},
+                  response: { output: e.message, error: true }
+                }
+              });
+            }
+            continue;
+          }
+          if (pool.hasTool(name)) {
+            const serverName = pool.getServerName(name) ?? "unknown";
+            logger.info("mcp_stdio_tool", { iter, tool: name, server: serverName });
+            try {
+              const result = await pool.callTool(name, blockInput);
+              trackTool2(name, result.length);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...callId !== void 0 ? { id: callId } : {},
+                  response: { output: result }
+                }
+              });
+            } catch (e) {
+              trackTool2(name, 0);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...callId !== void 0 ? { id: callId } : {},
+                  response: { output: e.message, error: true }
+                }
+              });
+            }
+            continue;
+          }
+          const argHint = blockInput.path ?? blockInput.source ?? blockInput.command ?? blockInput.pattern ?? "";
+          logger.info("tool", {
+            iter,
+            tool: name,
+            ...argHint ? { arg: String(argHint).slice(0, 120) } : {}
+          });
+          try {
+            const result = await opts.executeTool(repoRoot, name, blockInput);
+            trackTool2(name, result.length);
+            toolResultParts.push({
+              functionResponse: {
+                name,
+                ...callId !== void 0 ? { id: callId } : {},
+                response: { output: result }
+              }
+            });
+          } catch (e) {
+            trackTool2(name, 0);
+            toolResultParts.push({
+              functionResponse: {
+                name,
+                ...callId !== void 0 ? { id: callId } : {},
+                response: { output: e.message, error: true }
+              }
+            });
+          }
+        }
+        messages.push({ role: "user", parts: toolResultParts });
+        compactOldToolResults3(messages, compactWindow);
+        if (done) {
+          emitDebug(
+            {
+              type: "result",
+              subtype: "success",
+              iterations: iter,
+              total_in: usage.input_tokens,
+              total_out: usage.output_tokens,
+              elapsed_ms: Date.now() - loopStart
+            },
+            logger
+          );
+          return { done, usage, iterations: iter, toolCounts, toolCallRecords };
+        }
+      }
+      throw new FerryError("state-invariant", {
+        reason: "iteration-cap-exceeded",
+        cap: maxIterations
+      });
+    } finally {
+      await pool.close();
+    }
+  }
+  return {
+    run(input) {
+      return runLoop(input);
+    }
+  };
+}
+
+// src/lib/llm/agent-loop/index.ts
+function requireEnv(key) {
+  const val = process.env[key];
+  if (!val) {
+    throw new FerryError("state-invariant", { reason: "missing-env", key });
+  }
+  return val;
+}
+function createAgentLoop(opts) {
+  if (opts.provider === "anthropic") {
+    const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
+    return createAnthropicAgentLoop({
+      ...auth2,
+      model: opts.model,
+      executeTool: opts.executeTool,
+      commitProgress: opts.commitProgress,
+      spawnSubagent: opts.spawnSubagent,
+      maxIterations: opts.maxIterations,
+      maxInputTokens: opts.maxInputTokens,
+      maxTokens: opts.maxTokens,
+      compactWindow: opts.compactWindow,
+      logger: opts.logger
+    });
+  }
+  if (opts.provider === "openai") {
+    const apiKey = requireEnv("FERRY_OPENAI_KEY");
+    return createOpenAIAgentLoop({
+      apiKey,
+      model: opts.model,
+      executeTool: opts.executeTool,
+      commitProgress: opts.commitProgress,
+      maxIterations: opts.maxIterations,
+      maxInputTokens: opts.maxInputTokens,
+      maxTokens: opts.maxTokens,
+      compactWindow: opts.compactWindow,
+      logger: opts.logger
+    });
+  }
+  if (opts.provider === "google") {
+    const apiKey = requireEnv("FERRY_GOOGLE_AI_KEY");
+    return createGoogleAgentLoop({
+      apiKey,
+      model: opts.model,
+      executeTool: opts.executeTool,
+      commitProgress: opts.commitProgress,
+      maxIterations: opts.maxIterations,
+      maxInputTokens: opts.maxInputTokens,
+      maxTokens: opts.maxTokens,
+      compactWindow: opts.compactWindow,
+      logger: opts.logger
+    });
+  }
+  throw new FerryError("state-invariant", {
+    reason: "unknown-provider",
+    provider: opts.provider
+  });
 }
 
 // src/agents/iterator/outcome-guard.ts
@@ -1367,7 +2075,7 @@ function filterMcpServers(pool, capabilities, hasLabelsConfig) {
 }
 
 // src/lib/agent-runtime/env.ts
-function requireEnv(key) {
+function requireEnv2(key) {
   const val = process.env[key];
   if (!val) throw new FerryError("state-invariant", { reason: "missing-env", key });
   return val;
@@ -1425,7 +2133,7 @@ async function runAgent(role, handler2) {
   const component = COMPONENT[role];
   const bootstrapLogger = createLogger("", component);
   try {
-    const rawPayload = requireEnv("FERRY_ENVELOPE_PAYLOAD");
+    const rawPayload = requireEnv2("FERRY_ENVELOPE_PAYLOAD");
     const envelope = validateEnvelope(JSON.parse(rawPayload));
     const logger = createLogger(envelope.event_id, component);
     await handler2(envelope, logger);
@@ -6492,8 +7200,8 @@ function createTrackerFromEnv() {
 
 // src/lib/agent-runtime/context.ts
 function createGitHubContext(repoRoot) {
-  const githubToken = requireEnv("GITHUB_TOKEN");
-  const githubRepo = requireEnv("GITHUB_REPO");
+  const githubToken = requireEnv2("GITHUB_TOKEN");
+  const githubRepo = requireEnv2("GITHUB_REPO");
   const [owner, repo] = githubRepo.split("/");
   if (!owner || !repo) {
     throw new FerryError("state-invariant", { reason: "invalid-github-repo", githubRepo });
@@ -6516,7 +7224,6 @@ async function resolveGitConfig(ferryCfg, runner, owner, repo) {
 var REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
-  const anthropicAuth = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT);
   const { baseBranch, workingBranchPrefix } = await resolveGitConfig(
     initialCfg,
@@ -6526,17 +7233,9 @@ async function main(envelope, logger) {
   );
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
   const { provider: iterProvider, model } = ferryCfg.models.iterate;
-  if (iterProvider !== "anthropic") {
-    throw new FerryError("state-invariant", {
-      reason: "unsupported-provider",
-      provider: iterProvider,
-      phase: "iterator",
-      detail: "The iterator phase requires provider 'anthropic'. OpenAI and Google support for agentic phases is planned for a future release."
-    });
-  }
   const iteratorWorkflow = ferryCfg.workflow.agents.iterator;
   const shouldAutoTransition = iteratorWorkflow.auto_transition !== null;
-  const reviewTransitionId = shouldAutoTransition ? requireEnv("FERRY_REVIEW_TRANSITION_ID") : "";
+  const reviewTransitionId = shouldAutoTransition ? requireEnv2("FERRY_REVIEW_TRANSITION_ID") : "";
   const issue = await tracker.getIssue(ticketKey);
   const existingComments = issue.comments;
   const mcpPool = loadMcpServers();
@@ -6628,8 +7327,8 @@ ${existingLog}` : "",
     "When you have fixed all findings, call the `done` tool."
   ].filter(Boolean).join("\n");
   const secretScan = makeSecretScan(REPO_ROOT);
-  const loop = createAnthropicAgentLoop({
-    ...anthropicAuth,
+  const loop = createAgentLoop({
+    provider: iterProvider,
     model,
     maxIterations: ferryCfg.limits.max_agent_iterations,
     maxInputTokens: ferryCfg.limits.max_tokens_per_run,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -59,16 +59,16 @@ All variables marked **wired** below are read directly by the standard consumer 
 
 #### Model and provider overrides
 
-| Variable                 | Default             | Wired?          | Affects         | Description                                                                                          |
-| ------------------------ | ------------------- | --------------- | --------------- | ---------------------------------------------------------------------------------------------------- |
-| `FERRY_DEV_MODEL`        | `claude-sonnet-4-6` | yes (`dev`)     | Developer agent | Override the model ID for the Developer. Wired via the `ferry_dev_model` composite action input.     |
-| `FERRY_DEV_PROVIDER`     | `anthropic`         | yes (`dev`)     | Developer agent | LLM provider override for the Developer. Currently only `anthropic` is supported for agentic phases. |
-| `FERRY_REVIEW_MODEL`     | `claude-sonnet-4-6` | yes (`review`)  | Reviewer agent  | Override the model ID for the Reviewer. Wired via the `ferry_review_model` composite action input.   |
-| `FERRY_REVIEW_PROVIDER`  | `anthropic`         | yes (`review`)  | Reviewer agent  | LLM provider override for the Reviewer. Currently only `anthropic` is supported for agentic phases.  |
-| `FERRY_ITER_MODEL`       | `claude-sonnet-4-6` | yes (`iterate`) | Iterator agent  | Override the model ID for the Iterator. Wired via the `ferry_iter_model` composite action input.     |
-| `FERRY_ITER_PROVIDER`    | `anthropic`         | yes (`iterate`) | Iterator agent  | LLM provider override for the Iterator. Currently only `anthropic` is supported for agentic phases.  |
-| `FERRY_REFINER_MODEL`    | `claude-sonnet-4-6` | yes (`refine`)  | Refiner agent   | Override the model ID for the Refiner. Wired via the `ferry_refiner_model` composite action input.   |
-| `FERRY_REFINER_PROVIDER` | `anthropic`         | yes (`refine`)  | Refiner agent   | LLM provider override for the Refiner (`anthropic` / `openai` / `google`).                           |
+| Variable                 | Default             | Wired?          | Affects         | Description                                                                                                 |
+| ------------------------ | ------------------- | --------------- | --------------- | ----------------------------------------------------------------------------------------------------------- |
+| `FERRY_DEV_MODEL`        | `claude-sonnet-4-6` | yes (`dev`)     | Developer agent | Override the model ID for the Developer. Wired via the `ferry_dev_model` composite action input.            |
+| `FERRY_DEV_PROVIDER`     | `anthropic`         | yes (`dev`)     | Developer agent | LLM provider override for the Developer. Accepts `anthropic`, `openai`, or `google`. See capability matrix. |
+| `FERRY_REVIEW_MODEL`     | `claude-sonnet-4-6` | yes (`review`)  | Reviewer agent  | Override the model ID for the Reviewer. Wired via the `ferry_review_model` composite action input.          |
+| `FERRY_REVIEW_PROVIDER`  | `anthropic`         | yes (`review`)  | Reviewer agent  | LLM provider override for the Reviewer. Currently only `anthropic` is supported for agentic phases.         |
+| `FERRY_ITER_MODEL`       | `claude-sonnet-4-6` | yes (`iterate`) | Iterator agent  | Override the model ID for the Iterator. Wired via the `ferry_iter_model` composite action input.            |
+| `FERRY_ITER_PROVIDER`    | `anthropic`         | yes (`iterate`) | Iterator agent  | LLM provider override for the Iterator. Accepts `anthropic`, `openai`, or `google`. See capability matrix.  |
+| `FERRY_REFINER_MODEL`    | `claude-sonnet-4-6` | yes (`refine`)  | Refiner agent   | Override the model ID for the Refiner. Wired via the `ferry_refiner_model` composite action input.          |
+| `FERRY_REFINER_PROVIDER` | `anthropic`         | yes (`refine`)  | Refiner agent   | LLM provider override for the Refiner (`anthropic` / `openai` / `google`).                                  |
 
 #### Token and iteration limits
 
@@ -220,24 +220,41 @@ Each agent phase can be configured independently. All `models.*` fields are opti
 
 Ferry supports three LLM providers: **`anthropic`**, **`openai`**, and **`google`**. Provider support varies by phase:
 
-| Phase     | Supported providers             | Notes                                                                       |
-| --------- | ------------------------------- | --------------------------------------------------------------------------- |
-| `refiner` | `anthropic`, `openai`, `google` | Uses a single-turn LLM call — all three providers are supported             |
-| `dev`     | `anthropic`                     | Anthropic only (multi-provider in progress) — uses an agentic tool-use loop |
-| `review`  | `anthropic`                     | Anthropic only (multi-provider in progress) — uses an agentic tool-use loop |
-| `iterate` | `anthropic`                     | Anthropic only (multi-provider in progress) — uses an agentic tool-use loop |
+| Phase     | Supported providers             | Notes                                                                                   |
+| --------- | ------------------------------- | --------------------------------------------------------------------------------------- |
+| `refiner` | `anthropic`, `openai`, `google` | Single-turn LLM call — all three providers are supported                                |
+| `dev`     | `anthropic`, `openai`, `google` | Multi-turn agentic loop. See capability matrix below for provider-specific limitations. |
+| `review`  | `anthropic`                     | Anthropic only — uses an agentic tool-use loop                                          |
+| `iterate` | `anthropic`, `openai`, `google` | Multi-turn agentic loop. See capability matrix below for provider-specific limitations. |
 
-> **MCP:** Model Context Protocol (MCP) server integration is Anthropic-only and is not available when using other providers. MCP availability is also independent of the provider support table above — even with `provider: anthropic`, **only the Developer and Iterator agents consume `AGENT_MCP_SERVERS`**. The Refiner and Reviewer do not load MCP servers regardless of provider or configuration.
+#### Provider capability matrix (agentic phases)
+
+| Capability                    | `anthropic` | `openai`           | `google`           |
+| ----------------------------- | ----------- | ------------------ | ------------------ |
+| Multi-turn tool use           | ✅          | ✅                 | ✅                 |
+| HTTP MCP servers              | ✅          | ❌ (stdio only)    | ❌ (stdio only)    |
+| Stdio MCP servers             | ✅          | ✅                 | ✅                 |
+| Explicit prompt cache control | ✅          | ❌ (automatic)     | ❌ (not supported) |
+| Cache-weighted token budget   | ✅          | ❌ (raw token sum) | ❌ (raw token sum) |
+| Expected cost per long run    | Baseline    | ~2–3× higher       | ~2–3× higher       |
+
+> **HTTP MCP:** Anthropic's HTTP MCP beta connector (`type: url` servers in `AGENT_MCP_SERVERS`) is Anthropic-only. Configuring an HTTP MCP server for an OpenAI or Google run raises a hard error at startup. Use stdio MCP servers for cross-provider compatibility.
+>
+> **Prompt caching:** With OpenAI and Google, token budgets (`FERRY_DEV_MAX_INPUT_TOKENS`, `max_tokens_per_run`) are applied against the raw sum of input + output tokens. Anthropic uses a cache-weighted formula (`input + cache_read × 0.1 + cache_creation`) that better approximates actual cost.
+>
+> **Cost note:** The Developer and Iterator agents run multi-turn agentic loops with many tool calls. Without Anthropic's prompt cache, OpenAI and Google runs are typically 2–3× more expensive for long tasks.
+>
+> **MCP availability:** Even with `provider: anthropic`, only the Developer and Iterator agents load MCP servers from `AGENT_MCP_SERVERS`. The Refiner and Reviewer ignore MCP configuration regardless of provider.
 
 | Field                     | Default               | Description                                                                                                                                |
 | ------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `models.refiner.provider` | `"anthropic"`         | LLM provider for the Refiner agent. Accepts `"anthropic"`, `"openai"`, or `"google"`.                                                      |
 | `models.refiner.model`    | `"claude-sonnet-4-6"` | Model ID for the Refiner agent (overridden by `FERRY_REFINER_MODEL` env var)                                                               |
-| `models.dev.provider`     | `"anthropic"`         | LLM provider for the Developer agent. Currently only `"anthropic"` is supported.                                                           |
+| `models.dev.provider`     | `"anthropic"`         | LLM provider for the Developer agent. Accepts `"anthropic"`, `"openai"`, or `"google"`. See capability matrix above.                       |
 | `models.dev.model`        | `"claude-sonnet-4-6"` | Model ID for the Developer agent. The standard `dev.yml` workflow always runs `claude-sonnet-4-6`; override here to use a different model. |
 | `models.review.provider`  | `"anthropic"`         | LLM provider for the Reviewer agent. Currently only `"anthropic"` is supported.                                                            |
 | `models.review.model`     | `"claude-sonnet-4-6"` | Model ID for the Reviewer agent (overridden by `FERRY_REVIEW_MODEL` env var)                                                               |
-| `models.iterate.provider` | `"anthropic"`         | LLM provider for the Iterator agent. Currently only `"anthropic"` is supported.                                                            |
+| `models.iterate.provider` | `"anthropic"`         | LLM provider for the Iterator agent. Accepts `"anthropic"`, `"openai"`, or `"google"`. See capability matrix above.                        |
 | `models.iterate.model`    | `"claude-sonnet-4-6"` | Model ID for the Iterator agent (overridden by `FERRY_ITER_MODEL` env var)                                                                 |
 
 #### `limits`

--- a/src/agents/developer/dev-action.ts
+++ b/src/agents/developer/dev-action.ts
@@ -21,7 +21,6 @@ import {
 import type { EventEnvelopeV1 } from '../../lib/envelope/types.js';
 import type { Logger } from '../../lib/agent-runtime/index.js';
 import { isDryRun } from '../../lib/dry-run.js';
-import { FerryError } from '../../lib/errors/index.js';
 import { formatDeveloperCommit } from './commit.js';
 import { formatPullRequestTitle, formatPullRequestBody } from './pr.js';
 import {
@@ -30,10 +29,9 @@ import {
   SPAWN_SUBAGENT_SCHEMA,
   executeTool,
 } from './tools.js';
-import { createAnthropicAgentLoop } from '../../lib/llm/agent-loop/anthropic.js';
+import { createAgentLoop } from '../../lib/llm/agent-loop/index.js';
 import type { AgentLoop } from '../../lib/llm/agent-loop/types.js';
 import { resolveCapabilities, filterMcpServers } from '../../lib/labels/capabilities.js';
-import { resolveAnthropicAuth } from '../../lib/llm/anthropic-auth.js';
 import { detectTestRunner, repoTree, packageJsonPath, detectPackageManager } from './workspace.js';
 import { assertDevOutputContract } from './outcome-guard.js';
 import { runWipFinalizer } from './wip-finalizer.js';
@@ -48,7 +46,6 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
     logger.info('DRY_RUN mode — no branch push, no PR, no Jira writes');
   }
 
-  const anthropicAuth = resolveAnthropicAuth({ apiKeyEnv: 'ANTHROPIC_API_KEY' });
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT);
 
   // Resolve baseBranch before using any config values, then reload config from that branch.
@@ -65,15 +62,6 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
 
   const { provider: devProvider } = ferryCfg.models.dev;
-  if (devProvider !== 'anthropic') {
-    throw new FerryError('state-invariant', {
-      reason: 'unsupported-provider',
-      provider: devProvider,
-      phase: 'developer',
-      detail:
-        "The developer phase requires provider 'anthropic'. OpenAI and Google support for agentic phases is planned for a future release.",
-    });
-  }
   const devWorkflow = ferryCfg.workflow.agents.developer;
   const shouldAutoTransition = devWorkflow.auto_transition !== null;
   const reviewTransitionId =
@@ -185,8 +173,8 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const allToolSchemas = [...TOOL_SCHEMAS, COMMIT_PROGRESS_SCHEMA, SPAWN_SUBAGENT_SCHEMA];
 
   let loop!: AgentLoop;
-  loop = createAnthropicAgentLoop({
-    ...anthropicAuth,
+  loop = createAgentLoop({
+    provider: devProvider,
     model,
     maxIterations: ferryCfg.limits.max_agent_iterations,
     maxInputTokens: ferryCfg.limits.max_tokens_per_run,

--- a/src/agents/iterator/iterate-action.ts
+++ b/src/agents/iterator/iterate-action.ts
@@ -2,10 +2,8 @@ import { execFileSync } from 'node:child_process';
 import { delimitUntrusted } from '../../lib/llm/delimit-untrusted.js';
 import { checkIdempotencyMarker } from '../../lib/io/idempotency.js';
 import { TOOL_SCHEMAS, COMMIT_PROGRESS_SCHEMA, executeTool } from '../developer/tools.js';
-import { createAnthropicAgentLoop } from '../../lib/llm/agent-loop/anthropic.js';
-import { resolveAnthropicAuth } from '../../lib/llm/anthropic-auth.js';
+import { createAgentLoop } from '../../lib/llm/agent-loop/index.js';
 import { assertIterOutputContract } from './outcome-guard.js';
-import { FerryError } from '../../lib/errors/index.js';
 import { checkIterationCap } from './cap.js';
 import { decideIteratorTransition } from './transition.js';
 import { formatCommitMessage } from './prompt.js';
@@ -38,7 +36,6 @@ const REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
 
-  const anthropicAuth = resolveAnthropicAuth({ apiKeyEnv: 'ANTHROPIC_API_KEY' });
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT);
 
   // Resolve baseBranch before using any config values, then reload config from that branch.
@@ -53,15 +50,6 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
 
   const { provider: iterProvider, model } = ferryCfg.models.iterate;
-  if (iterProvider !== 'anthropic') {
-    throw new FerryError('state-invariant', {
-      reason: 'unsupported-provider',
-      provider: iterProvider,
-      phase: 'iterator',
-      detail:
-        "The iterator phase requires provider 'anthropic'. OpenAI and Google support for agentic phases is planned for a future release.",
-    });
-  }
   const iteratorWorkflow = ferryCfg.workflow.agents.iterator;
   const shouldAutoTransition = iteratorWorkflow.auto_transition !== null;
   const reviewTransitionId = shouldAutoTransition ? requireEnv('FERRY_REVIEW_TRANSITION_ID') : '';
@@ -182,8 +170,8 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
 
   const secretScan = makeSecretScan(REPO_ROOT);
 
-  const loop = createAnthropicAgentLoop({
-    ...anthropicAuth,
+  const loop = createAgentLoop({
+    provider: iterProvider,
     model,
     maxIterations: ferryCfg.limits.max_agent_iterations,
     maxInputTokens: ferryCfg.limits.max_tokens_per_run,

--- a/src/lib/llm/agent-loop/google.test.ts
+++ b/src/lib/llm/agent-loop/google.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GoogleGenAI } from '@google/genai';
+import { FerryError } from '../../errors/index.js';
+import { createGoogleAgentLoop } from './google.js';
+import type { McpServerConfig } from './types.js';
+
+const { mockPool, MockMcpClientPool } = vi.hoisted(() => {
+  const pool = {
+    connect: vi.fn().mockResolvedValue(undefined),
+    getTools: vi.fn().mockReturnValue([]),
+    hasTool: vi.fn().mockReturnValue(false),
+    getServerName: vi.fn().mockReturnValue(undefined),
+    callTool: vi.fn().mockResolvedValue('mcp result'),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  const ctor = vi.fn().mockImplementation(function () {
+    return pool;
+  });
+  return { mockPool: pool, MockMcpClientPool: ctor };
+});
+
+vi.mock('../../mcp/pool.js', () => ({
+  McpClientPool: MockMcpClientPool,
+}));
+
+type FakePart = {
+  text?: string;
+  functionCall?: { name: string; args?: Record<string, unknown>; id?: string };
+};
+
+type FakeResponse = {
+  candidates?: Array<{
+    finishReason?: string;
+    content?: { role: string; parts: FakePart[] };
+  }>;
+  usageMetadata?: {
+    promptTokenCount?: number;
+    candidatesTokenCount?: number;
+  };
+};
+
+function makeDoneResponse(): FakeResponse {
+  return {
+    candidates: [
+      {
+        finishReason: 'STOP',
+        content: {
+          role: 'model',
+          parts: [{ functionCall: { name: 'done', args: { actionable: true, summary: 'done' } } }],
+        },
+      },
+    ],
+    usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 },
+  };
+}
+
+function makeToolCallResponse(
+  name: string,
+  args: Record<string, unknown>,
+  id?: string,
+): FakeResponse {
+  return {
+    candidates: [
+      {
+        finishReason: 'STOP',
+        content: {
+          role: 'model',
+          parts: [{ functionCall: { name, args, ...(id !== undefined ? { id } : {}) } }],
+        },
+      },
+    ],
+    usageMetadata: { promptTokenCount: 20, candidatesTokenCount: 10 },
+  };
+}
+
+function makeAi(responses: FakeResponse[]): GoogleGenAI {
+  let idx = 0;
+  const generateContent = vi.fn().mockImplementation(async () => {
+    return responses[idx++];
+  });
+  return { models: { generateContent } } as unknown as GoogleGenAI;
+}
+
+function restorePoolDefaults(): void {
+  MockMcpClientPool.mockImplementation(function () {
+    return mockPool;
+  });
+  mockPool.connect.mockResolvedValue(undefined);
+  mockPool.getTools.mockReturnValue([]);
+  mockPool.hasTool.mockReturnValue(false);
+  mockPool.getServerName.mockReturnValue(undefined);
+  mockPool.callTool.mockResolvedValue('mcp result');
+  mockPool.close.mockResolvedValue(undefined);
+}
+
+const noopExecuteTool =
+  vi.fn<(r: string, n: string, i: Record<string, unknown>) => Promise<string>>();
+
+const baseInput = {
+  system: 's',
+  initialPrompt: 'p',
+  tools: [],
+  repoRoot: '/r',
+  branchName: 'ferry/TEST-1',
+  secretScan: async () => {},
+};
+
+describe('createGoogleAgentLoop — basic', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restorePoolDefaults();
+  });
+
+  it('calls done and returns result', async () => {
+    const ai = makeAi([makeDoneResponse()]);
+    const loop = createGoogleAgentLoop({ model: 'm', ai, executeTool: noopExecuteTool });
+    const result = await loop.run(baseInput);
+    expect(result.done.actionable).toBe(true);
+    expect(result.done.summary).toBe('done');
+    expect(result.iterations).toBe(1);
+  });
+
+  it('accumulates token usage across turns', async () => {
+    const execTool = vi.fn().mockResolvedValue('content');
+    const ai = makeAi([makeToolCallResponse('read_file', { path: 'x.ts' }), makeDoneResponse()]);
+    const loop = createGoogleAgentLoop({ model: 'm', ai, executeTool: execTool });
+    const result = await loop.run(baseInput);
+    expect(result.usage.input_tokens).toBe(30);
+    expect(result.usage.output_tokens).toBe(15);
+    expect(result.iterations).toBe(2);
+  });
+
+  it('dispatches tool calls to executeTool', async () => {
+    const execTool = vi.fn().mockResolvedValueOnce('contents');
+    const ai = makeAi([
+      makeToolCallResponse('read_file', { path: 'src/index.ts' }),
+      makeDoneResponse(),
+    ]);
+    const loop = createGoogleAgentLoop({ model: 'm', ai, executeTool: execTool });
+    await loop.run(baseInput);
+    expect(execTool).toHaveBeenCalledWith('/r', 'read_file', { path: 'src/index.ts' });
+  });
+
+  it('tracks tool counts and call records', async () => {
+    const execTool = vi.fn().mockResolvedValue('ok');
+    const ai = makeAi([
+      makeToolCallResponse('read_file', { path: 'a.ts' }),
+      makeToolCallResponse('read_file', { path: 'b.ts' }),
+      makeDoneResponse(),
+    ]);
+    const loop = createGoogleAgentLoop({ model: 'm', ai, executeTool: execTool });
+    const result = await loop.run(baseInput);
+    expect(result.toolCounts['read_file']).toBe(2);
+    expect(result.toolCallRecords.length).toBe(2);
+  });
+
+  it('throws FerryError when response has no function calls', async () => {
+    const textOnlyResponse: FakeResponse = {
+      candidates: [
+        {
+          finishReason: 'STOP',
+          content: { role: 'model', parts: [{ text: 'I am done.' }] },
+        },
+      ],
+      usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 5 },
+    };
+    const ai = makeAi([textOnlyResponse]);
+    const loop = createGoogleAgentLoop({ model: 'm', ai, executeTool: noopExecuteTool });
+    await expect(loop.run(baseInput)).rejects.toThrow(FerryError);
+  });
+
+  it('handles commit_progress tool calls', async () => {
+    const commitProgress = vi.fn().mockResolvedValue('committed');
+    const ai = makeAi([
+      makeToolCallResponse('commit_progress', { message: 'feat: add feature' }),
+      makeDoneResponse(),
+    ]);
+    const loop = createGoogleAgentLoop({
+      model: 'm',
+      ai,
+      executeTool: noopExecuteTool,
+      commitProgress,
+    });
+    await loop.run(baseInput);
+    expect(commitProgress).toHaveBeenCalledWith(
+      '/r',
+      'ferry/TEST-1',
+      'feat: add feature',
+      expect.any(Function),
+    );
+  });
+
+  it('closes the pool after a successful run', async () => {
+    const ai = makeAi([makeDoneResponse()]);
+    const loop = createGoogleAgentLoop({ model: 'm', ai, executeTool: noopExecuteTool });
+    await loop.run(baseInput);
+    expect(mockPool.close).toHaveBeenCalledOnce();
+  });
+
+  it('closes the pool even when the loop throws', async () => {
+    const textOnlyResponse: FakeResponse = {
+      candidates: [{ finishReason: 'STOP', content: { role: 'model', parts: [{ text: 'oops' }] } }],
+    };
+    const ai = makeAi([textOnlyResponse]);
+    const loop = createGoogleAgentLoop({ model: 'm', ai, executeTool: noopExecuteTool });
+    await expect(loop.run(baseInput)).rejects.toThrow(FerryError);
+    expect(mockPool.close).toHaveBeenCalledOnce();
+  });
+});
+
+describe('createGoogleAgentLoop — HTTP MCP rejection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restorePoolDefaults();
+  });
+
+  it('throws FerryError for HTTP MCP servers', async () => {
+    const ai = makeAi([makeDoneResponse()]);
+    const loop = createGoogleAgentLoop({ model: 'm', ai, executeTool: noopExecuteTool });
+    const server: McpServerConfig = { name: 'ctx', url: 'https://mcp.ctx.com/mcp' };
+    await expect(loop.run({ ...baseInput, mcpServers: [server] })).rejects.toThrow(FerryError);
+  });
+
+  it('does not throw for stdio MCP servers', async () => {
+    const ai = makeAi([makeDoneResponse()]);
+    const loop = createGoogleAgentLoop({ model: 'm', ai, executeTool: noopExecuteTool });
+    const server: McpServerConfig = { type: 'stdio', name: 'fs', command: 'node', args: [] };
+    await expect(loop.run({ ...baseInput, mcpServers: [server] })).resolves.toBeDefined();
+  });
+});
+
+describe('createGoogleAgentLoop — stdio MCP tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restorePoolDefaults();
+  });
+
+  it('dispatches stdio MCP tool calls to the pool', async () => {
+    mockPool.getTools.mockReturnValue([
+      {
+        name: 'read_resource',
+        description: 'Read',
+        input_schema: { type: 'object', properties: {} },
+      },
+    ]);
+    mockPool.hasTool.mockImplementation((n: string) => n === 'read_resource');
+    mockPool.callTool.mockResolvedValue('resource contents');
+
+    const ai = makeAi([
+      makeToolCallResponse('read_resource', { uri: 'file:///tmp/x' }),
+      makeDoneResponse(),
+    ]);
+    const execTool = vi.fn();
+    const loop = createGoogleAgentLoop({ model: 'm', ai, executeTool: execTool });
+    const stdioServer: McpServerConfig = { type: 'stdio', name: 'fs', command: 'node', args: [] };
+    const result = await loop.run({ ...baseInput, mcpServers: [stdioServer] });
+    expect(mockPool.callTool).toHaveBeenCalledWith('read_resource', { uri: 'file:///tmp/x' });
+    expect(execTool).not.toHaveBeenCalled();
+    expect(result.done.actionable).toBe(true);
+  });
+});
+
+describe('createGoogleAgentLoop — budget cap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restorePoolDefaults();
+  });
+
+  it('throws spend-cap when total tokens exceed the cap', async () => {
+    const toolResp = makeToolCallResponse('read_file', { path: 'x.ts' });
+    toolResp.usageMetadata = { promptTokenCount: 600, candidatesTokenCount: 400 };
+    const execTool = vi.fn().mockResolvedValue('content');
+    const ai = makeAi([toolResp, makeDoneResponse()]);
+    const loop = createGoogleAgentLoop({
+      model: 'm',
+      ai,
+      executeTool: execTool,
+      maxInputTokens: 999,
+    });
+    const err = await loop.run(baseInput).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(FerryError);
+    expect((err as FerryError).code).toBe('spend-cap');
+  });
+});
+
+describe('createGoogleAgentLoop — budget warnings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restorePoolDefaults();
+  });
+
+  function makeCapturingAi(responses: FakeResponse[]) {
+    let idx = 0;
+    const calls: Array<{ contents: unknown[]; config: unknown }> = [];
+    const generateContent = vi
+      .fn()
+      .mockImplementation(async (params: { contents: unknown[]; config: unknown }) => {
+        calls.push({
+          contents: JSON.parse(JSON.stringify(params.contents)) as unknown[],
+          config: JSON.parse(JSON.stringify(params.config)) as unknown,
+        });
+        return responses[idx++];
+      });
+    const ai = { models: { generateContent } } as unknown as GoogleGenAI;
+    return { ai, calls };
+  }
+
+  it('injects 70% warning into conversation when budget crosses 70%', async () => {
+    const toolResp = makeToolCallResponse('read_file', { path: 'x.ts' });
+    toolResp.usageMetadata = { promptTokenCount: 750, candidatesTokenCount: 0 };
+    const execTool = vi.fn().mockResolvedValue('content');
+    const { ai, calls } = makeCapturingAi([toolResp, makeDoneResponse()]);
+    const loop = createGoogleAgentLoop({
+      model: 'm',
+      ai,
+      executeTool: execTool,
+      maxInputTokens: 1000,
+    });
+    await loop.run(baseInput);
+    // iter 2 contents should contain a [ferry] text part somewhere
+    expect(calls.length).toBe(2);
+    const iter2Contents = calls[1].contents as Array<{ role: string; parts: FakePart[] }>;
+    const hasWarning = iter2Contents.some((c) =>
+      c.parts?.some((p) => typeof p.text === 'string' && p.text.includes('[ferry]')),
+    );
+    expect(hasWarning).toBe(true);
+  });
+
+  it('restricts tools to commit-and-stop set at 85%', async () => {
+    const toolResp = makeToolCallResponse('read_file', { path: 'x.ts' });
+    toolResp.usageMetadata = { promptTokenCount: 900, candidatesTokenCount: 0 };
+    const execTool = vi.fn().mockResolvedValue('content');
+    const toolDefs = ['read_file', 'bash', 'done', 'list_dir'].map((n) => ({
+      name: n,
+      description: n,
+      input_schema: { type: 'object' as const, properties: {} },
+    }));
+    const { ai, calls } = makeCapturingAi([toolResp, makeDoneResponse()]);
+    const loop = createGoogleAgentLoop({
+      model: 'm',
+      ai,
+      executeTool: execTool,
+      maxInputTokens: 1000,
+    });
+    await loop.run({ ...baseInput, tools: toolDefs });
+    // iter 2 config should contain only commit-and-stop tools
+    const iter2Config = calls[1].config as {
+      tools?: Array<{ functionDeclarations?: Array<{ name?: string }> }>;
+    };
+    const toolNames = new Set(
+      (iter2Config.tools?.[0]?.functionDeclarations ?? []).map((d) => d.name),
+    );
+    expect(toolNames.has('bash')).toBe(true);
+    expect(toolNames.has('done')).toBe(true);
+    expect(toolNames.has('read_file')).toBe(false);
+    expect(toolNames.has('list_dir')).toBe(false);
+  });
+});
+
+describe('createGoogleAgentLoop — iteration cap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restorePoolDefaults();
+  });
+
+  it('throws iteration-cap-exceeded when maxIterations is reached', async () => {
+    const execTool = vi.fn().mockResolvedValue('ok');
+    const generateContent = vi
+      .fn()
+      .mockResolvedValue(makeToolCallResponse('read_file', { path: 'x.ts' }));
+    const ai = { models: { generateContent } } as unknown as GoogleGenAI;
+    const loop = createGoogleAgentLoop({
+      model: 'm',
+      ai,
+      executeTool: execTool,
+      maxIterations: 2,
+    });
+    const err = await loop.run(baseInput).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(FerryError);
+    expect((err as FerryError).context).toMatchObject({ reason: 'iteration-cap-exceeded' });
+  });
+});

--- a/src/lib/llm/agent-loop/google.ts
+++ b/src/lib/llm/agent-loop/google.ts
@@ -1,0 +1,453 @@
+import { GoogleGenAI, FunctionCallingConfigMode } from '@google/genai';
+import type { Content, Part } from '@google/genai';
+import { FerryError } from '../../errors/index.js';
+import { emitDebug } from '../debug-log.js';
+import { McpClientPool } from '../../mcp/pool.js';
+import { createLogger } from '../../logger/index.js';
+import type { Logger } from '../../logger/index.js';
+import type {
+  AgentTool,
+  AgentLoop,
+  AgentLoopResult,
+  AgentLoopUsage,
+  DonePayload,
+  DoneOutcome,
+  McpServerConfig,
+  StdioMcpServerConfig,
+  ToolCallRecord,
+} from './types.js';
+import { isStdioMcpServer, isHttpMcpServer } from './types.js';
+
+const COMMIT_AND_STOP_TOOL_NAMES = new Set([
+  'bash',
+  'write_file',
+  'str_replace',
+  'commit_progress',
+  'done',
+]);
+
+const KEEP_LAST_TURNS = 6;
+const STUB = '[truncated: tool result elided to save context]';
+
+type ToolExecutor = (
+  repoRoot: string,
+  name: string,
+  input: Record<string, unknown>,
+) => Promise<string>;
+type CommitProgressHandler = (
+  repoRoot: string,
+  branchName: string,
+  message: string,
+  secretScan: () => Promise<void>,
+) => Promise<string>;
+
+function pruneMessageHistory(messages: Content[]): void {
+  // Collect indices of user messages that contain functionResponse parts.
+  const toolResultIndices: number[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role === 'user' && msg.parts?.some((p) => p.functionResponse !== undefined)) {
+      toolResultIndices.push(i);
+    }
+  }
+
+  // messages[0] is the initial user prompt — never prune it.
+  const cutoff = messages.length - KEEP_LAST_TURNS * 2;
+  if (cutoff <= 1) return;
+
+  for (const idx of toolResultIndices) {
+    if (idx >= cutoff) break;
+    const msg = messages[idx];
+    if (!msg.parts) continue;
+    for (let j = 0; j < msg.parts.length; j++) {
+      const part = msg.parts[j];
+      if (part.functionResponse === undefined) continue;
+      const output = part.functionResponse.response?.['output'];
+      if (typeof output === 'string' && output !== STUB) {
+        msg.parts[j] = {
+          functionResponse: {
+            name: part.functionResponse.name,
+            id: part.functionResponse.id,
+            response: { output: STUB },
+          },
+        };
+      }
+    }
+  }
+}
+
+function injectBudgetWarning(messages: Content[], text: string): void {
+  const last = messages[messages.length - 1];
+  if (last?.role === 'user') {
+    last.parts = [...(last.parts ?? []), { text }];
+  } else {
+    messages.push({ role: 'user', parts: [{ text }] });
+  }
+}
+
+function compactOldToolResults(messages: Content[], windowTurns: number): void {
+  const toolResultIndices: number[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role === 'user' && msg.parts?.some((p) => p.functionResponse !== undefined)) {
+      toolResultIndices.push(i);
+    }
+  }
+
+  if (toolResultIndices.length <= windowTurns) return;
+
+  const compactCount = toolResultIndices.length - windowTurns;
+  for (let k = 0; k < compactCount; k++) {
+    const idx = toolResultIndices[k];
+    const msg = messages[idx];
+    if (!msg.parts) continue;
+    for (let j = 0; j < msg.parts.length; j++) {
+      const part = msg.parts[j];
+      if (part.functionResponse === undefined) continue;
+      const output = part.functionResponse.response?.['output'];
+      if (typeof output !== 'string' || output.startsWith('[compacted')) continue;
+      const tokens = Math.ceil(output.length / 4);
+      msg.parts[j] = {
+        functionResponse: {
+          name: part.functionResponse.name,
+          id: part.functionResponse.id,
+          response: { output: `[compacted — ~${tokens} tokens elided]` },
+        },
+      };
+    }
+  }
+}
+
+export function createGoogleAgentLoop(opts: {
+  apiKey?: string;
+  model: string;
+  ai?: GoogleGenAI;
+  executeTool: ToolExecutor;
+  commitProgress?: CommitProgressHandler;
+  maxIterations?: number;
+  maxInputTokens?: number;
+  maxTokens?: number;
+  compactWindow?: number;
+  logger?: Logger;
+}): AgentLoop {
+  const ai = opts.ai ?? new GoogleGenAI({ apiKey: opts.apiKey });
+  const logger = opts.logger ?? createLogger('', 'ferry:dev-loop');
+
+  async function runLoop(input: {
+    system: string;
+    initialPrompt: string;
+    tools: AgentTool[];
+    repoRoot: string;
+    branchName: string;
+    secretScan: () => Promise<void>;
+    mcpServers?: McpServerConfig[];
+  }): Promise<AgentLoopResult> {
+    const { system, initialPrompt, tools, repoRoot, branchName, secretScan } = input;
+    const maxIterations =
+      opts.maxIterations ?? parseInt(process.env.FERRY_DEV_MAX_ITERATIONS ?? '200', 10);
+    const maxInputTokens =
+      opts.maxInputTokens ?? parseInt(process.env.FERRY_DEV_MAX_INPUT_TOKENS ?? '500000', 10);
+    const maxTokens = opts.maxTokens ?? parseInt(process.env.FERRY_DEV_MAX_TOKENS ?? '16384', 10);
+    const compactWindow =
+      opts.compactWindow ?? parseInt(process.env.FERRY_DEV_COMPACT_WINDOW ?? '8', 10);
+
+    const allServers = input.mcpServers ?? [];
+    const httpServers = allServers.filter((s) => isHttpMcpServer(s) && 'url' in s);
+    if (httpServers.length > 0) {
+      throw new FerryError('state-invariant', {
+        reason: 'http-mcp-unsupported',
+        provider: 'google',
+        detail:
+          'HTTP MCP servers are only supported with the Anthropic provider. Configure stdio MCP servers or switch to provider: anthropic.',
+      });
+    }
+    const stdioServers = allServers.filter((s): s is StdioMcpServerConfig => isStdioMcpServer(s));
+
+    const pool = new McpClientPool();
+    try {
+      if (stdioServers.length > 0) {
+        await pool.connect(stdioServers);
+        if (pool.getTools().length > 0) {
+          logger.info('stdio_mcp_tools', {
+            count: pool.getTools().length,
+            servers: stdioServers.map((s) => s.name).join(','),
+          });
+        }
+      }
+
+      const nativeAndStdioTools = [...tools, ...pool.getTools()];
+      const allToolDeclarations = nativeAndStdioTools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        parametersJsonSchema: t.input_schema,
+      }));
+
+      const messages: Content[] = [{ role: 'user', parts: [{ text: initialPrompt }] }];
+
+      const usage: AgentLoopUsage = {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      };
+      const toolCounts: Record<string, number> = {};
+      const toolCallRecords: ToolCallRecord[] = [];
+      function trackTool(name: string, outputSize: number): void {
+        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+        toolCallRecords.push({ name, outputSize });
+      }
+      let done: DonePayload | null = null;
+      let iter = 0;
+      const loopStart = Date.now();
+      let warned70 = false;
+      let warned85 = false;
+
+      while (iter < maxIterations) {
+        iter++;
+        const iterStart = Date.now();
+
+        const billableEquiv = usage.input_tokens + usage.output_tokens;
+        if (billableEquiv > maxInputTokens) {
+          throw new FerryError('spend-cap', {
+            reason: 'input-token-budget-exceeded',
+            cap: maxInputTokens,
+            consumed: billableEquiv,
+          });
+        }
+
+        const budgetFraction = maxInputTokens > 0 ? billableEquiv / maxInputTokens : 0;
+
+        if (!warned70 && budgetFraction >= 0.7) {
+          warned70 = true;
+          const remaining = Math.round((1 - budgetFraction) * 100);
+          logger.info('budget_warning', { iter, threshold: 70, remaining_pct: remaining });
+          injectBudgetWarning(
+            messages,
+            `[ferry] You have used ~${Math.round(budgetFraction * 100)}% of your input budget (${remaining}% remaining). ` +
+              `Wrap up now: stop exploration, finish the current change, commit, and push.`,
+          );
+        }
+
+        if (!warned85 && budgetFraction >= 0.85) {
+          warned85 = true;
+          logger.info('budget_warning', { iter, threshold: 85, mode: 'commit-and-stop' });
+          injectBudgetWarning(
+            messages,
+            `[ferry] BUDGET CRITICAL: ~${Math.round(budgetFraction * 100)}% of your input budget is consumed. ` +
+              `You are now in commit-and-stop mode. ` +
+              `Only use: bash (git operations), write_file, str_replace, commit_progress, or done. ` +
+              `No exploration, no new reads — commit all work and call done immediately.`,
+          );
+        }
+
+        const effectiveToolDeclarations = warned85
+          ? allToolDeclarations.filter((t) => COMMIT_AND_STOP_TOOL_NAMES.has(t.name ?? ''))
+          : allToolDeclarations;
+
+        pruneMessageHistory(messages);
+
+        const response = await ai.models.generateContent({
+          model: opts.model,
+          contents: messages,
+          config: {
+            systemInstruction: system,
+            maxOutputTokens: maxTokens,
+            tools:
+              effectiveToolDeclarations.length > 0
+                ? [{ functionDeclarations: effectiveToolDeclarations }]
+                : undefined,
+            toolConfig:
+              effectiveToolDeclarations.length > 0
+                ? {
+                    functionCallingConfig: {
+                      mode: FunctionCallingConfigMode.ANY,
+                    },
+                  }
+                : undefined,
+            automaticFunctionCalling: { disable: true },
+          },
+        });
+
+        usage.input_tokens += response.usageMetadata?.promptTokenCount ?? 0;
+        usage.output_tokens += response.usageMetadata?.candidatesTokenCount ?? 0;
+
+        const candidate = response.candidates?.[0];
+        const finishReason = candidate?.finishReason ?? 'STOP';
+        const modelContent = candidate?.content;
+        const parts: Part[] = modelContent?.parts ?? [];
+
+        const functionCallParts = parts.filter((p) => p.functionCall !== undefined);
+
+        logger.info('turn', {
+          iter,
+          stop_reason: finishReason,
+          tools: functionCallParts.length,
+          in: response.usageMetadata?.promptTokenCount ?? 0,
+          out: response.usageMetadata?.candidatesTokenCount ?? 0,
+        });
+        emitDebug(
+          {
+            type: 'turn',
+            iter,
+            depth: 0,
+            stop_reason: finishReason,
+            tools: functionCallParts.length,
+            mcp_tools: 0,
+            in: response.usageMetadata?.promptTokenCount ?? 0,
+            cache_w: 0,
+            cache_r: 0,
+            out: response.usageMetadata?.candidatesTokenCount ?? 0,
+            elapsed_ms: Date.now() - iterStart,
+          },
+          logger,
+        );
+
+        if (functionCallParts.length === 0) {
+          throw new FerryError('state-invariant', {
+            reason: 'agent-stopped-without-done',
+            stop_reason: finishReason,
+          });
+        }
+
+        // Push model's response with function calls.
+        messages.push({ role: 'model', parts });
+
+        const toolResultParts: Part[] = [];
+
+        for (const part of functionCallParts) {
+          const fc = part.functionCall!;
+          const name = fc.name ?? '';
+          const blockInput = (fc.args ?? {}) as Record<string, unknown>;
+          const callId = fc.id;
+
+          if (name === 'done') {
+            const outcome = blockInput.outcome as DoneOutcome | undefined;
+            const actionable =
+              outcome !== undefined ? outcome !== 'blocked' : (blockInput.actionable as boolean);
+            done = { ...blockInput, actionable, outcome } as unknown as DonePayload;
+            toolResultParts.push({
+              functionResponse: {
+                name,
+                ...(callId !== undefined ? { id: callId } : {}),
+                response: { output: 'ok' },
+              },
+            });
+            continue;
+          }
+
+          if (name === 'commit_progress' && opts.commitProgress) {
+            const { message } = blockInput as { message: string };
+            logger.info('tool', { iter, tool: 'commit_progress', arg: message.slice(0, 120) });
+            try {
+              const result = await opts.commitProgress(repoRoot, branchName, message, secretScan);
+              trackTool('commit_progress', result.length);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...(callId !== undefined ? { id: callId } : {}),
+                  response: { output: result },
+                },
+              });
+            } catch (e) {
+              trackTool('commit_progress', 0);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...(callId !== undefined ? { id: callId } : {}),
+                  response: { output: (e as Error).message, error: true },
+                },
+              });
+            }
+            continue;
+          }
+
+          if (pool.hasTool(name)) {
+            const serverName = pool.getServerName(name) ?? 'unknown';
+            logger.info('mcp_stdio_tool', { iter, tool: name, server: serverName });
+            try {
+              const result = await pool.callTool(name, blockInput);
+              trackTool(name, result.length);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...(callId !== undefined ? { id: callId } : {}),
+                  response: { output: result },
+                },
+              });
+            } catch (e) {
+              trackTool(name, 0);
+              toolResultParts.push({
+                functionResponse: {
+                  name,
+                  ...(callId !== undefined ? { id: callId } : {}),
+                  response: { output: (e as Error).message, error: true },
+                },
+              });
+            }
+            continue;
+          }
+
+          const argHint =
+            blockInput.path ?? blockInput.source ?? blockInput.command ?? blockInput.pattern ?? '';
+          logger.info('tool', {
+            iter,
+            tool: name,
+            ...(argHint ? { arg: String(argHint).slice(0, 120) } : {}),
+          });
+
+          try {
+            const result = await opts.executeTool(repoRoot, name, blockInput);
+            trackTool(name, result.length);
+            toolResultParts.push({
+              functionResponse: {
+                name,
+                ...(callId !== undefined ? { id: callId } : {}),
+                response: { output: result },
+              },
+            });
+          } catch (e) {
+            trackTool(name, 0);
+            toolResultParts.push({
+              functionResponse: {
+                name,
+                ...(callId !== undefined ? { id: callId } : {}),
+                response: { output: (e as Error).message, error: true },
+              },
+            });
+          }
+        }
+
+        messages.push({ role: 'user', parts: toolResultParts });
+        compactOldToolResults(messages, compactWindow);
+
+        if (done) {
+          emitDebug(
+            {
+              type: 'result',
+              subtype: 'success',
+              iterations: iter,
+              total_in: usage.input_tokens,
+              total_out: usage.output_tokens,
+              elapsed_ms: Date.now() - loopStart,
+            },
+            logger,
+          );
+          return { done, usage, iterations: iter, toolCounts, toolCallRecords };
+        }
+      }
+
+      throw new FerryError('state-invariant', {
+        reason: 'iteration-cap-exceeded',
+        cap: maxIterations,
+      });
+    } finally {
+      await pool.close();
+    }
+  }
+
+  return {
+    run(input) {
+      return runLoop(input);
+    },
+  };
+}

--- a/src/lib/llm/agent-loop/index.ts
+++ b/src/lib/llm/agent-loop/index.ts
@@ -1,0 +1,102 @@
+import { FerryError } from '../../errors/index.js';
+import { resolveAnthropicAuth } from '../anthropic-auth.js';
+import { createAnthropicAgentLoop } from './anthropic.js';
+import { createOpenAIAgentLoop } from './openai.js';
+import { createGoogleAgentLoop } from './google.js';
+import type { AgentLoop } from './types.js';
+
+export type {
+  AgentLoop,
+  AgentTool,
+  AgentLoopResult,
+  AgentLoopUsage,
+  DonePayload,
+  McpServerConfig,
+} from './types.js';
+
+type ToolExecutor = (
+  repoRoot: string,
+  name: string,
+  input: Record<string, unknown>,
+) => Promise<string>;
+type CommitProgressHandler = (
+  repoRoot: string,
+  branchName: string,
+  message: string,
+  secretScan: () => Promise<void>,
+) => Promise<string>;
+type SpawnSubagentHandler = (task: string) => Promise<import('./types.js').AgentLoopResult>;
+
+export interface CreateAgentLoopOpts {
+  provider: 'anthropic' | 'openai' | 'google';
+  model: string;
+  executeTool: ToolExecutor;
+  commitProgress?: CommitProgressHandler;
+  spawnSubagent?: SpawnSubagentHandler;
+  maxIterations?: number;
+  maxInputTokens?: number;
+  maxTokens?: number;
+  compactWindow?: number;
+  logger?: import('../../logger/index.js').Logger;
+}
+
+function requireEnv(key: string): string {
+  const val = process.env[key];
+  if (!val) {
+    throw new FerryError('state-invariant', { reason: 'missing-env', key });
+  }
+  return val;
+}
+
+export function createAgentLoop(opts: CreateAgentLoopOpts): AgentLoop {
+  if (opts.provider === 'anthropic') {
+    const auth = resolveAnthropicAuth({ apiKeyEnv: 'ANTHROPIC_API_KEY' });
+    return createAnthropicAgentLoop({
+      ...auth,
+      model: opts.model,
+      executeTool: opts.executeTool,
+      commitProgress: opts.commitProgress,
+      spawnSubagent: opts.spawnSubagent,
+      maxIterations: opts.maxIterations,
+      maxInputTokens: opts.maxInputTokens,
+      maxTokens: opts.maxTokens,
+      compactWindow: opts.compactWindow,
+      logger: opts.logger,
+    });
+  }
+
+  if (opts.provider === 'openai') {
+    const apiKey = requireEnv('FERRY_OPENAI_KEY');
+    return createOpenAIAgentLoop({
+      apiKey,
+      model: opts.model,
+      executeTool: opts.executeTool,
+      commitProgress: opts.commitProgress,
+      maxIterations: opts.maxIterations,
+      maxInputTokens: opts.maxInputTokens,
+      maxTokens: opts.maxTokens,
+      compactWindow: opts.compactWindow,
+      logger: opts.logger,
+    });
+  }
+
+  if (opts.provider === 'google') {
+    const apiKey = requireEnv('FERRY_GOOGLE_AI_KEY');
+    return createGoogleAgentLoop({
+      apiKey,
+      model: opts.model,
+      executeTool: opts.executeTool,
+      commitProgress: opts.commitProgress,
+      maxIterations: opts.maxIterations,
+      maxInputTokens: opts.maxInputTokens,
+      maxTokens: opts.maxTokens,
+      compactWindow: opts.compactWindow,
+      logger: opts.logger,
+    });
+  }
+
+  throw new FerryError('state-invariant', {
+    reason: 'unknown-provider',
+    provider: opts.provider,
+  });
+}

--- a/src/lib/llm/agent-loop/openai.test.ts
+++ b/src/lib/llm/agent-loop/openai.test.ts
@@ -1,0 +1,499 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import OpenAI from 'openai';
+import { FerryError } from '../../errors/index.js';
+import { createOpenAIAgentLoop } from './openai.js';
+import type { McpServerConfig } from './types.js';
+
+const { mockPool, MockMcpClientPool } = vi.hoisted(() => {
+  const pool = {
+    connect: vi.fn().mockResolvedValue(undefined),
+    getTools: vi.fn().mockReturnValue([]),
+    hasTool: vi.fn().mockReturnValue(false),
+    getServerName: vi.fn().mockReturnValue(undefined),
+    callTool: vi.fn().mockResolvedValue('mcp result'),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  const ctor = vi.fn().mockImplementation(function () {
+    return pool;
+  });
+  return { mockPool: pool, MockMcpClientPool: ctor };
+});
+
+vi.mock('../../mcp/pool.js', () => ({
+  McpClientPool: MockMcpClientPool,
+}));
+
+type FakeChoice = {
+  finish_reason: string;
+  message: {
+    role: 'assistant';
+    content: string | null;
+    refusal: string | null;
+    tool_calls?: Array<{
+      id: string;
+      type: 'function';
+      function: { name: string; arguments: string };
+    }>;
+  };
+};
+
+type FakeResponse = {
+  choices: FakeChoice[];
+  usage?: { prompt_tokens: number; completion_tokens: number };
+};
+
+function makeDoneResponse(): FakeResponse {
+  return {
+    choices: [
+      {
+        finish_reason: 'tool_calls',
+        message: {
+          role: 'assistant',
+          content: null,
+          refusal: null,
+          tool_calls: [
+            {
+              id: 'tc_done',
+              type: 'function',
+              function: {
+                name: 'done',
+                arguments: JSON.stringify({ actionable: true, summary: 'done' }),
+              },
+            },
+          ],
+        },
+      },
+    ],
+    usage: { prompt_tokens: 10, completion_tokens: 5 },
+  };
+}
+
+function makeToolCallResponse(
+  name: string,
+  args: Record<string, unknown>,
+  id = 'tc_1',
+): FakeResponse {
+  return {
+    choices: [
+      {
+        finish_reason: 'tool_calls',
+        message: {
+          role: 'assistant',
+          content: null,
+          refusal: null,
+          tool_calls: [
+            { id, type: 'function', function: { name, arguments: JSON.stringify(args) } },
+          ],
+        },
+      },
+    ],
+    usage: { prompt_tokens: 20, completion_tokens: 10 },
+  };
+}
+
+function makeClient(responses: FakeResponse[]): OpenAI {
+  let idx = 0;
+  const create = vi.fn().mockImplementation(async () => {
+    return responses[idx++];
+  });
+  return { chat: { completions: { create } } } as unknown as OpenAI;
+}
+
+function restorePoolDefaults(): void {
+  MockMcpClientPool.mockImplementation(function () {
+    return mockPool;
+  });
+  mockPool.connect.mockResolvedValue(undefined);
+  mockPool.getTools.mockReturnValue([]);
+  mockPool.hasTool.mockReturnValue(false);
+  mockPool.getServerName.mockReturnValue(undefined);
+  mockPool.callTool.mockResolvedValue('mcp result');
+  mockPool.close.mockResolvedValue(undefined);
+}
+
+const noopExecuteTool =
+  vi.fn<(r: string, n: string, i: Record<string, unknown>) => Promise<string>>();
+
+const baseInput = {
+  system: 's',
+  initialPrompt: 'p',
+  tools: [],
+  repoRoot: '/r',
+  branchName: 'ferry/TEST-1',
+  secretScan: async () => {},
+};
+
+describe('createOpenAIAgentLoop — basic', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restorePoolDefaults();
+  });
+
+  it('calls done and returns result', async () => {
+    const client = makeClient([makeDoneResponse()]);
+    const loop = createOpenAIAgentLoop({ model: 'm', client, executeTool: noopExecuteTool });
+    const result = await loop.run(baseInput);
+    expect(result.done.actionable).toBe(true);
+    expect(result.done.summary).toBe('done');
+    expect(result.iterations).toBe(1);
+  });
+
+  it('accumulates token usage across turns', async () => {
+    const execTool = vi.fn().mockResolvedValue('file content');
+    const client = makeClient([
+      makeToolCallResponse('read_file', { path: 'x.ts' }),
+      makeDoneResponse(),
+    ]);
+    const loop = createOpenAIAgentLoop({ model: 'm', client, executeTool: execTool });
+    const result = await loop.run(baseInput);
+    expect(result.usage.input_tokens).toBe(30);
+    expect(result.usage.output_tokens).toBe(15);
+    expect(result.iterations).toBe(2);
+  });
+
+  it('dispatches tool calls to executeTool', async () => {
+    const execTool = vi.fn().mockResolvedValueOnce('contents');
+    const client = makeClient([
+      makeToolCallResponse('read_file', { path: 'src/index.ts' }),
+      makeDoneResponse(),
+    ]);
+    const loop = createOpenAIAgentLoop({ model: 'm', client, executeTool: execTool });
+    await loop.run(baseInput);
+    expect(execTool).toHaveBeenCalledWith('/r', 'read_file', { path: 'src/index.ts' });
+  });
+
+  it('tracks tool counts and call records', async () => {
+    const execTool = vi.fn().mockResolvedValue('ok');
+    const responses = [
+      makeToolCallResponse('read_file', { path: 'a.ts' }, 'tc_a'),
+      makeToolCallResponse('read_file', { path: 'b.ts' }, 'tc_b'),
+      makeDoneResponse(),
+    ];
+    const client = makeClient(responses);
+    const loop = createOpenAIAgentLoop({ model: 'm', client, executeTool: execTool });
+    const result = await loop.run(baseInput);
+    expect(result.toolCounts['read_file']).toBe(2);
+    expect(result.toolCallRecords.length).toBe(2);
+  });
+
+  it('throws FerryError when finish_reason is stop with no tool calls', async () => {
+    const stopResponse: FakeResponse = {
+      choices: [
+        {
+          finish_reason: 'stop',
+          message: { role: 'assistant', content: 'I am done.', refusal: null },
+        },
+      ],
+    };
+    const client = makeClient([stopResponse]);
+    const loop = createOpenAIAgentLoop({ model: 'm', client, executeTool: noopExecuteTool });
+    await expect(loop.run(baseInput)).rejects.toThrow(FerryError);
+  });
+
+  it('handles commit_progress tool calls', async () => {
+    const commitProgress = vi.fn().mockResolvedValue('committed sha abc123');
+    const client = makeClient([
+      makeToolCallResponse('commit_progress', { message: 'feat: add feature' }),
+      makeDoneResponse(),
+    ]);
+    const loop = createOpenAIAgentLoop({
+      model: 'm',
+      client,
+      executeTool: noopExecuteTool,
+      commitProgress,
+    });
+    await loop.run(baseInput);
+    expect(commitProgress).toHaveBeenCalledWith(
+      '/r',
+      'ferry/TEST-1',
+      'feat: add feature',
+      expect.any(Function),
+    );
+  });
+
+  it('closes the pool after a successful run', async () => {
+    const client = makeClient([makeDoneResponse()]);
+    const loop = createOpenAIAgentLoop({ model: 'm', client, executeTool: noopExecuteTool });
+    await loop.run(baseInput);
+    expect(mockPool.close).toHaveBeenCalledOnce();
+  });
+
+  it('closes the pool even when the loop throws', async () => {
+    const stopResponse: FakeResponse = {
+      choices: [
+        { finish_reason: 'stop', message: { role: 'assistant', content: 'oops', refusal: null } },
+      ],
+    };
+    const client = makeClient([stopResponse]);
+    const loop = createOpenAIAgentLoop({ model: 'm', client, executeTool: noopExecuteTool });
+    await expect(loop.run(baseInput)).rejects.toThrow(FerryError);
+    expect(mockPool.close).toHaveBeenCalledOnce();
+  });
+});
+
+describe('createOpenAIAgentLoop — HTTP MCP rejection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restorePoolDefaults();
+  });
+
+  it('throws FerryError for HTTP MCP servers', async () => {
+    const client = makeClient([makeDoneResponse()]);
+    const loop = createOpenAIAgentLoop({ model: 'm', client, executeTool: noopExecuteTool });
+    const server: McpServerConfig = { name: 'ctx', url: 'https://mcp.ctx.com/mcp' };
+    await expect(loop.run({ ...baseInput, mcpServers: [server] })).rejects.toThrow(FerryError);
+  });
+
+  it('does not throw for stdio MCP servers', async () => {
+    const client = makeClient([makeDoneResponse()]);
+    const loop = createOpenAIAgentLoop({ model: 'm', client, executeTool: noopExecuteTool });
+    const server: McpServerConfig = { type: 'stdio', name: 'fs', command: 'node', args: [] };
+    await expect(loop.run({ ...baseInput, mcpServers: [server] })).resolves.toBeDefined();
+  });
+});
+
+describe('createOpenAIAgentLoop — stdio MCP tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restorePoolDefaults();
+  });
+
+  it('dispatches stdio MCP tool calls to the pool', async () => {
+    mockPool.getTools.mockReturnValue([
+      {
+        name: 'read_resource',
+        description: 'Read',
+        input_schema: { type: 'object', properties: {} },
+      },
+    ]);
+    mockPool.hasTool.mockImplementation((n: string) => n === 'read_resource');
+    mockPool.callTool.mockResolvedValue('resource contents');
+
+    const client = makeClient([
+      makeToolCallResponse('read_resource', { uri: 'file:///tmp/x' }),
+      makeDoneResponse(),
+    ]);
+    const execTool = vi.fn();
+    const loop = createOpenAIAgentLoop({ model: 'm', client, executeTool: execTool });
+    const stdioServer: McpServerConfig = { type: 'stdio', name: 'fs', command: 'node', args: [] };
+    const result = await loop.run({ ...baseInput, mcpServers: [stdioServer] });
+    expect(mockPool.callTool).toHaveBeenCalledWith('read_resource', { uri: 'file:///tmp/x' });
+    expect(execTool).not.toHaveBeenCalled();
+    expect(result.done.actionable).toBe(true);
+  });
+});
+
+describe('createOpenAIAgentLoop — budget cap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restorePoolDefaults();
+  });
+
+  it('throws spend-cap when total tokens exceed the cap', async () => {
+    const toolResp: FakeResponse = {
+      choices: [
+        {
+          finish_reason: 'tool_calls',
+          message: {
+            role: 'assistant',
+            content: null,
+            refusal: null,
+            tool_calls: [
+              {
+                id: 'tc_r',
+                type: 'function',
+                function: { name: 'read_file', arguments: '{"path":"x.ts"}' },
+              },
+            ],
+          },
+        },
+      ],
+      usage: { prompt_tokens: 600, completion_tokens: 400 }, // total 1000 = exceeds 999 cap
+    };
+    const execTool = vi.fn().mockResolvedValue('content');
+    const client = makeClient([toolResp, makeDoneResponse()]);
+    const loop = createOpenAIAgentLoop({
+      model: 'm',
+      client,
+      executeTool: execTool,
+      maxInputTokens: 999,
+    });
+    const err = await loop.run(baseInput).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(FerryError);
+    expect((err as FerryError).code).toBe('spend-cap');
+  });
+
+  it('does not trip cap when tokens stay under limit', async () => {
+    const toolResp: FakeResponse = {
+      choices: [
+        {
+          finish_reason: 'tool_calls',
+          message: {
+            role: 'assistant',
+            content: null,
+            refusal: null,
+            tool_calls: [
+              {
+                id: 'tc_r',
+                type: 'function',
+                function: { name: 'read_file', arguments: '{"path":"x.ts"}' },
+              },
+            ],
+          },
+        },
+      ],
+      usage: { prompt_tokens: 400, completion_tokens: 200 }, // total 600 < 1000 cap
+    };
+    const execTool = vi.fn().mockResolvedValue('content');
+    const client = makeClient([toolResp, makeDoneResponse()]);
+    const loop = createOpenAIAgentLoop({
+      model: 'm',
+      client,
+      executeTool: execTool,
+      maxInputTokens: 1000,
+    });
+    await expect(loop.run(baseInput)).resolves.toBeDefined();
+  });
+});
+
+describe('createOpenAIAgentLoop — budget warnings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restorePoolDefaults();
+  });
+
+  function makeCapturingClient(responses: FakeResponse[]) {
+    let idx = 0;
+    const calls: Array<{ messages: unknown[]; tools: unknown[] }> = [];
+    const create = vi
+      .fn()
+      .mockImplementation(async (params: { messages: unknown[]; tools: unknown[] }) => {
+        calls.push({
+          messages: JSON.parse(JSON.stringify(params.messages)) as unknown[],
+          tools: JSON.parse(JSON.stringify(params.tools ?? [])) as unknown[],
+        });
+        return responses[idx++];
+      });
+    const client = { chat: { completions: { create } } } as unknown as OpenAI;
+    return { client, calls };
+  }
+
+  it('injects 70% warning when budget crosses 70%', async () => {
+    const toolResp: FakeResponse = {
+      choices: [
+        {
+          finish_reason: 'tool_calls',
+          message: {
+            role: 'assistant',
+            content: null,
+            refusal: null,
+            tool_calls: [
+              {
+                id: 'tc_r',
+                type: 'function',
+                function: { name: 'read_file', arguments: '{"path":"x.ts"}' },
+              },
+            ],
+          },
+        },
+      ],
+      usage: { prompt_tokens: 750, completion_tokens: 0 }, // 75% of 1000
+    };
+    const execTool = vi.fn().mockResolvedValue('content');
+    const { client, calls } = makeCapturingClient([toolResp, makeDoneResponse()]);
+    const loop = createOpenAIAgentLoop({
+      model: 'm',
+      client,
+      executeTool: execTool,
+      maxInputTokens: 1000,
+    });
+    await loop.run(baseInput);
+    // iter 2 messages should contain the 70% warning
+    expect(calls.length).toBe(2);
+    const iter2Messages = calls[1].messages as Array<{ role: string; content: unknown }>;
+    const hasWarning = iter2Messages.some(
+      (m) =>
+        (m.role === 'user' || m.role === 'system') &&
+        typeof m.content === 'string' &&
+        m.content.includes('[ferry]'),
+    );
+    // Also check for array content
+    const hasWarningInArray = iter2Messages.some(
+      (m) =>
+        Array.isArray(m.content) &&
+        (m.content as Array<{ type: string; text?: string }>).some(
+          (b) => b.type === 'text' && typeof b.text === 'string' && b.text.includes('[ferry]'),
+        ),
+    );
+    expect(hasWarning || hasWarningInArray).toBe(true);
+  });
+
+  it('restricts tools to commit-and-stop set at 85%', async () => {
+    const toolResp: FakeResponse = {
+      choices: [
+        {
+          finish_reason: 'tool_calls',
+          message: {
+            role: 'assistant',
+            content: null,
+            refusal: null,
+            tool_calls: [
+              {
+                id: 'tc_r',
+                type: 'function',
+                function: { name: 'read_file', arguments: '{"path":"x.ts"}' },
+              },
+            ],
+          },
+        },
+      ],
+      usage: { prompt_tokens: 900, completion_tokens: 0 }, // 90% of 1000
+    };
+    const execTool = vi.fn().mockResolvedValue('content');
+    const toolDefs = ['read_file', 'bash', 'done', 'list_dir'].map((n) => ({
+      name: n,
+      description: n,
+      input_schema: { type: 'object' as const, properties: {} },
+    }));
+    const { client, calls } = makeCapturingClient([toolResp, makeDoneResponse()]);
+    const loop = createOpenAIAgentLoop({
+      model: 'm',
+      client,
+      executeTool: execTool,
+      maxInputTokens: 1000,
+    });
+    await loop.run({ ...baseInput, tools: toolDefs });
+    // iter 2 tools should exclude read_file and list_dir
+    const iter2Tools = calls[1].tools as Array<{ type: string; function?: { name: string } }>;
+    const toolNames = new Set(
+      iter2Tools.filter((t) => t.type === 'function').map((t) => t.function?.name),
+    );
+    expect(toolNames.has('bash')).toBe(true);
+    expect(toolNames.has('done')).toBe(true);
+    expect(toolNames.has('read_file')).toBe(false);
+    expect(toolNames.has('list_dir')).toBe(false);
+  });
+});
+
+describe('createOpenAIAgentLoop — iteration cap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    restorePoolDefaults();
+  });
+
+  it('throws iteration-cap-exceeded when maxIterations is reached', async () => {
+    const execTool = vi.fn().mockResolvedValue('ok');
+    // Always return a tool call — never done.
+    const create = vi.fn().mockResolvedValue(makeToolCallResponse('read_file', { path: 'x.ts' }));
+    const client = { chat: { completions: { create } } } as unknown as OpenAI;
+    const loop = createOpenAIAgentLoop({
+      model: 'm',
+      client,
+      executeTool: execTool,
+      maxIterations: 2,
+    });
+    const err = await loop.run(baseInput).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(FerryError);
+    expect((err as FerryError).context).toMatchObject({ reason: 'iteration-cap-exceeded' });
+  });
+});

--- a/src/lib/llm/agent-loop/openai.ts
+++ b/src/lib/llm/agent-loop/openai.ts
@@ -1,0 +1,413 @@
+import OpenAI from 'openai';
+import { FerryError } from '../../errors/index.js';
+import { emitDebug } from '../debug-log.js';
+import { McpClientPool } from '../../mcp/pool.js';
+import { createLogger } from '../../logger/index.js';
+import type { Logger } from '../../logger/index.js';
+import type {
+  AgentTool,
+  AgentLoop,
+  AgentLoopResult,
+  AgentLoopUsage,
+  DonePayload,
+  DoneOutcome,
+  McpServerConfig,
+  StdioMcpServerConfig,
+  ToolCallRecord,
+} from './types.js';
+import { isStdioMcpServer, isHttpMcpServer } from './types.js';
+import type {
+  ChatCompletionMessageParam,
+  ChatCompletionFunctionTool,
+  ChatCompletionMessageFunctionToolCall,
+} from 'openai/resources/chat/completions.js';
+
+const COMMIT_AND_STOP_TOOL_NAMES = new Set([
+  'bash',
+  'write_file',
+  'str_replace',
+  'commit_progress',
+  'done',
+]);
+
+const KEEP_LAST_TURNS = 6;
+const STUB = '[truncated: tool result elided to save context]';
+
+type ToolExecutor = (
+  repoRoot: string,
+  name: string,
+  input: Record<string, unknown>,
+) => Promise<string>;
+type CommitProgressHandler = (
+  repoRoot: string,
+  branchName: string,
+  message: string,
+  secretScan: () => Promise<void>,
+) => Promise<string>;
+
+function agentToolToOpenAI(t: AgentTool): ChatCompletionFunctionTool {
+  return {
+    type: 'function',
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: t.input_schema as Record<string, unknown>,
+    },
+  };
+}
+
+function pruneMessageHistory(messages: ChatCompletionMessageParam[]): void {
+  // Collect indices of 'tool' role messages (tool results).
+  const toolResultIndices: number[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i].role === 'tool') {
+      toolResultIndices.push(i);
+    }
+  }
+
+  // messages[0] is the initial user prompt — never prune it.
+  const cutoff = messages.length - KEEP_LAST_TURNS * 2;
+  if (cutoff <= 1) return;
+
+  for (let i = 0; i < toolResultIndices.length; i++) {
+    const idx = toolResultIndices[i];
+    if (idx >= cutoff) break;
+    const msg = messages[idx];
+    if (msg.role === 'tool' && typeof msg.content === 'string' && msg.content !== STUB) {
+      (messages[idx] as { role: 'tool'; tool_call_id: string; content: string }).content = STUB;
+    }
+  }
+}
+
+function injectBudgetWarning(messages: ChatCompletionMessageParam[], text: string): void {
+  const last = messages[messages.length - 1];
+  if (!last) return;
+  if (last.role === 'user') {
+    if (typeof last.content === 'string') {
+      (messages[messages.length - 1] as { role: 'user'; content: string }).content =
+        last.content + '\n\n' + text;
+    } else if (Array.isArray(last.content)) {
+      (last.content as Array<{ type: string; text: string }>).push({ type: 'text', text });
+    }
+  } else {
+    // Append a new user message with the warning.
+    messages.push({ role: 'user', content: text });
+  }
+}
+
+function compactOldToolResults(messages: ChatCompletionMessageParam[], windowTurns: number): void {
+  const toolResultIndices: number[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    if (messages[i].role === 'tool') {
+      toolResultIndices.push(i);
+    }
+  }
+
+  if (toolResultIndices.length <= windowTurns) return;
+
+  const compactCount = toolResultIndices.length - windowTurns;
+  for (let k = 0; k < compactCount; k++) {
+    const idx = toolResultIndices[k];
+    const msg = messages[idx];
+    if (msg.role !== 'tool' || typeof msg.content !== 'string') continue;
+    if (msg.content.startsWith('[compacted')) continue;
+    const tokens = Math.ceil(msg.content.length / 4);
+    (messages[idx] as { role: 'tool'; tool_call_id: string; content: string }).content =
+      `[compacted — ~${tokens} tokens elided]`;
+  }
+}
+
+export function createOpenAIAgentLoop(opts: {
+  apiKey?: string;
+  model: string;
+  client?: OpenAI;
+  executeTool: ToolExecutor;
+  commitProgress?: CommitProgressHandler;
+  maxIterations?: number;
+  maxInputTokens?: number;
+  maxTokens?: number;
+  compactWindow?: number;
+  logger?: Logger;
+}): AgentLoop {
+  const openai = opts.client ?? new OpenAI({ apiKey: opts.apiKey });
+  const logger = opts.logger ?? createLogger('', 'ferry:dev-loop');
+
+  async function runLoop(input: {
+    system: string;
+    initialPrompt: string;
+    tools: AgentTool[];
+    repoRoot: string;
+    branchName: string;
+    secretScan: () => Promise<void>;
+    mcpServers?: McpServerConfig[];
+  }): Promise<AgentLoopResult> {
+    const { system, initialPrompt, tools, repoRoot, branchName, secretScan } = input;
+    const maxIterations =
+      opts.maxIterations ?? parseInt(process.env.FERRY_DEV_MAX_ITERATIONS ?? '200', 10);
+    const maxInputTokens =
+      opts.maxInputTokens ?? parseInt(process.env.FERRY_DEV_MAX_INPUT_TOKENS ?? '500000', 10);
+    const maxTokens = opts.maxTokens ?? parseInt(process.env.FERRY_DEV_MAX_TOKENS ?? '16384', 10);
+    const compactWindow =
+      opts.compactWindow ?? parseInt(process.env.FERRY_DEV_COMPACT_WINDOW ?? '8', 10);
+
+    const allServers = input.mcpServers ?? [];
+    const httpServers = allServers.filter((s) => isHttpMcpServer(s) && 'url' in s);
+    if (httpServers.length > 0) {
+      throw new FerryError('state-invariant', {
+        reason: 'http-mcp-unsupported',
+        provider: 'openai',
+        detail:
+          'HTTP MCP servers are only supported with the Anthropic provider. Configure stdio MCP servers or switch to provider: anthropic.',
+      });
+    }
+    const stdioServers = allServers.filter((s): s is StdioMcpServerConfig => isStdioMcpServer(s));
+
+    const pool = new McpClientPool();
+    try {
+      if (stdioServers.length > 0) {
+        await pool.connect(stdioServers);
+        if (pool.getTools().length > 0) {
+          logger.info('stdio_mcp_tools', {
+            count: pool.getTools().length,
+            servers: stdioServers.map((s) => s.name).join(','),
+          });
+        }
+      }
+
+      const nativeAndStdioTools = [...tools, ...pool.getTools()];
+      const openaiTools: ChatCompletionFunctionTool[] = nativeAndStdioTools.map(agentToolToOpenAI);
+
+      const messages: ChatCompletionMessageParam[] = [
+        { role: 'system', content: system },
+        { role: 'user', content: initialPrompt },
+      ];
+
+      const usage: AgentLoopUsage = {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      };
+      const toolCounts: Record<string, number> = {};
+      const toolCallRecords: ToolCallRecord[] = [];
+      function trackTool(name: string, outputSize: number): void {
+        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
+        toolCallRecords.push({ name, outputSize });
+      }
+      let done: DonePayload | null = null;
+      let iter = 0;
+      const loopStart = Date.now();
+      let warned70 = false;
+      let warned85 = false;
+
+      while (iter < maxIterations) {
+        iter++;
+        const iterStart = Date.now();
+
+        // OpenAI/Google: no cache weighting, just raw token sum.
+        const billableEquiv = usage.input_tokens + usage.output_tokens;
+        if (billableEquiv > maxInputTokens) {
+          throw new FerryError('spend-cap', {
+            reason: 'input-token-budget-exceeded',
+            cap: maxInputTokens,
+            consumed: billableEquiv,
+          });
+        }
+
+        const budgetFraction = maxInputTokens > 0 ? billableEquiv / maxInputTokens : 0;
+
+        if (!warned70 && budgetFraction >= 0.7) {
+          warned70 = true;
+          const remaining = Math.round((1 - budgetFraction) * 100);
+          logger.info('budget_warning', { iter, threshold: 70, remaining_pct: remaining });
+          injectBudgetWarning(
+            messages,
+            `[ferry] You have used ~${Math.round(budgetFraction * 100)}% of your input budget (${remaining}% remaining). ` +
+              `Wrap up now: stop exploration, finish the current change, commit, and push.`,
+          );
+        }
+
+        if (!warned85 && budgetFraction >= 0.85) {
+          warned85 = true;
+          logger.info('budget_warning', { iter, threshold: 85, mode: 'commit-and-stop' });
+          injectBudgetWarning(
+            messages,
+            `[ferry] BUDGET CRITICAL: ~${Math.round(budgetFraction * 100)}% of your input budget is consumed. ` +
+              `You are now in commit-and-stop mode. ` +
+              `Only use: bash (git operations), write_file, str_replace, commit_progress, or done. ` +
+              `No exploration, no new reads — commit all work and call done immediately.`,
+          );
+        }
+
+        const effectiveTools: ChatCompletionFunctionTool[] = warned85
+          ? openaiTools.filter((t) => COMMIT_AND_STOP_TOOL_NAMES.has(t.function.name))
+          : openaiTools;
+
+        pruneMessageHistory(messages);
+
+        const response = await openai.chat.completions.create({
+          model: opts.model,
+          max_tokens: maxTokens,
+          tools: effectiveTools,
+          tool_choice: effectiveTools.length > 0 ? 'required' : 'none',
+          messages,
+        });
+
+        usage.input_tokens += response.usage?.prompt_tokens ?? 0;
+        usage.output_tokens += response.usage?.completion_tokens ?? 0;
+
+        const choice = response.choices[0];
+        if (!choice) {
+          throw new FerryError('state-invariant', {
+            reason: 'agent-stopped-without-done',
+            stop_reason: 'no-choices',
+          });
+        }
+
+        const assistantMsg = choice.message;
+        messages.push(assistantMsg);
+
+        const allToolCalls = assistantMsg.tool_calls ?? [];
+        const toolCalls = allToolCalls.filter(
+          (tc): tc is ChatCompletionMessageFunctionToolCall => tc.type === 'function',
+        );
+        logger.info('turn', {
+          iter,
+          stop_reason: choice.finish_reason,
+          tools: toolCalls.length,
+          in: response.usage?.prompt_tokens ?? 0,
+          out: response.usage?.completion_tokens ?? 0,
+        });
+        emitDebug(
+          {
+            type: 'turn',
+            iter,
+            depth: 0,
+            stop_reason: choice.finish_reason,
+            tools: toolCalls.length,
+            mcp_tools: 0,
+            in: response.usage?.prompt_tokens ?? 0,
+            cache_w: 0,
+            cache_r: 0,
+            out: response.usage?.completion_tokens ?? 0,
+            elapsed_ms: Date.now() - iterStart,
+          },
+          logger,
+        );
+
+        if (choice.finish_reason !== 'tool_calls' && toolCalls.length === 0) {
+          throw new FerryError('state-invariant', {
+            reason: 'agent-stopped-without-done',
+            stop_reason: choice.finish_reason,
+          });
+        }
+
+        for (const toolCall of toolCalls) {
+          const name = toolCall.function.name;
+          let blockInput: Record<string, unknown>;
+          try {
+            blockInput = JSON.parse(toolCall.function.arguments) as Record<string, unknown>;
+          } catch {
+            blockInput = {};
+          }
+
+          if (name === 'done') {
+            const outcome = blockInput.outcome as DoneOutcome | undefined;
+            const actionable =
+              outcome !== undefined ? outcome !== 'blocked' : (blockInput.actionable as boolean);
+            done = { ...blockInput, actionable, outcome } as unknown as DonePayload;
+            messages.push({ role: 'tool', tool_call_id: toolCall.id, content: 'ok' });
+            continue;
+          }
+
+          if (name === 'commit_progress' && opts.commitProgress) {
+            const { message } = blockInput as { message: string };
+            logger.info('tool', { iter, tool: 'commit_progress', arg: message.slice(0, 120) });
+            try {
+              const result = await opts.commitProgress(repoRoot, branchName, message, secretScan);
+              trackTool('commit_progress', result.length);
+              messages.push({ role: 'tool', tool_call_id: toolCall.id, content: result });
+            } catch (e) {
+              trackTool('commit_progress', 0);
+              messages.push({
+                role: 'tool',
+                tool_call_id: toolCall.id,
+                content: (e as Error).message,
+              });
+            }
+            continue;
+          }
+
+          if (pool.hasTool(name)) {
+            const serverName = pool.getServerName(name) ?? 'unknown';
+            logger.info('mcp_stdio_tool', { iter, tool: name, server: serverName });
+            try {
+              const result = await pool.callTool(name, blockInput);
+              trackTool(name, result.length);
+              messages.push({ role: 'tool', tool_call_id: toolCall.id, content: result });
+            } catch (e) {
+              trackTool(name, 0);
+              messages.push({
+                role: 'tool',
+                tool_call_id: toolCall.id,
+                content: (e as Error).message,
+              });
+            }
+            continue;
+          }
+
+          const argHint =
+            blockInput.path ?? blockInput.source ?? blockInput.command ?? blockInput.pattern ?? '';
+          logger.info('tool', {
+            iter,
+            tool: name,
+            ...(argHint ? { arg: String(argHint).slice(0, 120) } : {}),
+          });
+
+          try {
+            const result = await opts.executeTool(repoRoot, name, blockInput);
+            trackTool(name, result.length);
+            messages.push({ role: 'tool', tool_call_id: toolCall.id, content: result });
+          } catch (e) {
+            trackTool(name, 0);
+            messages.push({
+              role: 'tool',
+              tool_call_id: toolCall.id,
+              content: (e as Error).message,
+            });
+          }
+        }
+
+        compactOldToolResults(messages, compactWindow);
+
+        if (done) {
+          emitDebug(
+            {
+              type: 'result',
+              subtype: 'success',
+              iterations: iter,
+              total_in: usage.input_tokens,
+              total_out: usage.output_tokens,
+              elapsed_ms: Date.now() - loopStart,
+            },
+            logger,
+          );
+          return { done, usage, iterations: iter, toolCounts, toolCallRecords };
+        }
+      }
+
+      throw new FerryError('state-invariant', {
+        reason: 'iteration-cap-exceeded',
+        cap: maxIterations,
+      });
+    } finally {
+      await pool.close();
+    }
+  }
+
+  return {
+    run(input) {
+      return runLoop(input);
+    },
+  };
+}


### PR DESCRIPTION
Part of #219.


Closes https://github.com/big-emotion/ferry/issues/219


## Summary

- Adds `src/lib/llm/agent-loop/openai.ts` — full OpenAI agent loop using `chat.completions.create` with function calling, budget warnings (70%/85%), commit-and-stop mode, message pruning, stdio MCP support, HTTP MCP rejection
- Adds `src/lib/llm/agent-loop/google.ts` — full Google agent loop using `@google/genai` generateContent with functionDeclarations, same budget/pruning/compaction features
- Adds `src/lib/llm/agent-loop/index.ts` — `createAgentLoop()` factory dispatching to the right provider
- Removes `provider !== 'anthropic'` guards from `dev-action.ts` and `iterate-action.ts`
- Updates `docs/CONFIGURATION.md` with provider capability matrix
- Full test suites for both providers

Generated with [Claude Code](https://claude.ai/code)