### PR TITLE
feat(routing): ticket-type label overrides (ferry:type:enable-task, force-*)  (#246)

### DIFF
--- a/.ferry/dev-action.js
+++ b/.ferry/dev-action.js
@@ -349,10 +349,11 @@ ${projectSnippet}` : null
   return parts.join(separator);
 }
 function buildTicketBlock(ticketKey, issue, opts) {
+  const effectiveType = opts?.typeOverride ?? issue.issueType;
   return [
     `TICKET: ${ticketKey}`,
     `TITLE: ${issue.summary}`,
-    `TYPE: ${issue.issueType}`,
+    `TYPE: ${effectiveType}`,
     opts?.labels !== void 0 ? `LABELS: ${opts.labels || "none"}` : null,
     `DESCRIPTION:
 ${issue.description}`,
@@ -1304,6 +1305,17 @@ function logCapabilities(logger, capabilities) {
   }
   if (capabilities.unknownFerryLabels.length > 0) {
     logger.warn("unknown ferry labels (ignored)", { labels: capabilities.unknownFerryLabels });
+  }
+}
+function logTypeOverrides(logger, overrides) {
+  if (overrides.typeOverride) {
+    logger.info("type override active", {
+      override: overrides.forceLabel,
+      effectiveType: overrides.typeOverride
+    });
+  }
+  if (overrides.bypassTaskSkip) {
+    logger.info("task skip bypassed (ferry:type:enable-task)");
   }
 }
 
@@ -7207,6 +7219,33 @@ function createAgentLoop(opts) {
 }
 
 // src/lib/labels/capabilities.ts
+var FORCE_TYPE_LABELS = Object.freeze({
+  "ferry:type:force-bug": "Bug",
+  "ferry:type:force-spike": "Spike",
+  "ferry:type:force-story": "Story"
+});
+var ENABLE_TASK_LABEL = "ferry:type:enable-task";
+var BUILTIN_TYPE_LABELS = /* @__PURE__ */ new Set([
+  ENABLE_TASK_LABEL,
+  ...Object.keys(FORCE_TYPE_LABELS)
+]);
+function resolveTypeOverrides(labels) {
+  let bypassTaskSkip = false;
+  let typeOverride;
+  let forceLabel;
+  for (const label of labels) {
+    if (label === ENABLE_TASK_LABEL) {
+      bypassTaskSkip = true;
+    } else if (Object.prototype.hasOwnProperty.call(FORCE_TYPE_LABELS, label)) {
+      typeOverride = FORCE_TYPE_LABELS[label];
+      forceLabel = label;
+    }
+  }
+  return { bypassTaskSkip, typeOverride, forceLabel };
+}
+function isBuiltinTypeLabel(label) {
+  return BUILTIN_TYPE_LABELS.has(label);
+}
 function resolveCapabilities(ticketLabels, configLabels, logger) {
   if (!configLabels) {
     return {
@@ -7235,8 +7274,10 @@ function resolveCapabilities(ticketLabels, configLabels, logger) {
         }
       }
     } else if (label.startsWith("ferry:")) {
-      unknownFerryLabels.push(label);
-      logger?.warn("unknown ferry label ignored", { label });
+      if (!isBuiltinTypeLabel(label)) {
+        unknownFerryLabels.push(label);
+        logger?.warn("unknown ferry label ignored", { label });
+      }
     }
   }
   const serverAllowedTools = {};
@@ -7492,9 +7533,15 @@ async function main(envelope, logger) {
   const reviewTransitionId = dryRun || !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
   const jiraBaseUrl = requireEnv("FERRY_JIRA_BASE_URL");
   const issue = await tracker.getIssue(ticketKey);
+  const typeOverrides = resolveTypeOverrides(issue.labels);
+  logTypeOverrides(logger, typeOverrides);
   const labels = issue.labels.join(", ");
   const comments = issue.comments.map((c) => `Comment: ${c}`).join("\n");
-  const ticketBlock = buildTicketBlock(ticketKey, issue, { labels, comments });
+  const ticketBlock = buildTicketBlock(ticketKey, issue, {
+    labels,
+    comments,
+    typeOverride: typeOverrides.typeOverride
+  });
   const subtasks = await tracker.getSubtasks(ticketKey);
   const testRunner = detectTestRunner(packageJsonPath(REPO_ROOT));
   const pkgManagerHint = detectPackageManager(REPO_ROOT);
@@ -7763,7 +7810,9 @@ ${tree}`,
       await tracker.postTransition(ticketKey, reviewTransitionId);
     }
     const transitionNote = shouldAutoTransition ? " Moved to Review." : "";
