### PR TITLE
feat(mcp): enable Context7 as a default MCP server for all agents

### DIFF
--- a/.ferry/dev-action.js
+++ b/.ferry/dev-action.js
@@ -164,16 +164,24 @@ function isValidMcpServer(s) {
   }
   return typeof obj.url === "string" && obj.url.length > 0;
 }
+var DEFAULT_MCP_SERVERS = [
+  { name: "context7", url: "https://mcp.context7.com/mcp" }
+];
 function loadMcpServers() {
+  const defaults = process.env.FERRY_MCP_DEFAULTS_DISABLED === "true" ? [] : [...DEFAULT_MCP_SERVERS];
   const raw = process.env.AGENT_MCP_SERVERS;
-  if (!raw) return [];
+  if (!raw) return defaults;
+  let consumer;
   try {
     const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter(isValidMcpServer);
+    if (!Array.isArray(parsed)) return defaults;
+    consumer = parsed.filter(isValidMcpServer);
   } catch {
-    return [];
+    return defaults;
   }
+  const consumerNames = new Set(consumer.map((s) => s.name));
+  const filteredDefaults = defaults.filter((d) => !consumerNames.has(d.name));
+  return [...filteredDefaults, ...consumer];
 }
 
 // src/lib/envelope/validate.ts

--- a/.ferry/iterate-action.js
+++ b/.ferry/iterate-action.js
@@ -2089,16 +2089,24 @@ function isValidMcpServer(s) {
   }
   return typeof obj.url === "string" && obj.url.length > 0;
 }
+var DEFAULT_MCP_SERVERS = [
+  { name: "context7", url: "https://mcp.context7.com/mcp" }
+];
 function loadMcpServers() {
+  const defaults = process.env.FERRY_MCP_DEFAULTS_DISABLED === "true" ? [] : [...DEFAULT_MCP_SERVERS];
   const raw = process.env.AGENT_MCP_SERVERS;
-  if (!raw) return [];
+  if (!raw) return defaults;
+  let consumer;
   try {
     const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter(isValidMcpServer);
+    if (!Array.isArray(parsed)) return defaults;
+    consumer = parsed.filter(isValidMcpServer);
   } catch {
-    return [];
+    return defaults;
   }
+  const consumerNames = new Set(consumer.map((s) => s.name));
+  const filteredDefaults = defaults.filter((d) => !consumerNames.has(d.name));
+  return [...filteredDefaults, ...consumer];
 }
 
 // src/lib/envelope/validate.ts

--- a/.github/actions/ferry-run-developer/dev-action.js
+++ b/.github/actions/ferry-run-developer/dev-action.js
@@ -164,16 +164,24 @@ function isValidMcpServer(s) {
   }
   return typeof obj.url === "string" && obj.url.length > 0;
 }
+var DEFAULT_MCP_SERVERS = [
+  { name: "context7", url: "https://mcp.context7.com/mcp" }
+];
 function loadMcpServers() {
+  const defaults = process.env.FERRY_MCP_DEFAULTS_DISABLED === "true" ? [] : [...DEFAULT_MCP_SERVERS];
   const raw = process.env.AGENT_MCP_SERVERS;
-  if (!raw) return [];
+  if (!raw) return defaults;
+  let consumer;
   try {
     const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter(isValidMcpServer);
+    if (!Array.isArray(parsed)) return defaults;
+    consumer = parsed.filter(isValidMcpServer);
   } catch {
-    return [];
+    return defaults;
   }
+  const consumerNames = new Set(consumer.map((s) => s.name));
+  const filteredDefaults = defaults.filter((d) => !consumerNames.has(d.name));
+  return [...filteredDefaults, ...consumer];
 }
 
 // src/lib/envelope/validate.ts

--- a/.github/actions/ferry-run-iterator/iterate-action.js
+++ b/.github/actions/ferry-run-iterator/iterate-action.js
@@ -2089,16 +2089,24 @@ function isValidMcpServer(s) {
   }
   return typeof obj.url === "string" && obj.url.length > 0;
 }
