### PR TITLE
test: add locale-invariance regression tests for step-summary and wip-finalizer (#226)

### DIFF
--- a/src/agents/developer/wip-finalizer.test.ts
+++ b/src/agents/developer/wip-finalizer.test.ts
@@ -60,6 +60,32 @@ describe('classifyError', () => {
     expect(detail).toContain('500,000');
   });
 
+  it('formats token counts in en-US regardless of host locale (regression #226)', () => {
+    // Simulate a non-English host locale: patch toLocaleString to use 'fr-FR' when
+    // no explicit locale is passed. If production code ever drops the 'en-US' argument,
+    // French formatting will cause these assertions to fail.
+    const original = Number.prototype.toLocaleString;
+    Number.prototype.toLocaleString = function (
+      locale?: string | string[],
+      opts?: Intl.NumberFormatOptions,
+    ) {
+      return original.call(this, locale ?? 'fr-FR', opts);
+    };
+    try {
+      const err = new FerryError('spend-cap', {
+        reason: 'input-token-budget-exceeded',
+        cap: 500_000,
+        consumed: 520_000,
+      });
+      const { code, detail } = classifyError(err);
+      expect(code).toBe('spend-cap');
+      expect(detail).toContain('520,000');
+      expect(detail).toContain('500,000');
+    } finally {
+      Number.prototype.toLocaleString = original;
+    }
+  });
+
   it('classifies spend-cap without counts when context is missing', () => {
     const err = new FerryError('spend-cap', {});
     const { code, detail } = classifyError(err);

--- a/src/lib/agent-runtime/step-summary.test.ts
+++ b/src/lib/agent-runtime/step-summary.test.ts
@@ -98,6 +98,28 @@ describe('formatStepSummary', () => {
     expect(out).not.toContain('5,000');
   });
 
+  it('formats numbers in en-US regardless of host locale (regression #226)', () => {
+    // Simulate a non-English host locale: patch toLocaleString to use 'fr-FR' when
+    // no explicit locale is passed. If production code ever drops the 'en-US' argument,
+    // French formatting (non-breaking-space grouping) will cause these assertions to fail.
+    const original = Number.prototype.toLocaleString;
+    Number.prototype.toLocaleString = function (
+      locale?: string | string[],
+      opts?: Intl.NumberFormatOptions,
+    ) {
+      return original.call(this, locale ?? 'fr-FR', opts);
+    };
+    try {
+      const out = formatStepSummary(baseStats);
+      expect(out).toContain('12,000');
+      expect(out).toContain('3,000');
+      expect(out).toContain('50,000');
+      expect(out).toContain('30,000');
+    } finally {
+      Number.prototype.toLocaleString = original;
+    }
+  });
+
   it('shows files touched', () => {
     const out = formatStepSummary(baseStats);
     expect(out).toContain('`src/foo.ts`');


### PR DESCRIPTION
Closes #226

Adds two regression tests that simulate a French host locale by patching `Number.prototype.toLocaleString` to default to `'fr-FR'` when called without an explicit locale. If the `'en-US'` argument is ever removed from a production call, the test fails with French grouping separators instead of commas.

Generated with [Claude Code](https://claude.ai/code)