### PR TITLE
feat(cli): ferry-cost-reconcile — diff Ferry spend vs Anthropic CSV export

### DIFF
--- a/docs/COST.md
+++ b/docs/COST.md
@@ -119,3 +119,50 @@ The audit log is populated by Ferry's `ferry-emit-audit` composite action after 
 - **Green** — 5 or more entries present
 
 Run `npx -p @big-emotion/ferry ferry-doctor` to see the full health check.
+
+---
+
+## Reconciling Ferry spend vs your provider bill (`ferry-cost-reconcile`)
+
+`ferry-cost-reconcile` answers "is Ferry's reported spend close to what Anthropic actually billed me?" by diffing your local `ferry-audit.jsonl` against a provider billing CSV export.
+
+### Getting the Anthropic CSV
+
+In the [Anthropic Console](https://console.anthropic.com) → **Usage** → **Export** (top-right). Select the date range matching your Ferry audit log. The downloaded file has columns: `usage_date_utc`, `model`, `workspace`, `api_key`, `usage_type`, `context_window`, `token_type`, `cost_usd`, `list_price_usd`, `cost_type`, `inference_geo`, `speed`.
+
+### Usage
+
+```bash
+npx -p @big-emotion/ferry ferry-cost-reconcile \
+  --provider anthropic \
+  --provider-csv ./claude_api_cost_2026_05_01_to_2026_05_09.csv \
+  --audit-log ./ferry-audit.jsonl
+```
+
+### Options
+
+| Flag                    | Description                                                   | Default               |
+| ----------------------- | ------------------------------------------------------------- | --------------------- |
+| `--provider <name>`     | Provider to reconcile against (`anthropic` only today)        | (required)            |
+| `--provider-csv <path>` | Path to the billing CSV export                                | (required)            |
+| `--audit-log <path>`    | Ferry audit log path                                          | `./ferry-audit.jsonl` |
+| `--tolerance <0-1>`     | Acceptable relative diff before ⚠️ (e.g. `0.10` = 10%)       | `0.10`                |
+| `--format <md\|json>`   | Output format                                                 | `md`                  |
+| `--out <path>`          | Write output to file instead of stdout                        |                       |
+| `-h, --help`            | Show usage                                                    |                       |
+
+### How reconciliation works
+
+1. **Normalize models** — Anthropic's human-readable names (e.g. `Claude Sonnet 4.6`) are mapped to Ferry's model IDs (e.g. `claude-sonnet-4-6`).
+2. **Aggregate Ferry** — costs are summed per `(date, model)` and converted from EUR to USD using the same pinned rate as `pricing.ts` (1 USD = 0.93 EUR).
+3. **Diff** — for each matched `(date, model)` pair, the absolute relative difference is compared against `--tolerance`.
+4. **Report** — matched rows show ✅ (within tolerance) or ⚠️ (outside). Unmatched provider rows (manual usage, unknown models) and unmatched Ferry rows (test runs, date range gaps) are listed separately.
+
+### Interpreting unmatched rows
+
+- **Provider rows Ferry cannot explain** — usage in the provider CSV with no Ferry audit entry. Common causes: manual API calls in the same workspace, models not yet in the normalization table, or runs that predated the current audit log.
+- **Ferry runs not found in provider CSV** — Ferry audit entries with no provider match. Common causes: date range mismatch between the CSV and the audit log, test/dry runs that did not reach Anthropic, or non-Anthropic provider runs.
+
+### Provider support
+
+Today only `--provider anthropic` is implemented. OpenAI and Google billing exports follow different CSV schemas — follow-up issues will add them.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "ferry-doctor": "./dist/cli/doctor/index.js",
     "ferry-uninstall": "./dist/cli/uninstall/index.js",
     "ferry-update": "./dist/cli/update/index.js",
-    "ferry-cost-report": "./dist/cli/cost/run.js"
+    "ferry-cost-report": "./dist/cli/cost/run.js",
+    "ferry-cost-reconcile": "./dist/cli/cost/reconcile-cmd.js"
   },
   "files": [
     "dist/cli/",
@@ -46,6 +47,7 @@
     "ferry-reconcile": "tsx src/reconciler/run.ts",
     "ferry-cost-check": "tsx src/cost-governance/run.ts",
     "ferry-cost-report": "tsx src/cli/cost/run.ts",
+    "ferry-cost-reconcile": "tsx src/cli/cost/reconcile-cmd.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -41,6 +41,11 @@ await Promise.all([
     entryPoints: ['src/cli/cost/run.ts'],
     outfile: 'dist/cli/cost/run.js',
   }),