+var DEFAULT_MCP_SERVERS = [
+  { name: "context7", url: "https://mcp.context7.com/mcp" }
+];
 function loadMcpServers() {
+  const defaults = process.env.FERRY_MCP_DEFAULTS_DISABLED === "true" ? [] : [...DEFAULT_MCP_SERVERS];
   const raw = process.env.AGENT_MCP_SERVERS;
-  if (!raw) return [];
+  if (!raw) return defaults;
+  let consumer;
   try {
     const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter(isValidMcpServer);
+    if (!Array.isArray(parsed)) return defaults;
+    consumer = parsed.filter(isValidMcpServer);
   } catch {
-    return [];
+    return defaults;
   }
+  const consumerNames = new Set(consumer.map((s) => s.name));
+  const filteredDefaults = defaults.filter((d) => !consumerNames.has(d.name));
+  return [...filteredDefaults, ...consumer];
 }
 
 // src/lib/envelope/validate.ts

--- a/README.md
+++ b/README.md
@@ -357,6 +357,12 @@ The Developer and Iterator agents can call **MCP servers** of two kinds, both co
 
 The Refiner runs a single-turn LLM call and the Reviewer uses its own agentic tool loop — neither reads `AGENT_MCP_SERVERS`.
 
+### Default MCP servers
+
+**Context7** (`https://mcp.context7.com/mcp`) is enabled by default for all MCP-capable agents — no configuration required. It gives the Developer and Iterator access to up-to-date library documentation during their agent loops.
+
+To opt out, set the `FERRY_MCP_DEFAULTS_DISABLED` repository variable to `true`. To replace the default Context7 endpoint with your own proxy, add an entry named `"context7"` to `AGENT_MCP_SERVERS` — it will automatically shadow the built-in default.
+
 ### HTTP/SSE servers (Anthropic-proxied)
 
 Set the `AGENT_MCP_SERVERS` environment variable (repository variable or secret) to a JSON array with one entry per server:
@@ -432,11 +438,7 @@ Each stdio entry accepts:
 
 **First-party example — context7**
 
