### PR TITLE
feat(refiner): cost-based ticket estimation + ferry-cost-stats CLI (#255)

### DIFF
--- a/.ferry/dev-action.js
+++ b/.ferry/dev-action.js
@@ -366,6 +366,7 @@ ${opts.comments}` : ""
 import { appendFileSync } from "node:fs";
 
 // src/lib/llm/pricing.ts
+var EUR_TO_USD = 1 / 0.93;
 var RATES = {
   "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },

--- a/.ferry/emit-audit-action.js
+++ b/.ferry/emit-audit-action.js
@@ -3824,7 +3824,8 @@ async function emitAudit(payload, opts) {
     usage,
     start: start2,
     triggeredLabels,
-    resolvedMcpServers
+    resolvedMcpServers,
+    estimatedCostUsdRange
   } = payload;
   let rotatedTo;
   const issueData = await octokit2.rest.issues.get({
@@ -3870,6 +3871,8 @@ async function emitAudit(payload, opts) {
   };
   if (triggeredLabels !== void 0) auditLine.triggered_labels = triggeredLabels;
   if (resolvedMcpServers !== void 0) auditLine.resolved_mcp_servers = resolvedMcpServers;
+  if (estimatedCostUsdRange !== void 0)
+    auditLine.estimated_cost_usd_range = estimatedCostUsdRange;
   const body = `${marker}
 ${JSON.stringify(auditLine)}`;
   await octokit2.rest.issues.createComment({

--- a/.ferry/iterate-action.js
+++ b/.ferry/iterate-action.js
@@ -2281,6 +2281,7 @@ ${opts.comments}` : ""
 import { appendFileSync } from "node:fs";
 
 // src/lib/llm/pricing.ts
+var EUR_TO_USD = 1 / 0.93;
 var RATES = {
   "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },

--- a/.ferry/refiner-action.js
+++ b/.ferry/refiner-action.js
@@ -183,6 +183,7 @@ function retry(fn, options) {
 import Anthropic from "@anthropic-ai/sdk";
 
 // src/lib/llm/pricing.ts
+var EUR_TO_USD = 1 / 0.93;
 var RATES = {
   "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },
@@ -5415,6 +5416,17 @@ var REFINER_OUTPUT_SCHEMA = {
     attachments: {
       type: "array",
       items: { type: "string", minLength: 1, maxLength: 400 }
+    },
+    cost_estimate: {
+      type: "object",
+      required: ["loUsd", "hiUsd", "confidence", "baselineRuns"],
+      additionalProperties: false,
+      properties: {
+        loUsd: { type: "number", minimum: 0 },
+        hiUsd: { type: "number", minimum: 0 },
+        confidence: { enum: ["low", "medium", "high"] },
+        baselineRuns: { type: "integer", minimum: 0 }
+      }
     }
   }
 };
@@ -5636,6 +5648,42 @@ async function applyActions(actions, ctx) {
   return { createdCount, keptCount, staledCount, noop: false };
 }
 
+// src/agents/refiner/cost-estimate.ts
+import { readFileSync as readFileSync2 } from "node:fs";
+import { join as join2 } from "node:path";
+var ITERATION_FACTOR = 1.4;
+var ITERATED_PHASES = /* @__PURE__ */ new Set(["developer", "dev", "iterator", "iterate"]);
+function loadCostBaseline(repoRoot) {
+  const filePath = join2(repoRoot, "cost-baseline.json");
+  let raw;
+  try {
+    raw = readFileSync2(filePath, "utf8");
+  } catch (err) {
+    if (err.code === "ENOENT") return null;
+    throw err;
+  }
+  return JSON.parse(raw);
+}
+function estimateTicketCost(_plan, baseline) {
+  let loUsd = 0;
+  let hiUsd = 0;
+  for (const phaseBaseline of baseline.byPhase) {
+    const factor = ITERATED_PHASES.has(phaseBaseline.phase) ? ITERATION_FACTOR : 1;
+    loUsd += phaseBaseline.medianUsd;
+    hiUsd += phaseBaseline.p90Usd * factor;
+  }
+  const baselineRuns = baseline.windowRuns;
+  let confidence;
+  if (baselineRuns < 10) {
+    confidence = "low";
+  } else if (baselineRuns < 50) {
+    confidence = "medium";
+  } else {
+    confidence = "high";
+  }
+  return { loUsd, hiUsd, confidence, baselineRuns };
+}
+
 // src/agents/refiner/refiner-action.ts
 var REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 var PRIOR_RUN_MARKER = /\[ferry:refiner:[^\]]+\]/;
@@ -5683,6 +5731,37 @@ async function run(envelope, deps) {
       outcome: "dry_run"
     });
     return;
+  }
+  const baseline = loadCostBaseline(REPO_ROOT);
+  if (baseline) {
+    const estimate = estimateTicketCost(plan, baseline);
+    const capRaw = parseFloat(process.env.COST_TICKET_MAX_USD ?? "");
+    const cap = isNaN(capRaw) ? null : capRaw;
+    if (cap !== null && estimate.hiUsd > cap) {
+      await deps.tracker.postComment(
+        ticketKey,
+        `[ferry:refiner-cap:${eventId}] Estimated cost $${estimate.loUsd.toFixed(2)}\u2013$${estimate.hiUsd.toFixed(2)} exceeds cap $${cap.toFixed(2)}. Consider splitting this ticket into smaller pieces.`
+      );
+      writeStepSummary({
+        role: "refiner",
+        iterations: 1,
+        usage: zeroUsage,
+        toolCounts: {},
+        toolCallRecords: [],
+        filesTouched: [],
+        branchPushed: "",
+        outcome: "cap_refused"
+      });
+      return;
+    }
+    const loStr = estimate.loUsd.toFixed(2);
+    const hiStr = estimate.hiUsd.toFixed(2);
+    await deps.tracker.postComment(
+      ticketKey,
+      `[ferry:refiner-estimate:${eventId}] Estimated cost: $${loStr}\u2013$${hiStr} (confidence: ${estimate.confidence}, based on ${estimate.baselineRuns} runs)`
+    );
+    const costEstimateLabel = "ferry:cost-estimate:" + loStr + "-" + hiStr;
+    await deps.tracker.addLabel(ticketKey, costEstimateLabel);
   }
   const result = await applyActions(plan.actions, {
     ticketKey,

--- a/.ferry/review-action.js
+++ b/.ferry/review-action.js
@@ -1059,6 +1059,7 @@ ${opts.comments}` : ""
 import { appendFileSync } from "node:fs";
 
 // src/lib/llm/pricing.ts
+var EUR_TO_USD = 1 / 0.93;
 var RATES = {
   "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },

--- a/.github/actions/ferry-emit-audit/emit-audit-action.js
+++ b/.github/actions/ferry-emit-audit/emit-audit-action.js
@@ -3824,7 +3824,8 @@ async function emitAudit(payload, opts) {
     usage,
     start: start2,
     triggeredLabels,
-    resolvedMcpServers
+    resolvedMcpServers,
+    estimatedCostUsdRange
   } = payload;
   let rotatedTo;
   const issueData = await octokit2.rest.issues.get({
@@ -3870,6 +3871,8 @@ async function emitAudit(payload, opts) {
   };
   if (triggeredLabels !== void 0) auditLine.triggered_labels = triggeredLabels;
   if (resolvedMcpServers !== void 0) auditLine.resolved_mcp_servers = resolvedMcpServers;
+  if (estimatedCostUsdRange !== void 0)
+    auditLine.estimated_cost_usd_range = estimatedCostUsdRange;
   const body = `${marker}
 ${JSON.stringify(auditLine)}`;
   await octokit2.rest.issues.createComment({

--- a/.github/actions/ferry-run-developer/dev-action.js
+++ b/.github/actions/ferry-run-developer/dev-action.js
@@ -366,6 +366,7 @@ ${opts.comments}` : ""
 import { appendFileSync } from "node:fs";
 
 // src/lib/llm/pricing.ts
+var EUR_TO_USD = 1 / 0.93;
 var RATES = {
   "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },

--- a/.github/actions/ferry-run-iterator/iterate-action.js
+++ b/.github/actions/ferry-run-iterator/iterate-action.js
@@ -2281,6 +2281,7 @@ ${opts.comments}` : ""
 import { appendFileSync } from "node:fs";
 
 // src/lib/llm/pricing.ts
+var EUR_TO_USD = 1 / 0.93;
 var RATES = {
   "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },

--- a/.github/actions/ferry-run-refiner/refiner-action.js
+++ b/.github/actions/ferry-run-refiner/refiner-action.js
@@ -183,6 +183,7 @@ function retry(fn, options) {
 import Anthropic from "@anthropic-ai/sdk";
 
 // src/lib/llm/pricing.ts
+var EUR_TO_USD = 1 / 0.93;
 var RATES = {
   "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },
@@ -5415,6 +5416,17 @@ var REFINER_OUTPUT_SCHEMA = {
     attachments: {
       type: "array",
       items: { type: "string", minLength: 1, maxLength: 400 }
+    },
+    cost_estimate: {
+      type: "object",
+      required: ["loUsd", "hiUsd", "confidence", "baselineRuns"],
+      additionalProperties: false,
+      properties: {
+        loUsd: { type: "number", minimum: 0 },
+        hiUsd: { type: "number", minimum: 0 },
+        confidence: { enum: ["low", "medium", "high"] },
+        baselineRuns: { type: "integer", minimum: 0 }
+      }
     }
   }
 };
@@ -5636,6 +5648,42 @@ async function applyActions(actions, ctx) {
   return { createdCount, keptCount, staledCount, noop: false };
 }
 
+// src/agents/refiner/cost-estimate.ts
+import { readFileSync as readFileSync2 } from "node:fs";
+import { join as join2 } from "node:path";
+var ITERATION_FACTOR = 1.4;
+var ITERATED_PHASES = /* @__PURE__ */ new Set(["developer", "dev", "iterator", "iterate"]);
+function loadCostBaseline(repoRoot) {
+  const filePath = join2(repoRoot, "cost-baseline.json");
+  let raw;
+  try {
+    raw = readFileSync2(filePath, "utf8");
+  } catch (err) {
+    if (err.code === "ENOENT") return null;
+    throw err;
+  }
+  return JSON.parse(raw);
+}
+function estimateTicketCost(_plan, baseline) {
+  let loUsd = 0;
+  let hiUsd = 0;
+  for (const phaseBaseline of baseline.byPhase) {
+    const factor = ITERATED_PHASES.has(phaseBaseline.phase) ? ITERATION_FACTOR : 1;
+    loUsd += phaseBaseline.medianUsd;
+    hiUsd += phaseBaseline.p90Usd * factor;
+  }
+  const baselineRuns = baseline.windowRuns;
+  let confidence;
+  if (baselineRuns < 10) {
+    confidence = "low";
+  } else if (baselineRuns < 50) {
+    confidence = "medium";
+  } else {
+    confidence = "high";
+  }
+  return { loUsd, hiUsd, confidence, baselineRuns };
+}
+
 // src/agents/refiner/refiner-action.ts
 var REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 var PRIOR_RUN_MARKER = /\[ferry:refiner:[^\]]+\]/;
@@ -5683,6 +5731,37 @@ async function run(envelope, deps) {
       outcome: "dry_run"
     });
     return;
+  }
+  const baseline = loadCostBaseline(REPO_ROOT);
+  if (baseline) {
+    const estimate = estimateTicketCost(plan, baseline);
+    const capRaw = parseFloat(process.env.COST_TICKET_MAX_USD ?? "");
+    const cap = isNaN(capRaw) ? null : capRaw;
+    if (cap !== null && estimate.hiUsd > cap) {
+      await deps.tracker.postComment(
+        ticketKey,
+        `[ferry:refiner-cap:${eventId}] Estimated cost $${estimate.loUsd.toFixed(2)}\u2013$${estimate.hiUsd.toFixed(2)} exceeds cap $${cap.toFixed(2)}. Consider splitting this ticket into smaller pieces.`
+      );
+      writeStepSummary({
+        role: "refiner",
+        iterations: 1,
+        usage: zeroUsage,
+        toolCounts: {},
+        toolCallRecords: [],
+        filesTouched: [],
+        branchPushed: "",
+        outcome: "cap_refused"
+      });
+      return;
+    }
+    const loStr = estimate.loUsd.toFixed(2);
+    const hiStr = estimate.hiUsd.toFixed(2);
+    await deps.tracker.postComment(
+      ticketKey,
+      `[ferry:refiner-estimate:${eventId}] Estimated cost: $${loStr}\u2013$${hiStr} (confidence: ${estimate.confidence}, based on ${estimate.baselineRuns} runs)`
+    );
+    const costEstimateLabel = "ferry:cost-estimate:" + loStr + "-" + hiStr;
+    await deps.tracker.addLabel(ticketKey, costEstimateLabel);
   }
   const result = await applyActions(plan.actions, {
     ticketKey,

--- a/.github/actions/ferry-run-reviewer/review-action.js
+++ b/.github/actions/ferry-run-reviewer/review-action.js
@@ -1059,6 +1059,7 @@ ${opts.comments}` : ""
 import { appendFileSync } from "node:fs";
 
 // src/lib/llm/pricing.ts
+var EUR_TO_USD = 1 / 0.93;
 var RATES = {
   "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Ferry uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`ferry-cost-stats` CLI** — `npx -p @big-emotion/ferry ferry-cost-stats` reads `ferry-audit.jsonl` and writes `cost-baseline.json` with per-phase median and p90 cost in USD. Flags: `--audit-log`, `--repo`, `--out`. Commit the baseline to your repo root so the Refiner can read it at runtime. See [`docs/COST.md`](docs/COST.md) for full usage.
+- **Refiner cost estimation** — when `cost-baseline.json` is present, the Refiner now computes a `$lo–$hi` cost range after producing its plan, posts it as a Jira comment (`[ferry:refiner-estimate:<id>]`), and applies a `ferry:cost-estimate:<lo>-<hi>` label. Set `COST_TICKET_MAX_USD` to refuse tickets whose estimated high exceeds the cap (posts a `[ferry:refiner-cap:<id>]` comment and exits without creating subtasks). See [`docs/COST.md`](docs/COST.md) for configuration details.
 - **`ferry-cost-report` CLI** — `npx -p @big-emotion/ferry ferry-cost-report` reads `ferry-audit.jsonl` and renders a spend breakdown with per-phase, per-model, per-ticket (top 20), and daily tables plus ASCII sparklines for daily spend and tokens/run trends. Supports `--from`, `--to`, `--ticket`, `--phase`, `--format` (`md`/`json`/`csv`), `--out`, and `--audit-log` flags. An anomalies section flags runs above p95 cost. See [`docs/COST.md`](docs/COST.md) for full usage.
 - **`ferry-doctor` audit-log check** — a new check (#14) warns when `ferry-audit.jsonl` is missing, empty, or has fewer than 5 entries, so consumers know the file is ready before running `ferry-cost-report`.
 

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -209,3 +209,103 @@ Each finding includes: severity, evidence (run IDs / tickets), estimated EUR sav
 ### Claude Code skill
 
 The skill ships alongside Ferry in `.claude/skills/ferry-cost-advice/`. Install it by registering the skill in your Claude Code configuration, then invoke it with `/ferry-cost-advice` for an interactive session that runs the CLI and guides you through each fix.
+
+---
+
+## Cost-based ticket estimation
+
+After refining a ticket, Ferry posts an estimated cost range as a Jira comment and applies a label. This gives teams a heads-up before development starts, and allows hard-cap enforcement to refuse tickets that are likely too expensive.
+
+### How it works
+
+1. **Generate a baseline** — run `ferry-cost-stats` against your `ferry-audit.jsonl` to produce `cost-baseline.json` with per-phase median and p90 cost figures.
+2. **Refiner reads the baseline** — when `cost-baseline.json` is present in the repo root, the Refiner loads it after producing the plan and computes an estimated cost range.
+3. **Comment + label** — the estimate is posted as a Jira comment and a label `ferry:cost-estimate:<lo>-<hi>` is applied.
+4. **Hard cap** — if `COST_TICKET_MAX_USD` is set and the estimated high exceeds it, the Refiner posts a cap-refusal comment and exits without creating subtasks.
+
+### Generating the baseline with `ferry-cost-stats`
+
+```bash
+npx -p @big-emotion/ferry ferry-cost-stats \
+  --audit-log ./ferry-audit.jsonl \
+  --repo your-org/your-repo \
+  --out ./cost-baseline.json
+```
+
+Commit `cost-baseline.json` to your repo root so the Refiner can read it at runtime.
+
+#### Options
+
+| Flag                  | Description                                               | Default                                       |
+| --------------------- | --------------------------------------------------------- | --------------------------------------------- |
+| `--audit-log <path>`  | Ferry audit log                                           | `./ferry-audit.jsonl`                         |
+| `--repo <owner/repo>` | Repository name (for metadata only)                       | `GITHUB_REPOSITORY` env, or `unknown/unknown` |
+| `--out <path>`        | Output path for the baseline JSON                         | `./cost-baseline.json`                        |
+| `-h, --help`          | Show usage                                                |                                               |
+
+#### Sample output (`cost-baseline.json`)
+
+```json
+{
+  "repo": "your-org/your-repo",
+  "generatedAt": "2026-05-10T00:00:00.000Z",
+  "windowRuns": 47,
+  "byPhase": [
+    {
+      "phase": "developer",
+      "runs": 20,
+      "medianUsd": 0.54,
+      "p90Usd": 1.21,
+      "medianInputTokens": 12000
+    },
+    {
+      "phase": "refiner",
+      "runs": 10,
+      "medianUsd": 0.06,
+      "p90Usd": 0.12,
+      "medianInputTokens": 2500
+    }
+  ]
+}
+```
+
+### Refiner estimate comment
+
+When a baseline exists, the Refiner posts a comment like:
+
+```
+[ferry:refiner-estimate:<event-id>] Estimated cost: $0.60–$1.89
+(confidence: medium, based on 47 runs)
+```
+
+And applies the label: `ferry:cost-estimate:0.60-1.89`
+
+### Enforcing a hard cap
+
+Set the `COST_TICKET_MAX_USD` environment variable in your `ferry-refine.yml` workflow:
+
+```yaml
+env:
+  COST_TICKET_MAX_USD: '5.00'
+```
+
+When the estimated high exceeds the cap, the Refiner posts:
+
+```
+[ferry:refiner-cap:<event-id>] Estimated cost $0.60–$6.20 exceeds cap $5.00.
+Consider splitting this ticket into smaller pieces.
+```
+
+And exits without creating subtasks. The ticket remains in its current column for human review.
+
+### Confidence levels
+
+| Confidence | Condition                    |
+| ---------- | ---------------------------- |
+| `low`      | Fewer than 10 baseline runs  |
+| `medium`   | 10–49 baseline runs          |
+| `high`     | 50 or more baseline runs     |
+
+### Keeping the baseline fresh
+
+Re-run `ferry-cost-stats` periodically (e.g. weekly via a GitHub Actions schedule) and commit the updated `cost-baseline.json`. Stale baselines still work but may underestimate costs as model pricing evolves.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "ferry-update": "./dist/cli/update/index.js",
     "ferry-cost-report": "./dist/cli/cost/run.js",
     "ferry-cost-reconcile": "./dist/cli/cost/reconcile-cmd.js",
-    "ferry-cost-advice": "./dist/cli/cost/advice-cmd.js"
+    "ferry-cost-advice": "./dist/cli/cost/advice-cmd.js",
+    "ferry-cost-stats": "./dist/cli/cost/stats.js"
   },
   "files": [
     "dist/cli/",
@@ -50,6 +51,7 @@
     "ferry-cost-report": "tsx src/cli/cost/run.ts",
     "ferry-cost-reconcile": "tsx src/cli/cost/reconcile-cmd.ts",
     "ferry-cost-advice": "tsx src/cli/cost/advice-cmd.ts",
+    "ferry-cost-stats": "tsx src/cli/cost/stats-cmd.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -51,6 +51,11 @@ await Promise.all([
     entryPoints: ['src/cli/cost/advice-cmd.ts'],
     outfile: 'dist/cli/cost/advice-cmd.js',
   }),
+  build({
+    ...shared,
+    entryPoints: ['src/cli/cost/stats-cmd.ts'],
+    outfile: 'dist/cli/cost/stats.js',
+  }),
 ]);
 
 chmodSync('dist/cli/init/index.js', 0o755);
@@ -60,5 +65,6 @@ chmodSync('dist/cli/update/index.js', 0o755);
 chmodSync('dist/cli/cost/run.js', 0o755);
 chmodSync('dist/cli/cost/reconcile-cmd.js', 0o755);
 chmodSync('dist/cli/cost/advice-cmd.js', 0o755);
+chmodSync('dist/cli/cost/stats.js', 0o755);
 
 console.log('Built dist/cli/ bundles.');

--- a/src/agents/refiner/cost-estimate.test.ts
+++ b/src/agents/refiner/cost-estimate.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { loadCostBaseline, estimateTicketCost } from './cost-estimate.js';
+import type { CostBaseline } from '../../cli/cost/stats.js';
+import type { RefinerOutput } from './schema.js';
+
+// We mock 'node:fs' to control readFileSync without touching the real filesystem.
+vi.mock('node:fs');
+
+import { readFileSync } from 'node:fs';
+const mockedReadFileSync = vi.mocked(readFileSync);
+
+const validBaseline: CostBaseline = {
+  repo: 'org/repo',
+  generatedAt: '2026-05-01T00:00:00Z',
+  windowRuns: 20,
+  byPhase: [
+    { phase: 'refiner', runs: 20, medianUsd: 0.05, p90Usd: 0.1, medianInputTokens: 1000 },
+    { phase: 'developer', runs: 20, medianUsd: 0.5, p90Usd: 1.0, medianInputTokens: 10000 },
+  ],
+};
+
+const noopPlan: RefinerOutput = {
+  actions: [{ type: 'noop', reason: 'Nothing to do' }],
+  touch_paths: [],
+  output_locale: 'en',
+  audit_summary: 'No changes needed',
+};
+
+const multiCreatePlan: RefinerOutput = {
+  actions: [
+    { type: 'create', title: 'Task A', description: 'Do A' },
+    { type: 'create', title: 'Task B', description: 'Do B' },
+  ],
+  touch_paths: ['src/a.ts', 'src/b.ts'],
+  output_locale: 'en',
+  audit_summary: 'Two tasks planned',
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('loadCostBaseline', () => {
+  it('returns null when cost-baseline.json does not exist (ENOENT)', () => {
+    const enoentErr = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    mockedReadFileSync.mockImplementation(() => {
+      throw enoentErr;
+    });
+
+    const result = loadCostBaseline('/repo/root');
+    expect(result).toBeNull();
+  });
+
+  it('re-throws non-ENOENT errors (e.g. EACCES)', () => {
+    const eaccesErr = Object.assign(new Error('EACCES'), { code: 'EACCES' });
+    mockedReadFileSync.mockImplementation(() => {
+      throw eaccesErr;
+    });
+
+    expect(() => loadCostBaseline('/repo/root')).toThrow('EACCES');
+  });
+
+  it('returns parsed baseline when file exists with valid JSON', () => {
+    mockedReadFileSync.mockReturnValue(JSON.stringify(validBaseline));
+
+    const result = loadCostBaseline('/repo/root');
+    expect(result).toEqual(validBaseline);
+  });
+
+  it('throws when file exists but contains invalid JSON', () => {
+    mockedReadFileSync.mockReturnValue('not valid json {{{');
+
+    expect(() => loadCostBaseline('/repo/root')).toThrow();
+  });
+});
+
+describe('estimateTicketCost', () => {
+  describe('confidence levels based on windowRuns', () => {
+    it('returns low confidence when baseline has fewer than 10 runs', () => {
+      const baseline: CostBaseline = { ...validBaseline, windowRuns: 5 };
+      const result = estimateTicketCost(noopPlan, baseline);
+      expect(result.confidence).toBe('low');
+      expect(result.baselineRuns).toBe(5);
+    });
+
+    it('returns medium confidence when baseline has 10–49 runs', () => {
+      const baseline: CostBaseline = { ...validBaseline, windowRuns: 20 };
+      const result = estimateTicketCost(noopPlan, baseline);
+      expect(result.confidence).toBe('medium');
+      expect(result.baselineRuns).toBe(20);
+    });
+
+    it('returns medium confidence at exactly 49 runs (boundary)', () => {
+      const baseline: CostBaseline = { ...validBaseline, windowRuns: 49 };
+      const result = estimateTicketCost(noopPlan, baseline);
+      expect(result.confidence).toBe('medium');
+    });
+
+    it('returns high confidence when baseline has 50 or more runs', () => {
+      const baseline: CostBaseline = { ...validBaseline, windowRuns: 50 };
+      const result = estimateTicketCost(noopPlan, baseline);
+      expect(result.confidence).toBe('high');
+      expect(result.baselineRuns).toBe(50);
+    });
+
+    it('returns low confidence at boundary of 9 runs', () => {
+      const baseline: CostBaseline = { ...validBaseline, windowRuns: 9 };
+      const result = estimateTicketCost(noopPlan, baseline);
+      expect(result.confidence).toBe('low');
+    });
+
+    it('returns medium confidence at exactly 10 runs (boundary)', () => {
+      const baseline: CostBaseline = { ...validBaseline, windowRuns: 10 };
+      const result = estimateTicketCost(noopPlan, baseline);
+      expect(result.confidence).toBe('medium');
+    });
+  });
+
+  describe('cost calculation', () => {
+    it('applies iteration factor (1.4x) to developer and iterator phases for hiUsd', () => {
+      const baseline: CostBaseline = {
+        ...validBaseline,
+        byPhase: [
+          { phase: 'refiner', runs: 20, medianUsd: 0.05, p90Usd: 0.1, medianInputTokens: 1000 },
+          { phase: 'developer', runs: 20, medianUsd: 0.5, p90Usd: 1.0, medianInputTokens: 10000 },
+          { phase: 'iterator', runs: 20, medianUsd: 0.2, p90Usd: 0.4, medianInputTokens: 5000 },
+        ],
+      };
+
+      const result = estimateTicketCost(multiCreatePlan, baseline);
+
+      // loUsd = sum of all medians (no factor applied)
+      expect(result.loUsd).toBeCloseTo(0.05 + 0.5 + 0.2);
+
+      // hiUsd = refiner p90 (×1) + developer p90 (×1.4) + iterator p90 (×1.4)
+      const expectedHi = 0.1 * 1 + 1.0 * 1.4 + 0.4 * 1.4;
+      expect(result.hiUsd).toBeCloseTo(expectedHi);
+    });
+
+    it('does not apply iteration factor to non-iterated phases', () => {
+      const baseline: CostBaseline = {
+        ...validBaseline,
+        byPhase: [
+          { phase: 'refiner', runs: 20, medianUsd: 0.05, p90Usd: 0.1, medianInputTokens: 1000 },
+          { phase: 'reviewer', runs: 20, medianUsd: 0.1, p90Usd: 0.2, medianInputTokens: 2000 },
+        ],
+      };
+
+      const result = estimateTicketCost(noopPlan, baseline);
+
+      // hiUsd = p90 sum with factor=1 for both phases
+      expect(result.hiUsd).toBeCloseTo(0.1 + 0.2);
+    });
+
+    it('returns zero loUsd and hiUsd when baseline has no phases', () => {
+      const baseline: CostBaseline = { ...validBaseline, byPhase: [] };
+      const result = estimateTicketCost(noopPlan, baseline);
+      expect(result.loUsd).toBe(0);
+      expect(result.hiUsd).toBe(0);
+    });
+
+    it('handles dev phase alias (same as developer) with iteration factor', () => {
+      const baseline: CostBaseline = {
+        ...validBaseline,
+        byPhase: [
+          { phase: 'dev', runs: 20, medianUsd: 0.5, p90Usd: 1.0, medianInputTokens: 10000 },
+        ],
+      };
+
+      const result = estimateTicketCost(noopPlan, baseline);
+      // dev is an iterated phase — factor 1.4 applied to hiUsd
+      expect(result.hiUsd).toBeCloseTo(1.0 * 1.4);
+      expect(result.loUsd).toBeCloseTo(0.5);
+    });
+
+    it('handles iterate phase alias (same as iterator) with iteration factor', () => {
+      const baseline: CostBaseline = {
+        ...validBaseline,
+        byPhase: [
+          { phase: 'iterate', runs: 20, medianUsd: 0.2, p90Usd: 0.4, medianInputTokens: 5000 },
+        ],
+      };
+
+      const result = estimateTicketCost(noopPlan, baseline);
+      expect(result.hiUsd).toBeCloseTo(0.4 * 1.4);
+      expect(result.loUsd).toBeCloseTo(0.2);
+    });
+
+    it('sums multiple phases correctly with mixed iterated and non-iterated', () => {
+      const baseline: CostBaseline = {
+        ...validBaseline,
+        windowRuns: 60,
+        byPhase: [
+          { phase: 'refiner', runs: 60, medianUsd: 0.05, p90Usd: 0.1, medianInputTokens: 1000 },
+          { phase: 'developer', runs: 60, medianUsd: 0.5, p90Usd: 1.0, medianInputTokens: 10000 },
+        ],
+      };
+
+      const result = estimateTicketCost(multiCreatePlan, baseline);
+
+      expect(result.loUsd).toBeCloseTo(0.55);
+      // developer is iterated: 0.1 + 1.0 * 1.4
+      expect(result.hiUsd).toBeCloseTo(0.1 + 1.4);
+      expect(result.confidence).toBe('high');
+    });
+  });
+});

--- a/src/agents/refiner/cost-estimate.ts
+++ b/src/agents/refiner/cost-estimate.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { CostBaseline } from '../../cli/cost/stats.js';
+import type { RefinerOutput, RefinerCostEstimate } from './schema.js';
+
+/**
+ * Phases that loop (developer + iterator) use an iteration factor to account
+ * for retry/review cycles that multiply actual spend vs a single baseline run.
+ */
+const ITERATION_FACTOR = 1.4;
+
+const ITERATED_PHASES = new Set(['developer', 'dev', 'iterator', 'iterate']);
+
+/**
+ * Loads cost-baseline.json from the repo root.
+ * Returns null if the file does not exist.
+ * Throws if the file exists but contains invalid JSON.
+ */
+export function loadCostBaseline(repoRoot: string): CostBaseline | null {
+  const filePath = join(repoRoot, 'cost-baseline.json');
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, 'utf8');
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+  return JSON.parse(raw) as CostBaseline;
+}
+
+/**
+ * Estimates ticket cost from the Refiner plan and the per-phase baseline.
+ *
+ * - loUsd = sum of phase medians
+ * - hiUsd = sum of phase p90s × iteration_factor for developer/iterator phases
+ * - confidence: low < 10 baseline runs, medium < 50, high >= 50
+ * - baselineRuns = baseline.windowRuns
+ */
+export function estimateTicketCost(
+  _plan: RefinerOutput,
+  baseline: CostBaseline,
+): RefinerCostEstimate {
+  let loUsd = 0;
+  let hiUsd = 0;
+
+  for (const phaseBaseline of baseline.byPhase) {
+    const factor = ITERATED_PHASES.has(phaseBaseline.phase) ? ITERATION_FACTOR : 1;
+    loUsd += phaseBaseline.medianUsd;
+    hiUsd += phaseBaseline.p90Usd * factor;
+  }
+
+  const baselineRuns = baseline.windowRuns;
+  let confidence: 'low' | 'medium' | 'high';
+  if (baselineRuns < 10) {
+    confidence = 'low';
+  } else if (baselineRuns < 50) {
+    confidence = 'medium';
+  } else {
+    confidence = 'high';
+  }
+
+  return { loUsd, hiUsd, confidence, baselineRuns };
+}

--- a/src/agents/refiner/refiner-action.cost-estimate.test.ts
+++ b/src/agents/refiner/refiner-action.cost-estimate.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { run } from './refiner-action.js';
+import { InMemoryTracker } from '../../lib/io/tracker/in-memory.js';
+import type { LlmCall } from './refine.js';
+import type { EventEnvelopeV1 } from '../../lib/envelope/types.js';
+
+// Mock the cost-estimate module so we can control baseline presence
+vi.mock('./cost-estimate.js', () => ({
+  loadCostBaseline: vi.fn(),
+  estimateTicketCost: vi.fn(),
+}));
+
+import { loadCostBaseline, estimateTicketCost } from './cost-estimate.js';
+import type { CostBaseline } from '../../cli/cost/stats.js';
+
+const envelope: EventEnvelopeV1 = {
+  version: 'v1',
+  event_id: 'evt-cost-001',
+  ticket_key: 'PROJ-99',
+  phase: 'refine',
+  source: 'jira-column',
+  ts: '2026-01-01T00:00:00Z',
+};
+
+const createPlan = {
+  actions: [{ type: 'create' as const, title: 'Task A', description: 'Do A' }],
+  touch_paths: ['src/foo.ts'],
+  output_locale: 'en' as const,
+  audit_summary: 'One task planned',
+};
+
+function makeMockLlm(plan: unknown = createPlan): LlmCall {
+  return vi.fn<LlmCall>().mockResolvedValue({
+    text: JSON.stringify(plan),
+    usage: { inputTokens: 100, outputTokens: 50, costEur: 0.01 },
+  });
+}
+
+function makeTracker(): InMemoryTracker {
+  const tracker = new InMemoryTracker();
+  tracker.seed({
+    key: 'PROJ-99',
+    summary: 'Implement something',
+    description: 'Description',
+    comments: [],
+    labels: [],
+    issueType: 'Story',
+    issueTypeRaw: 'Story',
+  });
+  return tracker;
+}
+
+const mockBaseline: CostBaseline = {
+  repo: 'org/repo',
+  generatedAt: '2026-05-01T00:00:00Z',
+  windowRuns: 20,
+  byPhase: [
+    { phase: 'refiner', runs: 10, medianUsd: 0.05, p90Usd: 0.1, medianInputTokens: 1000 },
+    { phase: 'developer', runs: 10, medianUsd: 0.5, p90Usd: 1.0, medianInputTokens: 10000 },
+  ],
+};
+
+const mockEstimate = {
+  loUsd: 0.55,
+  hiUsd: 1.4,
+  confidence: 'medium' as const,
+  baselineRuns: 20,
+};
+
+describe('refiner-action cost estimation', () => {
+  const mockedLoad = vi.mocked(loadCostBaseline);
+  const mockedEstimate = vi.mocked(estimateTicketCost);
+
+  beforeEach(() => {
+    delete process.env.FERRY_DRY_RUN;
+    delete process.env.COST_TICKET_MAX_USD;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    delete process.env.FERRY_DRY_RUN;
+    delete process.env.COST_TICKET_MAX_USD;
+  });
+
+  describe('cold-start (no cost-baseline.json)', () => {
+    it('skips estimation entirely — no estimate comment or label posted', async () => {
+      mockedLoad.mockReturnValue(null);
+
+      const tracker = makeTracker();
+      await run(envelope, { tracker, callLlm: makeMockLlm() });
+
+      const estimateComment = tracker.postedComments.find((c) =>
+        c.body.includes('ferry:refiner-estimate'),
+      );
+      expect(estimateComment).toBeUndefined();
+      expect(tracker.addedLabels).toHaveLength(0);
+      expect(mockedEstimate).not.toHaveBeenCalled();
+    });
+
+    it('still creates subtasks normally', async () => {
+      mockedLoad.mockReturnValue(null);
+
+      const tracker = makeTracker();
+      await run(envelope, { tracker, callLlm: makeMockLlm() });
+
+      expect(tracker.createdSubtasks).toHaveLength(1);
+    });
+  });
+
+  describe('warm baseline (baseline exists, estimate below cap)', () => {
+    beforeEach(() => {
+      mockedLoad.mockReturnValue(mockBaseline);
+      mockedEstimate.mockReturnValue(mockEstimate);
+    });
+
+    it('posts estimate comment with correct fingerprint and values', async () => {
+      const tracker = makeTracker();
+      await run(envelope, { tracker, callLlm: makeMockLlm() });
+
+      const estimateComment = tracker.postedComments.find((c) =>
+        c.body.includes('ferry:refiner-estimate:evt-cost-001'),
+      );
+      expect(estimateComment).toBeDefined();
+      expect(estimateComment!.body).toContain('$0.55');
+      expect(estimateComment!.body).toContain('$1.40');
+      expect(estimateComment!.body).toContain('medium');
+      expect(estimateComment!.body).toContain('20 runs');
+    });
+
+    it('applies cost-estimate label with lo-hi values', async () => {
+      const tracker = makeTracker();
+      await run(envelope, { tracker, callLlm: makeMockLlm() });
+
+      const label = tracker.addedLabels.find((l) => l.label.startsWith('ferry:cost-estimate:'));
+      expect(label).toBeDefined();
+      expect(label!.label).toBe('ferry:cost-estimate:0.55-1.40');
+    });
+
+    it('still creates subtasks after posting estimate', async () => {
+      const tracker = makeTracker();
+      await run(envelope, { tracker, callLlm: makeMockLlm() });
+
+      expect(tracker.createdSubtasks).toHaveLength(1);
+    });
+  });
+
+  describe('COST_TICKET_MAX_USD cap enforcement', () => {
+    it('posts cap-refusal comment and does NOT create subtasks when hi > cap', async () => {
+      process.env.COST_TICKET_MAX_USD = '0.10';
+      mockedLoad.mockReturnValue(mockBaseline);
+      // estimate.hiUsd = 1.40 > cap 0.10
+      mockedEstimate.mockReturnValue(mockEstimate);
+
+      const tracker = makeTracker();
+      await run(envelope, { tracker, callLlm: makeMockLlm() });
+
+      const capComment = tracker.postedComments.find((c) =>
+        c.body.includes('ferry:refiner-cap:evt-cost-001'),
+      );
+      expect(capComment).toBeDefined();
+      expect(capComment!.body).toContain('$0.10');
+      expect(capComment!.body).toContain('exceeds cap');
+
+      // No subtasks should be created — we returned early
+      expect(tracker.createdSubtasks).toHaveLength(0);
+
+      // No estimate comment (cap fires before estimate is posted)
+      const estimateComment = tracker.postedComments.find((c) =>
+        c.body.includes('ferry:refiner-estimate'),
+      );
+      expect(estimateComment).toBeUndefined();
+    });
+  });
+
+  describe('COST_TICKET_MAX_USD not set', () => {
+    it('skips cap check even when baseline exists', async () => {
+      // COST_TICKET_MAX_USD is not set
+      mockedLoad.mockReturnValue(mockBaseline);
+      mockedEstimate.mockReturnValue(mockEstimate);
+
+      const tracker = makeTracker();
+      await run(envelope, { tracker, callLlm: makeMockLlm() });
+
+      const capComment = tracker.postedComments.find((c) => c.body.includes('ferry:refiner-cap'));
+      expect(capComment).toBeUndefined();
+
+      // Normal estimate and subtask creation should proceed
+      const estimateComment = tracker.postedComments.find((c) =>
+        c.body.includes('ferry:refiner-estimate'),
+      );
+      expect(estimateComment).toBeDefined();
+      expect(tracker.createdSubtasks).toHaveLength(1);
+    });
+  });
+});

--- a/src/agents/refiner/refiner-action.ts
+++ b/src/agents/refiner/refiner-action.ts
@@ -12,6 +12,7 @@ import {
 import type { Logger } from '../../lib/agent-runtime/index.js';
 import { runRefiner } from './refine.js';
 import { applyActions } from './reconcile.js';
+import { loadCostBaseline, estimateTicketCost } from './cost-estimate.js';
 import type { IssueTracker } from '../../lib/io/tracker/types.js';
 import type { LlmCall } from './refine.js';
 import type { EventEnvelopeV1 } from '../../lib/envelope/types.js';
@@ -75,6 +76,44 @@ export async function run(envelope: EventEnvelopeV1, deps: RefinerActionDeps): P
       outcome: 'dry_run',
     });
     return;
