### PR TITLE
docs(mcp): qualify Anthropic HTTP MCP beta status in constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ Each HTTP/SSE entry accepts:
 - Tool calls only — MCP prompts and resources are not in scope.
 - Only available when the developer agent uses the Anthropic provider; not supported on Bedrock or Vertex.
 - Not eligible for Anthropic Zero Data Retention.
+- Uses the Anthropic beta connector `mcp-client-2025-11-20`. The API contract may change before GA. The routing logic is covered by unit tests with a mocked Anthropic client; there are no live-network integration tests for this path.
 
 ### Stdio servers (client-side)
 


### PR DESCRIPTION
## Summary

- Adds a constraint bullet to the README HTTP/SSE MCP section noting that: (1) this path uses the `mcp-client-2025-11-20` beta connector and may change before GA, (2) the routing logic is covered by unit tests with a mocked Anthropic client, (3) there are no live-network integration tests

Background: the HTTP MCP path is already well-tested (8 unit tests in `src/lib/llm/agent-loop/anthropic.test.ts` lines 145-338 verify the beta header, `mcp_servers` param, tool filtering, and usage accumulation). The caveat is about GA stability and live-network coverage, not test coverage.

Closes #249.

## Test plan

- [x] `npm test` passes (1240 tests, no regressions)
- [ ] Verify the README renders correctly on GitHub