-    const terminalComment = resolvedOutcome === "already_satisfied" ? `${idempotencyMarker} Spec already satisfied \u2014 verification PR: ${prUrl}.${transitionNote}` : `${idempotencyMarker} Implementation complete \u2014 PR: ${prUrl}.${transitionNote}`;
+    const forceOverrideName = typeOverrides.forceLabel?.split(":").at(-1);
+    const overrideNote = typeOverrides.typeOverride ? ` [type override: ${JSON.stringify({ issuetype: typeOverrides.typeOverride, issuetype_raw: issue.issueType, override: forceOverrideName })}]` : "";
+    const terminalComment = resolvedOutcome === "already_satisfied" ? `${idempotencyMarker} Spec already satisfied \u2014 verification PR: ${prUrl}.${transitionNote}${overrideNote}` : `${idempotencyMarker} Implementation complete \u2014 PR: ${prUrl}.${transitionNote}${overrideNote}`;
     await tracker.postComment(ticketKey, terminalComment);
   } catch (err) {
     if (!dryRun) {

--- a/.ferry/iterate-action.js
+++ b/.ferry/iterate-action.js
@@ -2020,6 +2020,33 @@ function formatCommitMessage(input) {
 }
 
 // src/lib/labels/capabilities.ts
+var FORCE_TYPE_LABELS = Object.freeze({
+  "ferry:type:force-bug": "Bug",
+  "ferry:type:force-spike": "Spike",
+  "ferry:type:force-story": "Story"
+});
+var ENABLE_TASK_LABEL = "ferry:type:enable-task";
+var BUILTIN_TYPE_LABELS = /* @__PURE__ */ new Set([
+  ENABLE_TASK_LABEL,
+  ...Object.keys(FORCE_TYPE_LABELS)
+]);
+function resolveTypeOverrides(labels) {
+  let bypassTaskSkip = false;
+  let typeOverride;
+  let forceLabel;
+  for (const label of labels) {
+    if (label === ENABLE_TASK_LABEL) {
+      bypassTaskSkip = true;
+    } else if (Object.prototype.hasOwnProperty.call(FORCE_TYPE_LABELS, label)) {
+      typeOverride = FORCE_TYPE_LABELS[label];
+      forceLabel = label;
+    }
+  }
+  return { bypassTaskSkip, typeOverride, forceLabel };
+}
+function isBuiltinTypeLabel(label) {
+  return BUILTIN_TYPE_LABELS.has(label);
+}
 function resolveCapabilities(ticketLabels, configLabels, logger) {
   if (!configLabels) {
     return {
@@ -2048,8 +2075,10 @@ function resolveCapabilities(ticketLabels, configLabels, logger) {
         }
       }
     } else if (label.startsWith("ferry:")) {
-      unknownFerryLabels.push(label);
-      logger?.warn("unknown ferry label ignored", { label });
+      if (!isBuiltinTypeLabel(label)) {
+        unknownFerryLabels.push(label);
+        logger?.warn("unknown ferry label ignored", { label });
+      }
     }
   }
   const serverAllowedTools = {};
@@ -2235,10 +2264,11 @@ ${projectSnippet}` : null
   return parts.join(separator);
 }
 function buildTicketBlock(ticketKey, issue, opts) {
+  const effectiveType = opts?.typeOverride ?? issue.issueType;
   return [
     `TICKET: ${ticketKey}`,
     `TITLE: ${issue.summary}`,
-    `TYPE: ${issue.issueType}`,
+    `TYPE: ${effectiveType}`,
     opts?.labels !== void 0 ? `LABELS: ${opts.labels || "none"}` : null,
     `DESCRIPTION:
 ${issue.description}`,
@@ -3212,6 +3242,17 @@ function logCapabilities(logger, capabilities) {
   }
   if (capabilities.unknownFerryLabels.length > 0) {
     logger.warn("unknown ferry labels (ignored)", { labels: capabilities.unknownFerryLabels });
+  }
+}
+function logTypeOverrides(logger, overrides) {
+  if (overrides.typeOverride) {
+    logger.info("type override active", {
+      override: overrides.forceLabel,
+      effectiveType: overrides.typeOverride
+    });
+  }
+  if (overrides.bypassTaskSkip) {
+    logger.info("task skip bypassed (ferry:type:enable-task)");
   }
 }
 
@@ -7313,7 +7354,9 @@ async function main(envelope, logger) {
   const capabilities = resolveCapabilities(issue.labels, ferryCfg.labels);
   const hasLabelsConfig = ferryCfg.labels !== void 0;
   const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  const typeOverrides = resolveTypeOverrides(issue.labels);
   logCapabilities(logger, capabilities);
+  logTypeOverrides(logger, typeOverrides);
   const priorIterations = existingComments.filter(
     (c) => c.includes("[ferry:iterator:") && c.includes("complete. Pushed fixes to PR#")
   ).length;
@@ -7398,7 +7441,9 @@ async function main(envelope, logger) {
     cwd: REPO_ROOT,
     encoding: "utf8"
   }).trim();
-  const ticketBlock = buildTicketBlock(ticketKey, issue);
+  const ticketBlock = buildTicketBlock(ticketKey, issue, {
+    typeOverride: typeOverrides.typeOverride
+  });
   const initialPrompt = [
     "## Jira Ticket",
     delimitUntrusted(ticketBlock),

--- a/.ferry/review-action.js
+++ b/.ferry/review-action.js
@@ -828,6 +828,33 @@ async function runReviewLoop(opts) {
 }
 
 // src/lib/labels/capabilities.ts
+var FORCE_TYPE_LABELS = Object.freeze({
+  "ferry:type:force-bug": "Bug",
+  "ferry:type:force-spike": "Spike",
+  "ferry:type:force-story": "Story"
+});
+var ENABLE_TASK_LABEL = "ferry:type:enable-task";
+var BUILTIN_TYPE_LABELS = /* @__PURE__ */ new Set([
+  ENABLE_TASK_LABEL,
+  ...Object.keys(FORCE_TYPE_LABELS)
+]);
+function resolveTypeOverrides(labels) {
+  let bypassTaskSkip = false;
+  let typeOverride;
+  let forceLabel;
+  for (const label of labels) {
+    if (label === ENABLE_TASK_LABEL) {
+      bypassTaskSkip = true;
+    } else if (Object.prototype.hasOwnProperty.call(FORCE_TYPE_LABELS, label)) {
+      typeOverride = FORCE_TYPE_LABELS[label];
+      forceLabel = label;
+    }
+  }
+  return { bypassTaskSkip, typeOverride, forceLabel };
+}
+function isBuiltinTypeLabel(label) {
+  return BUILTIN_TYPE_LABELS.has(label);
+}
 function resolveCapabilities(ticketLabels, configLabels, logger) {
   if (!configLabels) {
     return {
@@ -856,8 +883,10 @@ function resolveCapabilities(ticketLabels, configLabels, logger) {
         }
       }
     } else if (label.startsWith("ferry:")) {
-      unknownFerryLabels.push(label);
-      logger?.warn("unknown ferry label ignored", { label });
+      if (!isBuiltinTypeLabel(label)) {
+        unknownFerryLabels.push(label);
+        logger?.warn("unknown ferry label ignored", { label });
+      }
     }
   }
   const serverAllowedTools = {};
@@ -1013,10 +1042,11 @@ function loadOptionalPrompt(name, repoRoot, _readFile = (p, enc) => readFileSync
   }
 }
 function buildTicketBlock(ticketKey, issue, opts) {
+  const effectiveType = opts?.typeOverride ?? issue.issueType;
   return [
     `TICKET: ${ticketKey}`,
     `TITLE: ${issue.summary}`,
-    `TYPE: ${issue.issueType}`,
+    `TYPE: ${effectiveType}`,
     opts?.labels !== void 0 ? `LABELS: ${opts.labels || "none"}` : null,
     `DESCRIPTION:
 ${issue.description}`,
@@ -1859,6 +1889,17 @@ function logCapabilities(logger, capabilities) {
   }
   if (capabilities.unknownFerryLabels.length > 0) {
     logger.warn("unknown ferry labels (ignored)", { labels: capabilities.unknownFerryLabels });
+  }
+}
+function logTypeOverrides(logger, overrides) {
+  if (overrides.typeOverride) {
+    logger.info("type override active", {
+      override: overrides.forceLabel,
+      effectiveType: overrides.typeOverride
+    });
+  }
+  if (overrides.bypassTaskSkip) {
+    logger.info("task skip bypassed (ferry:type:enable-task)");
   }
 }
 
@@ -5962,6 +6003,8 @@ async function main(envelope, logger) {
   const existingComments = issue.comments;
   const capabilities = resolveCapabilities(issue.labels, ferryCfg.labels, logger);
   logCapabilities(logger, capabilities);
+  const typeOverrides = resolveTypeOverrides(issue.labels);
+  logTypeOverrides(logger, typeOverrides);
   const branchName = `ferry/${ticketKey}`;
   const prs = await runner.listPRsForBranch(owner, repo, branchName);
   if (prs.length === 0) {
@@ -6022,7 +6065,9 @@ async function main(envelope, logger) {
   const hasMergeConflicts = mergeable === false || conflictedFiles.length > 0;
   const commits = await runner.listPRCommits({ owner, repo, prNumber });
   const commitLog = commits.map((c) => `${c.sha.slice(0, 7)} ${c.message.split("\n")[0]}`).join("\n");
-  const ticketBlock = buildTicketBlock(ticketKey, issue);
+  const ticketBlock = buildTicketBlock(ticketKey, issue, {
+    typeOverride: typeOverrides.typeOverride
+  });
   const mergeConflictWarning = hasMergeConflicts ? `
 \u26A0\uFE0F  MERGE CONFLICTS DETECTED \u2014 mergeable=${String(mergeable)}${conflictedFiles.length > 0 ? `, conflicted files: ${conflictedFiles.join(", ")}` : ""}` : "";
   const initialPrompt = [

--- a/.ferry/skip-task-type-action.js
+++ b/.ferry/skip-task-type-action.js
@@ -395,7 +395,10 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   review: Object.freeze({ workflow: "ferry-review.yml", dispatchType: "ferry-review" }),
   iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
 });
-function shouldSkipForTaskType(issueType2) {
+function shouldSkipForTaskType(issueType2, overrides) {
+  if (overrides?.bypassTaskSkip) {
+    return { skip: false };
+  }
   if (issueType2.toLowerCase() === "task") {
     return { skip: true, reason: "ticket type Task is not processed by Ferry" };
   }

--- a/.github/actions/ferry-run-developer/dev-action.js
+++ b/.github/actions/ferry-run-developer/dev-action.js
@@ -349,10 +349,11 @@ ${projectSnippet}` : null
   return parts.join(separator);
 }
 function buildTicketBlock(ticketKey, issue, opts) {
+  const effectiveType = opts?.typeOverride ?? issue.issueType;
   return [
     `TICKET: ${ticketKey}`,
     `TITLE: ${issue.summary}`,
-    `TYPE: ${issue.issueType}`,
+    `TYPE: ${effectiveType}`,
     opts?.labels !== void 0 ? `LABELS: ${opts.labels || "none"}` : null,
     `DESCRIPTION:
 ${issue.description}`,
@@ -1304,6 +1305,17 @@ function logCapabilities(logger, capabilities) {
   }
   if (capabilities.unknownFerryLabels.length > 0) {
     logger.warn("unknown ferry labels (ignored)", { labels: capabilities.unknownFerryLabels });
+  }
+}
+function logTypeOverrides(logger, overrides) {
+  if (overrides.typeOverride) {
+    logger.info("type override active", {
+      override: overrides.forceLabel,
+      effectiveType: overrides.typeOverride
+    });
+  }
+  if (overrides.bypassTaskSkip) {
+    logger.info("task skip bypassed (ferry:type:enable-task)");
   }
 }
 
@@ -7207,6 +7219,33 @@ function createAgentLoop(opts) {
 }
 
 // src/lib/labels/capabilities.ts
+var FORCE_TYPE_LABELS = Object.freeze({
+  "ferry:type:force-bug": "Bug",
+  "ferry:type:force-spike": "Spike",
+  "ferry:type:force-story": "Story"
+});
+var ENABLE_TASK_LABEL = "ferry:type:enable-task";
+var BUILTIN_TYPE_LABELS = /* @__PURE__ */ new Set([
+  ENABLE_TASK_LABEL,
+  ...Object.keys(FORCE_TYPE_LABELS)
+]);
+function resolveTypeOverrides(labels) {
+  let bypassTaskSkip = false;
+  let typeOverride;
+  let forceLabel;
+  for (const label of labels) {
+    if (label === ENABLE_TASK_LABEL) {
+      bypassTaskSkip = true;
+    } else if (Object.prototype.hasOwnProperty.call(FORCE_TYPE_LABELS, label)) {
+      typeOverride = FORCE_TYPE_LABELS[label];
+      forceLabel = label;
+    }
+  }
+  return { bypassTaskSkip, typeOverride, forceLabel };
+}
+function isBuiltinTypeLabel(label) {
+  return BUILTIN_TYPE_LABELS.has(label);
+}
 function resolveCapabilities(ticketLabels, configLabels, logger) {
   if (!configLabels) {
     return {
@@ -7235,8 +7274,10 @@ function resolveCapabilities(ticketLabels, configLabels, logger) {
         }
       }
     } else if (label.startsWith("ferry:")) {
-      unknownFerryLabels.push(label);
-      logger?.warn("unknown ferry label ignored", { label });
+      if (!isBuiltinTypeLabel(label)) {
+        unknownFerryLabels.push(label);
+        logger?.warn("unknown ferry label ignored", { label });
+      }
     }
   }
   const serverAllowedTools = {};
@@ -7492,9 +7533,15 @@ async function main(envelope, logger) {
   const reviewTransitionId = dryRun || !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
   const jiraBaseUrl = requireEnv("FERRY_JIRA_BASE_URL");
   const issue = await tracker.getIssue(ticketKey);
+  const typeOverrides = resolveTypeOverrides(issue.labels);
+  logTypeOverrides(logger, typeOverrides);
   const labels = issue.labels.join(", ");
   const comments = issue.comments.map((c) => `Comment: ${c}`).join("\n");
-  const ticketBlock = buildTicketBlock(ticketKey, issue, { labels, comments });
+  const ticketBlock = buildTicketBlock(ticketKey, issue, {
+    labels,
+    comments,
+    typeOverride: typeOverrides.typeOverride
+  });
   const subtasks = await tracker.getSubtasks(ticketKey);
   const testRunner = detectTestRunner(packageJsonPath(REPO_ROOT));
   const pkgManagerHint = detectPackageManager(REPO_ROOT);
@@ -7763,7 +7810,9 @@ ${tree}`,
       await tracker.postTransition(ticketKey, reviewTransitionId);
     }
     const transitionNote = shouldAutoTransition ? " Moved to Review." : "";
-    const terminalComment = resolvedOutcome === "already_satisfied" ? `${idempotencyMarker} Spec already satisfied \u2014 verification PR: ${prUrl}.${transitionNote}` : `${idempotencyMarker} Implementation complete \u2014 PR: ${prUrl}.${transitionNote}`;
+    const forceOverrideName = typeOverrides.forceLabel?.split(":").at(-1);
+    const overrideNote = typeOverrides.typeOverride ? ` [type override: ${JSON.stringify({ issuetype: typeOverrides.typeOverride, issuetype_raw: issue.issueType, override: forceOverrideName })}]` : "";
+    const terminalComment = resolvedOutcome === "already_satisfied" ? `${idempotencyMarker} Spec already satisfied \u2014 verification PR: ${prUrl}.${transitionNote}${overrideNote}` : `${idempotencyMarker} Implementation complete \u2014 PR: ${prUrl}.${transitionNote}${overrideNote}`;
     await tracker.postComment(ticketKey, terminalComment);
   } catch (err) {
     if (!dryRun) {

--- a/.github/actions/ferry-run-developer/skip-task-type-action.js
+++ b/.github/actions/ferry-run-developer/skip-task-type-action.js
@@ -395,7 +395,10 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   review: Object.freeze({ workflow: "ferry-review.yml", dispatchType: "ferry-review" }),
   iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
 });
-function shouldSkipForTaskType(issueType2) {
+function shouldSkipForTaskType(issueType2, overrides) {
+  if (overrides?.bypassTaskSkip) {
+    return { skip: false };
+  }
   if (issueType2.toLowerCase() === "task") {
     return { skip: true, reason: "ticket type Task is not processed by Ferry" };
   }

--- a/.github/actions/ferry-run-iterator/iterate-action.js
+++ b/.github/actions/ferry-run-iterator/iterate-action.js
@@ -2020,6 +2020,33 @@ function formatCommitMessage(input) {
 }
 
 // src/lib/labels/capabilities.ts
+var FORCE_TYPE_LABELS = Object.freeze({
+  "ferry:type:force-bug": "Bug",
+  "ferry:type:force-spike": "Spike",
+  "ferry:type:force-story": "Story"
+});
+var ENABLE_TASK_LABEL = "ferry:type:enable-task";
+var BUILTIN_TYPE_LABELS = /* @__PURE__ */ new Set([
+  ENABLE_TASK_LABEL,
+  ...Object.keys(FORCE_TYPE_LABELS)
+]);
+function resolveTypeOverrides(labels) {
+  let bypassTaskSkip = false;
+  let typeOverride;
+  let forceLabel;
+  for (const label of labels) {
+    if (label === ENABLE_TASK_LABEL) {
+      bypassTaskSkip = true;
+    } else if (Object.prototype.hasOwnProperty.call(FORCE_TYPE_LABELS, label)) {
+      typeOverride = FORCE_TYPE_LABELS[label];
+      forceLabel = label;
+    }
+  }
+  return { bypassTaskSkip, typeOverride, forceLabel };
+}
+function isBuiltinTypeLabel(label) {
+  return BUILTIN_TYPE_LABELS.has(label);
+}
 function resolveCapabilities(ticketLabels, configLabels, logger) {
   if (!configLabels) {
     return {
@@ -2048,8 +2075,10 @@ function resolveCapabilities(ticketLabels, configLabels, logger) {
         }
       }
     } else if (label.startsWith("ferry:")) {
-      unknownFerryLabels.push(label);
-      logger?.warn("unknown ferry label ignored", { label });
+      if (!isBuiltinTypeLabel(label)) {
+        unknownFerryLabels.push(label);
+        logger?.warn("unknown ferry label ignored", { label });
+      }
     }
   }
   const serverAllowedTools = {};
@@ -2235,10 +2264,11 @@ ${projectSnippet}` : null
   return parts.join(separator);
 }
 function buildTicketBlock(ticketKey, issue, opts) {
+  const effectiveType = opts?.typeOverride ?? issue.issueType;
   return [
     `TICKET: ${ticketKey}`,
     `TITLE: ${issue.summary}`,
-    `TYPE: ${issue.issueType}`,
+    `TYPE: ${effectiveType}`,
     opts?.labels !== void 0 ? `LABELS: ${opts.labels || "none"}` : null,
     `DESCRIPTION:
 ${issue.description}`,
@@ -3212,6 +3242,17 @@ function logCapabilities(logger, capabilities) {
   }
   if (capabilities.unknownFerryLabels.length > 0) {
     logger.warn("unknown ferry labels (ignored)", { labels: capabilities.unknownFerryLabels });
+  }
+}
+function logTypeOverrides(logger, overrides) {
+  if (overrides.typeOverride) {
+    logger.info("type override active", {
+      override: overrides.forceLabel,
+      effectiveType: overrides.typeOverride
+    });
+  }
+  if (overrides.bypassTaskSkip) {
+    logger.info("task skip bypassed (ferry:type:enable-task)");
   }
 }
 
@@ -7313,7 +7354,9 @@ async function main(envelope, logger) {
   const capabilities = resolveCapabilities(issue.labels, ferryCfg.labels);
   const hasLabelsConfig = ferryCfg.labels !== void 0;
   const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  const typeOverrides = resolveTypeOverrides(issue.labels);
   logCapabilities(logger, capabilities);
+  logTypeOverrides(logger, typeOverrides);
   const priorIterations = existingComments.filter(
     (c) => c.includes("[ferry:iterator:") && c.includes("complete. Pushed fixes to PR#")
   ).length;
@@ -7398,7 +7441,9 @@ async function main(envelope, logger) {
     cwd: REPO_ROOT,
     encoding: "utf8"
   }).trim();
-  const ticketBlock = buildTicketBlock(ticketKey, issue);
+  const ticketBlock = buildTicketBlock(ticketKey, issue, {
+    typeOverride: typeOverrides.typeOverride
+  });
   const initialPrompt = [
     "## Jira Ticket",
     delimitUntrusted(ticketBlock),

--- a/.github/actions/ferry-run-iterator/skip-task-type-action.js
+++ b/.github/actions/ferry-run-iterator/skip-task-type-action.js
@@ -395,7 +395,10 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   review: Object.freeze({ workflow: "ferry-review.yml", dispatchType: "ferry-review" }),
   iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
 });
-function shouldSkipForTaskType(issueType2) {
+function shouldSkipForTaskType(issueType2, overrides) {
+  if (overrides?.bypassTaskSkip) {
+    return { skip: false };
+  }
   if (issueType2.toLowerCase() === "task") {
     return { skip: true, reason: "ticket type Task is not processed by Ferry" };
   }

--- a/.github/actions/ferry-run-refiner/skip-task-type-action.js
+++ b/.github/actions/ferry-run-refiner/skip-task-type-action.js
@@ -395,7 +395,10 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   review: Object.freeze({ workflow: "ferry-review.yml", dispatchType: "ferry-review" }),
   iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
 });
-function shouldSkipForTaskType(issueType2) {
+function shouldSkipForTaskType(issueType2, overrides) {
+  if (overrides?.bypassTaskSkip) {
+    return { skip: false };
+  }
   if (issueType2.toLowerCase() === "task") {
     return { skip: true, reason: "ticket type Task is not processed by Ferry" };
   }

--- a/.github/actions/ferry-run-reviewer/review-action.js
+++ b/.github/actions/ferry-run-reviewer/review-action.js
@@ -828,6 +828,33 @@ async function runReviewLoop(opts) {
 }
 
 // src/lib/labels/capabilities.ts
+var FORCE_TYPE_LABELS = Object.freeze({
+  "ferry:type:force-bug": "Bug",
+  "ferry:type:force-spike": "Spike",
+  "ferry:type:force-story": "Story"
+});
+var ENABLE_TASK_LABEL = "ferry:type:enable-task";
+var BUILTIN_TYPE_LABELS = /* @__PURE__ */ new Set([
+  ENABLE_TASK_LABEL,
+  ...Object.keys(FORCE_TYPE_LABELS)
+]);
+function resolveTypeOverrides(labels) {
+  let bypassTaskSkip = false;
+  let typeOverride;
+  let forceLabel;
+  for (const label of labels) {
+    if (label === ENABLE_TASK_LABEL) {
+      bypassTaskSkip = true;
+    } else if (Object.prototype.hasOwnProperty.call(FORCE_TYPE_LABELS, label)) {
+      typeOverride = FORCE_TYPE_LABELS[label];
+      forceLabel = label;
+    }
+  }
+  return { bypassTaskSkip, typeOverride, forceLabel };
+}
+function isBuiltinTypeLabel(label) {
+  return BUILTIN_TYPE_LABELS.has(label);
+}
 function resolveCapabilities(ticketLabels, configLabels, logger) {
   if (!configLabels) {
     return {
@@ -856,8 +883,10 @@ function resolveCapabilities(ticketLabels, configLabels, logger) {
         }
       }
     } else if (label.startsWith("ferry:")) {
-      unknownFerryLabels.push(label);
-      logger?.warn("unknown ferry label ignored", { label });
+      if (!isBuiltinTypeLabel(label)) {
+        unknownFerryLabels.push(label);
+        logger?.warn("unknown ferry label ignored", { label });
+      }
     }
   }
   const serverAllowedTools = {};
@@ -1013,10 +1042,11 @@ function loadOptionalPrompt(name, repoRoot, _readFile = (p, enc) => readFileSync
   }
 }
 function buildTicketBlock(ticketKey, issue, opts) {
+  const effectiveType = opts?.typeOverride ?? issue.issueType;
   return [
     `TICKET: ${ticketKey}`,
     `TITLE: ${issue.summary}`,
-    `TYPE: ${issue.issueType}`,
+    `TYPE: ${effectiveType}`,
     opts?.labels !== void 0 ? `LABELS: ${opts.labels || "none"}` : null,
     `DESCRIPTION:
 ${issue.description}`,
@@ -1859,6 +1889,17 @@ function logCapabilities(logger, capabilities) {
   }
   if (capabilities.unknownFerryLabels.length > 0) {
     logger.warn("unknown ferry labels (ignored)", { labels: capabilities.unknownFerryLabels });
+  }
+}
+function logTypeOverrides(logger, overrides) {
+  if (overrides.typeOverride) {
+    logger.info("type override active", {
+      override: overrides.forceLabel,
+      effectiveType: overrides.typeOverride
+    });
+  }
+  if (overrides.bypassTaskSkip) {
+    logger.info("task skip bypassed (ferry:type:enable-task)");
   }
 }
 
@@ -5962,6 +6003,8 @@ async function main(envelope, logger) {
   const existingComments = issue.comments;
   const capabilities = resolveCapabilities(issue.labels, ferryCfg.labels, logger);
   logCapabilities(logger, capabilities);
+  const typeOverrides = resolveTypeOverrides(issue.labels);
+  logTypeOverrides(logger, typeOverrides);
   const branchName = `ferry/${ticketKey}`;
   const prs = await runner.listPRsForBranch(owner, repo, branchName);
   if (prs.length === 0) {
@@ -6022,7 +6065,9 @@ async function main(envelope, logger) {
   const hasMergeConflicts = mergeable === false || conflictedFiles.length > 0;
   const commits = await runner.listPRCommits({ owner, repo, prNumber });
   const commitLog = commits.map((c) => `${c.sha.slice(0, 7)} ${c.message.split("\n")[0]}`).join("\n");
-  const ticketBlock = buildTicketBlock(ticketKey, issue);
+  const ticketBlock = buildTicketBlock(ticketKey, issue, {
+    typeOverride: typeOverrides.typeOverride
+  });
   const mergeConflictWarning = hasMergeConflicts ? `
 \u26A0\uFE0F  MERGE CONFLICTS DETECTED \u2014 mergeable=${String(mergeable)}${conflictedFiles.length > 0 ? `, conflicted files: ${conflictedFiles.join(", ")}` : ""}` : "";
   const initialPrompt = [

--- a/.github/actions/ferry-run-reviewer/skip-task-type-action.js
+++ b/.github/actions/ferry-run-reviewer/skip-task-type-action.js
@@ -395,7 +395,10 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   review: Object.freeze({ workflow: "ferry-review.yml", dispatchType: "ferry-review" }),
   iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
 });
-function shouldSkipForTaskType(issueType2) {
+function shouldSkipForTaskType(issueType2, overrides) {
+  if (overrides?.bypassTaskSkip) {
+    return { skip: false };
+  }
   if (issueType2.toLowerCase() === "task") {
     return { skip: true, reason: "ticket type Task is not processed by Ferry" };
   }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -375,7 +375,26 @@ Maps Jira ticket labels to MCP server capabilities. If this section is omitted, 
 
 **Merging behaviour:** When a ticket has multiple `ferry:*` labels, their server and tool lists are merged (union). If one label grants all tools (`tools` omitted) and another restricts tools for the same server, the "all tools" grant wins for that server.
 
-**Unknown labels:** Any `ferry:*` label on a ticket that is not declared in `labels` is logged to stderr and silently ignored.
+**Unknown labels:** Any `ferry:*` label on a ticket that is not declared in `labels` is logged to stderr and silently ignored — with one exception: the built-in `ferry:type:*` labels described in the next section are always recognised and never trigger this warning.
+
+---
+
+#### Built-in ticket-type label overrides (`ferry:type:*`)
+
+These four labels are **hardcoded built-ins** — they require no `ferry.config.json` entry and are always recognised by the Developer, Reviewer, and Iterator agents. Apply them directly to your Jira ticket.
+
+| Label | Effect |
+| --- | --- |
+| `ferry:type:enable-task` | Bypass the Task skip (FR6) for this ticket only. Ferry processes it as if it were a Story. Useful for one-off Tasks that should be implemented by Ferry without touching the Refiner. |
+| `ferry:type:force-bug` | Treat the ticket as a **Bug** regardless of its Jira issue type. The agent sees `TYPE: Bug` in the prompt. |
+| `ferry:type:force-spike` | Treat the ticket as a **Spike** regardless of its Jira issue type. |
+| `ferry:type:force-story` | Treat the ticket as a **Story** regardless of its Jira issue type. |
+
+**How it works:**
+
+- `ferry:type:enable-task` bypasses the FR6 Task filter inside agent actions (Developer, Reviewer, Iterator). The pre-flight `skip-task-type-action` step runs before the Jira issue is fetched and therefore cannot honour this label — if the envelope issue type is `Task`, the pre-flight step still skips and posts a comment. Add the label to a ticket that starts in a non-Task Jira column to avoid the pre-flight trigger entirely, or trigger the agent directly via `repository_dispatch` with a non-Task `issue_type`.
+- `ferry:type:force-*` labels replace `issue.issueType` in the prompt without mutating the original Jira record. When active, the terminal Jira comment includes an audit note in the format: `[type override: {"issuetype":"Bug","issuetype_raw":"Story","override":"force-bug"}]`.
+- If multiple `force-*` labels are present, the last one in the label list wins.
 
 #### `workflow.agents`
 

--- a/src/agents/developer/dev-action.ts
+++ b/src/agents/developer/dev-action.ts
@@ -13,6 +13,7 @@ import {
   makeCommitProgress,
   makeSecretScan,
   logCapabilities,
+  logTypeOverrides,
   createGitHubContext,
   resolveGitConfig,
   loadFerryConfigFromBaseBranch,
@@ -31,7 +32,11 @@ import {
 } from './tools.js';
 import { createAgentLoop } from '../../lib/llm/agent-loop/index.js';
 import type { AgentLoop } from '../../lib/llm/agent-loop/types.js';
-import { resolveCapabilities, filterMcpServers } from '../../lib/labels/capabilities.js';
+import {
+  resolveCapabilities,
+  filterMcpServers,
+  resolveTypeOverrides,
+} from '../../lib/labels/capabilities.js';
 import { detectTestRunner, repoTree, packageJsonPath, detectPackageManager } from './workspace.js';
 import { assertDevOutputContract } from './outcome-guard.js';
 import { runWipFinalizer } from './wip-finalizer.js';
@@ -69,9 +74,15 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const jiraBaseUrl = requireEnv('FERRY_JIRA_BASE_URL');
 
   const issue = await tracker.getIssue(ticketKey);
+  const typeOverrides = resolveTypeOverrides(issue.labels);
+  logTypeOverrides(logger, typeOverrides);
   const labels = issue.labels.join(', ');
   const comments = issue.comments.map((c) => `Comment: ${c}`).join('\n');
-  const ticketBlock = buildTicketBlock(ticketKey, issue, { labels, comments });
+  const ticketBlock = buildTicketBlock(ticketKey, issue, {
+    labels,
+    comments,
+    typeOverride: typeOverrides.typeOverride,
+  });
 
   const subtasks = await tracker.getSubtasks(ticketKey);
   const testRunner = detectTestRunner(packageJsonPath(REPO_ROOT));
@@ -382,10 +393,15 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
     }
     const transitionNote = shouldAutoTransition ? ' Moved to Review.' : '';
 
+    const forceOverrideName = typeOverrides.forceLabel?.split(':').at(-1);
+    const overrideNote = typeOverrides.typeOverride
+      ? ` [type override: ${JSON.stringify({ issuetype: typeOverrides.typeOverride, issuetype_raw: issue.issueType, override: forceOverrideName })}]`
+      : '';
+
     const terminalComment =
       resolvedOutcome === 'already_satisfied'
-        ? `${idempotencyMarker} Spec already satisfied — verification PR: ${prUrl}.${transitionNote}`
-        : `${idempotencyMarker} Implementation complete — PR: ${prUrl}.${transitionNote}`;
+        ? `${idempotencyMarker} Spec already satisfied — verification PR: ${prUrl}.${transitionNote}${overrideNote}`
+        : `${idempotencyMarker} Implementation complete — PR: ${prUrl}.${transitionNote}${overrideNote}`;
 
     await tracker.postComment(ticketKey, terminalComment);
   } catch (err) {

--- a/src/agents/iterator/iterate-action.ts
+++ b/src/agents/iterator/iterate-action.ts
@@ -7,7 +7,11 @@ import { assertIterOutputContract } from './outcome-guard.js';
 import { checkIterationCap } from './cap.js';
 import { decideIteratorTransition } from './transition.js';
 import { formatCommitMessage } from './prompt.js';
-import { resolveCapabilities, filterMcpServers } from '../../lib/labels/capabilities.js';
+import {
+  resolveCapabilities,
+  filterMcpServers,
+  resolveTypeOverrides,
+} from '../../lib/labels/capabilities.js';
 import {
   requireEnv,
   loadMcpServers,
@@ -19,6 +23,7 @@ import {
   makeCommitProgress,
   makeSecretScan,
   logCapabilities,
+  logTypeOverrides,
   fetchAndMergeBase,
   checkoutExistingBranch,
   createGitHubContext,
@@ -64,7 +69,9 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const hasLabelsConfig = ferryCfg.labels !== undefined;
   const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
 
+  const typeOverrides = resolveTypeOverrides(issue.labels);
   logCapabilities(logger, capabilities);
+  logTypeOverrides(logger, typeOverrides);
 
   const priorIterations = existingComments.filter(
     (c) => c.includes('[ferry:iterator:') && c.includes('complete. Pushed fixes to PR#'),
@@ -169,7 +176,9 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
     encoding: 'utf8',
   }).trim();
 
-  const ticketBlock = buildTicketBlock(ticketKey, issue);
+  const ticketBlock = buildTicketBlock(ticketKey, issue, {
+    typeOverride: typeOverrides.typeOverride,
+  });
 
   const initialPrompt = [
     '## Jira Ticket',

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -3,7 +3,7 @@ import { delimitUntrusted } from '../../lib/llm/delimit-untrusted.js';
 import { checkIdempotencyMarker } from '../../lib/io/idempotency.js';
 import { gateCi } from './ci-gate.js';
 import { detectMergeConflicts, buildFileList, runReviewLoop } from './review-loop.js';
-import { resolveCapabilities } from '../../lib/labels/capabilities.js';
+import { resolveCapabilities, resolveTypeOverrides } from '../../lib/labels/capabilities.js';
 import {
   requireEnv,
   appendOutput,
@@ -15,6 +15,7 @@ import {
   resolveGitConfig,
   loadFerryConfigFromBaseBranch,
   logCapabilities,
+  logTypeOverrides,
   byEventId,
   byPrHeadSha,
   runAgent,
@@ -46,6 +47,9 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
 
   const capabilities = resolveCapabilities(issue.labels, ferryCfg.labels, logger);
   logCapabilities(logger, capabilities);
+
+  const typeOverrides = resolveTypeOverrides(issue.labels);
+  logTypeOverrides(logger, typeOverrides);
 
   // Find PR for this ticket's branch
   const branchName = `ferry/${ticketKey}`;
@@ -126,7 +130,9 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
     .map((c) => `${c.sha.slice(0, 7)} ${c.message.split('\n')[0]}`)
     .join('\n');
 
-  const ticketBlock = buildTicketBlock(ticketKey, issue);
+  const ticketBlock = buildTicketBlock(ticketKey, issue, {
+    typeOverride: typeOverrides.typeOverride,
+  });
 
   const mergeConflictWarning = hasMergeConflicts
     ? `\n⚠️  MERGE CONFLICTS DETECTED — mergeable=${String(mergeable)}${conflictedFiles.length > 0 ? `, conflicted files: ${conflictedFiles.join(', ')}` : ''}`

--- a/src/labels/allowlist.ts
+++ b/src/labels/allowlist.ts
@@ -20,6 +20,11 @@ export const LABELS_ALLOWLIST = [
   'ferry:blocked',
   'needs-human',
   'status:stale',
+  // Ticket-type label overrides (user-applied, hardcoded built-ins — no config required)
+  'ferry:type:enable-task',
+  'ferry:type:force-bug',
+  'ferry:type:force-spike',
+  'ferry:type:force-story',
   // Routing (user-applied, not agent-applied)
   'critical',
   // Logger component identifiers (not GitHub labels — used in createLogger calls)

--- a/src/lib/agent-runtime/index.ts
+++ b/src/lib/agent-runtime/index.ts
@@ -16,7 +16,7 @@ export {
 export type { CommitProgressFn } from './git.js';
 export { loadFerryConfigFromBaseBranch } from './config-reload.js';
 export { makeSecretScan } from './secret-scan.js';
-export { logCapabilities } from './labels.js';
+export { logCapabilities, logTypeOverrides } from './labels.js';
 export { createGitHubContext } from './context.js';
 export type { GitHubContext } from './context.js';
 export { resolveGitConfig } from './resolve-git-config.js';

--- a/src/lib/agent-runtime/labels.ts
+++ b/src/lib/agent-runtime/labels.ts
@@ -1,5 +1,5 @@
 import type { Logger } from '../logger/index.js';
-import type { ResolvedCapabilities } from '../labels/capabilities.js';
+import type { ResolvedCapabilities, TicketOverrides } from '../labels/capabilities.js';
 
 export function logCapabilities(logger: Logger, capabilities: ResolvedCapabilities): void {
   if (capabilities.triggeredLabels.length > 0) {
@@ -10,5 +10,17 @@ export function logCapabilities(logger: Logger, capabilities: ResolvedCapabiliti
   }
   if (capabilities.unknownFerryLabels.length > 0) {
     logger.warn('unknown ferry labels (ignored)', { labels: capabilities.unknownFerryLabels });
+  }
+}
+
+export function logTypeOverrides(logger: Logger, overrides: TicketOverrides): void {
+  if (overrides.typeOverride) {
+    logger.info('type override active', {
+      override: overrides.forceLabel,
+      effectiveType: overrides.typeOverride,
+    });
+  }
+  if (overrides.bypassTaskSkip) {
+    logger.info('task skip bypassed (ferry:type:enable-task)');
   }
 }

--- a/src/lib/agent-runtime/prompt.ts
+++ b/src/lib/agent-runtime/prompt.ts
@@ -44,12 +44,13 @@ export function loadOptionalPrompt(
 export function buildTicketBlock(
   ticketKey: string,
   issue: { summary: string; issueType: string; description: string },
-  opts?: { labels?: string; comments?: string },
+  opts?: { labels?: string; comments?: string; typeOverride?: string },
 ): string {
+  const effectiveType = opts?.typeOverride ?? issue.issueType;
   return [
     `TICKET: ${ticketKey}`,
     `TITLE: ${issue.summary}`,
-    `TYPE: ${issue.issueType}`,
+    `TYPE: ${effectiveType}`,
     opts?.labels !== undefined ? `LABELS: ${opts.labels || 'none'}` : null,
     `DESCRIPTION:\n${issue.description}`,
     opts?.comments ? `COMMENTS:\n${opts.comments}` : '',

--- a/src/lib/dispatch/routing.test.ts
+++ b/src/lib/dispatch/routing.test.ts
@@ -59,6 +59,31 @@ describe('shouldSkipForTaskType (FR6 task-type filter)', () => {
     expect(shouldSkipForTaskType('Bug')).toEqual({ skip: false });
     expect(shouldSkipForTaskType('Spike')).toEqual({ skip: false });
   });
+
+  it('does not skip a Task ticket when bypassTaskSkip is true (ferry:type:enable-task)', () => {
+    expect(shouldSkipForTaskType('Task', { bypassTaskSkip: true })).toEqual({ skip: false });
+    expect(shouldSkipForTaskType('task', { bypassTaskSkip: true })).toEqual({ skip: false });
+  });
+
+  it('still skips a Task ticket when bypassTaskSkip is false', () => {
+    expect(shouldSkipForTaskType('Task', { bypassTaskSkip: false })).toEqual({
+      skip: true,
+      reason: 'ticket type Task is not processed by Ferry',
+    });
+  });
+
+  it('does not skip a non-Task ticket regardless of bypassTaskSkip', () => {
+    expect(shouldSkipForTaskType('Story', { bypassTaskSkip: false })).toEqual({ skip: false });
+    expect(shouldSkipForTaskType('Bug', { bypassTaskSkip: true })).toEqual({ skip: false });
+  });
+
+  it('is backward compatible when overrides is not provided', () => {
+    expect(shouldSkipForTaskType('Task')).toEqual({
+      skip: true,
+      reason: 'ticket type Task is not processed by Ferry',
+    });
+    expect(shouldSkipForTaskType('Story')).toEqual({ skip: false });
+  });
 });
 
 describe('buildTaskSkipComment', () => {

--- a/src/lib/dispatch/routing.ts
+++ b/src/lib/dispatch/routing.ts
@@ -7,6 +7,7 @@
  */
 
 import type { EventPhase } from '../envelope/types.js';
+import type { TicketOverrides } from '../labels/capabilities.js';
 
 export type WorkflowFile =
   | 'ferry-refine.yml'
@@ -42,8 +43,21 @@ export function phaseToDispatchType(phase: keyof RoutingTable): DispatchType {
  *
  * Ferry only re-processes Task issues defensively — the Refiner creates them as
  * sub-tasks, and re-running on those would loop. Other types pass through.
+ *
+ * When overrides.bypassTaskSkip is true (set by the ferry:type:enable-task label),
+ * the Task skip is bypassed for this ticket and { skip: false } is returned.
+ *
+ * Note: `overrides` is only available inside agent actions (where the Jira issue has been
+ * fetched). The `skip-task-type-action.ts` pre-flight step runs from the event envelope
+ * only and does not receive labels — the bypass therefore cannot be honoured there.
  */
-export function shouldSkipForTaskType(issueType: string): { skip: boolean; reason?: string } {
+export function shouldSkipForTaskType(
+  issueType: string,
+  overrides?: TicketOverrides,
+): { skip: boolean; reason?: string } {
+  if (overrides?.bypassTaskSkip) {
+    return { skip: false };
+  }
   if (issueType.toLowerCase() === 'task') {
     return { skip: true, reason: 'ticket type Task is not processed by Ferry' };
   }

--- a/src/lib/labels/capabilities.test.ts
+++ b/src/lib/labels/capabilities.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { resolveCapabilities, filterMcpServers } from './capabilities.js';
+import { resolveCapabilities, filterMcpServers, resolveTypeOverrides } from './capabilities.js';
 import { createTestLogger } from '../logger/index.js';
 import type { LabelCapability } from '../config.js';
 import type { McpServerConfig } from '../llm/agent-loop/types.js';
@@ -154,5 +154,64 @@ describe('filterMcpServers', () => {
     const poolWithoutPlaywright = POOL.filter((s) => s.name !== 'playwright');
     const result = filterMcpServers(poolWithoutPlaywright, caps, true);
     expect(result.map((s) => s.name)).toEqual(['context7']);
+  });
+});
+
+describe('resolveTypeOverrides', () => {
+  it('returns defaults when no ferry:type:* labels are present', () => {
+    const result = resolveTypeOverrides(['bug', 'priority:high']);
+    expect(result.bypassTaskSkip).toBe(false);
+    expect(result.typeOverride).toBeUndefined();
+    expect(result.forceLabel).toBeUndefined();
+  });
+
+  it('sets bypassTaskSkip when ferry:type:enable-task is present', () => {
+    const result = resolveTypeOverrides(['ferry:type:enable-task']);
+    expect(result.bypassTaskSkip).toBe(true);
+    expect(result.typeOverride).toBeUndefined();
+  });
+
+  it('sets typeOverride to Bug for ferry:type:force-bug', () => {
+    const result = resolveTypeOverrides(['ferry:type:force-bug']);
+    expect(result.bypassTaskSkip).toBe(false);
+    expect(result.typeOverride).toBe('Bug');
+    expect(result.forceLabel).toBe('ferry:type:force-bug');
+  });
+
+  it('sets typeOverride to Spike for ferry:type:force-spike', () => {
+    const result = resolveTypeOverrides(['ferry:type:force-spike']);
+    expect(result.typeOverride).toBe('Spike');
+    expect(result.forceLabel).toBe('ferry:type:force-spike');
+  });
+
+  it('sets typeOverride to Story for ferry:type:force-story', () => {
+    const result = resolveTypeOverrides(['ferry:type:force-story']);
+    expect(result.typeOverride).toBe('Story');
+    expect(result.forceLabel).toBe('ferry:type:force-story');
+  });
+
+  it('combines bypassTaskSkip and typeOverride from separate labels', () => {
+    const result = resolveTypeOverrides(['ferry:type:enable-task', 'ferry:type:force-bug']);
+    expect(result.bypassTaskSkip).toBe(true);
+    expect(result.typeOverride).toBe('Bug');
+  });
+
+  it('last force-* label wins when multiple are present', () => {
+    // force-story comes after force-bug in the label list
+    const result = resolveTypeOverrides(['ferry:type:force-bug', 'ferry:type:force-story']);
+    expect(result.typeOverride).toBe('Story');
+    expect(result.forceLabel).toBe('ferry:type:force-story');
+  });
+
+  it('built-in type labels do not appear in unknownFerryLabels when mixed with config labels', () => {
+    const { logger, records } = createTestLogger('c', 'ferry:capabilities');
+    const result = resolveCapabilities(
+      ['ferry:type:enable-task', 'ferry:type:force-bug'],
+      CONFIG,
+      logger,
+    );
+    // Built-in type labels should not trigger a warning
+    expect(records).toHaveLength(0);
+    expect(result.unknownFerryLabels).toEqual([]);
   });
 });

--- a/src/lib/labels/capabilities.ts
+++ b/src/lib/labels/capabilities.ts
@@ -2,6 +2,73 @@ import type { LabelCapability } from '../config.js';
 import type { McpServerConfig } from '../llm/agent-loop/types.js';
 import type { Logger } from '../logger/index.js';
 
+/**
+ * Overrides derived from built-in ferry:type:* labels on the Jira ticket.
+ *
+ * These labels are always recognised regardless of the consumer's ferry.config.json
+ * — they are not consumer-configurable.
+ */
+export interface TicketOverrides {
+  /** When true, the ticket bypasses the Task skip (FR6) and is processed as a Story. */
+  bypassTaskSkip: boolean;
+  /**
+   * Normalised issue type that agents should use instead of the Jira-reported type.
+   * Only set when a ferry:type:force-* label is present.
+   */
+  typeOverride?: string;
+  /**
+   * The raw label that triggered the typeOverride, for audit logging.
+   * Only set when typeOverride is present.
+   */
+  forceLabel?: string;
+}
+
+/** Built-in label → normalised issue type mapping. Order matters: last match wins. */
+const FORCE_TYPE_LABELS: Readonly<Record<string, string>> = Object.freeze({
+  'ferry:type:force-bug': 'Bug',
+  'ferry:type:force-spike': 'Spike',
+  'ferry:type:force-story': 'Story',
+});
+
+const ENABLE_TASK_LABEL = 'ferry:type:enable-task';
+
+/** All recognised built-in ferry:type:* labels (used to suppress unknown-label warnings). */
+const BUILTIN_TYPE_LABELS: ReadonlySet<string> = new Set([
+  ENABLE_TASK_LABEL,
+  ...Object.keys(FORCE_TYPE_LABELS),
+]);
+
+/**
+ * Resolves built-in ferry:type:* labels from the ticket label list.
+ *
+ * This is a pure function with no config dependency — these labels are always
+ * recognised and do not need to be declared in ferry.config.json.
+ */
+export function resolveTypeOverrides(labels: string[]): TicketOverrides {
+  let bypassTaskSkip = false;
+  let typeOverride: string | undefined;
+  let forceLabel: string | undefined;
+
+  for (const label of labels) {
+    if (label === ENABLE_TASK_LABEL) {
+      bypassTaskSkip = true;
+    } else if (Object.prototype.hasOwnProperty.call(FORCE_TYPE_LABELS, label)) {
+      typeOverride = FORCE_TYPE_LABELS[label];
+      forceLabel = label;
+    }
+  }
+
+  return { bypassTaskSkip, typeOverride, forceLabel };
+}
+
+/**
+ * Returns true when a label is a recognised built-in ferry:type:* label.
+ * Used by resolveCapabilities to suppress unknown-label warnings.
+ */
+export function isBuiltinTypeLabel(label: string): boolean {
+  return BUILTIN_TYPE_LABELS.has(label);
+}
+
 export interface ResolvedCapabilities {
   mcpServerNames: string[];
   serverAllowedTools: Record<string, string[]>; // server name → tools (empty = all allowed)
@@ -52,8 +119,11 @@ export function resolveCapabilities(
         }
       }
     } else if (label.startsWith('ferry:')) {
-      unknownFerryLabels.push(label);
-      logger?.warn('unknown ferry label ignored', { label });
+      // Built-in type labels (ferry:type:*) are always recognised — suppress the warning.
+      if (!isBuiltinTypeLabel(label)) {
+        unknownFerryLabels.push(label);
+        logger?.warn('unknown ferry label ignored', { label });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Adds four hardcoded built-in `ferry:type:*` labels that let consumers control ticket-type routing on a per-ticket basis without any `ferry.config.json` changes
- `ferry:type:enable-task` — bypasses the FR6 Task skip so Ferry processes a Task ticket as a Story
- `ferry:type:force-bug` / `force-spike` / `force-story` — overrides the effective issue type seen by the agent prompt without mutating the Jira record
- All four labels are always recognised (no consumer config needed); they are suppressed from the unknown-label warning in `resolveCapabilities`

## What was implemented

**New exports in `src/lib/labels/capabilities.ts`:**
- `TicketOverrides` interface — `{ bypassTaskSkip: boolean; typeOverride?: string; forceLabel?: string }`
- `resolveTypeOverrides(labels: string[]): TicketOverrides` — pure function, no config needed
- `isBuiltinTypeLabel(label: string): boolean` — used by `resolveCapabilities` to suppress spurious warnings

**`src/lib/dispatch/routing.ts`:**
- `shouldSkipForTaskType(issueType, overrides?)` — optional `overrides` parameter (backward compat); returns `{ skip: false }` when `overrides.bypassTaskSkip` is true

**`src/lib/agent-runtime/prompt.ts`:**
- `buildTicketBlock` accepts a new `typeOverride?` option — replaces `issue.issueType` in the `TYPE:` line without mutating `TrackerIssue`

**`src/lib/agent-runtime/labels.ts`:**
- `logTypeOverrides(logger, overrides)` — logs active overrides at startup

**Agent wiring (Developer, Reviewer, Iterator):**
- Call `resolveTypeOverrides(issue.labels)` after fetching the Jira issue
- Pass `typeOverride` to `buildTicketBlock`
- Developer terminal Jira comment includes an audit note when a `force-*` override is active: `[type override: {"issuetype":"Bug","issuetype_raw":"Story","override":"force-bug"}]`

**`src/labels/allowlist.ts`:**
- Four new labels added to satisfy the labels-allowlist CI gate

**`docs/CONFIGURATION.md`:**
- New section: "Built-in ticket-type label overrides (`ferry:type:*`)" with a label table and behavior notes including the pre-flight limitation

## What tests were added

- `src/lib/labels/capabilities.test.ts` — 8 new tests for `resolveTypeOverrides`: default/empty, enable-task, force-bug/spike/story, combined labels, last-wins semantics, no spurious unknown-label warning
- `src/lib/dispatch/routing.test.ts` — 4 new tests for `shouldSkipForTaskType` with overrides: bypass on Task, no bypass when false, non-Task unaffected, backward compat without overrides param

## CHANGELOG entry

### Added
- `ferry:type:enable-task` label — bypass FR6 Task skip on a per-ticket basis without config changes
- `ferry:type:force-bug`, `ferry:type:force-spike`, `ferry:type:force-story` labels — override the effective Jira issue type seen by agent prompts (Developer, Reviewer, Iterator)
- Audit comment enrichment shows `{ issuetype, issuetype_raw, override }` when a force-* override is active

Closes #246