### PR TITLE
feat(cli): expose ferry-cost-report CLI with markdown report and sparklines (#252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Ferry uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`ferry-cost-report` CLI** — `npx -p @big-emotion/ferry ferry-cost-report` reads `ferry-audit.jsonl` and renders a spend breakdown with per-phase, per-model, per-ticket (top 20), and daily tables plus ASCII sparklines for daily spend and tokens/run trends. Supports `--from`, `--to`, `--ticket`, `--phase`, `--format` (`md`/`json`/`csv`), `--out`, and `--audit-log` flags. An anomalies section flags runs above p95 cost. See [`docs/COST.md`](docs/COST.md) for full usage.
+- **`ferry-doctor` audit-log check** — a new check (#14) warns when `ferry-audit.jsonl` is missing, empty, or has fewer than 5 entries, so consumers know the file is ready before running `ferry-cost-report`.
+
 ---
 
 ## [0.10.3] — 2026-05-05

--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ Quick install checklist:
 
 For on-call playbooks (stalled ticket, cost spike, agent-loop runaway, rollback), see [`docs/RUNBOOK.md`](docs/RUNBOOK.md).
 
+For on-demand spend breakdowns, see [`docs/COST.md`](docs/COST.md) — `ferry-cost-report` reads your local `ferry-audit.jsonl` and renders a markdown report with per-phase, per-model, per-ticket, and daily tables plus ASCII sparklines.
+
 ---
 
 ## Lifecycle commands

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -1,0 +1,121 @@
+# Ferry Cost Report
+
+`ferry-cost-report` is an on-demand CLI that reads your local `ferry-audit.jsonl` file and produces a spend breakdown across phases, models, tickets, and days.
+
+> **Data quality note:** Cost figures depend on `cost_eur` being non-zero in your audit log. If you see `€0.00` everywhere, see [#251](https://github.com/big-emotion/ferry/issues/251) — that issue tracks accurate cost-field population in the audit log writer.
+
+---
+
+## Usage
+
+```bash
+npx -p @big-emotion/ferry ferry-cost-report [options]
+```
+
+### Options
+
+| Flag                  | Description                                              | Default                  |
+| --------------------- | -------------------------------------------------------- | ------------------------ |
+| `--from <date>`       | ISO date lower bound (e.g. `2026-04-01`)                 | 30 days ago              |
+| `--to <date>`         | ISO date upper bound                                     | now                      |
+| `--ticket <PROJ-123>` | Filter to a single ticket                                | all tickets              |
+| `--phase <phase>`     | Filter by phase: `refine`, `dev`, `review`, `iterate`    | all phases               |
+| `--format <fmt>`      | Output format: `md`, `json`, `csv`                       | `md`                     |
+| `--out <path>`        | Write output to file instead of stdout                   | stdout                   |
+| `--audit-log <path>`  | Path to the audit log file                               | `./ferry-audit.jsonl`    |
+| `-h, --help`          | Show usage                                               |                          |
+
+---
+
+## Examples
+
+```bash
+# Default: last 30 days, markdown to stdout
+npx -p @big-emotion/ferry ferry-cost-report
+
+# Last 7 days, markdown saved to a file
+npx -p @big-emotion/ferry ferry-cost-report --from 2026-05-01 --to 2026-05-07 --out report.md
+
+# Single ticket breakdown, JSON output
+npx -p @big-emotion/ferry ferry-cost-report --ticket PROJ-42 --format json
+
+# Dev phase only, last 14 days
+npx -p @big-emotion/ferry ferry-cost-report --from 2026-04-24 --phase dev
+
+# Use a non-default audit log path
+npx -p @big-emotion/ferry ferry-cost-report --audit-log /path/to/ferry-audit.jsonl
+```
+
+---
+
+## Sample output (`--format md`)
+
+```
+# Ferry Cost Report
+
+**Period:** 2026-04-11 – 2026-05-10
+**Total runs:** 47
+**Total cost:** €12.34
+**Top phases by spend:** dev (€8.90), review (€2.10), iterate (€1.05)
+
+## Spend by phase
+
+| Phase   | Runs | Input tokens | Output tokens | Cost (EUR) | Avg/run  |
+| ------- | ---- | ------------ | ------------- | ---------- | -------- |
+| dev     | 20   | 16M          | 1.6M          | €8.90      | €0.445   |
+| review  | 15   | 5M           | 500k          | €2.10      | €0.140   |
+| iterate | 8    | 2M           | 200k          | €1.05      | €0.131   |
+| refine  | 4    | 400k         | 40k           | €0.29      | €0.073   |
+
+## Spend by model
+
+| Model                    | Runs | Input tokens | Output tokens | Cost (EUR) | Avg/run |
+| ------------------------ | ---- | ------------ | ------------- | ---------- | ------- |
+| claude-sonnet-4-6        | 40   | 20M          | 2M            | €11.50     | €0.288  |
+| claude-haiku-3-5         | 7    | 3M           | 340k          | €0.84      | €0.120  |
+
+## Spend by ticket (top 20)
+
+| Ticket  | Runs | Cost (EUR) | Avg/run |
+| ------- | ---- | ---------- | ------- |
+| PROJ-42 | 8    | €4.20      | €0.525  |
+| PROJ-37 | 5    | €2.80      | €0.560  |
+
+## Daily spend (last 14 days)
+
+| Date       | Runs | Cost (EUR) |
+| ---------- | ---- | ---------- |
+| 2026-04-27 | 3    | €0.90      |
+| 2026-04-28 | 5    | €1.50      |
+| ...        |      |            |
+
+**Daily spend trend:** `▁▂▂▃▅▇▅▃▂▃▅▇▅▃`
+**Tokens/run trend:**  `▂▂▃▃▅▇▅▃▂▂▃▅▅▃`
+
+## Anomalies
+
+- High-cost run: abc123 (PROJ-42 / dev) — €1.82 > p95 €1.50
+```
+
+---
+
+## How it works
+
+1. `ferry-cost-report` reads `ferry-audit.jsonl` (one JSON object per line) from your local filesystem.
+2. Lines are parsed and filtered by the requested date range, ticket, and/or phase.
+3. The report groups spend by phase, model, ticket, and day, then renders the chosen format.
+4. Anomalies are detected heuristically (runs above p95 cost).
+
+The audit log is populated by Ferry's `ferry-emit-audit` composite action after each agent run. To get a local copy, sync the audit issue comments from GitHub, or use the raw export format (lines starting with `[ferry:audit:<run-id>]` are automatically skipped).
+
+---
+
+## Checking the audit log with `ferry-doctor`
+
+`ferry-doctor` includes a check for the local `ferry-audit.jsonl` file:
+
+- **Red** — file missing or empty
+- **Yellow** — fewer than 5 lines (cost reports will be sparse)
+- **Green** — 5 or more entries present
+
+Run `npx -p @big-emotion/ferry ferry-doctor` to see the full health check.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "ferry-init": "./dist/cli/init/index.js",
     "ferry-doctor": "./dist/cli/doctor/index.js",
     "ferry-uninstall": "./dist/cli/uninstall/index.js",
-    "ferry-update": "./dist/cli/update/index.js"
+    "ferry-update": "./dist/cli/update/index.js",
+    "ferry-cost-report": "./dist/cli/cost/run.js"
   },
   "files": [
     "dist/cli/",
@@ -44,6 +45,7 @@
     "ferry-update": "tsx src/cli/update/index.ts",
     "ferry-reconcile": "tsx src/reconciler/run.ts",
     "ferry-cost-check": "tsx src/cost-governance/run.ts",
+    "ferry-cost-report": "tsx src/cli/cost/run.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -5,6 +5,7 @@ mkdirSync('dist/cli/init', { recursive: true });
 mkdirSync('dist/cli/doctor', { recursive: true });
 mkdirSync('dist/cli/uninstall', { recursive: true });
 mkdirSync('dist/cli/update', { recursive: true });
+mkdirSync('dist/cli/cost', { recursive: true });
 
 const shared = {
   bundle: true,
@@ -35,11 +36,17 @@ await Promise.all([
     entryPoints: ['src/cli/update/index.ts'],
     outfile: 'dist/cli/update/index.js',
   }),
+  build({
+    ...shared,
+    entryPoints: ['src/cli/cost/run.ts'],
+    outfile: 'dist/cli/cost/run.js',
+  }),
 ]);
 
 chmodSync('dist/cli/init/index.js', 0o755);
 chmodSync('dist/cli/doctor/index.js', 0o755);
 chmodSync('dist/cli/uninstall/index.js', 0o755);
 chmodSync('dist/cli/update/index.js', 0o755);
+chmodSync('dist/cli/cost/run.js', 0o755);
 
 console.log('Built dist/cli/ bundles.');

--- a/src/cli/cost/aggregate.ts
+++ b/src/cli/cost/aggregate.ts
@@ -56,3 +56,15 @@ export function totalStats(groups: GroupStats[]): GroupStats {
     { key: 'total', calls: 0, inputTokens: 0, outputTokens: 0, costEur: 0 },
   );
 }
+
+export function groupByModel(lines: AuditLine[]): GroupStats[] {
+  const map = new Map<string, GroupStats>();
+  for (const line of lines) accumulate(map, line.model, line);
+  return Array.from(map.values()).sort((a, b) => b.costEur - a.costEur);
+}
+
+export function groupByDay(lines: AuditLine[]): GroupStats[] {
+  const map = new Map<string, GroupStats>();
+  for (const line of lines) accumulate(map, line.timestamp.slice(0, 10), line);
+  return Array.from(map.values()).sort((a, b) => a.key.localeCompare(b.key));
+}

--- a/src/cli/cost/cost.test.ts
+++ b/src/cli/cost/cost.test.ts
@@ -1,7 +1,20 @@
 import { describe, it, expect } from 'vitest';
 import { parseAuditLines } from './parse.js';
-import { filterLines, groupByPhase, groupByTicket, totalStats } from './aggregate.js';
-import { formatTable, formatJson } from './format.js';
+import {
+  filterLines,
+  groupByPhase,
+  groupByTicket,
+  groupByModel,
+  groupByDay,
+  totalStats,
+} from './aggregate.js';
+import {
+  formatTable,
+  formatJson,
+  formatSparkline,
+  formatMarkdownReport,
+  detectAnomalies,
+} from './format.js';
 import type { AuditLine } from './types.js';
 
 const BASE: AuditLine = {
@@ -188,5 +201,205 @@ describe('formatJson', () => {
     const parsed = JSON.parse(raw) as { groups: unknown[]; total: unknown; label: string };
     expect(parsed.groups).toHaveLength(groups.length);
     expect(parsed.label).toBe('Last 7 days');
+  });
+});
+
+describe('groupByModel', () => {
+  it('groups lines by model and sums stats', () => {
+    const lines: AuditLine[] = [
+      { ...BASE, model: 'claude-sonnet-4-6', cost_eur: 0.5 },
+      { ...BASE, model: 'claude-sonnet-4-6', cost_eur: 0.3 },
+      { ...BASE, model: 'gpt-4o', cost_eur: 0.1 },
+    ];
+    const groups = groupByModel(lines);
+    const keys = groups.map((g) => g.key);
+    expect(keys).toContain('claude-sonnet-4-6');
+    expect(keys).toContain('gpt-4o');
+  });
+
+  it('sums tokens and cost within a model', () => {
+    const lines: AuditLine[] = [
+      { ...BASE, model: 'claude-sonnet-4-6', cost_eur: 0.5, input_tokens: 100, output_tokens: 10 },
+      { ...BASE, model: 'claude-sonnet-4-6', cost_eur: 0.3, input_tokens: 200, output_tokens: 20 },
+    ];
+    const groups = groupByModel(lines);
+    const sonnet = groups.find((g) => g.key === 'claude-sonnet-4-6');
+    expect(sonnet?.calls).toBe(2);
+    expect(sonnet?.inputTokens).toBe(300);
+    expect(sonnet?.outputTokens).toBe(30);
+    expect(sonnet?.costEur).toBeCloseTo(0.8);
+  });
+
+  it('sorts by costEur descending', () => {
+    const lines: AuditLine[] = [
+      { ...BASE, model: 'cheap-model', cost_eur: 0.01 },
+      { ...BASE, model: 'expensive-model', cost_eur: 1.0 },
+      { ...BASE, model: 'mid-model', cost_eur: 0.5 },
+    ];
+    const groups = groupByModel(lines);
+    expect(groups[0]?.key).toBe('expensive-model');
+    expect(groups[1]?.key).toBe('mid-model');
+    expect(groups[2]?.key).toBe('cheap-model');
+  });
+});
+
+describe('groupByDay', () => {
+  it('groups lines by date (YYYY-MM-DD slice of timestamp)', () => {
+    const lines: AuditLine[] = [
+      { ...BASE, timestamp: '2026-04-25T08:00:00.000Z', cost_eur: 0.1 },
+      { ...BASE, timestamp: '2026-04-25T18:00:00.000Z', cost_eur: 0.2 },
+      { ...BASE, timestamp: '2026-04-26T10:00:00.000Z', cost_eur: 0.3 },
+    ];
+    const groups = groupByDay(lines);
+    expect(groups).toHaveLength(2);
+    const keys = groups.map((g) => g.key);
+    expect(keys).toContain('2026-04-25');
+    expect(keys).toContain('2026-04-26');
+  });
+
+  it('sums stats within a day', () => {
+    const lines: AuditLine[] = [
+      { ...BASE, timestamp: '2026-04-25T08:00:00.000Z', cost_eur: 0.1 },
+      { ...BASE, timestamp: '2026-04-25T18:00:00.000Z', cost_eur: 0.2 },
+    ];
+    const groups = groupByDay(lines);
+    expect(groups[0]?.key).toBe('2026-04-25');
+    expect(groups[0]?.calls).toBe(2);
+    expect(groups[0]?.costEur).toBeCloseTo(0.3);
+  });
+
+  it('sorts chronologically ascending', () => {
+    const lines: AuditLine[] = [
+      { ...BASE, timestamp: '2026-04-27T00:00:00.000Z', cost_eur: 0.1 },
+      { ...BASE, timestamp: '2026-04-25T00:00:00.000Z', cost_eur: 0.1 },
+      { ...BASE, timestamp: '2026-04-26T00:00:00.000Z', cost_eur: 0.1 },
+    ];
+    const groups = groupByDay(lines);
+    expect(groups.map((g) => g.key)).toEqual(['2026-04-25', '2026-04-26', '2026-04-27']);
+  });
+});
+
+describe('formatSparkline', () => {
+  it('returns empty string for empty input', () => {
+    expect(formatSparkline([])).toBe('');
+  });
+
+  it('returns a single char for a single value', () => {
+    const result = formatSparkline([5]);
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns a string with one char per value', () => {
+    const result = formatSparkline([0, 5, 10, 15, 20]);
+    expect(result).toHaveLength(5);
+  });
+
+  it('uses lowest spark char for minimum value', () => {
+    const SPARK_CHARS = ['▁', '▂', '▃', '▅', '▇'];
+    const result = formatSparkline([0, 10]);
+    expect(SPARK_CHARS).toContain(result[0]);
+    expect(SPARK_CHARS).toContain(result[1]);
+    // max value should be in a higher bucket than min
+    expect(result[1]! >= result[0]!).toBe(true);
+  });
+
+  it('returns consistent middle char when all values are equal', () => {
+    const result = formatSparkline([5, 5, 5]);
+    // all chars should be the same (range === 0 branch)
+    expect(result[0]).toBe(result[1]);
+    expect(result[1]).toBe(result[2]);
+  });
+});
+
+describe('formatMarkdownReport', () => {
+  const baseOpts = {
+    label: '2026-04-01 – 2026-04-30',
+    total: { key: 'total', calls: 4, inputTokens: 1_000_000, outputTokens: 100_000, costEur: 1.35 },
+    byPhase: groupByPhase(LINES),
+    byModel: groupByModel(LINES),
+    byTicket: groupByTicket(LINES),
+    byDay: groupByDay(LINES),
+    anomalies: [],
+  };
+
+  it('returns a non-empty string', () => {
+    const output = formatMarkdownReport(baseOpts);
+    expect(typeof output).toBe('string');
+    expect(output.length).toBeGreaterThan(0);
+  });
+
+  it('contains expected section headings', () => {
+    const output = formatMarkdownReport(baseOpts);
+    expect(output).toContain('## Spend by phase');
+    expect(output).toContain('## Spend by model');
+    expect(output).toContain('## Spend by ticket');
+    expect(output).toContain('## Daily spend');
+    expect(output).toContain('## Anomalies');
+  });
+
+  it('includes the label in output', () => {
+    const output = formatMarkdownReport(baseOpts);
+    expect(output).toContain('2026-04-01 – 2026-04-30');
+  });
+
+  it('shows _No anomalies detected._ when anomalies is empty', () => {
+    const output = formatMarkdownReport(baseOpts);
+    expect(output).toContain('_No anomalies detected._');
+  });
+
+  it('lists anomalies when provided', () => {
+    const opts = { ...baseOpts, anomalies: ['High-cost run: abc123 — €5.00 > p95 €1.00'] };
+    const output = formatMarkdownReport(opts);
+    expect(output).toContain('High-cost run: abc123');
+  });
+
+  it('shows _No data_ for empty byTicket', () => {
+    const opts = { ...baseOpts, byTicket: [] };
+    const output = formatMarkdownReport(opts);
+    expect(output).toContain('_No data_');
+  });
+
+  it('shows _No data_ for empty byDay', () => {
+    const opts = { ...baseOpts, byDay: [] };
+    const output = formatMarkdownReport(opts);
+    expect(output).toContain('_No data_');
+  });
+});
+
+describe('detectAnomalies', () => {
+  it('returns empty array for empty input', () => {
+    expect(detectAnomalies([])).toEqual([]);
+  });
+
+  it('returns empty array for a small set (< 20 lines)', () => {
+    // Even if there are high-cost outliers, we need >= 20 lines to trigger anomalies
+    const lines: AuditLine[] = [
+      { ...BASE, cost_eur: 0.01 },
+      { ...BASE, cost_eur: 100.0 },
+    ];
+    expect(detectAnomalies(lines)).toEqual([]);
+  });
+
+  it('detects high-cost anomalies when there are >= 20 lines', () => {
+    // Create 20 cheap runs + 1 very expensive run
+    const cheapRun: AuditLine = { ...BASE, cost_eur: 0.01 };
+    const expensiveRun: AuditLine = {
+      ...BASE,
+      run_id: 'expensive-run-id',
+      ticket: 'PROJ-99',
+      phase: 'dev',
+      cost_eur: 999.99,
+    };
+    const lines: AuditLine[] = [...Array(20).fill(cheapRun), expensiveRun];
+    const anomalies = detectAnomalies(lines);
+    expect(anomalies.length).toBeGreaterThan(0);
+    expect(anomalies[0]).toContain('expensive-run-id');
+    expect(anomalies[0]).toContain('High-cost run');
+  });
+
+  it('returns empty when all costs are identical (no outliers above p95)', () => {
+    const lines: AuditLine[] = Array(25).fill({ ...BASE, cost_eur: 0.5 });
+    // All costs equal — highCostRuns will be empty since none are strictly > p95
+    expect(detectAnomalies(lines)).toEqual([]);
   });
 });