+  build({
+    ...shared,
+    entryPoints: ['src/cli/cost/reconcile-cmd.ts'],
+    outfile: 'dist/cli/cost/reconcile-cmd.js',
+  }),
 ]);
 
 chmodSync('dist/cli/init/index.js', 0o755);
@@ -48,5 +53,6 @@ chmodSync('dist/cli/doctor/index.js', 0o755);
 chmodSync('dist/cli/uninstall/index.js', 0o755);
 chmodSync('dist/cli/update/index.js', 0o755);
 chmodSync('dist/cli/cost/run.js', 0o755);
+chmodSync('dist/cli/cost/reconcile-cmd.js', 0o755);
 
 console.log('Built dist/cli/ bundles.');

--- a/src/cli/cost/aggregate.ts
+++ b/src/cli/cost/aggregate.ts
@@ -68,3 +68,13 @@ export function groupByDay(lines: AuditLine[]): GroupStats[] {
   for (const line of lines) accumulate(map, line.timestamp.slice(0, 10), line);
   return Array.from(map.values()).sort((a, b) => a.key.localeCompare(b.key));
 }
+
+/** Groups by ISO date + model ID, key format: "YYYY-MM-DD/model-id". Used by ferry-cost-reconcile. */
+export function groupByDateModel(lines: AuditLine[]): GroupStats[] {
+  const map = new Map<string, GroupStats>();
+  for (const line of lines) {
+    const date = line.timestamp.slice(0, 10);
+    accumulate(map, `${date}/${line.model}`, line);
+  }
+  return Array.from(map.values()).sort((a, b) => a.key.localeCompare(b.key));
+}

