### PR TITLE
fix(audit): wire cost_eur and token outputs through composite actions

### DIFF
--- a/.ferry/dev-action.js
+++ b/.ferry/dev-action.js
@@ -363,11 +363,62 @@ ${opts.comments}` : ""
 
 // src/lib/agent-runtime/output.ts
 import { appendFileSync } from "node:fs";
+
+// src/lib/llm/pricing.ts
+var RATES = {
+  "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
+  "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },
+  "anthropic/claude-haiku": { inputPer1M: 0.23, outputPer1M: 1.16 },
+  "openai/gpt-4.1-nano": { inputPer1M: 0.09, outputPer1M: 0.37 },
+  "openai/gpt-4.1-mini": { inputPer1M: 0.14, outputPer1M: 0.56 },
+  "openai/gpt-4.": { inputPer1M: 2.79, outputPer1M: 8.37 },
+  "openai/gpt-5.": { inputPer1M: 2.79, outputPer1M: 8.37 },
+  "google/gemini-2.5-flash": { inputPer1M: 0.07, outputPer1M: 0.28 },
+  "google/gemini-2.5-pro": { inputPer1M: 1.05, outputPer1M: 4.2 }
+};
+var PROVIDER_FALLBACK = {
+  anthropic: RATES["anthropic/claude-opus"],
+  openai: RATES["openai/gpt-4."],
+  google: RATES["google/gemini-2.5-pro"]
+};
+function lookupRates(provider, model) {
+  const exactKey = `${provider}/${model}`;
+  if (RATES[exactKey]) return RATES[exactKey];
+  for (const key of Object.keys(RATES)) {
+    if (key !== exactKey && key.startsWith(`${provider}/`) && model.startsWith(key.slice(provider.length + 1))) {
+      return RATES[key];
+    }
+  }
+  return PROVIDER_FALLBACK[provider];
+}
+function computeCostEur(provider, model, inputTokens, outputTokens) {
+  const rates = lookupRates(provider, model);
+  const cost = inputTokens / 1e6 * rates.inputPer1M + outputTokens / 1e6 * rates.outputPer1M;
+  return Math.round(cost * 1e4) / 1e4;
+}
+
+// src/lib/agent-runtime/output.ts
 function appendOutput(usage) {
   const githubOutput = process.env.GITHUB_OUTPUT;
   if (githubOutput) {
+    const cacheRead = usage.cache_read_input_tokens ?? 0;
+    const cacheWrite = usage.cache_creation_input_tokens ?? 0;
+    let costEur = 0;
+    if (usage.provider && usage.model && usage.model !== "placeholder") {
+      costEur = computeCostEur(
+        usage.provider,
+        usage.model,
+        usage.input_tokens,
+        usage.output_tokens
+      );
+    }
     let out = `input_tokens=${usage.input_tokens}
 output_tokens=${usage.output_tokens}
+`;
+    out += `cache_read_tokens=${cacheRead}
+cache_write_tokens=${cacheWrite}
+`;
+    out += `cost_eur=${costEur}
 `;
     if (usage.model) out += `model=${usage.model}
 `;

--- a/.ferry/iterate-action.js
+++ b/.ferry/iterate-action.js
@@ -2249,11 +2249,62 @@ ${opts.comments}` : ""
 
 // src/lib/agent-runtime/output.ts
 import { appendFileSync } from "node:fs";