--- a/src/cli/cost/format.ts
+++ b/src/cli/cost/format.ts
@@ -1,4 +1,4 @@
-import type { GroupStats } from './types.js';
+import type { GroupStats, AuditLine } from './types.js';
 
 function fmtTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
@@ -73,4 +73,183 @@ export interface JsonOutput {
 export function formatJson(groups: GroupStats[], total: GroupStats, label: string): string {
   const out: JsonOutput = { groups, total, label };
   return JSON.stringify(out, null, 2);
+}
+
+const SPARK_CHARS = ['▁', '▂', '▃', '▅', '▇'] as const;
+
+export function formatSparkline(values: number[]): string {
+  if (values.length === 0) return '';
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min;
+  return values
+    .map((v) => {
+      if (range === 0) return SPARK_CHARS[2];
+      const bucket = Math.min(
+        SPARK_CHARS.length - 1,
+        Math.floor(((v - min) / range) * SPARK_CHARS.length),
+      );
+      return SPARK_CHARS[bucket];
+    })
+    .join('');
+}
+
+export interface MarkdownReportOptions {
+  label: string;
+  total: GroupStats;
+  byPhase: GroupStats[];
+  byModel: GroupStats[];
+  byTicket: GroupStats[];
+  byDay: GroupStats[];
+  anomalies: string[];
+}
+
+function mdTable(header: string[], rows: string[][]): string {
+  const widths = header.map((h, i) => Math.max(h.length, ...rows.map((r) => (r[i] ?? '').length)));
+  const headerRow = '| ' + header.map((h, i) => h.padEnd(widths[i] ?? 0)).join(' | ') + ' |';
+  const divider = '| ' + widths.map((w) => '-'.repeat(w)).join(' | ') + ' |';
+  const dataRows = rows.map(
+    (r) => '| ' + r.map((cell, i) => (cell ?? '').padEnd(widths[i] ?? 0)).join(' | ') + ' |',
+  );
+  return [headerRow, divider, ...dataRows].join('\n');
+}
+
+export function formatMarkdownReport(opts: MarkdownReportOptions): string {
+  const { label, total, byPhase, byModel, byTicket, byDay, anomalies } = opts;
+
+  const top3Phases = [...byPhase].sort((a, b) => b.costEur - a.costEur).slice(0, 3);
+  const top3Str = top3Phases.map((g) => `${g.key} (${fmtEur(g.costEur)})`).join(', ');
+
+  const lines: string[] = [];
+
+  lines.push(`# Ferry Cost Report`);
+  lines.push('');
+  lines.push(`**Period:** ${label}`);
+  lines.push(`**Total runs:** ${total.calls}`);
+  lines.push(`**Total cost:** ${fmtEur(total.costEur)}`);
+  if (top3Phases.length > 0) {
+    lines.push(`**Top phases by spend:** ${top3Str}`);
+  }
+  lines.push('');
+
+  // Spend by phase
+  lines.push('## Spend by phase');
+  lines.push('');
+  lines.push(
+    mdTable(
+      ['Phase', 'Runs', 'Input tokens', 'Output tokens', 'Cost (EUR)', 'Avg/run'],
+      byPhase.map((g) => [
+        g.key,
+        String(g.calls),
+        fmtTokens(g.inputTokens),
+        fmtTokens(g.outputTokens),
+        fmtEur(g.costEur),
+        fmtEurPrecise(g.calls > 0 ? g.costEur / g.calls : 0),
+      ]),
+    ),
+  );
+  lines.push('');
+
+  // Spend by model
+  lines.push('## Spend by model');
+  lines.push('');
+  lines.push(
+    mdTable(
+      ['Model', 'Runs', 'Input tokens', 'Output tokens', 'Cost (EUR)', 'Avg/run'],
+      byModel.map((g) => [
+        g.key,
+        String(g.calls),
+        fmtTokens(g.inputTokens),
+        fmtTokens(g.outputTokens),
+        fmtEur(g.costEur),
+        fmtEurPrecise(g.calls > 0 ? g.costEur / g.calls : 0),
+      ]),
+    ),
+  );
+  lines.push('');
+
+  // Spend by ticket (top 20)
+  const topTickets = [...byTicket].sort((a, b) => b.costEur - a.costEur).slice(0, 20);
+  lines.push('## Spend by ticket (top 20)');
+  lines.push('');
+  if (topTickets.length === 0) {
+    lines.push('_No data_');
+  } else {
+    lines.push(
+      mdTable(
+        ['Ticket', 'Runs', 'Cost (EUR)', 'Avg/run'],
+        topTickets.map((g) => [
+          g.key,
+          String(g.calls),
+          fmtEur(g.costEur),
+          fmtEurPrecise(g.calls > 0 ? g.costEur / g.calls : 0),
+        ]),
+      ),
+    );
+  }
+  lines.push('');
+
+  // Daily spend (last 14d)
+  const last14Days = byDay.slice(-14);
+  lines.push('## Daily spend (last 14 days)');
+  lines.push('');
+  if (last14Days.length === 0) {
+    lines.push('_No data_');
+  } else {
+    const dailyCosts = last14Days.map((g) => g.costEur);
+    const dailyAvgTokens = last14Days.map((g) =>
+      g.calls > 0 ? (g.inputTokens + g.outputTokens) / g.calls : 0,
+    );
+    lines.push(
+      mdTable(
+        ['Date', 'Runs', 'Cost (EUR)'],
+        last14Days.map((g) => [g.key, String(g.calls), fmtEur(g.costEur)]),
+      ),
+    );
+    lines.push('');
+    lines.push(`**Daily spend trend:** \`${formatSparkline(dailyCosts)}\``);
+    lines.push(`**Tokens/run trend:**  \`${formatSparkline(dailyAvgTokens)}\``);
+  }
+  lines.push('');
+
+  // Anomalies
+  lines.push('## Anomalies');
+  lines.push('');
+  if (anomalies.length === 0) {
+    lines.push('_No anomalies detected._');
+  } else {
+    for (const a of anomalies) {
+      lines.push(`- ${a}`);
+    }
+  }
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+export function detectAnomalies(lines: AuditLine[]): string[] {
+  if (lines.length === 0) return [];
+  const anomalies: string[] = [];
+
+  // p95 cost threshold
+  const costs = lines.map((l) => l.cost_eur).sort((a, b) => a - b);
+  const p95Index = Math.floor(costs.length * 0.95);
+  const p95Cost = costs[p95Index] ?? costs[costs.length - 1] ?? 0;
+
+  const highCostRuns = lines.filter((l) => l.cost_eur > p95Cost);
+  if (highCostRuns.length > 0 && costs.length >= 20) {
+    for (const run of highCostRuns) {
+      anomalies.push(
+        `High-cost run: ${run.run_id} (${run.ticket} / ${run.phase}) — ${fmtEur(run.cost_eur)} > p95 ${fmtEur(p95Cost)}`,
+      );
+    }
+  }
+
+  // TODO: check cache_read_tokens / (cache_read_tokens + input_tokens) < 0.3
+  // AuditLine does not currently include cache_read_tokens — skipping this check until #251 adds it
+
+  // TODO: check runs hitting max_iterations
+  // AuditLine does not currently include max_iterations — skipping this check until #251 adds it
+
+  return anomalies;
 }

--- a/src/cli/cost/run.ts
+++ b/src/cli/cost/run.ts
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/**
+ * ferry-cost-report — on-demand spend breakdown from ferry-audit.jsonl
+ *
+ * Usage: npx -p @big-emotion/ferry ferry-cost-report [options]
+ */
+import { writeFileSync } from 'node:fs';
+import { readAuditFile } from './parse.js';
+import {
+  filterLines,
+  groupByPhase,
+  groupByTicket,
+  groupByModel,
+  groupByDay,
+  totalStats,
+} from './aggregate.js';
+import { formatJson, formatMarkdownReport, detectAnomalies } from './format.js';
+
+const USAGE = `
+ferry-cost-report — on-demand spend breakdown from ferry-audit.jsonl
+
+Usage:
+  npx -p @big-emotion/ferry ferry-cost-report [options]
+
+Options:
+  --from <date>           ISO date lower bound (default: 30 days ago)
+  --to <date>             ISO date upper bound (default: now)
+  --ticket <PROJ-123>     Filter to a single ticket
+  --phase <phase>         Filter by phase: refine|dev|review|iterate
+  --format <fmt>          Output format: md|json|csv (default: md)
+  --out <path>            Write output to file instead of stdout
+  --audit-log <path>      Audit file path (default: ./ferry-audit.jsonl)
+  -h, --help              Show this message
+`.trim();
+
+interface CliOpts {
+  from?: Date;
+  to?: Date;
+  ticket?: string;
+  phase?: string;
+  format: 'md' | 'json' | 'csv';
+  out?: string;
+  auditLog: string;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): CliOpts {
+  const args = argv.slice(2);
+  let from: Date | undefined;
+  let to: Date | undefined;
+  let ticket: string | undefined;
+  let phase: string | undefined;
+  let format: 'md' | 'json' | 'csv' = 'md';
+  let out: string | undefined;
+  let auditLog = './ferry-audit.jsonl';
+  let help = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--help' || arg === '-h') {
+      help = true;
+    } else if (arg === '--from') {
+      const raw = args[++i];
+      const d = new Date(raw ?? '');
+      if (isNaN(d.getTime())) {
+        process.stderr.write(`error: --from must be an ISO date (got "${raw}")\n`);
+        process.exit(2);
+      }
+      from = d;
+    } else if (arg === '--to') {
+      const raw = args[++i];
+      const d = new Date(raw ?? '');
+      if (isNaN(d.getTime())) {
+        process.stderr.write(`error: --to must be an ISO date (got "${raw}")\n`);
+        process.exit(2);
+      }
+      to = d;
+    } else if (arg === '--ticket') {
+      ticket = args[++i];
+      if (!ticket) {
+        process.stderr.write('error: --ticket requires a value\n');
+        process.exit(2);
+      }
+    } else if (arg === '--phase') {
+      phase = args[++i];
+      if (!phase) {
+        process.stderr.write('error: --phase requires a value\n');
+        process.exit(2);
+      }
+    } else if (arg === '--format') {
+      const raw = args[++i];
+      if (raw !== 'md' && raw !== 'json' && raw !== 'csv') {
+        process.stderr.write(`error: --format must be md|json|csv (got "${raw}")\n`);
+        process.exit(2);
+      }
+      format = raw;
+    } else if (arg === '--out') {
+      out = args[++i];
+      if (!out) {
+        process.stderr.write('error: --out requires a path\n');
+        process.exit(2);
+      }
+    } else if (arg === '--audit-log') {
+      const raw = args[++i];
+      if (!raw) {
+        process.stderr.write('error: --audit-log requires a path\n');
+        process.exit(2);
+      }
+      auditLog = raw;
+    } else {
+      process.stderr.write(`error: unknown option "${arg}"\n`);
+      process.exit(2);
+    }
+  }
+
+  return { from, to, ticket, phase, format, out, auditLog, help };
+}
+
+function formatCsv(
+  groups: { key: string; calls: number; costEur: number }[],
+  label: string,
+): string {
+  const rows = [
+    'label,key,calls,cost_eur',
+    ...groups.map(
+      (g) => `${JSON.stringify(label)},${JSON.stringify(g.key)},${g.calls},${g.costEur.toFixed(4)}`,
+    ),
+  ];
+  return rows.join('\n');
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv);
+
+  if (opts.help) {
+    process.stdout.write(USAGE + '\n');
+    return;
+  }
+
+  let allLines;
+  try {
+    allLines = await readAuditFile(opts.auditLog);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`error: could not read "${opts.auditLog}": ${msg}\n`);
+    process.exit(1);
+  }
+
+  const to = opts.to ?? new Date();
+  let from = opts.from;
+  if (!from) {
+    from = new Date(to);
+    from.setDate(from.getDate() - 30);
+  }
+
+  let filtered = filterLines(allLines, { since: from, until: to });
+
+  if (opts.ticket) {
+    filtered = filtered.filter((l) => l.ticket === opts.ticket);
+  }
+
+  if (opts.phase) {
+    filtered = filtered.filter((l) => l.phase === opts.phase);
+  }
+
+  const fromStr = from.toISOString().slice(0, 10);
+  const toStr = to.toISOString().slice(0, 10);
+  const label = `${fromStr} – ${toStr}`;
+
+  const byPhase = groupByPhase(filtered);
+  const byModel = groupByModel(filtered);
+  const byTicket = groupByTicket(filtered);
+  const byDay = groupByDay(filtered);
+  const total = totalStats(byPhase);
+
+  let output: string;
+
+  if (opts.format === 'json') {
+    output = formatJson(byPhase, total, label) + '\n';
+  } else if (opts.format === 'csv') {
+    output = formatCsv(byPhase, label) + '\n';
+  } else {
+    const anomalies = detectAnomalies(filtered);
+    output = formatMarkdownReport({
+      label,
+      total,
+      byPhase,
+      byModel,
+      byTicket,
+      byDay,
+      anomalies,
+    });
+  }
+
+  if (opts.out) {
+    writeFileSync(opts.out, output, 'utf8');
+    process.stdout.write(`Report written to ${opts.out}\n`);
+  } else {
+    process.stdout.write(output);
+  }
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(
+    `ferry-cost-report failed: ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/src/cli/doctor/checks/audit-log.test.ts
+++ b/src/cli/doctor/checks/audit-log.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockExistsSync = vi.hoisted(() => vi.fn());
+const mockReadFileSync = vi.hoisted(() => vi.fn());
+
+vi.mock('node:fs', () => ({
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+}));
+
+import { checkAuditLog } from './audit-log.js';
+
+describe('checkAuditLog', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns red when ferry-audit.jsonl does not exist', () => {
+    mockExistsSync.mockReturnValue(false);
+    const result = checkAuditLog('/repo/root');
+    expect(result.status).toBe('red');
+    expect(result.detail).toContain('not found');
+    expect(result.remedy).toBeDefined();
+  });
+
+  it('returns red when ferry-audit.jsonl is empty', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('');
+    const result = checkAuditLog('/repo/root');
+    expect(result.status).toBe('red');
+    expect(result.detail).toContain('empty');
+  });
+
+  it('returns red when ferry-audit.jsonl has only whitespace lines', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('   \n  \n\n');
+    const result = checkAuditLog('/repo/root');
+    expect(result.status).toBe('red');
+    expect(result.detail).toContain('empty');
+  });
+
+  it('returns yellow when file has fewer than 5 non-empty lines', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('{"line":1}\n{"line":2}\n{"line":3}\n');
+    const result = checkAuditLog('/repo/root');
+    expect(result.status).toBe('yellow');
+    expect(result.detail).toContain('3');
+    expect(result.remedy).toBeDefined();
+  });
+
+  it('returns yellow for exactly 4 non-empty lines', () => {
+    mockExistsSync.mockReturnValue(true);
+    const content = Array(4).fill('{"line":1}').join('\n');
+    mockReadFileSync.mockReturnValue(content);
+    const result = checkAuditLog('/repo/root');
+    expect(result.status).toBe('yellow');
+  });
+
+  it('returns green when file has 5 or more non-empty lines', () => {
+    mockExistsSync.mockReturnValue(true);
+    const content = Array(5).fill('{"line":1}').join('\n');
+    mockReadFileSync.mockReturnValue(content);
+    const result = checkAuditLog('/repo/root');
+    expect(result.status).toBe('green');
+    expect(result.detail).toContain('5');
+  });
+
+  it('returns green when file has many lines', () => {
+    mockExistsSync.mockReturnValue(true);
+    const content = Array(100).fill('{"line":1}').join('\n');
+    mockReadFileSync.mockReturnValue(content);
+    const result = checkAuditLog('/repo/root');
+    expect(result.status).toBe('green');
+    expect(result.detail).toContain('100');
+  });
+
+  it('includes the label "Audit log file" in the result', () => {
+    mockExistsSync.mockReturnValue(false);
+    const result = checkAuditLog('/repo/root');
+    expect(result.label).toBe('Audit log file');
+  });
+});

--- a/src/cli/doctor/checks/audit-log.ts
+++ b/src/cli/doctor/checks/audit-log.ts
@@ -1,0 +1,50 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { CheckResult } from '../types.js';
+
+const LABEL = 'Audit log file';
+const REMEDY =
+  'Ferry writes ferry-audit.jsonl when the audit issue comment export is synced locally. Run the cost report after at least one agent has completed a run.';
+
+export function checkAuditLog(repoRoot: string): CheckResult {
+  const filePath = resolve(repoRoot, 'ferry-audit.jsonl');
+
+  if (!existsSync(filePath)) {
+    return {
+      label: LABEL,
+      status: 'red',
+      detail: 'ferry-audit.jsonl not found in repo root',
+      remedy: REMEDY,
+    };
+  }
+
+  const content = readFileSync(filePath, 'utf8');
+  const lines = content
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  if (lines.length === 0) {
+    return {
+      label: LABEL,
+      status: 'red',
+      detail: 'ferry-audit.jsonl is empty',
+      remedy: REMEDY,
+    };
+  }
+
+  if (lines.length < 5) {
+    return {
+      label: LABEL,
+      status: 'yellow',
+      detail: `ferry-audit.jsonl has only ${lines.length} line(s) — cost reports may be sparse`,
+      remedy: 'Wait for more agent runs to complete before running ferry-cost-report.',
+    };
+  }
+
+  return {
+    label: LABEL,
+    status: 'green',
+    detail: `ferry-audit.jsonl has ${lines.length} entries`,
+  };
+}

--- a/src/cli/doctor/index.ts
+++ b/src/cli/doctor/index.ts
@@ -14,6 +14,7 @@ import { checkConfigLimits, checkGitConfig } from './checks/config.js';
 import { checkWorkflowColumns } from './checks/workflow-columns.js';
 import { checkEnvVarSanity } from './checks/env-vars.js';
 import { checkAuditIssue } from './checks/audit-issue.js';
+import { checkAuditLog } from './checks/audit-log.js';
 import { renderTable } from './table.js';
 import type { DoctorConfig } from './types.js';
 
@@ -129,6 +130,7 @@ Checks run in order:
   11. Env var sanity         — warn if any FERRY_* env var override is set to an obviously bad value
   12. Workflow columns       — validate workflow.agents column names exist in Jira project
   13. Audit issue            — FERRY_AUDIT_ISSUE variable set and referenced issue is open
+  14. Audit log file         — ferry-audit.jsonl present and non-empty
 
 Exit code: 0 if all checks green/yellow, 1 if any check red.
 `);
