### PR TITLE
fix(tracker): normalize Jira issue-type locale at tracker boundary

### DIFF
--- a/.ferry/dev-action.js
+++ b/.ferry/dev-action.js
@@ -5250,6 +5250,17 @@ function adfToText(adf) {
 }
 
 // src/lib/io/tracker/jira/tracker.ts
+var ISSUE_TYPE_LOCALE_MAP = {
+  // French
+  t\u00E2che: "Task",
+  bogue: "Bug",
+  histoire: "Story",
+  \u00E9pique: "Epic",
+  "sous-t\xE2che": "Sub-task"
+};
+function normalizeIssueType(raw) {
+  return ISSUE_TYPE_LOCALE_MAP[raw.toLowerCase()] ?? raw;
+}
 var JiraTracker = class {
   constructor(client) {
     this.client = client;
@@ -5263,7 +5274,8 @@ var JiraTracker = class {
       description: adfToText(issue.fields.description),
       comments: issue.fields.comment.comments.map((c) => adfToText(c.body)),
       labels: issue.fields.labels,
-      issueType: issue.fields.issuetype.name
+      issueType: normalizeIssueType(issue.fields.issuetype.name),
+      issueTypeRaw: issue.fields.issuetype.name
     };
   }
   async postComment(key, body) {

--- a/.ferry/iterate-action.js
+++ b/.ferry/iterate-action.js
@@ -7158,6 +7158,17 @@ function adfToText(adf) {
 }
 
 // src/lib/io/tracker/jira/tracker.ts
+var ISSUE_TYPE_LOCALE_MAP = {
+  // French
+  t\u00E2che: "Task",
+  bogue: "Bug",
+  histoire: "Story",
+  \u00E9pique: "Epic",
+  "sous-t\xE2che": "Sub-task"
+};
+function normalizeIssueType(raw) {
+  return ISSUE_TYPE_LOCALE_MAP[raw.toLowerCase()] ?? raw;
+}
 var JiraTracker = class {
   constructor(client) {
     this.client = client;
@@ -7171,7 +7182,8 @@ var JiraTracker = class {
       description: adfToText(issue.fields.description),
       comments: issue.fields.comment.comments.map((c) => adfToText(c.body)),
       labels: issue.fields.labels,
-      issueType: issue.fields.issuetype.name
+      issueType: normalizeIssueType(issue.fields.issuetype.name),
+      issueTypeRaw: issue.fields.issuetype.name
     };
   }
   async postComment(key, body) {

--- a/.ferry/refiner-action.js
+++ b/.ferry/refiner-action.js
@@ -5213,6 +5213,17 @@ function adfToText(adf) {
 }
 
 // src/lib/io/tracker/jira/tracker.ts
+var ISSUE_TYPE_LOCALE_MAP = {
+  // French
+  t\u00E2che: "Task",
+  bogue: "Bug",
+  histoire: "Story",
+  \u00E9pique: "Epic",
+  "sous-t\xE2che": "Sub-task"
+};
+function normalizeIssueType(raw) {
+  return ISSUE_TYPE_LOCALE_MAP[raw.toLowerCase()] ?? raw;
+}
 var JiraTracker = class {
   constructor(client) {
     this.client = client;
@@ -5226,7 +5237,8 @@ var JiraTracker = class {
       description: adfToText(issue.fields.description),
       comments: issue.fields.comment.comments.map((c) => adfToText(c.body)),
       labels: issue.fields.labels,
-      issueType: issue.fields.issuetype.name
+      issueType: normalizeIssueType(issue.fields.issuetype.name),
+      issueTypeRaw: issue.fields.issuetype.name
     };
   }
   async postComment(key, body) {

--- a/.ferry/review-action.js
+++ b/.ferry/review-action.js
@@ -5805,6 +5805,17 @@ function adfToText(adf) {
 }
 
 // src/lib/io/tracker/jira/tracker.ts
+var ISSUE_TYPE_LOCALE_MAP = {
+  // French
+  t\u00E2che: "Task",
+  bogue: "Bug",
+  histoire: "Story",
+  \u00E9pique: "Epic",
+  "sous-t\xE2che": "Sub-task"
+};
+function normalizeIssueType(raw) {
+  return ISSUE_TYPE_LOCALE_MAP[raw.toLowerCase()] ?? raw;
+}
 var JiraTracker = class {
   constructor(client) {
     this.client = client;
@@ -5818,7 +5829,8 @@ var JiraTracker = class {
       description: adfToText(issue.fields.description),
       comments: issue.fields.comment.comments.map((c) => adfToText(c.body)),
       labels: issue.fields.labels,
-      issueType: issue.fields.issuetype.name
+      issueType: normalizeIssueType(issue.fields.issuetype.name),
+      issueTypeRaw: issue.fields.issuetype.name
     };
   }
   async postComment(key, body) {

--- a/.ferry/skip-task-type-action.js
+++ b/.ferry/skip-task-type-action.js
@@ -396,7 +396,7 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
 });
 function shouldSkipForTaskType(issueType2) {
-  if (issueType2 === "Task") {
+  if (issueType2.toLowerCase() === "task") {
     return { skip: true, reason: "ticket type Task is not processed by Ferry" };
   }
   return { skip: false };

--- a/.github/actions/ferry-run-developer/dev-action.js
+++ b/.github/actions/ferry-run-developer/dev-action.js
@@ -5250,6 +5250,17 @@ function adfToText(adf) {
 }
 
 // src/lib/io/tracker/jira/tracker.ts
+var ISSUE_TYPE_LOCALE_MAP = {
+  // French
+  t\u00E2che: "Task",
+  bogue: "Bug",
+  histoire: "Story",
+  \u00E9pique: "Epic",
+  "sous-t\xE2che": "Sub-task"
+};
+function normalizeIssueType(raw) {
+  return ISSUE_TYPE_LOCALE_MAP[raw.toLowerCase()] ?? raw;
+}
 var JiraTracker = class {
   constructor(client) {
     this.client = client;
@@ -5263,7 +5274,8 @@ var JiraTracker = class {
       description: adfToText(issue.fields.description),
       comments: issue.fields.comment.comments.map((c) => adfToText(c.body)),
       labels: issue.fields.labels,
-      issueType: issue.fields.issuetype.name
+      issueType: normalizeIssueType(issue.fields.issuetype.name),
+      issueTypeRaw: issue.fields.issuetype.name
     };
   }
   async postComment(key, body) {

--- a/.github/actions/ferry-run-developer/skip-task-type-action.js
+++ b/.github/actions/ferry-run-developer/skip-task-type-action.js
@@ -396,7 +396,7 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
 });
 function shouldSkipForTaskType(issueType2) {
-  if (issueType2 === "Task") {
+  if (issueType2.toLowerCase() === "task") {
     return { skip: true, reason: "ticket type Task is not processed by Ferry" };
   }
   return { skip: false };

--- a/.github/actions/ferry-run-iterator/iterate-action.js
+++ b/.github/actions/ferry-run-iterator/iterate-action.js
@@ -7158,6 +7158,17 @@ function adfToText(adf) {
 }
 
 // src/lib/io/tracker/jira/tracker.ts
+var ISSUE_TYPE_LOCALE_MAP = {
+  // French
+  t\u00E2che: "Task",
+  bogue: "Bug",
+  histoire: "Story",
+  \u00E9pique: "Epic",
+  "sous-t\xE2che": "Sub-task"
+};
+function normalizeIssueType(raw) {
+  return ISSUE_TYPE_LOCALE_MAP[raw.toLowerCase()] ?? raw;
+}
 var JiraTracker = class {
   constructor(client) {
     this.client = client;
@@ -7171,7 +7182,8 @@ var JiraTracker = class {
       description: adfToText(issue.fields.description),
       comments: issue.fields.comment.comments.map((c) => adfToText(c.body)),
       labels: issue.fields.labels,
-      issueType: issue.fields.issuetype.name
+      issueType: normalizeIssueType(issue.fields.issuetype.name),
+      issueTypeRaw: issue.fields.issuetype.name
     };
   }
   async postComment(key, body) {

--- a/.github/actions/ferry-run-iterator/skip-task-type-action.js
+++ b/.github/actions/ferry-run-iterator/skip-task-type-action.js
@@ -396,7 +396,7 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
 });
 function shouldSkipForTaskType(issueType2) {
-  if (issueType2 === "Task") {
+  if (issueType2.toLowerCase() === "task") {
     return { skip: true, reason: "ticket type Task is not processed by Ferry" };
   }
   return { skip: false };

--- a/.github/actions/ferry-run-refiner/refiner-action.js
+++ b/.github/actions/ferry-run-refiner/refiner-action.js
@@ -5213,6 +5213,17 @@ function adfToText(adf) {
 }
 
 // src/lib/io/tracker/jira/tracker.ts
+var ISSUE_TYPE_LOCALE_MAP = {
+  // French
+  t\u00E2che: "Task",
+  bogue: "Bug",
+  histoire: "Story",
+  \u00E9pique: "Epic",
+  "sous-t\xE2che": "Sub-task"
+};
+function normalizeIssueType(raw) {
+  return ISSUE_TYPE_LOCALE_MAP[raw.toLowerCase()] ?? raw;
+}
 var JiraTracker = class {
   constructor(client) {
     this.client = client;
@@ -5226,7 +5237,8 @@ var JiraTracker = class {
       description: adfToText(issue.fields.description),
       comments: issue.fields.comment.comments.map((c) => adfToText(c.body)),
       labels: issue.fields.labels,
-      issueType: issue.fields.issuetype.name
+      issueType: normalizeIssueType(issue.fields.issuetype.name),
+      issueTypeRaw: issue.fields.issuetype.name
     };
   }
   async postComment(key, body) {

--- a/.github/actions/ferry-run-refiner/skip-task-type-action.js
+++ b/.github/actions/ferry-run-refiner/skip-task-type-action.js
@@ -396,7 +396,7 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
 });
 function shouldSkipForTaskType(issueType2) {
-  if (issueType2 === "Task") {
+  if (issueType2.toLowerCase() === "task") {
     return { skip: true, reason: "ticket type Task is not processed by Ferry" };
   }
   return { skip: false };

--- a/.github/actions/ferry-run-reviewer/review-action.js
+++ b/.github/actions/ferry-run-reviewer/review-action.js
@@ -5805,6 +5805,17 @@ function adfToText(adf) {
 }
 
 // src/lib/io/tracker/jira/tracker.ts
+var ISSUE_TYPE_LOCALE_MAP = {
+  // French
+  t\u00E2che: "Task",
+  bogue: "Bug",
+  histoire: "Story",
+  \u00E9pique: "Epic",
+  "sous-t\xE2che": "Sub-task"
+};
+function normalizeIssueType(raw) {
+  return ISSUE_TYPE_LOCALE_MAP[raw.toLowerCase()] ?? raw;
+}
 var JiraTracker = class {
   constructor(client) {
     this.client = client;
@@ -5818,7 +5829,8 @@ var JiraTracker = class {
       description: adfToText(issue.fields.description),
       comments: issue.fields.comment.comments.map((c) => adfToText(c.body)),
       labels: issue.fields.labels,
-      issueType: issue.fields.issuetype.name
+      issueType: normalizeIssueType(issue.fields.issuetype.name),
+      issueTypeRaw: issue.fields.issuetype.name
     };
   }
   async postComment(key, body) {

--- a/.github/actions/ferry-run-reviewer/skip-task-type-action.js
+++ b/.github/actions/ferry-run-reviewer/skip-task-type-action.js
@@ -396,7 +396,7 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
 });
 function shouldSkipForTaskType(issueType2) {
-  if (issueType2 === "Task") {
+  if (issueType2.toLowerCase() === "task") {
     return { skip: true, reason: "ticket type Task is not processed by Ferry" };
   }
   return { skip: false };

--- a/src/agents/developer/dev-action.dry-run.test.ts
+++ b/src/agents/developer/dev-action.dry-run.test.ts
@@ -38,6 +38,7 @@ describe('dry-run tracker isolation', () => {
       comments: [],
       labels: [],
       issueType: 'Story',
+      issueTypeRaw: 'Story',
     });
 
     const postCommentSpy = vi.spyOn(tracker, 'postComment');
@@ -67,6 +68,7 @@ describe('dry-run tracker isolation', () => {
       comments: [],
       labels: [],
       issueType: 'Story',
+      issueTypeRaw: 'Story',
     });
 
     const dryRun = isDryRun();

--- a/src/agents/developer/wip-finalizer.test.ts
+++ b/src/agents/developer/wip-finalizer.test.ts
@@ -27,6 +27,7 @@ function makeTracker(ticketKey: string): InMemoryTracker {
     comments: [],
     labels: [],
     issueType: 'Story',
+    issueTypeRaw: 'Story',
   });
   return tracker;
 }

--- a/src/agents/refiner/reconcile.test.ts
+++ b/src/agents/refiner/reconcile.test.ts
@@ -14,6 +14,7 @@ function makeTracker(parentKey: string, subtasks: TrackerSubtask[] = []) {
     comments: [],
     labels: [],
     issueType: 'Story',
+    issueTypeRaw: 'Story',
   });
   for (const s of subtasks) {
     tracker.seed({
@@ -23,6 +24,7 @@ function makeTracker(parentKey: string, subtasks: TrackerSubtask[] = []) {
       comments: [],
       labels: [],
       issueType: 'Sub-task',
+      issueTypeRaw: 'Sub-task',
     });
   }
   tracker.seedSubtaskDetails(parentKey, subtasks);

--- a/src/agents/refiner/refiner-action.dry-run.test.ts
+++ b/src/agents/refiner/refiner-action.dry-run.test.ts
@@ -47,6 +47,7 @@ function makeTracker(): InMemoryTracker {
     comments: [],
     labels: [],
     issueType: 'Story',
+    issueTypeRaw: 'Story',
   });
   return tracker;
 }
@@ -115,6 +116,7 @@ describe('refiner-action re-trigger scenario', () => {
       comments: ['[ferry:refiner:old-evt] Refined. Created 2...'],
       labels: [],
       issueType: 'Story',
+      issueTypeRaw: 'Story',
     });
 
     await run(envelope, { tracker, callLlm: makeMockLlm(noopPlan) });

--- a/src/e2e/pipeline.test.ts
+++ b/src/e2e/pipeline.test.ts
@@ -186,6 +186,7 @@ function buildMockIO(): MockIO {
     comments: [],
     labels: [],
     issueType: 'Story',
+    issueTypeRaw: 'Story',
   });
 
   const runner = new GitHubActionsRunner(octokit, OWNER, REPO);

--- a/src/lib/dispatch/routing.test.ts
+++ b/src/lib/dispatch/routing.test.ts
@@ -44,8 +44,14 @@ describe('shouldSkipForTaskType (FR6 task-type filter)', () => {
   });
 
   it('is case-insensitive (normalized French "Tâche" maps to "Task" before this call)', () => {
-    expect(shouldSkipForTaskType('task')).toEqual({ skip: true, reason: 'ticket type Task is not processed by Ferry' });
-    expect(shouldSkipForTaskType('TASK')).toEqual({ skip: true, reason: 'ticket type Task is not processed by Ferry' });
+    expect(shouldSkipForTaskType('task')).toEqual({
+      skip: true,
+      reason: 'ticket type Task is not processed by Ferry',
+    });
+    expect(shouldSkipForTaskType('TASK')).toEqual({
+      skip: true,
+      reason: 'ticket type Task is not processed by Ferry',
+    });
   });
 
   it('does not skip Story / Bug / Spike issue types', () => {

--- a/src/lib/dispatch/routing.test.ts
+++ b/src/lib/dispatch/routing.test.ts
@@ -43,6 +43,11 @@ describe('shouldSkipForTaskType (FR6 task-type filter)', () => {
     });
   });
 
+  it('is case-insensitive (normalized French "Tâche" maps to "Task" before this call)', () => {
+    expect(shouldSkipForTaskType('task')).toEqual({ skip: true, reason: 'ticket type Task is not processed by Ferry' });
+    expect(shouldSkipForTaskType('TASK')).toEqual({ skip: true, reason: 'ticket type Task is not processed by Ferry' });
+  });
+
   it('does not skip Story / Bug / Spike issue types', () => {
     expect(shouldSkipForTaskType('Story')).toEqual({ skip: false });
     expect(shouldSkipForTaskType('Bug')).toEqual({ skip: false });

--- a/src/lib/dispatch/routing.ts
+++ b/src/lib/dispatch/routing.ts
@@ -44,7 +44,7 @@ export function phaseToDispatchType(phase: keyof RoutingTable): DispatchType {
  * sub-tasks, and re-running on those would loop. Other types pass through.
  */
 export function shouldSkipForTaskType(issueType: string): { skip: boolean; reason?: string } {
-  if (issueType === 'Task') {
+  if (issueType.toLowerCase() === 'task') {
     return { skip: true, reason: 'ticket type Task is not processed by Ferry' };
   }
   return { skip: false };

--- a/src/lib/io/tracker/contract.test.ts
+++ b/src/lib/io/tracker/contract.test.ts
@@ -9,6 +9,7 @@ const SAMPLE_ISSUE: TrackerIssue = {
   comments: ['First comment', 'Second comment'],
   labels: ['bug'],
   issueType: 'Story',
+  issueTypeRaw: 'Story',
 };
 
 describe('IssueTracker contract — InMemoryTracker', () => {

--- a/src/lib/io/tracker/jira/tracker.test.ts
+++ b/src/lib/io/tracker/jira/tracker.test.ts
@@ -57,6 +57,7 @@ describe('JiraTracker', () => {
       expect(issue.comments).toEqual([adfToText(makeAdf(commentText))]);
       expect(issue.labels).toEqual(['bug']);
       expect(issue.issueType).toBe('Story');
+      expect(issue.issueTypeRaw).toBe('Story');
       expect(client.getIssue).toHaveBeenCalledWith('PROJ-1');
     });
 
@@ -75,6 +76,49 @@ describe('JiraTracker', () => {
 
       const issue = await tracker.getIssue('PROJ-2');
       expect(issue.description).toBe('');
+    });
+  });
+
+  describe('locale normalization (FR6 + issue #245)', () => {
+    it.each([
+      ['Tâche', 'Task'],
+      ['tâche', 'Task'],
+      ['Bogue', 'Bug'],
+      ['Histoire', 'Story'],
+      ['Épique', 'Epic'],
+      ['Sous-tâche', 'Sub-task'],
+    ])('normalizes "%s" → "%s"', async (rawName, expected) => {
+      vi.mocked(client.getIssue).mockResolvedValue({
+        id: '99',
+        key: 'FR-1',
+        fields: {
+          summary: 'Test',
+          description: null,
+          comment: { comments: [] },
+          labels: [],
+          issuetype: { name: rawName },
+        },
+      });
+      const issue = await tracker.getIssue('FR-1');
+      expect(issue.issueType).toBe(expected);
+      expect(issue.issueTypeRaw).toBe(rawName);
+    });
+
+    it('passes through unknown types unchanged', async () => {
+      vi.mocked(client.getIssue).mockResolvedValue({
+        id: '100',
+        key: 'FR-2',
+        fields: {
+          summary: 'Test',
+          description: null,
+          comment: { comments: [] },
+          labels: [],
+          issuetype: { name: 'CustomType' },
+        },
+      });
+      const issue = await tracker.getIssue('FR-2');
+      expect(issue.issueType).toBe('CustomType');
+      expect(issue.issueTypeRaw).toBe('CustomType');
     });
   });
 

--- a/src/lib/io/tracker/jira/tracker.ts
+++ b/src/lib/io/tracker/jira/tracker.ts
@@ -4,10 +4,10 @@ import type { IssueTracker, TrackerIssue, TrackerSubtask } from '../types.js';
 
 const ISSUE_TYPE_LOCALE_MAP: Record<string, string> = {
   // French
-  'tâche': 'Task',
-  'bogue': 'Bug',
-  'histoire': 'Story',
-  'épique': 'Epic',
+  tâche: 'Task',
+  bogue: 'Bug',
+  histoire: 'Story',
+  épique: 'Epic',
   'sous-tâche': 'Sub-task',
 };
 

--- a/src/lib/io/tracker/jira/tracker.ts
+++ b/src/lib/io/tracker/jira/tracker.ts
@@ -2,6 +2,19 @@ import { JiraRestClient } from '../../jira-rest.js';
 import { adfToText, textToAdf } from '../../jira-adf.js';
 import type { IssueTracker, TrackerIssue, TrackerSubtask } from '../types.js';
 
+const ISSUE_TYPE_LOCALE_MAP: Record<string, string> = {
+  // French
+  'tâche': 'Task',
+  'bogue': 'Bug',
+  'histoire': 'Story',
+  'épique': 'Epic',
+  'sous-tâche': 'Sub-task',
+};
+
+function normalizeIssueType(raw: string): string {
+  return ISSUE_TYPE_LOCALE_MAP[raw.toLowerCase()] ?? raw;
+}
+
 export class JiraTracker implements IssueTracker {
   constructor(private readonly client: JiraRestClient) {}
 
@@ -13,7 +26,8 @@ export class JiraTracker implements IssueTracker {
       description: adfToText(issue.fields.description),
       comments: issue.fields.comment.comments.map((c) => adfToText(c.body)),
       labels: issue.fields.labels,
-      issueType: issue.fields.issuetype.name,
+      issueType: normalizeIssueType(issue.fields.issuetype.name),
+      issueTypeRaw: issue.fields.issuetype.name,
     };
   }
 

--- a/src/lib/io/tracker/types.ts
+++ b/src/lib/io/tracker/types.ts
@@ -4,7 +4,10 @@ export interface TrackerIssue {
   description: string;
   comments: string[];
   labels: string[];
+  /** Canonical (normalized) English issue type name. */
   issueType: string;
+  /** Verbatim issue type name as returned by the tracker (may be a non-English locale). */
+  issueTypeRaw: string;
 }
 
 export interface TrackerSubtask {


### PR DESCRIPTION
## Summary

- Adds a locale map in `JiraTracker.getIssue()` normalizing French issue type names to canonical English (`Tâche→Task`, `Bogue→Bug`, `Histoire→Story`, `Épique→Epic`, `Sous-tâche→Sub-task`)
- `TrackerIssue` now has both `issueType` (normalized) and `issueTypeRaw` (verbatim from Jira) — preserving raw data for audit surfaces
- `shouldSkipForTaskType()` is now case-insensitive as belt-and-suspenders (handles `TASK`, `task`, etc.)
- All test fixtures updated with `issueTypeRaw`; new parameterized locale tests added

Closes #245.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` — 1248 tests pass (27 in routing + tracker suites including new locale normalization cases)
- [ ] Trigger a ticket from a French Jira (`Tâche`) and confirm it is correctly skipped