+
+// src/lib/llm/pricing.ts
+var RATES = {
+  "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
+  "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },
+  "anthropic/claude-haiku": { inputPer1M: 0.23, outputPer1M: 1.16 },
+  "openai/gpt-4.1-nano": { inputPer1M: 0.09, outputPer1M: 0.37 },
+  "openai/gpt-4.1-mini": { inputPer1M: 0.14, outputPer1M: 0.56 },
+  "openai/gpt-4.": { inputPer1M: 2.79, outputPer1M: 8.37 },
+  "openai/gpt-5.": { inputPer1M: 2.79, outputPer1M: 8.37 },
+  "google/gemini-2.5-flash": { inputPer1M: 0.07, outputPer1M: 0.28 },
+  "google/gemini-2.5-pro": { inputPer1M: 1.05, outputPer1M: 4.2 }
+};
+var PROVIDER_FALLBACK = {
+  anthropic: RATES["anthropic/claude-opus"],
+  openai: RATES["openai/gpt-4."],
+  google: RATES["google/gemini-2.5-pro"]
+};
+function lookupRates(provider, model) {
+  const exactKey = `${provider}/${model}`;
+  if (RATES[exactKey]) return RATES[exactKey];
+  for (const key of Object.keys(RATES)) {
+    if (key !== exactKey && key.startsWith(`${provider}/`) && model.startsWith(key.slice(provider.length + 1))) {
+      return RATES[key];
+    }
+  }
+  return PROVIDER_FALLBACK[provider];
+}
+function computeCostEur(provider, model, inputTokens, outputTokens) {
+  const rates = lookupRates(provider, model);
+  const cost = inputTokens / 1e6 * rates.inputPer1M + outputTokens / 1e6 * rates.outputPer1M;
+  return Math.round(cost * 1e4) / 1e4;
+}
+
+// src/lib/agent-runtime/output.ts
 function appendOutput(usage) {
   const githubOutput = process.env.GITHUB_OUTPUT;
   if (githubOutput) {
+    const cacheRead = usage.cache_read_input_tokens ?? 0;
+    const cacheWrite = usage.cache_creation_input_tokens ?? 0;
+    let costEur = 0;
+    if (usage.provider && usage.model && usage.model !== "placeholder") {
+      costEur = computeCostEur(
+        usage.provider,
+        usage.model,
+        usage.input_tokens,
+        usage.output_tokens
+      );
+    }
     let out = `input_tokens=${usage.input_tokens}
 output_tokens=${usage.output_tokens}
+`;
+    out += `cache_read_tokens=${cacheRead}
+cache_write_tokens=${cacheWrite}
+`;
+    out += `cost_eur=${costEur}
 `;
     if (usage.model) out += `model=${usage.model}
 `;

--- a/.ferry/review-action.js
+++ b/.ferry/review-action.js
@@ -1027,11 +1027,62 @@ ${opts.comments}` : ""
 
 // src/lib/agent-runtime/output.ts
 import { appendFileSync } from "node:fs";
+
+// src/lib/llm/pricing.ts
+var RATES = {
+  "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
+  "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },
+  "anthropic/claude-haiku": { inputPer1M: 0.23, outputPer1M: 1.16 },
+  "openai/gpt-4.1-nano": { inputPer1M: 0.09, outputPer1M: 0.37 },
+  "openai/gpt-4.1-mini": { inputPer1M: 0.14, outputPer1M: 0.56 },
+  "openai/gpt-4.": { inputPer1M: 2.79, outputPer1M: 8.37 },
+  "openai/gpt-5.": { inputPer1M: 2.79, outputPer1M: 8.37 },
+  "google/gemini-2.5-flash": { inputPer1M: 0.07, outputPer1M: 0.28 },
+  "google/gemini-2.5-pro": { inputPer1M: 1.05, outputPer1M: 4.2 }
+};
+var PROVIDER_FALLBACK = {
+  anthropic: RATES["anthropic/claude-opus"],
+  openai: RATES["openai/gpt-4."],
+  google: RATES["google/gemini-2.5-pro"]
+};
+function lookupRates(provider, model) {
+  const exactKey = `${provider}/${model}`;
+  if (RATES[exactKey]) return RATES[exactKey];
+  for (const key of Object.keys(RATES)) {
+    if (key !== exactKey && key.startsWith(`${provider}/`) && model.startsWith(key.slice(provider.length + 1))) {
+      return RATES[key];
+    }
+  }
+  return PROVIDER_FALLBACK[provider];
+}
+function computeCostEur(provider, model, inputTokens, outputTokens) {
+  const rates = lookupRates(provider, model);
+  const cost = inputTokens / 1e6 * rates.inputPer1M + outputTokens / 1e6 * rates.outputPer1M;
+  return Math.round(cost * 1e4) / 1e4;
+}
+
+// src/lib/agent-runtime/output.ts
 function appendOutput(usage) {
   const githubOutput = process.env.GITHUB_OUTPUT;
   if (githubOutput) {
+    const cacheRead = usage.cache_read_input_tokens ?? 0;
+    const cacheWrite = usage.cache_creation_input_tokens ?? 0;
+    let costEur = 0;
+    if (usage.provider && usage.model && usage.model !== "placeholder") {
+      costEur = computeCostEur(
+        usage.provider,
+        usage.model,
+        usage.input_tokens,
+        usage.output_tokens
+      );
+    }
     let out = `input_tokens=${usage.input_tokens}
 output_tokens=${usage.output_tokens}
+`;
+    out += `cache_read_tokens=${cacheRead}
+cache_write_tokens=${cacheWrite}
+`;
+    out += `cost_eur=${costEur}
 `;
     if (usage.model) out += `model=${usage.model}
 `;

--- a/.github/actions/ferry-run-developer/action.yml
+++ b/.github/actions/ferry-run-developer/action.yml
@@ -91,6 +91,15 @@ outputs:
   output_tokens:
     description: Number of LLM output tokens consumed
     value: ${{ steps.run-developer.outputs.output_tokens }}
+  cost_eur:
+    description: Cost in EUR for this agent run
+    value: ${{ steps.run-developer.outputs.cost_eur }}
+  cache_read_tokens:
+    description: Number of cache read input tokens consumed
+    value: ${{ steps.run-developer.outputs.cache_read_tokens }}
+  cache_write_tokens:
+    description: Number of cache write input tokens consumed
+    value: ${{ steps.run-developer.outputs.cache_write_tokens }}
 runs:
   using: composite
   steps:

--- a/.github/actions/ferry-run-developer/dev-action.js
+++ b/.github/actions/ferry-run-developer/dev-action.js
@@ -363,11 +363,62 @@ ${opts.comments}` : ""
 
 // src/lib/agent-runtime/output.ts
 import { appendFileSync } from "node:fs";
+
+// src/lib/llm/pricing.ts
+var RATES = {
+  "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
+  "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },
+  "anthropic/claude-haiku": { inputPer1M: 0.23, outputPer1M: 1.16 },
+  "openai/gpt-4.1-nano": { inputPer1M: 0.09, outputPer1M: 0.37 },
+  "openai/gpt-4.1-mini": { inputPer1M: 0.14, outputPer1M: 0.56 },
+  "openai/gpt-4.": { inputPer1M: 2.79, outputPer1M: 8.37 },
+  "openai/gpt-5.": { inputPer1M: 2.79, outputPer1M: 8.37 },
+  "google/gemini-2.5-flash": { inputPer1M: 0.07, outputPer1M: 0.28 },
+  "google/gemini-2.5-pro": { inputPer1M: 1.05, outputPer1M: 4.2 }
+};
+var PROVIDER_FALLBACK = {
+  anthropic: RATES["anthropic/claude-opus"],
+  openai: RATES["openai/gpt-4."],
+  google: RATES["google/gemini-2.5-pro"]
+};
+function lookupRates(provider, model) {
+  const exactKey = `${provider}/${model}`;
+  if (RATES[exactKey]) return RATES[exactKey];
+  for (const key of Object.keys(RATES)) {
+    if (key !== exactKey && key.startsWith(`${provider}/`) && model.startsWith(key.slice(provider.length + 1))) {
+      return RATES[key];
+    }
+  }
+  return PROVIDER_FALLBACK[provider];
+}
+function computeCostEur(provider, model, inputTokens, outputTokens) {
+  const rates = lookupRates(provider, model);
+  const cost = inputTokens / 1e6 * rates.inputPer1M + outputTokens / 1e6 * rates.outputPer1M;
+  return Math.round(cost * 1e4) / 1e4;
+}
+
+// src/lib/agent-runtime/output.ts
 function appendOutput(usage) {
   const githubOutput = process.env.GITHUB_OUTPUT;
   if (githubOutput) {
+    const cacheRead = usage.cache_read_input_tokens ?? 0;
+    const cacheWrite = usage.cache_creation_input_tokens ?? 0;
+    let costEur = 0;
+    if (usage.provider && usage.model && usage.model !== "placeholder") {
+      costEur = computeCostEur(
+        usage.provider,
+        usage.model,
+        usage.input_tokens,
+        usage.output_tokens
+      );
+    }
     let out = `input_tokens=${usage.input_tokens}
 output_tokens=${usage.output_tokens}
+`;
+    out += `cache_read_tokens=${cacheRead}
+cache_write_tokens=${cacheWrite}
+`;
+    out += `cost_eur=${costEur}
 `;
     if (usage.model) out += `model=${usage.model}
 `;

--- a/.github/actions/ferry-run-iterator/action.yml
+++ b/.github/actions/ferry-run-iterator/action.yml
@@ -94,6 +94,15 @@ outputs:
   model:
     description: Model ID actually used
     value: ${{ steps.run-iterator.outputs.model }}
+  cost_eur:
+    description: Cost in EUR for this agent run
+    value: ${{ steps.run-iterator.outputs.cost_eur }}
+  cache_read_tokens:
+    description: Number of cache read input tokens consumed
+    value: ${{ steps.run-iterator.outputs.cache_read_tokens }}
+  cache_write_tokens:
+    description: Number of cache write input tokens consumed
+    value: ${{ steps.run-iterator.outputs.cache_write_tokens }}
 runs:
   using: composite
   steps:

--- a/.github/actions/ferry-run-iterator/iterate-action.js
+++ b/.github/actions/ferry-run-iterator/iterate-action.js
@@ -2249,11 +2249,62 @@ ${opts.comments}` : ""
 
 // src/lib/agent-runtime/output.ts
 import { appendFileSync } from "node:fs";
+
+// src/lib/llm/pricing.ts
+var RATES = {
+  "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
+  "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },
+  "anthropic/claude-haiku": { inputPer1M: 0.23, outputPer1M: 1.16 },
+  "openai/gpt-4.1-nano": { inputPer1M: 0.09, outputPer1M: 0.37 },
+  "openai/gpt-4.1-mini": { inputPer1M: 0.14, outputPer1M: 0.56 },
+  "openai/gpt-4.": { inputPer1M: 2.79, outputPer1M: 8.37 },
+  "openai/gpt-5.": { inputPer1M: 2.79, outputPer1M: 8.37 },
+  "google/gemini-2.5-flash": { inputPer1M: 0.07, outputPer1M: 0.28 },
+  "google/gemini-2.5-pro": { inputPer1M: 1.05, outputPer1M: 4.2 }
+};
+var PROVIDER_FALLBACK = {
+  anthropic: RATES["anthropic/claude-opus"],
+  openai: RATES["openai/gpt-4."],
+  google: RATES["google/gemini-2.5-pro"]
+};
+function lookupRates(provider, model) {
+  const exactKey = `${provider}/${model}`;
+  if (RATES[exactKey]) return RATES[exactKey];
+  for (const key of Object.keys(RATES)) {
+    if (key !== exactKey && key.startsWith(`${provider}/`) && model.startsWith(key.slice(provider.length + 1))) {
+      return RATES[key];
+    }
+  }
+  return PROVIDER_FALLBACK[provider];
+}
+function computeCostEur(provider, model, inputTokens, outputTokens) {
+  const rates = lookupRates(provider, model);
+  const cost = inputTokens / 1e6 * rates.inputPer1M + outputTokens / 1e6 * rates.outputPer1M;
+  return Math.round(cost * 1e4) / 1e4;
+}
+
+// src/lib/agent-runtime/output.ts
 function appendOutput(usage) {
   const githubOutput = process.env.GITHUB_OUTPUT;
   if (githubOutput) {
+    const cacheRead = usage.cache_read_input_tokens ?? 0;
+    const cacheWrite = usage.cache_creation_input_tokens ?? 0;
+    let costEur = 0;
+    if (usage.provider && usage.model && usage.model !== "placeholder") {
+      costEur = computeCostEur(
+        usage.provider,
+        usage.model,
+        usage.input_tokens,
+        usage.output_tokens
+      );
+    }
     let out = `input_tokens=${usage.input_tokens}
 output_tokens=${usage.output_tokens}
+`;
+    out += `cache_read_tokens=${cacheRead}
+cache_write_tokens=${cacheWrite}
+`;
+    out += `cost_eur=${costEur}
 `;
     if (usage.model) out += `model=${usage.model}
 `;

--- a/.github/actions/ferry-run-reviewer/action.yml
+++ b/.github/actions/ferry-run-reviewer/action.yml
@@ -86,6 +86,15 @@ outputs:
   model:
     description: Model ID actually used
     value: ${{ steps.run-reviewer.outputs.model }}
+  cost_eur:
+    description: Cost in EUR for this agent run
+    value: ${{ steps.run-reviewer.outputs.cost_eur }}
+  cache_read_tokens:
+    description: Number of cache read input tokens consumed
+    value: ${{ steps.run-reviewer.outputs.cache_read_tokens }}
+  cache_write_tokens:
+    description: Number of cache write input tokens consumed
+    value: ${{ steps.run-reviewer.outputs.cache_write_tokens }}
 runs:
   using: composite
   steps:

--- a/.github/actions/ferry-run-reviewer/review-action.js
+++ b/.github/actions/ferry-run-reviewer/review-action.js
@@ -1027,11 +1027,62 @@ ${opts.comments}` : ""
 
 // src/lib/agent-runtime/output.ts
 import { appendFileSync } from "node:fs";
+
+// src/lib/llm/pricing.ts
+var RATES = {
+  "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
+  "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },
+  "anthropic/claude-haiku": { inputPer1M: 0.23, outputPer1M: 1.16 },
+  "openai/gpt-4.1-nano": { inputPer1M: 0.09, outputPer1M: 0.37 },
+  "openai/gpt-4.1-mini": { inputPer1M: 0.14, outputPer1M: 0.56 },
+  "openai/gpt-4.": { inputPer1M: 2.79, outputPer1M: 8.37 },
+  "openai/gpt-5.": { inputPer1M: 2.79, outputPer1M: 8.37 },
+  "google/gemini-2.5-flash": { inputPer1M: 0.07, outputPer1M: 0.28 },
+  "google/gemini-2.5-pro": { inputPer1M: 1.05, outputPer1M: 4.2 }
+};
+var PROVIDER_FALLBACK = {
+  anthropic: RATES["anthropic/claude-opus"],
+  openai: RATES["openai/gpt-4."],
+  google: RATES["google/gemini-2.5-pro"]
+};
+function lookupRates(provider, model) {
+  const exactKey = `${provider}/${model}`;
+  if (RATES[exactKey]) return RATES[exactKey];
+  for (const key of Object.keys(RATES)) {
+    if (key !== exactKey && key.startsWith(`${provider}/`) && model.startsWith(key.slice(provider.length + 1))) {
+      return RATES[key];
+    }
+  }
+  return PROVIDER_FALLBACK[provider];
+}
+function computeCostEur(provider, model, inputTokens, outputTokens) {
+  const rates = lookupRates(provider, model);
+  const cost = inputTokens / 1e6 * rates.inputPer1M + outputTokens / 1e6 * rates.outputPer1M;
+  return Math.round(cost * 1e4) / 1e4;
+}
+
+// src/lib/agent-runtime/output.ts
 function appendOutput(usage) {
   const githubOutput = process.env.GITHUB_OUTPUT;
   if (githubOutput) {
+    const cacheRead = usage.cache_read_input_tokens ?? 0;
+    const cacheWrite = usage.cache_creation_input_tokens ?? 0;
+    let costEur = 0;
+    if (usage.provider && usage.model && usage.model !== "placeholder") {
+      costEur = computeCostEur(
+        usage.provider,
+        usage.model,
+        usage.input_tokens,
+        usage.output_tokens
+      );
+    }
     let out = `input_tokens=${usage.input_tokens}
 output_tokens=${usage.output_tokens}
+`;
+    out += `cache_read_tokens=${cacheRead}
+cache_write_tokens=${cacheWrite}
+`;
+    out += `cost_eur=${costEur}
 `;
     if (usage.model) out += `model=${usage.model}
 `;

--- a/examples/consumer-setup/workflows/ferry-dev.yml
+++ b/examples/consumer-setup/workflows/ferry-dev.yml
@@ -58,6 +58,7 @@ jobs:
     outputs:
       input_tokens: ${{ steps.run-developer.outputs.input_tokens }}
       output_tokens: ${{ steps.run-developer.outputs.output_tokens }}
+      cost_eur: ${{ steps.run-developer.outputs.cost_eur }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -116,6 +117,7 @@ jobs:
           outcome: ${{ needs.run-agent.result }}
           input_tokens: ${{ needs.run-agent.outputs.input_tokens || '0' }}
           output_tokens: ${{ needs.run-agent.outputs.output_tokens || '0' }}
+          cost_eur: ${{ needs.run-agent.outputs.cost_eur || '0' }}
           start_ms: ${{ github.run_id }}
           audit_issue: ${{ vars.FERRY_AUDIT_ISSUE }}
           github_token: ${{ github.token }}

--- a/examples/consumer-setup/workflows/ferry-iterate.yml
+++ b/examples/consumer-setup/workflows/ferry-iterate.yml
@@ -58,6 +58,7 @@ jobs:
     outputs:
       input_tokens: ${{ steps.run-iterator.outputs.input_tokens }}
       output_tokens: ${{ steps.run-iterator.outputs.output_tokens }}
+      cost_eur: ${{ steps.run-iterator.outputs.cost_eur }}
       model: ${{ steps.run-iterator.outputs.model }}
     steps:
       - name: Checkout repository
@@ -119,6 +120,7 @@ jobs:
           outcome: ${{ needs.run-agent.result }}
           input_tokens: ${{ needs.run-agent.outputs.input_tokens || '0' }}
           output_tokens: ${{ needs.run-agent.outputs.output_tokens || '0' }}
+          cost_eur: ${{ needs.run-agent.outputs.cost_eur || '0' }}
           start_ms: ${{ github.run_id }}
           audit_issue: ${{ vars.FERRY_AUDIT_ISSUE }}
           github_token: ${{ github.token }}

--- a/examples/consumer-setup/workflows/ferry-review.yml
+++ b/examples/consumer-setup/workflows/ferry-review.yml
@@ -57,6 +57,7 @@ jobs:
     outputs:
       input_tokens: ${{ steps.run-reviewer.outputs.input_tokens }}
       output_tokens: ${{ steps.run-reviewer.outputs.output_tokens }}
+      cost_eur: ${{ steps.run-reviewer.outputs.cost_eur }}
       model: ${{ steps.run-reviewer.outputs.model }}
     steps:
       - name: Checkout repository
@@ -114,6 +115,7 @@ jobs:
           outcome: ${{ needs.run-agent.result }}
           input_tokens: ${{ needs.run-agent.outputs.input_tokens || '0' }}
           output_tokens: ${{ needs.run-agent.outputs.output_tokens || '0' }}
+          cost_eur: ${{ needs.run-agent.outputs.cost_eur || '0' }}
           start_ms: ${{ github.run_id }}
           audit_issue: ${{ vars.FERRY_AUDIT_ISSUE }}
           github_token: ${{ github.token }}

--- a/src/lib/agent-runtime/output.test.ts
+++ b/src/lib/agent-runtime/output.test.ts
@@ -66,7 +66,12 @@ describe('appendOutput', () => {
   });
 
   it('writes zero cache tokens on early-exit calls', () => {
-    appendOutput({ input_tokens: 0, output_tokens: 0, model: 'claude-sonnet-4-6', provider: 'anthropic' });
+    appendOutput({
+      input_tokens: 0,
+      output_tokens: 0,
+      model: 'claude-sonnet-4-6',
+      provider: 'anthropic',
+    });
     const content = readFileSync(outputFile, 'utf8');
     expect(content).toContain('cache_read_tokens=0');
     expect(content).toContain('cache_write_tokens=0');

--- a/src/lib/agent-runtime/output.test.ts
+++ b/src/lib/agent-runtime/output.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { appendOutput } from './output.js';
+
+describe('appendOutput', () => {
+  let tmpDir: string;
+  let outputFile: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'ferry-output-test-'));
+    outputFile = join(tmpDir, 'github-output');
+    process.env.GITHUB_OUTPUT = outputFile;
+  });
+
+  afterEach(() => {
+    delete process.env.GITHUB_OUTPUT;
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes non-zero cost_eur for a known Anthropic model', () => {
+    appendOutput({
+      input_tokens: 1000,
+      output_tokens: 500,
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+    });
+    const content = readFileSync(outputFile, 'utf8');
+    expect(content).toContain('input_tokens=1000');
+    expect(content).toContain('output_tokens=500');
+    const match = content.match(/cost_eur=([0-9.]+)/);
+    expect(match).toBeTruthy();
+    expect(parseFloat(match![1])).toBeGreaterThan(0);
+  });
+
+  it('writes cache_read_tokens and cache_write_tokens', () => {
+    appendOutput({
+      input_tokens: 1000,
+      output_tokens: 500,
+      cache_read_input_tokens: 200,
+      cache_creation_input_tokens: 100,
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+    });
+    const content = readFileSync(outputFile, 'utf8');
+    expect(content).toContain('cache_read_tokens=200');
+    expect(content).toContain('cache_write_tokens=100');
+  });
+
+  it('writes cost_eur=0 when model is "placeholder"', () => {
+    appendOutput({
+      input_tokens: 1000,
+      output_tokens: 500,
+      provider: 'anthropic',
+      model: 'placeholder',
+    });
+    const content = readFileSync(outputFile, 'utf8');
+    expect(content).toContain('cost_eur=0');
+  });
+
+  it('writes cost_eur=0 when no provider/model supplied', () => {
+    appendOutput({ input_tokens: 1000, output_tokens: 500 });
+    const content = readFileSync(outputFile, 'utf8');
+    expect(content).toContain('cost_eur=0');
+  });
+
+  it('writes zero cache tokens on early-exit calls', () => {
+    appendOutput({ input_tokens: 0, output_tokens: 0, model: 'claude-sonnet-4-6', provider: 'anthropic' });
+    const content = readFileSync(outputFile, 'utf8');
+    expect(content).toContain('cache_read_tokens=0');
+    expect(content).toContain('cache_write_tokens=0');
+    expect(content).toContain('cost_eur=0');
+  });
+
+  it('does not throw when GITHUB_OUTPUT is unset', () => {
+    delete process.env.GITHUB_OUTPUT;
+    expect(() => appendOutput({ input_tokens: 100, output_tokens: 50 })).not.toThrow();
+  });
+});

--- a/src/lib/agent-runtime/output.ts
+++ b/src/lib/agent-runtime/output.ts
@@ -1,14 +1,33 @@
 import { appendFileSync } from 'node:fs';
+import { computeCostEur } from '../llm/pricing.js';
+import type { LlmProvider } from '../llm/config.js';
 
 export function appendOutput(usage: {
   input_tokens: number;
   output_tokens: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
   model?: string;
   provider?: string;
 }): void {
   const githubOutput = process.env.GITHUB_OUTPUT;
   if (githubOutput) {
+    const cacheRead = usage.cache_read_input_tokens ?? 0;
+    const cacheWrite = usage.cache_creation_input_tokens ?? 0;
+
+    let costEur = 0;
+    if (usage.provider && usage.model && usage.model !== 'placeholder') {
+      costEur = computeCostEur(
+        usage.provider as LlmProvider,
+        usage.model,
+        usage.input_tokens,
+        usage.output_tokens,
+      );
+    }
+
     let out = `input_tokens=${usage.input_tokens}\noutput_tokens=${usage.output_tokens}\n`;
+    out += `cache_read_tokens=${cacheRead}\ncache_write_tokens=${cacheWrite}\n`;
+    out += `cost_eur=${costEur}\n`;
     if (usage.model) out += `model=${usage.model}\n`;
     if (usage.provider) out += `provider=${usage.provider}\n`;
     appendFileSync(githubOutput, out);


### PR DESCRIPTION
## Summary

- `appendOutput()` now computes and writes `cost_eur`, `cache_read_tokens`, and `cache_write_tokens` to `$GITHUB_OUTPUT`, using the existing `computeCostEur` helper in `pricing.ts` — no new math, just wiring
- All three `ferry-run-{developer,reviewer,iterator}` composite actions declare the three new outputs
- The matching consumer workflow examples (`ferry-dev.yml`, `ferry-review.yml`, `ferry-iterate.yml`) forward `cost_eur` to the `ferry-emit-audit` step
- Bonus: `model='placeholder'` guard prevents wrong cost values from test/placeholder model strings

Closes #251.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npx vitest run src/lib/agent-runtime/output.test.ts` — 6 tests pass (cost_eur non-zero for real model, cache tokens, placeholder guard, no-provider guard)
- [ ] Trigger one real ticket on a consumer repo and confirm audit comment shows non-zero `cost_eur`