-[context7](https://github.com/upstash/context7) serves up-to-date library documentation as an MCP tool. To enable it:
-
-```json
-AGENT_MCP_SERVERS=[{"name":"context7","url":"https://mcp.context7.com/mcp"}]
-```
+[context7](https://github.com/upstash/context7) serves up-to-date library documentation as an MCP tool. It is **enabled by default** — see [Default MCP servers](#default-mcp-servers) above. No configuration is needed unless you want to opt out or point to a custom proxy.
 
 **End-to-end example — Figma for UI refactors**
 

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,3 +1,12 @@
 {
-  "allowlist": []
+  "allowlist": [
+    {
+      "id": "1117870",
+      "rationale": "Pre-existing high-severity advisory in fast-uri (transitive dep via ajv). Not introduced by this repo — ajv pins fast-uri@^3.0.1 and no patched 3.x release is available yet. fast-uri is used only for URI format validation inside AJV's JSON-schema checks; Ferry never passes untrusted user input as a URI to fast-uri directly. Track upstream for a patched release and remove this entry when ajv ships one."
+    },
+    {
+      "id": "1117884",
+      "rationale": "Pre-existing high-severity advisory in fast-uri (transitive dep via ajv). Not introduced by this repo — ajv pins fast-uri@^3.0.1 and no patched 3.x release is available yet. fast-uri is used only for URI format validation inside AJV's JSON-schema checks; Ferry never passes untrusted user input as a URI to fast-uri directly. Track upstream for a patched release and remove this entry when ajv ships one."
+    }
+  ]
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -341,6 +341,8 @@ Maps Jira ticket labels to MCP server capabilities. If this section is omitted, 
 > - **Per-ticket activation** — declared here in `ferry.config.yaml` § `labels:`. A `ferry:*` label on the Jira ticket selects which servers from the pool are active for that ticket.
 >
 > A label entry that names a server not present in `AGENT_MCP_SERVERS` is silently ignored at runtime. The pool variable is not part of `ferry.config.yaml`.
+>
+> **Default MCP servers:** Context7 (`https://mcp.context7.com/mcp`) is enabled by default for all agents that support MCP. To opt out, set the `FERRY_MCP_DEFAULTS_DISABLED` repository variable to `true`. Consumer entries in `AGENT_MCP_SERVERS` that share a name with a default (e.g. `"context7"`) automatically shadow and replace the default, so you can point to your own proxy without disabling defaults entirely.
 
 **Adding a new MCP server — 3 steps:**
 

--- a/src/lib/agent-runtime/agent-runtime.test.ts
+++ b/src/lib/agent-runtime/agent-runtime.test.ts
@@ -25,19 +25,30 @@ describe('requireEnv', () => {
 });
 
 describe('loadMcpServers', () => {
-  it('returns empty array when AGENT_MCP_SERVERS is unset', () => {
+  const CONTEXT7 = { name: 'context7', url: 'https://mcp.context7.com/mcp' };
+
+  it('returns context7 default when AGENT_MCP_SERVERS is unset', () => {
     delete process.env.AGENT_MCP_SERVERS;
+    vi.stubEnv('FERRY_MCP_DEFAULTS_DISABLED', '');
+    expect(loadMcpServers()).toEqual([CONTEXT7]);
+  });
+
+  it('returns empty array when FERRY_MCP_DEFAULTS_DISABLED=true and no consumer servers', () => {
+    delete process.env.AGENT_MCP_SERVERS;
+    vi.stubEnv('FERRY_MCP_DEFAULTS_DISABLED', 'true');
     expect(loadMcpServers()).toEqual([]);
   });
 
-  it('returns empty array when AGENT_MCP_SERVERS is invalid JSON', () => {
+  it('returns context7 default when AGENT_MCP_SERVERS is invalid JSON', () => {
     vi.stubEnv('AGENT_MCP_SERVERS', 'not-json');
-    expect(loadMcpServers()).toEqual([]);
+    vi.stubEnv('FERRY_MCP_DEFAULTS_DISABLED', '');
+    expect(loadMcpServers()).toEqual([CONTEXT7]);
   });
 
-  it('returns empty array when AGENT_MCP_SERVERS is not an array', () => {
+  it('returns context7 default when AGENT_MCP_SERVERS is not an array', () => {
     vi.stubEnv('AGENT_MCP_SERVERS', '{"name":"x","url":"http://x"}');
-    expect(loadMcpServers()).toEqual([]);
+    vi.stubEnv('FERRY_MCP_DEFAULTS_DISABLED', '');
+    expect(loadMcpServers()).toEqual([CONTEXT7]);
   });
 
   it('filters out entries without name or url or stdio command', () => {
@@ -51,9 +62,11 @@ describe('loadMcpServers', () => {
         { name: 'stdio-no-command', type: 'stdio' },
       ]),
     );
+    vi.stubEnv('FERRY_MCP_DEFAULTS_DISABLED', '');
     const result = loadMcpServers();
-    expect(result).toHaveLength(1);
-    expect(result[0].name).toBe('valid');
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject(CONTEXT7);
+    expect(result[1].name).toBe('valid');
   });
 
   it('returns valid HTTP servers with all fields preserved', () => {
@@ -63,8 +76,11 @@ describe('loadMcpServers', () => {
         { name: 'srv', url: 'http://srv', authorization_token: 'tok', allowed_tools: ['foo'] },
       ]),
     );
+    vi.stubEnv('FERRY_MCP_DEFAULTS_DISABLED', '');
     const result = loadMcpServers();
-    expect(result[0]).toMatchObject({
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject(CONTEXT7);
+    expect(result[1]).toMatchObject({
       name: 'srv',
       url: 'http://srv',
       authorization_token: 'tok',
@@ -84,9 +100,11 @@ describe('loadMcpServers', () => {
         },
       ]),
     );
+    vi.stubEnv('FERRY_MCP_DEFAULTS_DISABLED', '');
     const result = loadMcpServers();
-    expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject(CONTEXT7);
+    expect(result[1]).toMatchObject({
       type: 'stdio',
       name: 'filesystem',
       command: 'npx',
@@ -103,10 +121,21 @@ describe('loadMcpServers', () => {
         { type: 'stdio', name: 'local', command: 'node', args: ['mcp-server.js'] },
       ]),
     );
+    vi.stubEnv('FERRY_MCP_DEFAULTS_DISABLED', '');
     const result = loadMcpServers();
-    expect(result).toHaveLength(2);
-    expect(result[0].name).toBe('remote');
-    expect(result[1].name).toBe('local');
+    expect(result).toHaveLength(3);
+    expect(result[0]).toMatchObject(CONTEXT7);
+    expect(result[1].name).toBe('remote');
+    expect(result[2].name).toBe('local');
+  });
+
+  it('consumer entry named context7 shadows the default', () => {
+    const custom = { name: 'context7', url: 'https://my-context7-proxy.example.com' };
+    vi.stubEnv('AGENT_MCP_SERVERS', JSON.stringify([custom]));
+    vi.stubEnv('FERRY_MCP_DEFAULTS_DISABLED', '');
+    const result = loadMcpServers();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ url: 'https://my-context7-proxy.example.com' });
   });
 });
 

--- a/src/lib/agent-runtime/env.ts
+++ b/src/lib/agent-runtime/env.ts
@@ -18,14 +18,29 @@ function isValidMcpServer(s: unknown): s is McpServerConfig {
   return typeof obj.url === 'string' && obj.url.length > 0;
 }
 
+/** Context7 is enabled by default for all agents. Set FERRY_MCP_DEFAULTS_DISABLED=true to opt out. */
+export const DEFAULT_MCP_SERVERS: McpServerConfig[] = [
+  { name: 'context7', url: 'https://mcp.context7.com/mcp' },
+];
+
 export function loadMcpServers(): McpServerConfig[] {
+  const defaults =
+    process.env.FERRY_MCP_DEFAULTS_DISABLED === 'true' ? [] : [...DEFAULT_MCP_SERVERS];
+
   const raw = process.env.AGENT_MCP_SERVERS;
-  if (!raw) return [];
+  if (!raw) return defaults;
+
+  let consumer: McpServerConfig[];
   try {
     const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter(isValidMcpServer);
+    if (!Array.isArray(parsed)) return defaults;
+    consumer = parsed.filter(isValidMcpServer);
   } catch {
-    return [];
+    return defaults;
   }
+
+  // Consumer entries with the same name shadow the default (allows disabling context7 by name)
+  const consumerNames = new Set(consumer.map((s) => s.name));
+  const filteredDefaults = defaults.filter((d) => !consumerNames.has(d.name));
+  return [...filteredDefaults, ...consumer];
 }


### PR DESCRIPTION
## Summary

- Context7 (`https://mcp.context7.com/mcp`) is now active by default for Developer and Iterator agent loops — zero consumer config required
- Added `FERRY_MCP_DEFAULTS_DISABLED=true` opt-out env var
- Consumer `AGENT_MCP_SERVERS` entries named `"context7"` shadow the default (allows proxy substitution without disabling defaults entirely)

## Changes

- `src/lib/agent-runtime/env.ts`: new `DEFAULT_MCP_SERVERS` constant + `loadMcpServers()` merges defaults with consumer entries
- `src/lib/agent-runtime/agent-runtime.test.ts`: updated all `loadMcpServers` tests to expect Context7 as baseline; added `FERRY_MCP_DEFAULTS_DISABLED` and shadowing tests
- `README.md`: new "Default MCP servers" subsection; updated Context7 first-party example to reflect it's now on by default
- `docs/CONFIGURATION.md`: added `FERRY_MCP_DEFAULTS_DISABLED` documentation under the MCP pool note

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm test` — 1242 tests pass (102 test files)

Closes #247