--- a/src/cli/cost/reconcile-cmd.ts
+++ b/src/cli/cost/reconcile-cmd.ts
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * ferry-cost-reconcile — diff Ferry-reported spend vs Anthropic CSV export
+ *
+ * Usage: npx -p @big-emotion/ferry ferry-cost-reconcile \
+ *   --provider anthropic \
+ *   --provider-csv ./claude_api_cost_2026_05_01_to_2026_05_09.csv \
+ *   --audit-log ./ferry-audit.jsonl
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { readAuditFile } from './parse.js';
+import { reconcile, formatReconcileReport } from './reconcile.js';
+
+const USAGE = `
+ferry-cost-reconcile — diff Ferry-reported spend vs Anthropic billing CSV
+
+Usage:
+  npx -p @big-emotion/ferry ferry-cost-reconcile [options]
+
+Options:
+  --provider <name>         Provider to reconcile against (only "anthropic" supported today)
+  --provider-csv <path>     Path to the provider billing CSV export
+  --audit-log <path>        Ferry audit log (default: ./ferry-audit.jsonl)
+  --tolerance <0.0-1.0>     Acceptable relative diff (default: 0.10 = 10%)
+  --format <md|json>        Output format (default: md)
+  --out <path>              Write output to file instead of stdout
+  -h, --help                Show this message
+`.trim();
+
+interface CliOpts {
+  provider: string;
+  providerCsv: string;
+  auditLog: string;
+  tolerance: number;
+  format: 'md' | 'json';
+  out?: string;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): CliOpts {
+  const args = argv.slice(2);
+  let provider = '';
+  let providerCsv = '';
+  let auditLog = './ferry-audit.jsonl';
+  let tolerance = 0.1;
+  let format: 'md' | 'json' = 'md';
+  let out: string | undefined;
+  let help = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--help' || arg === '-h') {
+      help = true;
+    } else if (arg === '--provider') {
+      provider = args[++i] ?? '';
+    } else if (arg === '--provider-csv') {
+      providerCsv = args[++i] ?? '';
+      if (!providerCsv) {
+        process.stderr.write('error: --provider-csv requires a path\n');
+        process.exit(2);
+      }
+    } else if (arg === '--audit-log') {
+      const raw = args[++i];
+      if (!raw) {
+        process.stderr.write('error: --audit-log requires a path\n');
+        process.exit(2);
+      }
+      auditLog = raw;
+    } else if (arg === '--tolerance') {
+      const raw = args[++i] ?? '';
+      const n = parseFloat(raw);
+      if (isNaN(n) || n < 0 || n > 1) {
+        process.stderr.write(
+          `error: --tolerance must be a decimal between 0 and 1 (got "${raw}")\n`,
+        );
+        process.exit(2);
+      }
+      tolerance = n;
+    } else if (arg === '--format') {
+      const raw = args[++i];
+      if (raw !== 'md' && raw !== 'json') {
+        process.stderr.write(`error: --format must be md|json (got "${raw}")\n`);
+        process.exit(2);
+      }
+      format = raw;
+    } else if (arg === '--out') {
+      out = args[++i];
+      if (!out) {
+        process.stderr.write('error: --out requires a path\n');
+        process.exit(2);
+      }
+    } else {
+      process.stderr.write(`error: unknown option "${arg}"\n`);
+      process.exit(2);
+    }
+  }
+
+  return { provider, providerCsv, auditLog, tolerance, format, out, help };
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv);
+
+  if (opts.help) {
+    process.stdout.write(USAGE + '\n');
+    return;
+  }
+
+  if (!opts.providerCsv) {
+    process.stderr.write('error: --provider-csv is required\n\n' + USAGE + '\n');
+    process.exit(2);
+  }
+
+  if (opts.provider && opts.provider !== 'anthropic') {
+    process.stderr.write(
+      `error: --provider "${opts.provider}" is not supported yet. Only "anthropic" is implemented.\n`,
+    );
+    process.exit(2);
+  }
+
+  let ferryLines;
+  try {
+    ferryLines = await readAuditFile(opts.auditLog);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`error: could not read audit log "${opts.auditLog}": ${msg}\n`);
+    process.exit(1);
+  }
+
+  let providerCsv: string;
+  try {
+    providerCsv = readFileSync(opts.providerCsv, 'utf8');
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`error: could not read provider CSV "${opts.providerCsv}": ${msg}\n`);
+    process.exit(1);
+  }
+
+  let result;
+  try {
+    result = reconcile(ferryLines, providerCsv, { tolerance: opts.tolerance });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`error: reconciliation failed: ${msg}\n`);
+    process.exit(1);
+  }
+
+  let output: string;
+  if (opts.format === 'json') {
+    output = JSON.stringify(result, null, 2) + '\n';
+  } else {
+    output = formatReconcileReport(result, { tolerance: opts.tolerance });
+  }
+
+  if (opts.out) {
+    writeFileSync(opts.out, output, 'utf8');
+    process.stdout.write(`Report written to ${opts.out}\n`);
+  } else {
+    process.stdout.write(output);
+  }
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(
+    `ferry-cost-reconcile failed: ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/src/cli/cost/reconcile.test.ts
+++ b/src/cli/cost/reconcile.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import { parseAnthropicCsv, reconcile, formatReconcileReport } from './reconcile.js';
+import { groupByDateModel } from './aggregate.js';
+import type { AuditLine } from './types.js';
+
+const makeAuditLine = (overrides: Partial<AuditLine> = {}): AuditLine => ({
+  ticket: 'PROJ-1',
+  phase: 'dev',
+  run_id: 'run-1',
+  model: 'claude-sonnet-4-6',
+  input_tokens: 100_000,
+  output_tokens: 10_000,
+  cost_eur: 0.42,
+  outcome: 'success',
+  duration_ms: 5000,
+  timestamp: '2026-05-01T10:00:00.000Z',
+  ...overrides,
+});
+
+const ANTHROPIC_CSV_HEADER =
+  'usage_date_utc,model,workspace,api_key,usage_type,context_window,token_type,cost_usd,list_price_usd,cost_type,inference_geo,speed';
+
+function makeAnthropicCsv(rows: { date: string; model: string; cost_usd: number }[]): string {
+  const dataRows = rows.map(
+    (r) =>
+      `${r.date},${r.model},my-workspace,key-1,api,200k,input_no_cache,${r.cost_usd},${r.cost_usd},standard,us,standard`,
+  );
+  return [ANTHROPIC_CSV_HEADER, ...dataRows].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// groupByDateModel
+// ---------------------------------------------------------------------------
+
+describe('groupByDateModel', () => {
+  it('groups by date/model key', () => {
+    const lines: AuditLine[] = [
+      makeAuditLine({
+        timestamp: '2026-05-01T10:00:00.000Z',
+        model: 'claude-sonnet-4-6',
+        cost_eur: 0.1,
+      }),
+      makeAuditLine({
+        timestamp: '2026-05-01T12:00:00.000Z',
+        model: 'claude-sonnet-4-6',
+        cost_eur: 0.2,
+      }),
+      makeAuditLine({
+        timestamp: '2026-05-02T10:00:00.000Z',
+        model: 'claude-sonnet-4-6',
+        cost_eur: 0.15,
+      }),
+    ];
+    const groups = groupByDateModel(lines);
+    expect(groups).toHaveLength(2);
+    const may1 = groups.find((g) => g.key === '2026-05-01/claude-sonnet-4-6');
+    expect(may1?.costEur).toBeCloseTo(0.3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseAnthropicCsv
+// ---------------------------------------------------------------------------
+
+describe('parseAnthropicCsv', () => {
+  it('parses valid CSV and maps known model names', () => {
+    const csv = makeAnthropicCsv([
+      { date: '2026-05-01', model: 'Claude Sonnet 4.6', cost_usd: 0.45 },
+    ]);
+    const rows = parseAnthropicCsv(csv);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.ferryModelId).toBe('claude-sonnet-4-6');
+    expect(rows[0]?.costUsd).toBeCloseTo(0.45);
+  });
+
+  it('aggregates multiple rows for the same date/model', () => {
+    const csv = makeAnthropicCsv([
+      { date: '2026-05-01', model: 'Claude Sonnet 4.6', cost_usd: 0.2 },
+      { date: '2026-05-01', model: 'Claude Sonnet 4.6', cost_usd: 0.25 },
+    ]);
+    const rows = parseAnthropicCsv(csv);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.costUsd).toBeCloseTo(0.45);
+  });
+
+  it('marks unknown model names with null ferryModelId', () => {
+    const csv = makeAnthropicCsv([
+      { date: '2026-05-01', model: 'Claude Mysterious 9.9', cost_usd: 1.0 },
+    ]);
+    const rows = parseAnthropicCsv(csv);
+    expect(rows[0]?.ferryModelId).toBeNull();
+  });
+
+  it('throws on missing required columns', () => {
+    expect(() => parseAnthropicCsv('foo,bar\n1,2')).toThrow('missing required columns');
+  });
+
+  it('returns empty array for empty or header-only CSV', () => {
+    expect(parseAnthropicCsv('')).toEqual([]);
+    expect(parseAnthropicCsv(ANTHROPIC_CSV_HEADER)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reconcile
+// ---------------------------------------------------------------------------
+
+describe('reconcile', () => {
+  it('matches Ferry and provider rows within tolerance', () => {
+    // Ferry: 0.42 EUR on 2026-05-01 with claude-sonnet-4-6
+    // Provider: 0.45 USD on same day (close to 0.42/0.93 ≈ 0.4516 USD → within 10%)
+    const ferryLines: AuditLine[] = [
+      makeAuditLine({ timestamp: '2026-05-01T10:00:00.000Z', cost_eur: 0.42 }),
+    ];
+    const csv = makeAnthropicCsv([
+      { date: '2026-05-01', model: 'Claude Sonnet 4.6', cost_usd: 0.45 },
+    ]);
+    const result = reconcile(ferryLines, csv, { tolerance: 0.1 });
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]?.withinTolerance).toBe(true);
+    expect(result.unmatchedProvider).toHaveLength(0);
+    expect(result.unmatchedFerry).toHaveLength(0);
+  });
+
+  it('flags rows outside tolerance', () => {
+    const ferryLines: AuditLine[] = [
+      makeAuditLine({ timestamp: '2026-05-01T10:00:00.000Z', cost_eur: 0.1 }),
+    ];
+    const csv = makeAnthropicCsv([
+      { date: '2026-05-01', model: 'Claude Sonnet 4.6', cost_usd: 0.5 },
+    ]);
+    const result = reconcile(ferryLines, csv, { tolerance: 0.1 });
+    expect(result.rows[0]?.withinTolerance).toBe(false);
+  });
+
+  it('classifies provider rows with unknown model as unmatchedProvider', () => {
+    const ferryLines: AuditLine[] = [];
+    const csv = makeAnthropicCsv([
+      { date: '2026-05-01', model: 'Claude Mysterious 9.9', cost_usd: 1.0 },
+    ]);
+    const result = reconcile(ferryLines, csv, {});
+    expect(result.unmatchedProvider).toHaveLength(1);
+    expect(result.rows).toHaveLength(0);
+  });
+
+  it('classifies Ferry runs with no provider match as unmatchedFerry', () => {
+    const ferryLines: AuditLine[] = [
+      makeAuditLine({ timestamp: '2026-05-03T10:00:00.000Z', cost_eur: 0.3 }),
+    ];
+    // Provider CSV only covers 2026-05-01
+    const csv = makeAnthropicCsv([
+      { date: '2026-05-01', model: 'Claude Sonnet 4.6', cost_usd: 0.45 },
+    ]);
+    const result = reconcile(ferryLines, csv, {});
+    expect(result.unmatchedFerry).toHaveLength(1);
+    expect(result.unmatchedFerry[0]?.date).toBe('2026-05-03');
+  });
+
+  it('computes coverage as ferry / provider ratio', () => {
+    const ferryLines: AuditLine[] = [
+      makeAuditLine({ timestamp: '2026-05-01T10:00:00.000Z', cost_eur: 0.42 }),
+    ];
+    const csv = makeAnthropicCsv([
+      { date: '2026-05-01', model: 'Claude Sonnet 4.6', cost_usd: 0.451 },
+    ]);
+    const result = reconcile(ferryLines, csv, {});
+    // ferryUsd ≈ 0.42 / 0.93 ≈ 0.4516; providerUsd = 0.451
+    expect(result.coverage).toBeGreaterThan(0.9);
+    expect(result.coverage).toBeLessThan(1.1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatReconcileReport
+// ---------------------------------------------------------------------------
+
+describe('formatReconcileReport', () => {
+  it('renders a markdown table with within-tolerance and out-of-tolerance rows', () => {
+    const result = reconcile(
+      [
+        makeAuditLine({ timestamp: '2026-05-01T10:00:00.000Z', cost_eur: 0.42 }),
+        makeAuditLine({ timestamp: '2026-05-02T10:00:00.000Z', cost_eur: 0.1 }),
+      ],
+      makeAnthropicCsv([
+        { date: '2026-05-01', model: 'Claude Sonnet 4.6', cost_usd: 0.45 },
+        { date: '2026-05-02', model: 'Claude Sonnet 4.6', cost_usd: 0.5 },
+      ]),
+      { tolerance: 0.1 },
+    );
+    const report = formatReconcileReport(result, { tolerance: 0.1 });
+    expect(report).toContain('# Ferry Cost Reconciliation');
+    expect(report).toContain('✅');
+    expect(report).toContain('⚠️');
+    expect(report).toContain('Per-day × model');
+  });
+
+  it('includes unmatched sections when present', () => {
+    const result = reconcile(
+      [makeAuditLine({ timestamp: '2026-05-03T10:00:00.000Z', cost_eur: 0.2 })],
+      makeAnthropicCsv([{ date: '2026-05-01', model: 'Claude Mysterious 9.9', cost_usd: 1.0 }]),
+      {},
+    );
+    const report = formatReconcileReport(result, { tolerance: 0.1 });
+    expect(report).toContain('Provider rows Ferry cannot explain');
+    expect(report).toContain('Ferry runs not found in provider CSV');
+  });
+});

--- a/src/cli/cost/reconcile.ts
+++ b/src/cli/cost/reconcile.ts
@@ -1,0 +1,228 @@
+import type { AuditLine } from './types.js';
+import { groupByDateModel } from './aggregate.js';
+
+// 1 USD = 0.93 EUR (same pinned rate as pricing.ts)
+const USD_TO_EUR = 0.93;
+const EUR_TO_USD = 1 / USD_TO_EUR;
+
+// Anthropic CSV human-readable model name → Ferry model ID
+const ANTHROPIC_MODEL_MAP: Record<string, string> = {
+  'Claude Opus 4.5': 'claude-opus-4-5',
+  'Claude Opus 4.7': 'claude-opus-4-7',
+  'Claude Sonnet 4.5': 'claude-sonnet-4-5',
+  'Claude Sonnet 4.6': 'claude-sonnet-4-6',
+  'Claude Haiku 4.5': 'claude-haiku-4-5',
+  'Claude Haiku 4.5 (20251001)': 'claude-haiku-4-5-20251001',
+};
+
+export interface ProviderRow {
+  date: string;
+  model: string;
+  ferryModelId: string | null;
+  costUsd: number;
+}
+
+export interface ReconcileRow {
+  date: string;
+  model: string;
+  ferryUsd: number;
+  providerUsd: number;
+  diffUsd: number;
+  diffPct: number;
+  withinTolerance: boolean;
+}
+
+export interface ReconcileResult {
+  rows: ReconcileRow[];
+  unmatchedProvider: ProviderRow[];
+  unmatchedFerry: { date: string; model: string; ferryUsd: number }[];
+  totalFerryUsd: number;
+  totalProviderUsd: number;
+  coverage: number;
+}
+
+function normalizeCsvField(s: string): string {
+  return s.replace(/^"|"$/g, '').trim();
+}
+
+function parseAnthropicCsvRow(headers: string[], fields: string[]): Record<string, string> {
+  const row: Record<string, string> = {};
+  for (let i = 0; i < headers.length; i++) {
+    row[headers[i]!] = normalizeCsvField(fields[i] ?? '');
+  }
+  return row;
+}
+
+export function parseAnthropicCsv(csv: string): ProviderRow[] {
+  const lines = csv.split('\n').filter((l) => l.trim().length > 0);
+  if (lines.length < 2) return [];
+
+  const headers = (lines[0] ?? '').split(',').map((h) => normalizeCsvField(h).toLowerCase());
+
+  const dateIdx = headers.indexOf('usage_date_utc');
+  const modelIdx = headers.indexOf('model');
+  const costIdx = headers.indexOf('cost_usd');
+
+  if (dateIdx === -1 || modelIdx === -1 || costIdx === -1) {
+    throw new Error(
+      'Anthropic CSV missing required columns: usage_date_utc, model, cost_usd. ' +
+        `Found: ${headers.join(', ')}`,
+    );
+  }
+
+  // Aggregate cost_usd per (date, model)
+  const map = new Map<string, ProviderRow>();
+  for (const line of lines.slice(1)) {
+    const fields = line.split(',');
+    const row = parseAnthropicCsvRow(headers, fields);
+    const date = (row['usage_date_utc'] ?? '').slice(0, 10);
+    const rawModel = row['model'] ?? '';
+    const cost = parseFloat(row['cost_usd'] ?? '0');
+    if (!date || !rawModel || isNaN(cost)) continue;
+
+    const ferryModelId = ANTHROPIC_MODEL_MAP[rawModel] ?? null;
+    const key = `${date}/${rawModel}`;
+    const existing = map.get(key);
+    if (existing) {
+      existing.costUsd += cost;
+    } else {
+      map.set(key, { date, model: rawModel, ferryModelId, costUsd: cost });
+    }
+  }
+
+  return Array.from(map.values()).sort((a, b) =>
+    `${a.date}/${a.model}`.localeCompare(`${b.date}/${b.model}`),
+  );
+}
+
+export function reconcile(
+  ferryLines: AuditLine[],
+  providerCsv: string,
+  opts: { tolerance?: number } = {},
+): ReconcileResult {
+  const tolerance = opts.tolerance ?? 0.1;
+
+  const ferryGroups = groupByDateModel(ferryLines);
+  const ferryByKey = new Map<string, number>();
+  for (const g of ferryGroups) {
+    const [date, ...modelParts] = g.key.split('/');
+    const model = modelParts.join('/');
+    ferryByKey.set(`${date ?? ''}/${model}`, g.costEur * EUR_TO_USD);
+  }
+
+  const providerRows = parseAnthropicCsv(providerCsv);
+  const providerByFerryKey = new Map<string, number>();
+  const unmatchedProvider: ProviderRow[] = [];
+
+  for (const p of providerRows) {
+    if (!p.ferryModelId) {
+      unmatchedProvider.push(p);
+      continue;
+    }
+    const key = `${p.date}/${p.ferryModelId}`;
+    providerByFerryKey.set(key, (providerByFerryKey.get(key) ?? 0) + p.costUsd);
+  }
+
+  const rows: ReconcileRow[] = [];
+  const matchedFerryKeys = new Set<string>();
+
+  for (const [key, providerUsd] of providerByFerryKey) {
+    const ferryUsd = ferryByKey.get(key) ?? 0;
+    const diffUsd = ferryUsd - providerUsd;
+    const diffPct = providerUsd > 0 ? Math.abs(diffUsd) / providerUsd : 0;
+    const [date, ...modelParts] = key.split('/');
+    rows.push({
+      date: date ?? '',
+      model: modelParts.join('/'),
+      ferryUsd,
+      providerUsd,
+      diffUsd,
+      diffPct,
+      withinTolerance: diffPct <= tolerance,
+    });
+    matchedFerryKeys.add(key);
+  }
+
+  const unmatchedFerry: { date: string; model: string; ferryUsd: number }[] = [];
+  for (const [key, ferryUsd] of ferryByKey) {
+    if (!matchedFerryKeys.has(key) && ferryUsd > 0) {
+      const [date, ...modelParts] = key.split('/');
+      unmatchedFerry.push({ date: date ?? '', model: modelParts.join('/'), ferryUsd });
+    }
+  }
+
+  rows.sort((a, b) => `${a.date}/${a.model}`.localeCompare(`${b.date}/${b.model}`));
+  unmatchedFerry.sort((a, b) => `${a.date}/${a.model}`.localeCompare(`${b.date}/${b.model}`));
+
+  const totalFerryUsd = rows.reduce((s, r) => s + r.ferryUsd, 0);
+  const totalProviderUsd = rows.reduce((s, r) => s + r.providerUsd, 0);
+  const coverage = totalProviderUsd > 0 ? totalFerryUsd / totalProviderUsd : 0;
+
+  return { rows, unmatchedProvider, unmatchedFerry, totalFerryUsd, totalProviderUsd, coverage };
+}
+
+export function formatReconcileReport(
+  result: ReconcileResult,
+  opts: { tolerance: number },
+): string {
+  const pct = (n: number) => `${(n * 100).toFixed(1)}%`;
+  const usd = (n: number) => `$${n.toFixed(4)}`;
+  const sign = (n: number) => (n >= 0 ? '+' : '') + usd(n);
+
+  const lines: string[] = [];
+  lines.push('# Ferry Cost Reconciliation');
+  lines.push('');
+  lines.push(`**Tolerance:** ${pct(opts.tolerance)}`);
+  lines.push(
+    `**Ferry total (converted to USD):** ${usd(result.totalFerryUsd)}  ` +
+      `**Provider total:** ${usd(result.totalProviderUsd)}`,
+  );
+  lines.push(`**Coverage:** ${pct(result.coverage)} of provider spend explained by Ferry`);
+  lines.push('');
+
+  if (result.rows.length > 0) {
+    lines.push('## Per-day × model');
+    lines.push('');
+    lines.push('| Date | Model | Ferry USD | Provider USD | Diff USD | Diff % | Status |');
+    lines.push('| ---- | ----- | --------- | ------------ | -------- | ------ | ------ |');
+    for (const r of result.rows) {
+      const status = r.withinTolerance ? '✅' : '⚠️';
+      lines.push(
+        `| ${r.date} | ${r.model} | ${usd(r.ferryUsd)} | ${usd(r.providerUsd)} | ${sign(r.diffUsd)} | ${pct(r.diffPct)} | ${status} |`,
+      );
+    }
+    lines.push('');
+  }
+
+  if (result.unmatchedProvider.length > 0) {
+    lines.push('## Provider rows Ferry cannot explain');
+    lines.push('');
+    lines.push(
+      '_These dates/models appear in the provider CSV but have no matching Ferry audit entry — likely manual API usage or a model not yet in the normalization table._',
+    );
+    lines.push('');
+    lines.push('| Date | Provider Model | Cost USD |');
+    lines.push('| ---- | -------------- | -------- |');
+    for (const p of result.unmatchedProvider) {
+      lines.push(`| ${p.date} | ${p.model} | ${usd(p.costUsd)} |`);
+    }
+    lines.push('');
+  }
+
+  if (result.unmatchedFerry.length > 0) {
+    lines.push('## Ferry runs not found in provider CSV');
+    lines.push('');
+    lines.push(
+      '_These Ferry audit entries have no matching provider row — possibly test runs, runs against a non-Anthropic provider, or date range mismatch._',
+    );
+    lines.push('');
+    lines.push('| Date | Model | Ferry USD |');
+    lines.push('| ---- | ----- | --------- |');
+    for (const f of result.unmatchedFerry) {
+      lines.push(`| ${f.date} | ${f.model} | ${usd(f.ferryUsd)} |`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary

- New `ferry-cost-reconcile` CLI: diffs `ferry-audit.jsonl` against an Anthropic billing CSV export and produces a per-day × model reconciliation report
- `--tolerance` (default 10%) marks rows ✅ within band or ⚠️ outside
- Unmatched provider rows (manual API calls, unknown models) and unmatched Ferry rows (test runs, date gaps) reported in separate sections
- Model normalization table: Anthropic human-readable names (`Claude Sonnet 4.6`) → Ferry model IDs (`claude-sonnet-4-6`)
- EUR→USD conversion uses the same 0.93 pinned rate as `pricing.ts`
- `groupByDateModel()` added to `aggregate.ts` (key format: `YYYY-MM-DD/model-id`)
- `docs/COST.md` extended with reconcile section including the exact command for your CSV at `/Users/jnk/Downloads/claude_api_cost_*.csv`

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm test` — 1312 tests pass (105 test files)
- [x] 13 new unit tests: CSV parsing, model normalization, within/outside tolerance, unmatched rows, coverage ratio, markdown report rendering

Closes #253