### PR TITLE
feat(cli): ferry-cost-advice — ranked cost optimisation recommendations (#254)

### DIFF
--- a/docs/COST.md
+++ b/docs/COST.md
@@ -166,3 +166,46 @@ npx -p @big-emotion/ferry ferry-cost-reconcile \
 ### Provider support
 
 Today only `--provider anthropic` is implemented. OpenAI and Google billing exports follow different CSV schemas — follow-up issues will add them.
+
+---
+
+## Cost optimisation recommendations (`ferry-cost-advice`)
+
+`ferry-cost-advice` reads your `ferry-audit.jsonl` and surfaces ranked, actionable findings to lower spend.
+
+### Usage
+
+```bash
+npx -p @big-emotion/ferry ferry-cost-advice [options]
+```
+
+### Options
+
+| Flag                 | Description                                       | Default               |
+| -------------------- | ------------------------------------------------- | --------------------- |
+| `--audit-log <path>` | Ferry audit log path                              | `./ferry-audit.jsonl` |
+| `--from <date>`      | ISO date lower bound                              | 30 days ago           |
+| `--to <date>`        | ISO date upper bound                              | now                   |
+| `--severity <level>` | Minimum severity: `info` or `warn`                | `info`                |
+| `--format <md\|json>`| Output format                                     | `md`                  |
+| `--out <path>`       | Write output to file instead of stdout            |                       |
+| `-h, --help`         | Show usage                                        |                       |
+
+The CLI always exits 0, even when findings are present — use it in CI without breaking builds.
+
+### Built-in heuristics
+
+| ID | Signal | Severity | Source issue |
+| -- | ------ | -------- | ------------ |
+| `low-cache-hit` | `cache_read / total_input < 30%` per phase | warn | [#176](https://github.com/big-emotion/ferry/issues/176) |
+| `iterator-cap` | >30% of iterate tickets have ≥3 runs (cap hit) | warn | [#168](https://github.com/big-emotion/ferry/issues/168), [#187](https://github.com/big-emotion/ferry/issues/187) |
+| `refiner-input-heavy` | Refiner avg input > 50k tokens | warn | [#178](https://github.com/big-emotion/ferry/issues/178), [#182](https://github.com/big-emotion/ferry/issues/182), [#185](https://github.com/big-emotion/ferry/issues/185) |
+| `cost-outlier` | Ticket above p90 and >3× median spend | warn | — |
+| `provider-phase-mismatch` | Opus used for Refiner phase (Sonnet is sufficient) | info | [#142](https://github.com/big-emotion/ferry/issues/142) |
+| `high-output-ratio` | Dev/iterate output tokens >15% of total | info | RTK insight |
+
+Each finding includes: severity, evidence (run IDs / tickets), estimated EUR saving per month, and an action with file/config reference.
+
+### Claude Code skill
+
+The skill ships alongside Ferry in `.claude/skills/ferry-cost-advice/`. Install it by registering the skill in your Claude Code configuration, then invoke it with `/ferry-cost-advice` for an interactive session that runs the CLI and guides you through each fix.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "ferry-uninstall": "./dist/cli/uninstall/index.js",
     "ferry-update": "./dist/cli/update/index.js",
     "ferry-cost-report": "./dist/cli/cost/run.js",
-    "ferry-cost-reconcile": "./dist/cli/cost/reconcile-cmd.js"
+    "ferry-cost-reconcile": "./dist/cli/cost/reconcile-cmd.js",
+    "ferry-cost-advice": "./dist/cli/cost/advice-cmd.js"
   },
   "files": [
     "dist/cli/",
@@ -48,6 +49,7 @@
     "ferry-cost-check": "tsx src/cost-governance/run.ts",
     "ferry-cost-report": "tsx src/cli/cost/run.ts",
     "ferry-cost-reconcile": "tsx src/cli/cost/reconcile-cmd.ts",
+    "ferry-cost-advice": "tsx src/cli/cost/advice-cmd.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -46,6 +46,11 @@ await Promise.all([
     entryPoints: ['src/cli/cost/reconcile-cmd.ts'],
     outfile: 'dist/cli/cost/reconcile-cmd.js',
   }),
+  build({
+    ...shared,
+    entryPoints: ['src/cli/cost/advice-cmd.ts'],
+    outfile: 'dist/cli/cost/advice-cmd.js',
+  }),
 ]);
 
 chmodSync('dist/cli/init/index.js', 0o755);
@@ -54,5 +59,6 @@ chmodSync('dist/cli/uninstall/index.js', 0o755);
 chmodSync('dist/cli/update/index.js', 0o755);
 chmodSync('dist/cli/cost/run.js', 0o755);
 chmodSync('dist/cli/cost/reconcile-cmd.js', 0o755);
+chmodSync('dist/cli/cost/advice-cmd.js', 0o755);
 
 console.log('Built dist/cli/ bundles.');

--- a/src/cli/cost/advice-cmd.ts
+++ b/src/cli/cost/advice-cmd.ts
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * ferry-cost-advice — actionable cost optimisation recommendations from ferry-audit.jsonl
+ *
+ * Usage: npx -p @big-emotion/ferry ferry-cost-advice [options]
+ */
+import { writeFileSync } from 'node:fs';
+import { readAuditFile } from './parse.js';
+import { analyseAuditLog, formatAdviceReport } from './advice.js';
+import type { Severity } from './advice.js';
+
+const USAGE = `
+ferry-cost-advice — actionable cost optimisation recommendations
+
+Usage:
+  npx -p @big-emotion/ferry ferry-cost-advice [options]
+
+Options:
+  --audit-log <path>      Ferry audit log path (default: ./ferry-audit.jsonl)
+  --from <date>           ISO date lower bound (default: 30 days ago)
+  --to <date>             ISO date upper bound (default: now)
+  --severity <info|warn>  Minimum severity to include (default: info)
+  --format <md|json>      Output format (default: md)
+  --out <path>            Write output to file instead of stdout
+  -h, --help              Show this message
+`.trim();
+
+interface CliOpts {
+  auditLog: string;
+  from?: Date;
+  to?: Date;
+  severity: Severity;
+  format: 'md' | 'json';
+  out?: string;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): CliOpts {
+  const args = argv.slice(2);
+  let auditLog = './ferry-audit.jsonl';
+  let from: Date | undefined;
+  let to: Date | undefined;
+  let severity: Severity = 'info';
+  let format: 'md' | 'json' = 'md';
+  let out: string | undefined;
+  let help = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--help' || arg === '-h') {
+      help = true;
+    } else if (arg === '--audit-log') {
+      const raw = args[++i];
+      if (!raw) {
+        process.stderr.write('error: --audit-log requires a path\n');
+        process.exit(2);
+      }
+      auditLog = raw;
+    } else if (arg === '--from') {
+      const raw = args[++i];
+      const d = new Date(raw ?? '');
+      if (isNaN(d.getTime())) {
+        process.stderr.write(`error: --from must be an ISO date (got "${raw}")\n`);
+        process.exit(2);
+      }
+      from = d;
+    } else if (arg === '--to') {
+      const raw = args[++i];
+      const d = new Date(raw ?? '');
+      if (isNaN(d.getTime())) {
+        process.stderr.write(`error: --to must be an ISO date (got "${raw}")\n`);
+        process.exit(2);
+      }
+      to = d;
+    } else if (arg === '--severity') {
+      const raw = args[++i];
+      if (raw !== 'info' && raw !== 'warn') {
+        process.stderr.write(`error: --severity must be info|warn (got "${raw}")\n`);
+        process.exit(2);
+      }
+      severity = raw;
+    } else if (arg === '--format') {
+      const raw = args[++i];
+      if (raw !== 'md' && raw !== 'json') {
+        process.stderr.write(`error: --format must be md|json (got "${raw}")\n`);
+        process.exit(2);
+      }
+      format = raw;
+    } else if (arg === '--out') {
+      out = args[++i];
+      if (!out) {
+        process.stderr.write('error: --out requires a path\n');
+        process.exit(2);
+      }
+    } else {
+      process.stderr.write(`error: unknown option "${arg}"\n`);
+      process.exit(2);
+    }
+  }
+
+  return { auditLog, from, to, severity, format, out, help };
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv);
+
+  if (opts.help) {
+    process.stdout.write(USAGE + '\n');
+    return;
+  }
+
+  let allLines;
+  try {
+    allLines = await readAuditFile(opts.auditLog);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`error: could not read audit log "${opts.auditLog}": ${msg}\n`);
+    process.exit(1);
+  }
+
+  const to = opts.to ?? new Date();
+  let from = opts.from;
+  if (!from) {
+    from = new Date(to);
+    from.setDate(from.getDate() - 30);
+  }
+
+  const result = analyseAuditLog(allLines, { since: from, until: to, severity: opts.severity });
+
+  let output: string;
+  if (opts.format === 'json') {
+    output = JSON.stringify(result, null, 2) + '\n';
+  } else {
+    output = formatAdviceReport(result);
+  }
+
+  if (opts.out) {
+    writeFileSync(opts.out, output, 'utf8');
+    process.stdout.write(`Report written to ${opts.out}\n`);
+  } else {
+    process.stdout.write(output);
+  }
+  // exits 0 even with findings — warnings, not failures
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(
+    `ferry-cost-advice failed: ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/src/cli/cost/advice.test.ts
+++ b/src/cli/cost/advice.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect } from 'vitest';
+import { analyseAuditLog, formatAdviceReport } from './advice.js';
+import type { AuditLine } from './types.js';
+
+const BASE: AuditLine = {
+  ticket: 'PROJ-1',
+  phase: 'dev',
+  run_id: 'run-1',
+  model: 'claude-sonnet-4-6',
+  input_tokens: 50_000,
+  output_tokens: 5_000,
+  cost_eur: 0.2,
+  outcome: 'success',
+  duration_ms: 5000,
+  timestamp: '2026-05-01T10:00:00.000Z',
+};
+
+function makeLine(overrides: Partial<AuditLine> = {}): AuditLine {
+  return { ...BASE, ...overrides };
+}
+
+// Minimal fixture with enough runs to trigger heuristics
+function makeLines(n: number, overrides: Partial<AuditLine> = {}): AuditLine[] {
+  return Array.from({ length: n }, (_, i) =>
+    makeLine({ ...overrides, run_id: `run-${i}`, ticket: `PROJ-${i + 1}` }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic 1 — low cache hit rate
+// ---------------------------------------------------------------------------
+
+describe('heuristic: low-cache-hit', () => {
+  it('fires when cache_read / total_input < 0.3 for a phase with ≥5 runs', () => {
+    const lines = makeLines(6, {
+      cache_read_input_tokens: 5_000,
+      input_tokens: 100_000,
+    });
+    const result = analyseAuditLog(lines);
+    const finding = result.findings.find((f) => f.id === 'low-cache-hit');
+    expect(finding).toBeDefined();
+    expect(finding?.severity).toBe('warn');
+  });
+
+  it('does not fire when cache hit rate ≥ 0.3', () => {
+    const lines = makeLines(6, {
+      cache_read_input_tokens: 40_000,
+      input_tokens: 100_000,
+    });
+    const result = analyseAuditLog(lines);
+    expect(result.findings.find((f) => f.id === 'low-cache-hit')).toBeUndefined();
+  });
+
+  it('does not fire when cache_read_input_tokens is absent (pre-v0.11 logs)', () => {
+    const lines = makeLines(6);
+    const result = analyseAuditLog(lines);
+    expect(result.findings.find((f) => f.id === 'low-cache-hit')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Heuristic 2 — iterator cap
+// ---------------------------------------------------------------------------
+
+describe('heuristic: iterator-cap', () => {
+  it('fires when >30% of iterate tickets have ≥3 runs', () => {
+    const lines = [
+      // Ticket A: 3 iterate runs → likely capped
+      makeLine({ phase: 'iterate', ticket: 'PROJ-1', run_id: 'r1' }),
+      makeLine({ phase: 'iterate', ticket: 'PROJ-1', run_id: 'r2' }),
+      makeLine({ phase: 'iterate', ticket: 'PROJ-1', run_id: 'r3' }),
+      // Ticket B: 1 iterate run → not capped
+      makeLine({ phase: 'iterate', ticket: 'PROJ-2', run_id: 'r4' }),
+    ];
+    const result = analyseAuditLog(lines);
+    const finding = result.findings.find((f) => f.id === 'iterator-cap');
+    expect(finding).toBeDefined();
+  });
+
+  it('does not fire when no iterate runs exist', () => {
+    const lines = makeLines(5, { phase: 'dev' });
+    const result = analyseAuditLog(lines);
+    expect(result.findings.find((f) => f.id === 'iterator-cap')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Heuristic 3 — refiner input heavy
+// ---------------------------------------------------------------------------
+
+describe('heuristic: refiner-input-heavy', () => {
+  it('fires when average Refiner input > 50k with ≥3 runs', () => {
+    const lines = makeLines(4, { phase: 'refine', input_tokens: 80_000 });
+    const result = analyseAuditLog(lines);
+    expect(result.findings.find((f) => f.id === 'refiner-input-heavy')).toBeDefined();
+  });
+
+  it('does not fire when average Refiner input ≤ 50k', () => {
+    const lines = makeLines(4, { phase: 'refine', input_tokens: 30_000 });
+    const result = analyseAuditLog(lines);
+    expect(result.findings.find((f) => f.id === 'refiner-input-heavy')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Heuristic 4 — cost outlier tickets
+// ---------------------------------------------------------------------------
+
+describe('heuristic: cost-outlier', () => {
+  it('fires when a ticket is >3× median and above p95', () => {
+    const base = makeLines(10, { cost_eur: 0.1 });
+    const outlier = makeLine({ ticket: 'PROJ-99', cost_eur: 5.0, run_id: 'r-outlier' });
+    const lines = [...base, outlier];
+    const result = analyseAuditLog(lines);
+    const finding = result.findings.find((f) => f.id === 'cost-outlier');
+    expect(finding).toBeDefined();
+    expect(finding?.evidence.some((e) => e.includes('PROJ-99'))).toBe(true);
+  });
+
+  it('does not fire with fewer than 5 distinct tickets', () => {
+    const lines = makeLines(4, { cost_eur: 0.1 });
+    const result = analyseAuditLog(lines);
+    expect(result.findings.find((f) => f.id === 'cost-outlier')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Heuristic 5 — provider/phase mismatch
+// ---------------------------------------------------------------------------
+
+describe('heuristic: provider-phase-mismatch', () => {
+  it('fires when ≥50% of Refiner runs use Opus', () => {
+    const lines = [
+      makeLine({ phase: 'refine', model: 'claude-opus-4-7', run_id: 'r1', ticket: 'PROJ-1' }),
+      makeLine({ phase: 'refine', model: 'claude-opus-4-7', run_id: 'r2', ticket: 'PROJ-2' }),
+      makeLine({ phase: 'refine', model: 'claude-sonnet-4-6', run_id: 'r3', ticket: 'PROJ-3' }),
+    ];
+    const result = analyseAuditLog(lines);
+    expect(result.findings.find((f) => f.id === 'provider-phase-mismatch')).toBeDefined();
+  });
+
+  it('does not fire when Refiner uses Sonnet', () => {
+    const lines = makeLines(3, { phase: 'refine', model: 'claude-sonnet-4-6' });
+    const result = analyseAuditLog(lines);
+    expect(result.findings.find((f) => f.id === 'provider-phase-mismatch')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Heuristic 6 — high output ratio
+// ---------------------------------------------------------------------------
+
+describe('heuristic: high-output-ratio', () => {
+  it('fires when >30% of dev/iterate runs have output ratio >15%', () => {
+    // output_tokens / (input + output) = 20_000 / 70_000 ≈ 28.6%
+    const lines = makeLines(6, {
+      phase: 'dev',
+      input_tokens: 50_000,
+      output_tokens: 20_000,
+    });
+    const result = analyseAuditLog(lines);
+    expect(result.findings.find((f) => f.id === 'high-output-ratio')).toBeDefined();
+  });
+
+  it('does not fire when output ratio is within threshold', () => {
+    // output / (input + output) = 5_000 / 55_000 ≈ 9%
+    const lines = makeLines(6, {
+      phase: 'dev',
+      input_tokens: 50_000,
+      output_tokens: 5_000,
+    });
+    const result = analyseAuditLog(lines);
+    expect(result.findings.find((f) => f.id === 'high-output-ratio')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// analyseAuditLog — severity filter and sorting
+// ---------------------------------------------------------------------------
+
+describe('analyseAuditLog', () => {
+  it('filters out info-level findings when severity=warn', () => {
+    // Trigger provider-phase-mismatch (info) + refiner-input-heavy (warn)
+    const lines = [
+      makeLine({
+        phase: 'refine',
+        model: 'claude-opus-4-7',
+        input_tokens: 80_000,
+        run_id: 'r1',
+        ticket: 'P-1',
+      }),
+      makeLine({
+        phase: 'refine',
+        model: 'claude-opus-4-7',
+        input_tokens: 80_000,
+        run_id: 'r2',
+        ticket: 'P-2',
+      }),
+      makeLine({
+        phase: 'refine',
+        model: 'claude-opus-4-7',
+        input_tokens: 80_000,
+        run_id: 'r3',
+        ticket: 'P-3',
+      }),
+    ];
+    const result = analyseAuditLog(lines, { severity: 'warn' });
+    expect(result.findings.every((f) => f.severity === 'warn')).toBe(true);
+  });
+
+  it('reports analysedRuns count and dateRange', () => {
+    const lines = [
+      makeLine({ timestamp: '2026-05-01T10:00:00.000Z', run_id: 'r1', ticket: 'P-1' }),
+      makeLine({ timestamp: '2026-05-05T10:00:00.000Z', run_id: 'r2', ticket: 'P-2' }),
+    ];
+    const result = analyseAuditLog(lines);
+    expect(result.analysedRuns).toBe(2);
+    expect(result.dateRange.from).toBe('2026-05-01');
+    expect(result.dateRange.to).toBe('2026-05-05');
+  });
+
+  it('returns no findings for an empty audit log', () => {
+    const result = analyseAuditLog([]);
+    expect(result.findings).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatAdviceReport
+// ---------------------------------------------------------------------------
+
+describe('formatAdviceReport', () => {
+  it('renders no-findings message when advice list is empty', () => {
+    const report = formatAdviceReport({
+      findings: [],
+      analysedRuns: 0,
+      dateRange: { from: '', to: '' },
+    });
+    expect(report).toContain('No actionable findings');
+  });
+
+  it('includes ⚠️ for warn and ℹ️ for info findings', () => {
+    const lines = [
+      // Trigger refiner-input-heavy (warn)
+      makeLine({ phase: 'refine', input_tokens: 80_000, run_id: 'r1', ticket: 'P-1' }),
+      makeLine({ phase: 'refine', input_tokens: 80_000, run_id: 'r2', ticket: 'P-2' }),
+      makeLine({ phase: 'refine', input_tokens: 80_000, run_id: 'r3', ticket: 'P-3' }),
+      // Trigger provider-phase-mismatch (info)
+      makeLine({
+        phase: 'refine',
+        model: 'claude-opus-4-7',
+        input_tokens: 80_000,
+        run_id: 'r4',
+        ticket: 'P-4',
+      }),
+    ];
+    const result = analyseAuditLog(lines);
+    const report = formatAdviceReport(result);
+    expect(report).toContain('⚠️');
+  });
+});

--- a/src/cli/cost/advice.ts
+++ b/src/cli/cost/advice.ts
@@ -1,0 +1,330 @@
+import type { AuditLine } from './types.js';
+import { filterLines, groupByTicket } from './aggregate.js';
+
+export type Severity = 'info' | 'warn';
+
+export interface Finding {
+  id: string;
+  severity: Severity;
+  title: string;
+  detail: string;
+  evidence: string[];
+  estimatedSavingEurPerMonth: number;
+  action: string;
+}
+
+export interface AdviceResult {
+  findings: Finding[];
+  analysedRuns: number;
+  dateRange: { from: string; to: string };
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic 1 — low cache hit rate (requires audit logs from Ferry ≥ v0.11)
+// Ref: #176
+// ---------------------------------------------------------------------------
+
+function heuristicLowCacheHit(lines: AuditLine[]): Finding | null {
+  const withCache = lines.filter((l) => l.cache_read_input_tokens !== undefined);
+  if (withCache.length < 5) return null;
+
+  const byPhase = new Map<string, { cacheRead: number; totalInput: number }>();
+  for (const l of withCache) {
+    const cacheRead = l.cache_read_input_tokens ?? 0;
+    const totalInput = l.input_tokens;
+    const existing = byPhase.get(l.phase);
+    if (existing) {
+      existing.cacheRead += cacheRead;
+      existing.totalInput += totalInput;
+    } else {
+      byPhase.set(l.phase, { cacheRead, totalInput });
+    }
+  }
+
+  const lowPhases: string[] = [];
+  for (const [phase, stats] of byPhase) {
+    if (stats.totalInput === 0) continue;
+    if (stats.cacheRead / stats.totalInput < 0.3) {
+      lowPhases.push(phase);
+    }
+  }
+
+  if (lowPhases.length === 0) return null;
+
+  const totalCostEur = withCache.reduce((s, l) => s + l.cost_eur, 0);
+  const potentialSaving = (totalCostEur * 0.5 * 0.7) / (withCache.length / 30);
+
+  return {
+    id: 'low-cache-hit',
+    severity: 'warn',
+    title: 'Cache hit rate below 30%',
+    detail: `Phase(s) ${lowPhases.join(', ')} have a cache_read / total_input ratio below 0.3. Cache misses mean you are paying full price for repeated prompt prefix tokens.`,
+    evidence: lowPhases.map((p) => {
+      const s = byPhase.get(p)!;
+      return `${p}: ${s.totalInput > 0 ? ((s.cacheRead / s.totalInput) * 100).toFixed(1) : 0}% cache hit`;
+    }),
+    estimatedSavingEurPerMonth: Math.round(potentialSaving * 100) / 100,
+    action:
+      'Ensure your system prompt prefix is stable across runs. Move frequently-changing content (issue description, PR diff) after the stable prefix. See prompts/<agent>.md for the current prefix layout.',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic 2 — Iterator hitting max_iterations cap
+// Approximation: a ticket that has ≥ 3 iterate-phase runs likely hit the loop
+// cap at some point (default cap is 3 per ticket). Ref: #168, #187
+// ---------------------------------------------------------------------------
+
+function heuristicIteratorCap(lines: AuditLine[]): Finding | null {
+  const iterateByTicket = new Map<string, number>();
+  for (const l of lines) {
+    if (l.phase === 'iterate') {
+      iterateByTicket.set(l.ticket, (iterateByTicket.get(l.ticket) ?? 0) + 1);
+    }
+  }
+
+  const capTickets = Array.from(iterateByTicket.entries())
+    .filter(([, count]) => count >= 3)
+    .map(([ticket]) => ticket);
+
+  const totalIterateTickets = iterateByTicket.size;
+  if (totalIterateTickets === 0) return null;
+  const capRate = capTickets.length / totalIterateTickets;
+  if (capRate < 0.3) return null;
+
+  const iterateTotal = lines.filter((l) => l.phase === 'iterate').length;
+
+  const iterateCostPerRun =
+    lines.filter((l) => l.phase === 'iterate').reduce((s, l) => s + l.cost_eur, 0) / iterateTotal;
+  const potentialSaving = capTickets.length * iterateCostPerRun * 0.4;
+
+  return {
+    id: 'iterator-cap',
+    severity: 'warn',
+    title: 'Iterator hitting iteration cap on >30% of tickets',
+    detail: `${capTickets.length} ticket(s) have ≥3 iterate-phase runs, suggesting the iteration cap is being reached. Review the review-feedback density or raise limits.max_iterations in ferry.config.json.`,
+    evidence: capTickets.slice(0, 5).map((t) => `${t}: ${iterateByTicket.get(t)} iterate runs`),
+    estimatedSavingEurPerMonth: Math.round(potentialSaving * 100) / 100,
+    action:
+      'Reduce Reviewer strictness (prompts/review.extra.md) or tighten sub-task granularity so each iteration resolves more findings. Alternatively, raise limits.max_iterations if the extra rounds deliver value.',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic 3 — Refiner reading too much context
+// Ref: #178, #182, #185
+// ---------------------------------------------------------------------------
+
+function heuristicRefinerHeavy(lines: AuditLine[]): Finding | null {
+  const refinerLines = lines.filter((l) => l.phase === 'refine');
+  if (refinerLines.length < 3) return null;
+
+  const avgInput = refinerLines.reduce((s, l) => s + l.input_tokens, 0) / refinerLines.length;
+  if (avgInput <= 50_000) return null;
+
+  const heavyRuns = refinerLines.filter((l) => l.input_tokens > 50_000);
+  const potentialSaving =
+    heavyRuns.reduce((s, l) => s + l.cost_eur, 0) * 0.4 * (30 / refinerLines.length);
+
+  return {
+    id: 'refiner-input-heavy',
+    severity: 'warn',
+    title: 'Refiner averaging >50k input tokens',
+    detail: `Average Refiner input is ${Math.round(avgInput / 1000)}k tokens — above the 50k threshold. High input token counts inflate cost and latency without proportional quality gain.`,
+    evidence: heavyRuns
+      .slice(0, 3)
+      .map(
+        (l) => `${l.ticket} (run ${l.run_id}): ${Math.round(l.input_tokens / 1000)}k input tokens`,
+      ),
+    estimatedSavingEurPerMonth: Math.round(potentialSaving * 100) / 100,
+    action:
+      'Add a prompts/_project.md file to narrow the Refiner\'s project context. Use --context-budget or limits.max_tokens_per_run to cap input. See docs/CONFIGURATION.md § "Token and iteration limits".',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic 4 — Cost outlier tickets (above p95)
+// ---------------------------------------------------------------------------
+
+function heuristicCostOutliers(lines: AuditLine[]): Finding | null {
+  const byTicket = groupByTicket(lines);
+  if (byTicket.length < 5) return null;
+
+  const costs = byTicket.map((g) => g.costEur).sort((a, b) => a - b);
+  const p90 = costs[Math.floor(costs.length * 0.9)] ?? costs[costs.length - 1] ?? 0;
+  const median = costs[Math.floor(costs.length * 0.5)] ?? 0;
+
+  if (median === 0) return null;
+
+  const outliers = byTicket.filter((g) => g.costEur > p90 && g.costEur > median * 3);
+  if (outliers.length === 0) return null;
+
+  return {
+    id: 'cost-outlier',
+    severity: 'warn',
+    title: `${outliers.length} ticket(s) exceed p90 cost threshold and >3× median`,
+    detail: `These tickets consumed disproportionate spend. They are likely large/complex tasks or runaway agent loops. Investigate and consider splitting the ticket or capping budget.`,
+    evidence: outliers
+      .slice(0, 5)
+      .map(
+        (g) => `${g.key}: €${g.costEur.toFixed(4)} (${(g.costEur / median).toFixed(1)}× median)`,
+      ),
+    estimatedSavingEurPerMonth:
+      Math.round(outliers.reduce((s, g) => s + g.costEur * 0.5, 0) * 100) / 100,
+    action:
+      'Set COST_TICKET_MAX_USD (or limits.max_cost_per_ticket in ferry.config.json) to cap runaway tickets. Consider splitting large tickets into smaller sub-tasks before Ferry processes them.',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic 5 — Expensive model for cheap phase (Opus on Refiner)
+// Ref: #142
+// ---------------------------------------------------------------------------
+
+function heuristicProviderMismatch(lines: AuditLine[]): Finding | null {
+  const refinerOpus = lines.filter(
+    (l) => l.phase === 'refine' && l.model.toLowerCase().includes('opus'),
+  );
+  if (refinerOpus.length === 0) return null;
+
+  const refinerAll = lines.filter((l) => l.phase === 'refine');
+  const opusFraction = refinerOpus.length / refinerAll.length;
+  if (opusFraction < 0.5) return null;
+
+  const opusCost = refinerOpus.reduce((s, l) => s + l.cost_eur, 0);
+  const sonnetCostEstimate = opusCost * (2.79 / 13.95);
+  const monthlySaving =
+    (opusCost - sonnetCostEstimate) * (30 / refinerOpus.length) * refinerOpus.length;
+
+  return {
+    id: 'provider-phase-mismatch',
+    severity: 'info',
+    title: 'Opus used for Refiner phase — Sonnet is sufficient',
+    detail: `${refinerOpus.length} Refiner run(s) used Opus. The Refiner is a single-turn summarisation task where Sonnet delivers equivalent quality at ~5× lower cost.`,
+    evidence: [
+      `${refinerOpus.length}/${refinerAll.length} Refiner runs used Opus (${(opusFraction * 100).toFixed(0)}%)`,
+    ],
+    estimatedSavingEurPerMonth: Math.round(monthlySaving * 100) / 100,
+    action:
+      'Set FERRY_REFINER_MODEL=claude-sonnet-4-6 (or models.refine.model in ferry.config.json). See docs/CONFIGURATION.md § "Model and provider overrides".',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic 6 — High output token ratio (LLM "rambling" between tool calls)
+// output_tokens / (input_tokens + output_tokens) > 0.15 for tool-heavy phases
+// ---------------------------------------------------------------------------
+
+function heuristicHighOutputRatio(lines: AuditLine[]): Finding | null {
+  const toolPhases = lines.filter((l) => l.phase === 'dev' || l.phase === 'iterate');
+  if (toolPhases.length < 5) return null;
+
+  const highRatio = toolPhases.filter((l) => {
+    const total = l.input_tokens + l.output_tokens;
+    return total > 0 && l.output_tokens / total > 0.15;
+  });
+
+  if (highRatio.length / toolPhases.length < 0.3) return null;
+
+  const wasted = highRatio.reduce((s, l) => {
+    const total = l.input_tokens + l.output_tokens;
+    const excessOutputRatio = l.output_tokens / total - 0.1;
+    return s + l.cost_eur * excessOutputRatio;
+  }, 0);
+
+  return {
+    id: 'high-output-ratio',
+    severity: 'info',
+    title: 'High output/total token ratio in dev/iterate phases',
+    detail: `${highRatio.length}/${toolPhases.length} dev/iterate runs have output tokens exceeding 15% of total tokens. In tool-use loops the model should mostly invoke tools (low output); high output suggests the model is thinking out loud or writing long explanations between tool calls.`,
+    evidence: highRatio.slice(0, 3).map((l) => {
+      const total = l.input_tokens + l.output_tokens;
+      return `${l.ticket} (${l.phase}, run ${l.run_id}): ${((l.output_tokens / total) * 100).toFixed(1)}% output ratio`;
+    }),
+    estimatedSavingEurPerMonth:
+      Math.round(wasted * (30 / toolPhases.length) * toolPhases.length * 100) / 100,
+    action:
+      'Tighten the Developer/Iterator system prompt to discourage prose between tool calls. Add "respond only with tool calls — no explanatory text" to prompts/dev.extra.md.',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function analyseAuditLog(
+  allLines: AuditLine[],
+  opts: { since?: Date; until?: Date; severity?: Severity } = {},
+): AdviceResult {
+  const filtered = filterLines(allLines, { since: opts.since, until: opts.until });
+
+  const heuristics = [
+    heuristicLowCacheHit,
+    heuristicIteratorCap,
+    heuristicRefinerHeavy,
+    heuristicCostOutliers,
+    heuristicProviderMismatch,
+    heuristicHighOutputRatio,
+  ];
+
+  const findings: Finding[] = [];
+  for (const h of heuristics) {
+    const finding = h(filtered);
+    if (!finding) continue;
+    if (opts.severity === 'warn' && finding.severity === 'info') continue;
+    findings.push(finding);
+  }
+
+  findings.sort((a, b) => {
+    if (a.severity !== b.severity) return a.severity === 'warn' ? -1 : 1;
+    return b.estimatedSavingEurPerMonth - a.estimatedSavingEurPerMonth;
+  });
+
+  const timestamps = filtered.map((l) => l.timestamp).sort();
+  return {
+    findings,
+    analysedRuns: filtered.length,
+    dateRange: {
+      from: timestamps[0]?.slice(0, 10) ?? '',
+      to: timestamps[timestamps.length - 1]?.slice(0, 10) ?? '',
+    },
+  };
+}
+
+export function formatAdviceReport(result: AdviceResult): string {
+  const lines: string[] = [];
+  lines.push('# Ferry Cost Advice');
+  lines.push('');
+  lines.push(
+    `**Analysed:** ${result.analysedRuns} runs` +
+      (result.dateRange.from ? ` (${result.dateRange.from} – ${result.dateRange.to})` : ''),
+  );
+  lines.push(`**Findings:** ${result.findings.length}`);
+  lines.push('');
+
+  if (result.findings.length === 0) {
+    lines.push('_No actionable findings. Looking good!_');
+    return lines.join('\n');
+  }
+
+  for (const f of result.findings) {
+    const icon = f.severity === 'warn' ? '⚠️' : 'ℹ️';
+    lines.push(`## ${icon} ${f.title}`);
+    lines.push('');
+    lines.push(f.detail);
+    lines.push('');
+    if (f.evidence.length > 0) {
+      lines.push('**Evidence:**');
+      for (const e of f.evidence) lines.push(`- ${e}`);
+      lines.push('');
+    }
+    if (f.estimatedSavingEurPerMonth > 0) {
+      lines.push(`**Estimated saving:** ~€${f.estimatedSavingEurPerMonth.toFixed(2)}/month`);
+      lines.push('');
+    }
+    lines.push(`**Action:** ${f.action}`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}

--- a/src/cli/cost/types.ts
+++ b/src/cli/cost/types.ts
@@ -5,6 +5,8 @@ export interface AuditLine {
   model: string;
   input_tokens: number;
   output_tokens: number;
+  /** Cache-read input tokens (populated in audit logs from Ferry ≥ v0.11). */
+  cache_read_input_tokens?: number;
   cost_eur: number;
   outcome: string;
   duration_ms: number;


### PR DESCRIPTION
## Summary

- Adds `ferry-cost-advice` CLI (`src/cli/cost/advice-cmd.ts`) exposed as `ferry-cost-advice` bin
- Implements `analyseAuditLog` + `formatAdviceReport` in `src/cli/cost/advice.ts` with six built-in heuristics:
  - `low-cache-hit` — cache_read/total_input < 30% per phase (warn)
  - `iterator-cap` — >30% of iterate tickets hit 3+ runs (warn)
  - `refiner-input-heavy` — avg Refiner input > 50k tokens (warn)
  - `cost-outlier` — ticket above p90 and >3× median (warn)
  - `provider-phase-mismatch` — Opus used for Refiner phase (info)
  - `high-output-ratio` — dev/iterate output > 15% of total tokens (info)
- Adds `cache_read_input_tokens?: number` to `AuditLine` type (Ferry ≥ v0.11)
- Flags: `--audit-log`, `--from`, `--to`, `--severity info|warn`, `--format md|json`, `--out`
- 18 tests in `advice.test.ts`, all passing
- Docs appended to `docs/COST.md`

Closes #254

## Test plan

- [x] `npm test` — all 1317 tests pass
- [x] `npm run typecheck` — clean
- [x] Each heuristic tested with positive (fires) + negative (does not fire) case
- [x] Severity filter and `formatAdviceReport` tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)