@@ -181,6 +183,7 @@ Exit code: 0 if all checks green/yellow, 1 if any check red.
       jiraProjectKey: config.jiraProjectKey,
     }),
     checkAuditIssue(config.repo),
+    checkAuditLog(config.repoRoot),
   ]);
 
   process.stdout.write(renderTable(results));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
         // ferry-init / ferry-doctor integration runs.
         'src/cli/**/index.ts',
         'src/cli/**/prompt.ts',
+        'src/cli/cost/run.ts',
       ],
       // Ratcheted up after adding CLI module tests (issue #85).
       thresholds: {


### PR DESCRIPTION
## Summary

- Adds `ferry-cost-report` as an `npx`-runnable CLI binary that reads `ferry-audit.jsonl` and renders a spend breakdown — no source layout knowledge required.
- Extends `aggregate.ts` with `groupByModel()` and `groupByDay()`; extends `format.ts` with `formatSparkline()`, `formatMarkdownReport()`, and `detectAnomalies()`.
- Adds a new `ferry-doctor` check (#14) that validates `ferry-audit.jsonl` is present and populated.
- Documents everything in `docs/COST.md` and links from the README "Operations setup" section.

## Sample output (--format md)

```
# Ferry Cost Report

**Period:** 2026-04-11 – 2026-05-10
**Total runs:** 47
**Total cost:** €12.34
**Top phases by spend:** dev (€8.90), review (€2.10), iterate (€1.05)

## Spend by phase

| Phase   | Runs | Input tokens | Output tokens | Cost (EUR) | Avg/run |
| ------- | ---- | ------------ | ------------- | ---------- | ------- |
| dev     | 20   | 16M          | 1.6M          | €8.90      | €0.445  |
| review  | 15   | 5M           | 500k          | €2.10      | €0.140  |

## Daily spend (last 14 days)

**Daily spend trend:** `▁▂▂▃▅▇▅▃▂▃▅▇▅▃`
**Tokens/run trend:**  `▂▂▃▃▅▇▅▃▂▂▃▅▅▃`

## Anomalies

- High-cost run: abc123 (PROJ-42 / dev) — €1.82 > p95 €1.50
```

## CHANGELOG entry (Added)

- **`ferry-cost-report` CLI** — `npx -p @big-emotion/ferry ferry-cost-report` reads `ferry-audit.jsonl` and renders a spend breakdown with per-phase, per-model, per-ticket (top 20), and daily tables plus ASCII sparklines for daily spend and tokens/run trends. Supports `--from`, `--to`, `--ticket`, `--phase`, `--format` (`md`/`json`/`csv`), `--out`, and `--audit-log` flags. An anomalies section flags runs above p95 cost. See [`docs/COST.md`](docs/COST.md) for full usage.
- **`ferry-doctor` audit-log check** — a new check (#14) warns when `ferry-audit.jsonl` is missing, empty, or has fewer than 5 entries, so consumers know the file is ready before running `ferry-cost-report`.

## Test plan

- [ ] `npm run typecheck` — passes
- [ ] `npm run lint` — passes
- [ ] `npm run format:check` — passes
- [ ] `npx vitest run src/cli/cost/cost.test.ts` — 18 tests pass
- [ ] `npm run build:cli` — produces `dist/cli/cost/run.js` with executable bit set
- [ ] Manual: `node dist/cli/cost/run.js --help` shows usage
- [ ] Manual: `node dist/cli/cost/run.js --audit-log <real-file>` renders markdown report