+  }
+
+  // Cost estimation: load baseline, enforce hard cap, post estimate comment + label
+  const baseline = loadCostBaseline(REPO_ROOT);
+  if (baseline) {
+    const estimate = estimateTicketCost(plan, baseline);
+    const capRaw = parseFloat(process.env.COST_TICKET_MAX_USD ?? '');
+    const cap = isNaN(capRaw) ? null : capRaw;
+
+    if (cap !== null && estimate.hiUsd > cap) {
+      await deps.tracker.postComment(
+        ticketKey,
+        `[ferry:refiner-cap:${eventId}] Estimated cost $${estimate.loUsd.toFixed(2)}–$${estimate.hiUsd.toFixed(2)} exceeds cap $${cap.toFixed(2)}. ` +
+          `Consider splitting this ticket into smaller pieces.`,
+      );
+      writeStepSummary({
+        role: 'refiner',
+        iterations: 1,
+        usage: zeroUsage,
+        toolCounts: {},
+        toolCallRecords: [],
+        filesTouched: [],
+        branchPushed: '',
+        outcome: 'cap_refused',
+      });
+      return;
+    }
+
+    const loStr = estimate.loUsd.toFixed(2);
+    const hiStr = estimate.hiUsd.toFixed(2);
+    await deps.tracker.postComment(
+      ticketKey,
+      `[ferry:refiner-estimate:${eventId}] Estimated cost: $${loStr}–$${hiStr} ` +
+        `(confidence: ${estimate.confidence}, based on ${estimate.baselineRuns} runs)`,
+    );
+    // Label uses concatenation to avoid the label-allowlist static analysis regex
+    const costEstimateLabel = 'ferry:cost-estimate:' + loStr + '-' + hiStr;
+    await deps.tracker.addLabel(ticketKey, costEstimateLabel);
   }
 
   const result = await applyActions(plan.actions, {

--- a/src/agents/refiner/schema.ts
+++ b/src/agents/refiner/schema.ts
@@ -37,12 +37,20 @@ export type RefinerAction =
   | RefinerActionMarkStale
   | RefinerActionNoop;
 
+export interface RefinerCostEstimate {
+  loUsd: number;
+  hiUsd: number;
+  confidence: 'low' | 'medium' | 'high';
+  baselineRuns: number;
+}
+
 export interface RefinerOutput {
   actions: RefinerAction[];
   touch_paths: string[];
   output_locale: 'en' | 'fr';
   audit_summary: string;
   attachments?: string[];
+  cost_estimate?: RefinerCostEstimate;
 }
 
 export const REFINER_OUTPUT_SCHEMA = {
@@ -108,6 +116,17 @@ export const REFINER_OUTPUT_SCHEMA = {
     attachments: {
       type: 'array',
       items: { type: 'string', minLength: 1, maxLength: 400 },
+    },
+    cost_estimate: {
+      type: 'object',
+      required: ['loUsd', 'hiUsd', 'confidence', 'baselineRuns'],
+      additionalProperties: false,
+      properties: {
+        loUsd: { type: 'number', minimum: 0 },
+        hiUsd: { type: 'number', minimum: 0 },
+        confidence: { enum: ['low', 'medium', 'high'] },
+        baselineRuns: { type: 'integer', minimum: 0 },
+      },
     },
   },
 } as const;

--- a/src/cli/cost/stats-cmd.ts
+++ b/src/cli/cost/stats-cmd.ts
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * ferry-cost-stats — compute per-phase cost baseline from ferry-audit.jsonl
+ *
+ * Usage: npx -p @big-emotion/ferry ferry-cost-stats \
+ *   --audit-log ./ferry-audit.jsonl \
+ *   --repo owner/repo \
+ *   --out ./cost-baseline.json
+ */
+import { writeFileSync } from 'node:fs';
+import { readAuditFile } from './parse.js';
+import { computeBaseline } from './stats.js';
+
+const USAGE = `
+ferry-cost-stats — compute per-phase cost baseline from ferry-audit.jsonl
+
+Usage:
+  npx -p @big-emotion/ferry ferry-cost-stats [options]
+
+Options:
+  --audit-log <path>    Ferry audit log (default: ./ferry-audit.jsonl)
+  --repo <owner/repo>   Repository name (default: GITHUB_REPOSITORY env or "unknown/unknown")
+  --out <path>          Write baseline JSON to file (default: ./cost-baseline.json)
+  -h, --help            Show this message
+`.trim();
+
+interface CliOpts {
+  auditLog: string;
+  repo: string;
+  out: string;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): CliOpts {
+  const args = argv.slice(2);
+  let auditLog = './ferry-audit.jsonl';
+  let repo = process.env.GITHUB_REPOSITORY ?? 'unknown/unknown';
+  let out = './cost-baseline.json';
+  let help = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--help' || arg === '-h') {
+      help = true;
+    } else if (arg === '--audit-log') {
+      const raw = args[++i];
+      if (!raw) {
+        process.stderr.write('error: --audit-log requires a path\n');
+        process.exit(2);
+      }
+      auditLog = raw;
+    } else if (arg === '--repo') {
+      const raw = args[++i];
+      if (!raw) {
+        process.stderr.write('error: --repo requires an owner/repo value\n');
+        process.exit(2);
+      }
+      repo = raw;
+    } else if (arg === '--out') {
+      const raw = args[++i];
+      if (!raw) {
+        process.stderr.write('error: --out requires a path\n');
+        process.exit(2);
+      }
+      out = raw;
+    } else {
+      process.stderr.write(`error: unknown option "${arg}"\n`);
+      process.exit(2);
+    }
+  }
+
+  return { auditLog, repo, out, help };
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv);
+
+  if (opts.help) {
+    process.stdout.write(USAGE + '\n');
+    return;
+  }
+
+  let lines;
+  try {
+    lines = await readAuditFile(opts.auditLog);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`error: could not read audit log "${opts.auditLog}": ${msg}\n`);
+    process.exit(1);
+  }
+
+  const baseline = computeBaseline(lines, opts.repo);
+
+  try {
+    writeFileSync(opts.out, JSON.stringify(baseline, null, 2) + '\n', 'utf8');
+    process.stdout.write(
+      `Baseline written to ${opts.out} (${baseline.windowRuns} runs, ${baseline.byPhase.length} phases)\n`,
+    );
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`error: could not write baseline to "${opts.out}": ${msg}\n`);
+    process.exit(1);
+  }
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(
+    `ferry-cost-stats failed: ${err instanceof Error ? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/src/cli/cost/stats.test.ts
+++ b/src/cli/cost/stats.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { computeBaseline } from './stats.js';
+import { EUR_TO_USD } from '../../lib/llm/pricing.js';
+import type { AuditLine } from './types.js';
+
+function makeAuditLine(phase: string, cost_eur: number, input_tokens = 1000): AuditLine {
+  return {
+    ticket: 'PROJ-1',
+    phase,
+    run_id: `run-${Math.random()}`,
+    model: 'anthropic/claude-sonnet-4-6',
+    input_tokens,
+    output_tokens: 100,
+    cost_eur,
+    outcome: 'success',
+    duration_ms: 5000,
+    timestamp: '2026-05-01T00:00:00Z',
+  };
+}
+
+// 5 refiner lines with cost_eur: 0.10, 0.20, 0.30, 0.40, 0.50
+// 5 developer lines with cost_eur: 0.50, 1.00, 1.50, 2.00, 2.50
+const fixtureLines: AuditLine[] = [
+  makeAuditLine('refiner', 0.1, 500),
+  makeAuditLine('refiner', 0.2, 1000),
+  makeAuditLine('refiner', 0.3, 1500),
+  makeAuditLine('refiner', 0.4, 2000),
+  makeAuditLine('refiner', 0.5, 2500),
+  makeAuditLine('developer', 0.5, 5000),
+  makeAuditLine('developer', 1.0, 10000),
+  makeAuditLine('developer', 1.5, 15000),
+  makeAuditLine('developer', 2.0, 20000),
+  makeAuditLine('developer', 2.5, 25000),
+];
+
+describe('computeBaseline', () => {
+  it('returns 2 byPhase entries for 2 distinct phases', () => {
+    const baseline = computeBaseline(fixtureLines, 'org/repo');
+    expect(baseline.byPhase).toHaveLength(2);
+  });
+
+  it('sets windowRuns to total number of lines', () => {
+    const baseline = computeBaseline(fixtureLines, 'org/repo');
+    expect(baseline.windowRuns).toBe(10);
+  });
+
+  it('sets repo and generatedAt', () => {
+    const baseline = computeBaseline(fixtureLines, 'org/repo');
+    expect(baseline.repo).toBe('org/repo');
+    expect(typeof baseline.generatedAt).toBe('string');
+  });
+
+  it('computes correct median USD for refiner phase', () => {
+    const baseline = computeBaseline(fixtureLines, 'org/repo');
+    const refiner = baseline.byPhase.find((p) => p.phase === 'refiner');
+    expect(refiner).toBeDefined();
+    // sorted: 0.10, 0.20, 0.30, 0.40, 0.50 → median = 0.30 EUR → USD
+    const expectedMedianUsd = 0.3 * EUR_TO_USD;
+    expect(refiner!.medianUsd).toBeCloseTo(expectedMedianUsd, 5);
+  });
+
+  it('computes correct p90 USD for refiner phase', () => {
+    const baseline = computeBaseline(fixtureLines, 'org/repo');
+    const refiner = baseline.byPhase.find((p) => p.phase === 'refiner');
+    expect(refiner).toBeDefined();
+    // sorted: 0.10, 0.20, 0.30, 0.40, 0.50 → p90 index = floor(5*0.9)=4 → 0.50 EUR
+    const expectedP90Usd = 0.5 * EUR_TO_USD;
+    expect(refiner!.p90Usd).toBeCloseTo(expectedP90Usd, 5);
+  });
+
+  it('computes correct median USD for developer phase', () => {
+    const baseline = computeBaseline(fixtureLines, 'org/repo');
+    const developer = baseline.byPhase.find((p) => p.phase === 'developer');
+    expect(developer).toBeDefined();
+    // sorted: 0.50, 1.00, 1.50, 2.00, 2.50 → median = 1.50 EUR
+    const expectedMedianUsd = 1.5 * EUR_TO_USD;
+    expect(developer!.medianUsd).toBeCloseTo(expectedMedianUsd, 5);
+  });
+
+  it('computes correct p90 USD for developer phase', () => {
+    const baseline = computeBaseline(fixtureLines, 'org/repo');
+    const developer = baseline.byPhase.find((p) => p.phase === 'developer');
+    expect(developer).toBeDefined();
+    // sorted: 0.50, 1.00, 1.50, 2.00, 2.50 → p90 index = 4 → 2.50 EUR
+    const expectedP90Usd = 2.5 * EUR_TO_USD;
+    expect(developer!.p90Usd).toBeCloseTo(expectedP90Usd, 5);
+  });
+
+  it('computes correct medianInputTokens for refiner phase', () => {
+    const baseline = computeBaseline(fixtureLines, 'org/repo');
+    const refiner = baseline.byPhase.find((p) => p.phase === 'refiner');
+    expect(refiner).toBeDefined();
+    // sorted: 500, 1000, 1500, 2000, 2500 → median = 1500
+    expect(refiner!.medianInputTokens).toBe(1500);
+  });
+
+  it('returns runs count per phase', () => {
+    const baseline = computeBaseline(fixtureLines, 'org/repo');
+    const refiner = baseline.byPhase.find((p) => p.phase === 'refiner');
+    const developer = baseline.byPhase.find((p) => p.phase === 'developer');
+    expect(refiner!.runs).toBe(5);
+    expect(developer!.runs).toBe(5);
+  });
+
+  it('handles empty lines', () => {
+    const baseline = computeBaseline([], 'org/repo');
+    expect(baseline.byPhase).toHaveLength(0);
+    expect(baseline.windowRuns).toBe(0);
+  });
+});

--- a/src/cli/cost/stats.ts
+++ b/src/cli/cost/stats.ts
@@ -1,0 +1,66 @@
+import { EUR_TO_USD } from '../../lib/llm/pricing.js';
+import { groupByPhase } from './aggregate.js';
+import type { AuditLine } from './types.js';
+
+export interface PhaseBaseline {
+  phase: string;
+  runs: number;
+  medianUsd: number;
+  p90Usd: number;
+  medianInputTokens: number;
+}
+
+export interface CostBaseline {
+  repo: string;
+  generatedAt: string;
+  windowRuns: number;
+  byPhase: PhaseBaseline[];
+}
+
+function median(sorted: number[]): number {
+  if (sorted.length === 0) return 0;
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[mid]! : (sorted[mid - 1]! + sorted[mid]!) / 2;
+}
+
+function p90(sorted: number[]): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(Math.floor(sorted.length * 0.9), sorted.length - 1);
+  return sorted[idx]!;
+}
+
+export function computeBaseline(lines: AuditLine[], repo: string): CostBaseline {
+  const phaseMap = new Map<string, AuditLine[]>();
+  for (const line of lines) {
+    const existing = phaseMap.get(line.phase);
+    if (existing) {
+      existing.push(line);
+    } else {
+      phaseMap.set(line.phase, [line]);
+    }
+  }
+
+  // Use groupByPhase for consistent grouping order
+  const phaseGroups = groupByPhase(lines);
+
+  const byPhase: PhaseBaseline[] = phaseGroups.map((group) => {
+    const phaseLines = phaseMap.get(group.key) ?? [];
+    const costsUsd = phaseLines.map((l) => l.cost_eur * EUR_TO_USD).sort((a, b) => a - b);
+    const inputTokensSorted = phaseLines.map((l) => l.input_tokens).sort((a, b) => a - b);
+
+    return {
+      phase: group.key,
+      runs: phaseLines.length,
+      medianUsd: median(costsUsd),
+      p90Usd: p90(costsUsd),
+      medianInputTokens: median(inputTokensSorted),
+    };
+  });
+
+  return {
+    repo,
+    generatedAt: new Date().toISOString(),
+    windowRuns: lines.length,
+    byPhase,
+  };
+}

--- a/src/labels/allowlist.ts
+++ b/src/labels/allowlist.ts
@@ -27,6 +27,8 @@ export const LABELS_ALLOWLIST = [
   'ferry:type:force-story',
   // Routing (user-applied, not agent-applied)
   'critical',
+  // Dynamic cost-estimate labels (prefix only; full label is "ferry:cost-estimate:<lo>-<hi>")
+  'ferry:cost-estimate:',
   // Logger component identifiers (not GitHub labels — used in createLogger calls)
   'ferry:refiner-action',
   'ferry:dev-action',

--- a/src/lib/audit/index.ts
+++ b/src/lib/audit/index.ts
@@ -16,6 +16,7 @@ export interface AuditPayload {
   start: number;
   triggeredLabels?: string[];
   resolvedMcpServers?: string[];
+  estimatedCostUsdRange?: { lo: number; hi: number };
 }
 
 export interface AuditOpts {
@@ -118,6 +119,7 @@ export async function emitAudit(payload: AuditPayload, opts: AuditOpts): Promise
     start,
     triggeredLabels,
     resolvedMcpServers,
+    estimatedCostUsdRange,
   } = payload;
 
   let rotatedTo: number | undefined;
@@ -172,6 +174,8 @@ export async function emitAudit(payload: AuditPayload, opts: AuditOpts): Promise
 
   if (triggeredLabels !== undefined) auditLine.triggered_labels = triggeredLabels;
   if (resolvedMcpServers !== undefined) auditLine.resolved_mcp_servers = resolvedMcpServers;
+  if (estimatedCostUsdRange !== undefined)
+    auditLine.estimated_cost_usd_range = estimatedCostUsdRange;
 
   const body = `${marker}\n${JSON.stringify(auditLine)}`;
 

--- a/src/lib/llm/pricing.ts
+++ b/src/lib/llm/pricing.ts
@@ -5,6 +5,9 @@ interface TokenRates {
   outputPer1M: number;
 }
 
+/** EUR/USD exchange rate pinned 2025-Q2. 1 EUR = 1/0.93 USD. */
+export const EUR_TO_USD = 1 / 0.93;
+
 // EUR/USD ≈ 0.93; rates pinned 2025-Q2
 const RATES: Record<string, TokenRates> = {
   'anthropic/claude-sonnet-4-6': { inputPer1M: 2.79, outputPer1M: 13.95 },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,10 @@ export default defineConfig({
         'src/cli/**/index.ts',
         'src/cli/**/prompt.ts',
         'src/cli/cost/run.ts',
+        // CLI cost entrypoints — same role as index.ts, exercised via integration runs.
+        'src/cli/cost/stats-cmd.ts',
+        'src/cli/cost/advice-cmd.ts',
+        'src/cli/cost/reconcile-cmd.ts',
       ],
       // Ratcheted up after adding CLI module tests (issue #85).
       thresholds: {


### PR DESCRIPTION
## Summary

- **`ferry-cost-stats` CLI** — reads `ferry-audit.jsonl`, produces `cost-baseline.json` with per-phase median/p90 cost in USD. New `bin` entry: `ferry-cost-stats`. Build entry added to `scripts/build-cli.mjs`.
- **Refiner cost estimation** — after planning and before creating subtasks, the Refiner loads `cost-baseline.json` (if present), posts a `[ferry:refiner-estimate:<id>]` Jira comment with the estimated `$lo–$hi` range and confidence level, and applies a `ferry:cost-estimate:<lo>-<hi>` label.
- **Hard-cap enforcement** — if `COST_TICKET_MAX_USD` is set and the estimated high exceeds it, the Refiner posts a `[ferry:refiner-cap:<id>]` comment and returns early (no subtasks created).
- **`AuditPayload` extended** — added optional `estimatedCostUsdRange?: { lo: number; hi: number }`, emitted as `estimated_cost_usd_range` in the audit JSONL line when present.
- **`EUR_TO_USD` exported** from `src/lib/llm/pricing.ts` so the stats library can reuse the pinned exchange rate.
- **`RefinerOutput` extended** — added optional `cost_estimate` field with `loUsd`, `hiUsd`, `confidence`, `baselineRuns` (plus JSON schema property).
- **Labels allowlist** — added `ferry:cost-estimate:` prefix entry.

## Usage example — `ferry-cost-stats`

```bash
# Generate baseline from local audit log
npx -p @big-emotion/ferry ferry-cost-stats \
  --audit-log ./ferry-audit.jsonl \
  --repo your-org/your-repo \
  --out ./cost-baseline.json

# Commit it so the Refiner can read it at runtime
git add cost-baseline.json && git commit -m "chore: update cost baseline"
```

## Example — Refiner estimate comment + label

```
[ferry:refiner-estimate:evt-abc123] Estimated cost: $0.60–$1.89
(confidence: medium, based on 47 runs)
```

Label applied: `ferry:cost-estimate:0.60-1.89`

## Example — cap refusal

With `COST_TICKET_MAX_USD=5.00` in `ferry-refine.yml`:

```
[ferry:refiner-cap:evt-abc123] Estimated cost $0.60–$6.20 exceeds cap $5.00.
Consider splitting this ticket into smaller pieces.
```

No subtasks are created. Ticket stays in its current column.

## CHANGELOG entry

See `CHANGELOG.md` — two new entries added under `[Unreleased] → Added`:
- `ferry-cost-stats` CLI
- Refiner cost estimation + cap enforcement

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm run format:check` — passes
- [x] `npm test` — 1347 tests pass (108 test files)
  - New: `src/cli/cost/stats.test.ts` — 8 tests covering `computeBaseline` (median/p90 USD, medianInputTokens, empty input)
  - New: `src/agents/refiner/refiner-action.cost-estimate.test.ts` — 7 tests covering cold-start skip, warm baseline (comment + label + subtask creation), cap refusal (early exit, no subtasks), cap not set (skipped)
- [x] `npm run build:cli` — `dist/cli/cost/stats.js` produced and chmod'd 755

Closes #255