### PR TITLE
feat(git): configurable working branch prefix per issue type + fix reviewer hardcoded prefix

### DIFF
--- a/.ferry/dev-action.js
+++ b/.ferry/dev-action.js
@@ -819,8 +819,24 @@ function validateConfigShape(raw) {
         errs.push("git.target_branch: must be a non-empty string or null");
       }
       if (g.working_branch_prefix !== void 0) {
-        if (typeof g.working_branch_prefix !== "string" || g.working_branch_prefix.length === 0) {
-          errs.push("git.working_branch_prefix: must be a non-empty string");
+        if (typeof g.working_branch_prefix === "string") {
+          if (g.working_branch_prefix.length === 0) {
+            errs.push("git.working_branch_prefix: must be a non-empty string");
+          }
+        } else if (g.working_branch_prefix !== null && typeof g.working_branch_prefix === "object" && !Array.isArray(g.working_branch_prefix)) {
+          const mapping = g.working_branch_prefix;
+          if (!("default" in mapping)) {
+            errs.push('git.working_branch_prefix: mapping must include a "default" key');
+          }
+          for (const [k, v] of Object.entries(mapping)) {
+            if (typeof v !== "string" || v.length === 0) {
+              errs.push(`git.working_branch_prefix.${k}: must be a non-empty string`);
+            }
+          }
+        } else {
+          errs.push(
+            'git.working_branch_prefix: must be a non-empty string or a mapping object with a "default" key'
+          );
         }
       }
     }
@@ -1015,7 +1031,7 @@ function mergeWithDefaults(raw) {
     git: {
       base_branch: "base_branch" in g ? nullableStr(g.base_branch, null) : DEFAULT_FERRY_CONFIG.git.base_branch,
       target_branch: "target_branch" in g ? nullableStr(g.target_branch, null) : DEFAULT_FERRY_CONFIG.git.target_branch,
-      working_branch_prefix: typeof g.working_branch_prefix === "string" ? g.working_branch_prefix : DEFAULT_FERRY_CONFIG.git.working_branch_prefix
+      working_branch_prefix: typeof g.working_branch_prefix === "string" ? g.working_branch_prefix : g.working_branch_prefix !== null && typeof g.working_branch_prefix === "object" && !Array.isArray(g.working_branch_prefix) ? g.working_branch_prefix : DEFAULT_FERRY_CONFIG.git.working_branch_prefix
     },
     ...labels !== void 0 ? { labels } : {},
     workflow: mergeWorkflow(raw.workflow)
@@ -5389,6 +5405,19 @@ function createGitHubContext(repoRoot) {
 }
 
 // src/lib/agent-runtime/resolve-git-config.ts
+function resolveBranchPrefix(prefix, issue) {
+  if (typeof prefix === "string") return prefix;
+  for (const label of issue.labels) {
+    const match = /^ferry:type:(.+)$/.exec(label);
+    if (match) {
+      const labelType = match[1];
+      if (labelType in prefix) return prefix[labelType];
+      break;
+    }
+  }
+  if (issue.issueType in prefix) return prefix[issue.issueType];
+  return prefix["default"];
+}
 async function resolveGitConfig(ferryCfg, runner, owner, repo) {
   const { base_branch, target_branch, working_branch_prefix } = ferryCfg.git;
   const baseBranch = base_branch ?? await runner.getRepoDefaultBranch(owner, repo);
@@ -7521,12 +7550,7 @@ async function main(envelope, logger) {
     logger.info("DRY_RUN mode \u2014 no branch push, no PR, no Jira writes");
   }
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT);
-  const { baseBranch, targetBranch, workingBranchPrefix } = await resolveGitConfig(
-    initialCfg,
-    runner,
-    owner,
-    repo
-  );
+  const { baseBranch, targetBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
   const { provider: devProvider } = ferryCfg.models.dev;
   const devWorkflow = ferryCfg.workflow.agents.developer;
@@ -7553,7 +7577,7 @@ async function main(envelope, logger) {
 ${pkgManagerHint}`] : []
   });
   const model = ferryCfg.models.dev.model;
-  const branchName = `${workingBranchPrefix}${ticketKey}`;
+  const branchName = `${resolveBranchPrefix(ferryCfg.git.working_branch_prefix, issue)}${ticketKey}`;
   configureFerryGitUser(REPO_ROOT);
   let resumeContext = "";
   let branchHeadSha = "";

--- a/.ferry/iterate-action.js
+++ b/.ferry/iterate-action.js
@@ -2756,8 +2756,24 @@ function validateConfigShape(raw) {
         errs.push("git.target_branch: must be a non-empty string or null");
       }
       if (g.working_branch_prefix !== void 0) {
-        if (typeof g.working_branch_prefix !== "string" || g.working_branch_prefix.length === 0) {
-          errs.push("git.working_branch_prefix: must be a non-empty string");
+        if (typeof g.working_branch_prefix === "string") {
+          if (g.working_branch_prefix.length === 0) {
+            errs.push("git.working_branch_prefix: must be a non-empty string");
+          }
+        } else if (g.working_branch_prefix !== null && typeof g.working_branch_prefix === "object" && !Array.isArray(g.working_branch_prefix)) {
+          const mapping = g.working_branch_prefix;
+          if (!("default" in mapping)) {
+            errs.push('git.working_branch_prefix: mapping must include a "default" key');
+          }
+          for (const [k, v] of Object.entries(mapping)) {
+            if (typeof v !== "string" || v.length === 0) {
+              errs.push(`git.working_branch_prefix.${k}: must be a non-empty string`);
+            }
+          }
+        } else {
+          errs.push(
+            'git.working_branch_prefix: must be a non-empty string or a mapping object with a "default" key'
+          );
         }
       }
     }
@@ -2952,7 +2968,7 @@ function mergeWithDefaults(raw) {
     git: {
       base_branch: "base_branch" in g ? nullableStr(g.base_branch, null) : DEFAULT_FERRY_CONFIG.git.base_branch,
       target_branch: "target_branch" in g ? nullableStr(g.target_branch, null) : DEFAULT_FERRY_CONFIG.git.target_branch,
-      working_branch_prefix: typeof g.working_branch_prefix === "string" ? g.working_branch_prefix : DEFAULT_FERRY_CONFIG.git.working_branch_prefix
+      working_branch_prefix: typeof g.working_branch_prefix === "string" ? g.working_branch_prefix : g.working_branch_prefix !== null && typeof g.working_branch_prefix === "object" && !Array.isArray(g.working_branch_prefix) ? g.working_branch_prefix : DEFAULT_FERRY_CONFIG.git.working_branch_prefix
     },
     ...labels !== void 0 ? { labels } : {},
     workflow: mergeWorkflow(raw.workflow)
@@ -7326,6 +7342,19 @@ function createGitHubContext(repoRoot) {
 }
 
 // src/lib/agent-runtime/resolve-git-config.ts
+function resolveBranchPrefix(prefix, issue) {
+  if (typeof prefix === "string") return prefix;
+  for (const label of issue.labels) {
+    const match = /^ferry:type:(.+)$/.exec(label);
+    if (match) {
+      const labelType = match[1];
+      if (labelType in prefix) return prefix[labelType];
+      break;
+    }
+  }
+  if (issue.issueType in prefix) return prefix[issue.issueType];
+  return prefix["default"];
+}
 async function resolveGitConfig(ferryCfg, runner, owner, repo) {
   const { base_branch, target_branch, working_branch_prefix } = ferryCfg.git;
   const baseBranch = base_branch ?? await runner.getRepoDefaultBranch(owner, repo);
@@ -7338,12 +7367,7 @@ var REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT);
-  const { baseBranch, workingBranchPrefix } = await resolveGitConfig(
-    initialCfg,
-    runner,
-    owner,
-    repo
-  );
+  const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
   const { provider: iterProvider, model } = ferryCfg.models.iterate;
   const iteratorWorkflow = ferryCfg.workflow.agents.iterator;
@@ -7365,7 +7389,7 @@ async function main(envelope, logger) {
     { iteration: priorIterations, hasFindings: true },
     ferryCfg.limits.max_iterations
   );
-  const branchName = `${workingBranchPrefix}${ticketKey}`;
+  const branchName = `${resolveBranchPrefix(ferryCfg.git.working_branch_prefix, issue)}${ticketKey}`;
   const prs = await runner.listPRsForBranch(owner, repo, branchName);
   if (prs.length === 0) {
     const eventMarker = byEventId("iterator", eventId);

--- a/.ferry/refiner-action.js
+++ b/.ferry/refiner-action.js
@@ -827,8 +827,24 @@ function validateConfigShape(raw) {
         errs.push("git.target_branch: must be a non-empty string or null");
       }
       if (g.working_branch_prefix !== void 0) {
-        if (typeof g.working_branch_prefix !== "string" || g.working_branch_prefix.length === 0) {
-          errs.push("git.working_branch_prefix: must be a non-empty string");
+        if (typeof g.working_branch_prefix === "string") {
+          if (g.working_branch_prefix.length === 0) {
+            errs.push("git.working_branch_prefix: must be a non-empty string");
+          }
+        } else if (g.working_branch_prefix !== null && typeof g.working_branch_prefix === "object" && !Array.isArray(g.working_branch_prefix)) {
+          const mapping = g.working_branch_prefix;
+          if (!("default" in mapping)) {
+            errs.push('git.working_branch_prefix: mapping must include a "default" key');
+          }
+          for (const [k, v] of Object.entries(mapping)) {
+            if (typeof v !== "string" || v.length === 0) {
+              errs.push(`git.working_branch_prefix.${k}: must be a non-empty string`);
+            }
+          }
+        } else {
+          errs.push(
+            'git.working_branch_prefix: must be a non-empty string or a mapping object with a "default" key'
+          );
         }
       }
     }
@@ -1023,7 +1039,7 @@ function mergeWithDefaults(raw) {
     git: {
       base_branch: "base_branch" in g ? nullableStr(g.base_branch, null) : DEFAULT_FERRY_CONFIG.git.base_branch,
       target_branch: "target_branch" in g ? nullableStr(g.target_branch, null) : DEFAULT_FERRY_CONFIG.git.target_branch,
-      working_branch_prefix: typeof g.working_branch_prefix === "string" ? g.working_branch_prefix : DEFAULT_FERRY_CONFIG.git.working_branch_prefix
+      working_branch_prefix: typeof g.working_branch_prefix === "string" ? g.working_branch_prefix : g.working_branch_prefix !== null && typeof g.working_branch_prefix === "object" && !Array.isArray(g.working_branch_prefix) ? g.working_branch_prefix : DEFAULT_FERRY_CONFIG.git.working_branch_prefix
     },
     ...labels !== void 0 ? { labels } : {},
     workflow: mergeWorkflow(raw.workflow)

--- a/.ferry/review-action.js
+++ b/.ferry/review-action.js
@@ -1487,8 +1487,24 @@ function validateConfigShape(raw) {
         errs.push("git.target_branch: must be a non-empty string or null");
       }
       if (g.working_branch_prefix !== void 0) {
-        if (typeof g.working_branch_prefix !== "string" || g.working_branch_prefix.length === 0) {
-          errs.push("git.working_branch_prefix: must be a non-empty string");
+        if (typeof g.working_branch_prefix === "string") {
+          if (g.working_branch_prefix.length === 0) {
+            errs.push("git.working_branch_prefix: must be a non-empty string");
+          }
+        } else if (g.working_branch_prefix !== null && typeof g.working_branch_prefix === "object" && !Array.isArray(g.working_branch_prefix)) {
+          const mapping = g.working_branch_prefix;
+          if (!("default" in mapping)) {
+            errs.push('git.working_branch_prefix: mapping must include a "default" key');
+          }
+          for (const [k, v] of Object.entries(mapping)) {
+            if (typeof v !== "string" || v.length === 0) {
+              errs.push(`git.working_branch_prefix.${k}: must be a non-empty string`);
+            }
+          }
+        } else {
+          errs.push(
+            'git.working_branch_prefix: must be a non-empty string or a mapping object with a "default" key'
+          );
         }
       }
     }
@@ -1683,7 +1699,7 @@ function mergeWithDefaults(raw) {
     git: {
       base_branch: "base_branch" in g ? nullableStr(g.base_branch, null) : DEFAULT_FERRY_CONFIG.git.base_branch,
       target_branch: "target_branch" in g ? nullableStr(g.target_branch, null) : DEFAULT_FERRY_CONFIG.git.target_branch,
-      working_branch_prefix: typeof g.working_branch_prefix === "string" ? g.working_branch_prefix : DEFAULT_FERRY_CONFIG.git.working_branch_prefix
+      working_branch_prefix: typeof g.working_branch_prefix === "string" ? g.working_branch_prefix : g.working_branch_prefix !== null && typeof g.working_branch_prefix === "object" && !Array.isArray(g.working_branch_prefix) ? g.working_branch_prefix : DEFAULT_FERRY_CONFIG.git.working_branch_prefix
     },
     ...labels !== void 0 ? { labels } : {},
     workflow: mergeWorkflow(raw.workflow)
@@ -5973,6 +5989,19 @@ function createGitHubContext(repoRoot) {
 }
 
 // src/lib/agent-runtime/resolve-git-config.ts
+function resolveBranchPrefix(prefix, issue) {
+  if (typeof prefix === "string") return prefix;
+  for (const label of issue.labels) {
+    const match = /^ferry:type:(.+)$/.exec(label);
+    if (match) {
+      const labelType = match[1];
+      if (labelType in prefix) return prefix[labelType];
+      break;
+    }
+  }
+  if (issue.issueType in prefix) return prefix[issue.issueType];
+  return prefix["default"];
+}
 async function resolveGitConfig(ferryCfg, runner, owner, repo) {
   const { base_branch, target_branch, working_branch_prefix } = ferryCfg.git;
   const baseBranch = base_branch ?? await runner.getRepoDefaultBranch(owner, repo);
@@ -6006,7 +6035,7 @@ async function main(envelope, logger) {
   logCapabilities(logger, capabilities);
   const typeOverrides = resolveTypeOverrides(issue.labels);
   logTypeOverrides(logger, typeOverrides);
-  const branchName = `ferry/${ticketKey}`;
+  const branchName = `${resolveBranchPrefix(ferryCfg.git.working_branch_prefix, issue)}${ticketKey}`;
   const prs = await runner.listPRsForBranch(owner, repo, branchName);
   if (prs.length === 0) {
     const errorMarker = byEventId("reviewer", eventId);

--- a/.github/actions/ferry-run-developer/dev-action.js
+++ b/.github/actions/ferry-run-developer/dev-action.js
@@ -819,8 +819,24 @@ function validateConfigShape(raw) {
         errs.push("git.target_branch: must be a non-empty string or null");
       }
       if (g.working_branch_prefix !== void 0) {
-        if (typeof g.working_branch_prefix !== "string" || g.working_branch_prefix.length === 0) {
-          errs.push("git.working_branch_prefix: must be a non-empty string");
+        if (typeof g.working_branch_prefix === "string") {
+          if (g.working_branch_prefix.length === 0) {
+            errs.push("git.working_branch_prefix: must be a non-empty string");
+          }
+        } else if (g.working_branch_prefix !== null && typeof g.working_branch_prefix === "object" && !Array.isArray(g.working_branch_prefix)) {
+          const mapping = g.working_branch_prefix;
+          if (!("default" in mapping)) {
+            errs.push('git.working_branch_prefix: mapping must include a "default" key');
+          }
+          for (const [k, v] of Object.entries(mapping)) {
+            if (typeof v !== "string" || v.length === 0) {
+              errs.push(`git.working_branch_prefix.${k}: must be a non-empty string`);
+            }
+          }
+        } else {
+          errs.push(
+            'git.working_branch_prefix: must be a non-empty string or a mapping object with a "default" key'
+          );
         }
       }
     }
@@ -1015,7 +1031,7 @@ function mergeWithDefaults(raw) {
     git: {
       base_branch: "base_branch" in g ? nullableStr(g.base_branch, null) : DEFAULT_FERRY_CONFIG.git.base_branch,
       target_branch: "target_branch" in g ? nullableStr(g.target_branch, null) : DEFAULT_FERRY_CONFIG.git.target_branch,
-      working_branch_prefix: typeof g.working_branch_prefix === "string" ? g.working_branch_prefix : DEFAULT_FERRY_CONFIG.git.working_branch_prefix
+      working_branch_prefix: typeof g.working_branch_prefix === "string" ? g.working_branch_prefix : g.working_branch_prefix !== null && typeof g.working_branch_prefix === "object" && !Array.isArray(g.working_branch_prefix) ? g.working_branch_prefix : DEFAULT_FERRY_CONFIG.git.working_branch_prefix
     },
     ...labels !== void 0 ? { labels } : {},
     workflow: mergeWorkflow(raw.workflow)
@@ -5389,6 +5405,19 @@ function createGitHubContext(repoRoot) {
 }
 
 // src/lib/agent-runtime/resolve-git-config.ts
+function resolveBranchPrefix(prefix, issue) {
+  if (typeof prefix === "string") return prefix;
+  for (const label of issue.labels) {
+    const match = /^ferry:type:(.+)$/.exec(label);
+    if (match) {
+      const labelType = match[1];
+      if (labelType in prefix) return prefix[labelType];
+      break;
+    }
+  }
+  if (issue.issueType in prefix) return prefix[issue.issueType];
+  return prefix["default"];
+}
 async function resolveGitConfig(ferryCfg, runner, owner, repo) {
   const { base_branch, target_branch, working_branch_prefix } = ferryCfg.git;
   const baseBranch = base_branch ?? await runner.getRepoDefaultBranch(owner, repo);
@@ -7521,12 +7550,7 @@ async function main(envelope, logger) {
     logger.info("DRY_RUN mode \u2014 no branch push, no PR, no Jira writes");
   }
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT);
-  const { baseBranch, targetBranch, workingBranchPrefix } = await resolveGitConfig(
-    initialCfg,
-    runner,
-    owner,
-    repo
-  );
+  const { baseBranch, targetBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
   const { provider: devProvider } = ferryCfg.models.dev;
   const devWorkflow = ferryCfg.workflow.agents.developer;
@@ -7553,7 +7577,7 @@ async function main(envelope, logger) {
 ${pkgManagerHint}`] : []
   });
   const model = ferryCfg.models.dev.model;
-  const branchName = `${workingBranchPrefix}${ticketKey}`;
+  const branchName = `${resolveBranchPrefix(ferryCfg.git.working_branch_prefix, issue)}${ticketKey}`;
   configureFerryGitUser(REPO_ROOT);
   let resumeContext = "";
   let branchHeadSha = "";

--- a/.github/actions/ferry-run-iterator/iterate-action.js
+++ b/.github/actions/ferry-run-iterator/iterate-action.js
@@ -2756,8 +2756,24 @@ function validateConfigShape(raw) {
         errs.push("git.target_branch: must be a non-empty string or null");
       }
       if (g.working_branch_prefix !== void 0) {
-        if (typeof g.working_branch_prefix !== "string" || g.working_branch_prefix.length === 0) {
-          errs.push("git.working_branch_prefix: must be a non-empty string");
+        if (typeof g.working_branch_prefix === "string") {
+          if (g.working_branch_prefix.length === 0) {
+            errs.push("git.working_branch_prefix: must be a non-empty string");
+          }
+        } else if (g.working_branch_prefix !== null && typeof g.working_branch_prefix === "object" && !Array.isArray(g.working_branch_prefix)) {
+          const mapping = g.working_branch_prefix;
+          if (!("default" in mapping)) {
+            errs.push('git.working_branch_prefix: mapping must include a "default" key');
+          }
+          for (const [k, v] of Object.entries(mapping)) {
+            if (typeof v !== "string" || v.length === 0) {
+              errs.push(`git.working_branch_prefix.${k}: must be a non-empty string`);
+            }
+          }
+        } else {
+          errs.push(
+            'git.working_branch_prefix: must be a non-empty string or a mapping object with a "default" key'
+          );
         }
       }
     }
@@ -2952,7 +2968,7 @@ function mergeWithDefaults(raw) {
     git: {
       base_branch: "base_branch" in g ? nullableStr(g.base_branch, null) : DEFAULT_FERRY_CONFIG.git.base_branch,
       target_branch: "target_branch" in g ? nullableStr(g.target_branch, null) : DEFAULT_FERRY_CONFIG.git.target_branch,
-      working_branch_prefix: typeof g.working_branch_prefix === "string" ? g.working_branch_prefix : DEFAULT_FERRY_CONFIG.git.working_branch_prefix
+      working_branch_prefix: typeof g.working_branch_prefix === "string" ? g.working_branch_prefix : g.working_branch_prefix !== null && typeof g.working_branch_prefix === "object" && !Array.isArray(g.working_branch_prefix) ? g.working_branch_prefix : DEFAULT_FERRY_CONFIG.git.working_branch_prefix
     },
     ...labels !== void 0 ? { labels } : {},
     workflow: mergeWorkflow(raw.workflow)
@@ -7326,6 +7342,19 @@ function createGitHubContext(repoRoot) {
 }
 
 // src/lib/agent-runtime/resolve-git-config.ts
+function resolveBranchPrefix(prefix, issue) {
+  if (typeof prefix === "string") return prefix;
+  for (const label of issue.labels) {
+    const match = /^ferry:type:(.+)$/.exec(label);
+    if (match) {
+      const labelType = match[1];
+      if (labelType in prefix) return prefix[labelType];
+      break;
+    }
+  }
+  if (issue.issueType in prefix) return prefix[issue.issueType];
+  return prefix["default"];
+}
 async function resolveGitConfig(ferryCfg, runner, owner, repo) {
   const { base_branch, target_branch, working_branch_prefix } = ferryCfg.git;
   const baseBranch = base_branch ?? await runner.getRepoDefaultBranch(owner, repo);
@@ -7338,12 +7367,7 @@ var REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT);
-  const { baseBranch, workingBranchPrefix } = await resolveGitConfig(
-    initialCfg,
-    runner,
-    owner,
-    repo
-  );
+  const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
   const { provider: iterProvider, model } = ferryCfg.models.iterate;
   const iteratorWorkflow = ferryCfg.workflow.agents.iterator;
@@ -7365,7 +7389,7 @@ async function main(envelope, logger) {
     { iteration: priorIterations, hasFindings: true },
     ferryCfg.limits.max_iterations
   );
-  const branchName = `${workingBranchPrefix}${ticketKey}`;
+  const branchName = `${resolveBranchPrefix(ferryCfg.git.working_branch_prefix, issue)}${ticketKey}`;
   const prs = await runner.listPRsForBranch(owner, repo, branchName);
   if (prs.length === 0) {
     const eventMarker = byEventId("iterator", eventId);

--- a/.github/actions/ferry-run-refiner/refiner-action.js
+++ b/.github/actions/ferry-run-refiner/refiner-action.js
@@ -827,8 +827,24 @@ function validateConfigShape(raw) {
         errs.push("git.target_branch: must be a non-empty string or null");
       }
       if (g.working_branch_prefix !== void 0) {
-        if (typeof g.working_branch_prefix !== "string" || g.working_branch_prefix.length === 0) {
-          errs.push("git.working_branch_prefix: must be a non-empty string");
+        if (typeof g.working_branch_prefix === "string") {
+          if (g.working_branch_prefix.length === 0) {
+            errs.push("git.working_branch_prefix: must be a non-empty string");
+          }
+        } else if (g.working_branch_prefix !== null && typeof g.working_branch_prefix === "object" && !Array.isArray(g.working_branch_prefix)) {
+          const mapping = g.working_branch_prefix;
+          if (!("default" in mapping)) {
+            errs.push('git.working_branch_prefix: mapping must include a "default" key');
+          }
+          for (const [k, v] of Object.entries(mapping)) {
+            if (typeof v !== "string" || v.length === 0) {
+              errs.push(`git.working_branch_prefix.${k}: must be a non-empty string`);
+            }
+          }
+        } else {
+          errs.push(
+            'git.working_branch_prefix: must be a non-empty string or a mapping object with a "default" key'
+          );
         }
       }
     }
@@ -1023,7 +1039,7 @@ function mergeWithDefaults(raw) {
     git: {
       base_branch: "base_branch" in g ? nullableStr(g.base_branch, null) : DEFAULT_FERRY_CONFIG.git.base_branch,
       target_branch: "target_branch" in g ? nullableStr(g.target_branch, null) : DEFAULT_FERRY_CONFIG.git.target_branch,
-      working_branch_prefix: typeof g.working_branch_prefix === "string" ? g.working_branch_prefix : DEFAULT_FERRY_CONFIG.git.working_branch_prefix
+      working_branch_prefix: typeof g.working_branch_prefix === "string" ? g.working_branch_prefix : g.working_branch_prefix !== null && typeof g.working_branch_prefix === "object" && !Array.isArray(g.working_branch_prefix) ? g.working_branch_prefix : DEFAULT_FERRY_CONFIG.git.working_branch_prefix
     },
     ...labels !== void 0 ? { labels } : {},
     workflow: mergeWorkflow(raw.workflow)

--- a/.github/actions/ferry-run-reviewer/review-action.js
+++ b/.github/actions/ferry-run-reviewer/review-action.js
@@ -1487,8 +1487,24 @@ function validateConfigShape(raw) {
         errs.push("git.target_branch: must be a non-empty string or null");
       }
       if (g.working_branch_prefix !== void 0) {
-        if (typeof g.working_branch_prefix !== "string" || g.working_branch_prefix.length === 0) {
-          errs.push("git.working_branch_prefix: must be a non-empty string");
+        if (typeof g.working_branch_prefix === "string") {
+          if (g.working_branch_prefix.length === 0) {
+            errs.push("git.working_branch_prefix: must be a non-empty string");
+          }
+        } else if (g.working_branch_prefix !== null && typeof g.working_branch_prefix === "object" && !Array.isArray(g.working_branch_prefix)) {
+          const mapping = g.working_branch_prefix;
+          if (!("default" in mapping)) {
+            errs.push('git.working_branch_prefix: mapping must include a "default" key');
+          }
+          for (const [k, v] of Object.entries(mapping)) {
+            if (typeof v !== "string" || v.length === 0) {
+              errs.push(`git.working_branch_prefix.${k}: must be a non-empty string`);
+            }
+          }
+        } else {
+          errs.push(
+            'git.working_branch_prefix: must be a non-empty string or a mapping object with a "default" key'
+          );
         }
       }
     }
@@ -1683,7 +1699,7 @@ function mergeWithDefaults(raw) {
     git: {
       base_branch: "base_branch" in g ? nullableStr(g.base_branch, null) : DEFAULT_FERRY_CONFIG.git.base_branch,
       target_branch: "target_branch" in g ? nullableStr(g.target_branch, null) : DEFAULT_FERRY_CONFIG.git.target_branch,
-      working_branch_prefix: typeof g.working_branch_prefix === "string" ? g.working_branch_prefix : DEFAULT_FERRY_CONFIG.git.working_branch_prefix
+      working_branch_prefix: typeof g.working_branch_prefix === "string" ? g.working_branch_prefix : g.working_branch_prefix !== null && typeof g.working_branch_prefix === "object" && !Array.isArray(g.working_branch_prefix) ? g.working_branch_prefix : DEFAULT_FERRY_CONFIG.git.working_branch_prefix
     },
     ...labels !== void 0 ? { labels } : {},
     workflow: mergeWorkflow(raw.workflow)
@@ -5973,6 +5989,19 @@ function createGitHubContext(repoRoot) {
 }
 
 // src/lib/agent-runtime/resolve-git-config.ts
+function resolveBranchPrefix(prefix, issue) {
+  if (typeof prefix === "string") return prefix;
+  for (const label of issue.labels) {
+    const match = /^ferry:type:(.+)$/.exec(label);
+    if (match) {
+      const labelType = match[1];
+      if (labelType in prefix) return prefix[labelType];
+      break;
+    }
+  }
+  if (issue.issueType in prefix) return prefix[issue.issueType];
+  return prefix["default"];
+}
 async function resolveGitConfig(ferryCfg, runner, owner, repo) {
   const { base_branch, target_branch, working_branch_prefix } = ferryCfg.git;
   const baseBranch = base_branch ?? await runner.getRepoDefaultBranch(owner, repo);
@@ -6006,7 +6035,7 @@ async function main(envelope, logger) {
   logCapabilities(logger, capabilities);
   const typeOverrides = resolveTypeOverrides(issue.labels);
   logTypeOverrides(logger, typeOverrides);
-  const branchName = `ferry/${ticketKey}`;
+  const branchName = `${resolveBranchPrefix(ferryCfg.git.working_branch_prefix, issue)}${ticketKey}`;
   const prs = await runner.listPRsForBranch(owner, repo, branchName);
   if (prs.length === 0) {
     const errorMarker = byEventId("reviewer", eventId);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Ferry uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Configurable working branch prefix per issue type** (`git.working_branch_prefix` mapping) — `working_branch_prefix` now accepts either a plain string (existing behaviour, default `"ferry/"`) or a mapping object whose keys are Jira issue type names and whose `default` key covers unmatched types. At runtime the prefix is resolved by checking for a `ferry:type:<name>` label on the ticket first, then the ticket's Jira issue type, then `mapping.default`. This enables [Conventional Branch](https://conventional-branch.github.io/) naming out of the box — see `docs/CONFIGURATION.md` for a copy-pasteable recipe. Existing consumers are unaffected; the default remains `"ferry/"`.
+
+### Fixed
+
+- **Reviewer agent was ignoring `git.working_branch_prefix` config** — `review-action.ts` hardcoded the PR branch lookup as `` `ferry/${ticketKey}` `` instead of reading the resolved prefix from `ferry.config`. Consumers who overrode `working_branch_prefix` found the Reviewer unable to locate the PR. The Reviewer now resolves the prefix from the reloaded base-branch config, consistent with the Developer and Iterator agents.
+
 - **`ferry-cost-stats` CLI** — `npx -p @big-emotion/ferry ferry-cost-stats` reads `ferry-audit.jsonl` and writes `cost-baseline.json` with per-phase median and p90 cost in USD. Flags: `--audit-log`, `--repo`, `--out`. Commit the baseline to your repo root so the Refiner can read it at runtime. See [`docs/COST.md`](docs/COST.md) for full usage.
 - **Refiner cost estimation** — when `cost-baseline.json` is present, the Refiner now computes a `$lo–$hi` cost range after producing its plan, posts it as a Jira comment (`[ferry:refiner-estimate:<id>]`), and applies a `ferry:cost-estimate:<lo>-<hi>` label. Set `COST_TICKET_MAX_USD` to refuse tickets whose estimated high exceeds the cap (posts a `[ferry:refiner-cap:<id>]` comment and exits without creating subtasks). See [`docs/COST.md`](docs/COST.md) for configuration details.
 - **`ferry-cost-report` CLI** — `npx -p @big-emotion/ferry ferry-cost-report` reads `ferry-audit.jsonl` and renders a spend breakdown with per-phase, per-model, per-ticket (top 20), and daily tables plus ASCII sparklines for daily spend and tokens/run trends. Supports `--from`, `--to`, `--ticket`, `--phase`, `--format` (`md`/`json`/`csv`), `--out`, and `--audit-log` flags. An anomalies section flags runs above p95 cost. See [`docs/COST.md`](docs/COST.md) for full usage.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -313,11 +313,11 @@ Controls which Jira issue types Ferry will process.
 
 Controls the Git branching strategy used by the Developer and Iterator agents. All three fields default to values that work without any configuration — omit this section entirely to use the defaults.
 
-| Field                       | Default    | Description                                                                                                                                            |
-| --------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `git.base_branch`           | `null`     | Branch the Developer checks out from when creating a working branch. `null` resolves to the repository's default branch at runtime via the GitHub API. |
-| `git.target_branch`         | `null`     | Branch the PR is opened against. `null` defaults to the same branch as `base_branch`.                                                                  |
-| `git.working_branch_prefix` | `"ferry/"` | Prefix for working branches created by the Developer agent (e.g., `ferry/PROJ-123`). Must be a non-empty string.                                       |
+| Field                       | Default    | Description                                                                                                                                                                      |
+| --------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `git.base_branch`           | `null`     | Branch the Developer checks out from when creating a working branch. `null` resolves to the repository's default branch at runtime via the GitHub API.                           |
+| `git.target_branch`         | `null`     | Branch the PR is opened against. `null` defaults to the same branch as `base_branch`.                                                                                            |
+| `git.working_branch_prefix` | `"ferry/"` | Prefix for working branches. Accepts a **string** (static, e.g. `"ferry/"`) or a **mapping** object (dynamic per Jira issue type — see below). Mapping requires a `default` key. |
 
 Teams using `develop`, `next`, `release/*`, or any other integration branch as their default should set `base_branch` to that branch name. If `target_branch` differs (e.g., PRs target a staging branch while work branches off `main`), set it explicitly.
 
@@ -328,6 +328,29 @@ git:
   target_branch: develop # branch PRs are opened against (omit to default to base_branch)
   working_branch_prefix: ferry/
 ```
+
+##### Conventional Branch naming (opt-in)
+
+Ferry supports [Conventional Branch](https://conventional-branch.github.io/) naming where the branch prefix encodes the type of work (`feature/`, `bugfix/`, `chore/`, `hotfix/`). Set `working_branch_prefix` to a mapping object whose keys are Jira issue type names and whose `default` key covers anything unmatched:
+
+```yaml
+# ferry.config.yaml — Conventional Branch recipe
+git:
+  working_branch_prefix:
+    Bug: bugfix/
+    Story: feature/
+    Task: chore/
+    Epic: feature/
+    default: feature/ # fallback for any unrecognised issue type
+```
+
+Resolution order at runtime:
+
+1. If the Jira ticket has a `ferry:type:<name>` label and `<name>` is a key in the mapping → use that prefix.
+2. Else if the ticket's Jira issue type is a key in the mapping → use that prefix.
+3. Else → use `mapping.default`.
+
+When the value is a plain string (the default `"ferry/"`), resolution is always the static string — no issue type lookup is performed.
 
 #### `labels`
 
@@ -383,12 +406,12 @@ Maps Jira ticket labels to MCP server capabilities. If this section is omitted, 
 
 These four labels are **hardcoded built-ins** — they require no `ferry.config.json` entry and are always recognised by the Developer, Reviewer, and Iterator agents. Apply them directly to your Jira ticket.
 
-| Label | Effect |
-| --- | --- |
+| Label                    | Effect                                                                                                                                                                                |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ferry:type:enable-task` | Bypass the Task skip (FR6) for this ticket only. Ferry processes it as if it were a Story. Useful for one-off Tasks that should be implemented by Ferry without touching the Refiner. |
-| `ferry:type:force-bug` | Treat the ticket as a **Bug** regardless of its Jira issue type. The agent sees `TYPE: Bug` in the prompt. |
-| `ferry:type:force-spike` | Treat the ticket as a **Spike** regardless of its Jira issue type. |
-| `ferry:type:force-story` | Treat the ticket as a **Story** regardless of its Jira issue type. |
+| `ferry:type:force-bug`   | Treat the ticket as a **Bug** regardless of its Jira issue type. The agent sees `TYPE: Bug` in the prompt.                                                                            |
+| `ferry:type:force-spike` | Treat the ticket as a **Spike** regardless of its Jira issue type.                                                                                                                    |
+| `ferry:type:force-story` | Treat the ticket as a **Story** regardless of its Jira issue type.                                                                                                                    |
 
 **How it works:**
 

--- a/src/agents/developer/dev-action.ts
+++ b/src/agents/developer/dev-action.ts
@@ -16,6 +16,7 @@ import {
   logTypeOverrides,
   createGitHubContext,
   resolveGitConfig,
+  resolveBranchPrefix,
   loadFerryConfigFromBaseBranch,
   runAgent,
 } from '../../lib/agent-runtime/index.js';
@@ -56,12 +57,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   // Resolve baseBranch before using any config values, then reload config from that branch.
   // On repository_dispatch, actions/checkout resolves to the default branch, not base_branch,
   // so the workspace may contain a stale ferry.config.json.
-  const { baseBranch, targetBranch, workingBranchPrefix } = await resolveGitConfig(
-    initialCfg,
-    runner,
-    owner,
-    repo,
-  );
+  const { baseBranch, targetBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   // loadFerryConfigFromBaseBranch also fetches origin/<baseBranch>, which makes
   // `git log origin/<base>..HEAD` work correctly later in this function.
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
@@ -95,7 +91,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const model = ferryCfg.models.dev.model;
 
   // Branch is determined upfront from the ticket key so restarts resume the same branch.
-  const branchName = `${workingBranchPrefix}${ticketKey}`;
+  const branchName = `${resolveBranchPrefix(ferryCfg.git.working_branch_prefix, issue)}${ticketKey}`;
 
   configureFerryGitUser(REPO_ROOT);
 

--- a/src/agents/iterator/iterate-action.ts
+++ b/src/agents/iterator/iterate-action.ts
@@ -28,6 +28,7 @@ import {
   checkoutExistingBranch,
   createGitHubContext,
   resolveGitConfig,
+  resolveBranchPrefix,
   loadFerryConfigFromBaseBranch,
   byEventId,
   byPrHeadSha,
@@ -46,12 +47,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   // Resolve baseBranch before using any config values, then reload config from that branch.
   // On repository_dispatch, actions/checkout resolves to the default branch, not base_branch,
   // so the workspace may contain a stale ferry.config.json.
-  const { baseBranch, workingBranchPrefix } = await resolveGitConfig(
-    initialCfg,
-    runner,
-    owner,
-    repo,
-  );
+  const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
 
   const { provider: iterProvider, model } = ferryCfg.models.iterate;
@@ -80,7 +76,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
     { iteration: priorIterations, hasFindings: true },
     ferryCfg.limits.max_iterations,
   );
-  const branchName = `${workingBranchPrefix}${ticketKey}`;
+  const branchName = `${resolveBranchPrefix(ferryCfg.git.working_branch_prefix, issue)}${ticketKey}`;
   const prs = await runner.listPRsForBranch(owner, repo, branchName);
 
   if (prs.length === 0) {

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -13,6 +13,7 @@ import {
   buildTicketBlock,
   createGitHubContext,
   resolveGitConfig,
+  resolveBranchPrefix,
   loadFerryConfigFromBaseBranch,
   logCapabilities,
   logTypeOverrides,
@@ -52,7 +53,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   logTypeOverrides(logger, typeOverrides);
 
   // Find PR for this ticket's branch
-  const branchName = `ferry/${ticketKey}`;
+  const branchName = `${resolveBranchPrefix(ferryCfg.git.working_branch_prefix, issue)}${ticketKey}`;
   const prs = await runner.listPRsForBranch(owner, repo, branchName);
 
   if (prs.length === 0) {

--- a/src/lib/agent-runtime/index.ts
+++ b/src/lib/agent-runtime/index.ts
@@ -19,7 +19,7 @@ export { makeSecretScan } from './secret-scan.js';
 export { logCapabilities, logTypeOverrides } from './labels.js';
 export { createGitHubContext } from './context.js';
 export type { GitHubContext } from './context.js';
-export { resolveGitConfig } from './resolve-git-config.js';
+export { resolveGitConfig, resolveBranchPrefix } from './resolve-git-config.js';
 export type { ResolvedGitConfig } from './resolve-git-config.js';
 export { createLogger } from '../logger/index.js';
 export type { Logger } from '../logger/index.js';

--- a/src/lib/agent-runtime/resolve-git-config.test.ts
+++ b/src/lib/agent-runtime/resolve-git-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { resolveGitConfig } from './resolve-git-config.js';
+import { resolveGitConfig, resolveBranchPrefix } from './resolve-git-config.js';
 import type { FerryConfig } from '../config.js';
 import { DEFAULT_FERRY_CONFIG } from '../config.js';
 import type { CIRunner } from '../dispatch/runner/types.js';
@@ -15,6 +15,13 @@ function makeConfig(git: Partial<FerryConfig['git']>): FerryConfig {
     ...DEFAULT_FERRY_CONFIG,
     git: { ...DEFAULT_FERRY_CONFIG.git, ...git },
   };
+}
+
+function makeIssue(opts: { issueType?: string; labels?: string[] } = {}): {
+  issueType: string;
+  labels: string[];
+} {
+  return { issueType: opts.issueType ?? 'Story', labels: opts.labels ?? [] };
 }
 
 describe('resolveGitConfig', () => {
@@ -43,7 +50,7 @@ describe('resolveGitConfig', () => {
     expect(result.targetBranch).toBe('staging');
   });
 
-  it('uses custom working_branch_prefix', async () => {
+  it('uses custom working_branch_prefix string', async () => {
     const runner = makeMockRunner('main');
     const cfg = makeConfig({ working_branch_prefix: 'bot/' });
     const result = await resolveGitConfig(cfg, runner, 'org', 'repo');
@@ -57,10 +64,109 @@ describe('resolveGitConfig', () => {
     expect(result.workingBranchPrefix).toBe('ferry/');
   });
 
+  it('passes through a mapping working_branch_prefix unchanged', async () => {
+    const runner = makeMockRunner('main');
+    const mapping = { Bug: 'bugfix/', Story: 'feature/', default: 'ferry/' };
+    const cfg = makeConfig({ working_branch_prefix: mapping });
+    const result = await resolveGitConfig(cfg, runner, 'org', 'repo');
+    expect(result.workingBranchPrefix).toEqual(mapping);
+  });
+
   it('only calls getRepoDefaultBranch once when both base and target are null', async () => {
     const runner = makeMockRunner('next');
     const cfg = makeConfig({ base_branch: null, target_branch: null });
     await resolveGitConfig(cfg, runner, 'org', 'repo');
     expect(runner.getRepoDefaultBranch as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('resolveBranchPrefix', () => {
+  describe('string prefix (static)', () => {
+    it('returns the string as-is', () => {
+      expect(resolveBranchPrefix('ferry/', makeIssue())).toBe('ferry/');
+    });
+
+    it('returns custom static prefix', () => {
+      expect(resolveBranchPrefix('bot/', makeIssue({ issueType: 'Bug' }))).toBe('bot/');
+    });
+  });
+
+  describe('mapping prefix — issueType resolution', () => {
+    const mapping = {
+      Bug: 'bugfix/',
+      Story: 'feature/',
+      Task: 'chore/',
+      default: 'ferry/',
+    };
+
+    it('maps Bug to bugfix/', () => {
+      expect(resolveBranchPrefix(mapping, makeIssue({ issueType: 'Bug' }))).toBe('bugfix/');
+    });
+
+    it('maps Story to feature/', () => {
+      expect(resolveBranchPrefix(mapping, makeIssue({ issueType: 'Story' }))).toBe('feature/');
+    });
+
+    it('maps Task to chore/', () => {
+      expect(resolveBranchPrefix(mapping, makeIssue({ issueType: 'Task' }))).toBe('chore/');
+    });
+
+    it('falls back to default when issueType not in mapping', () => {
+      expect(resolveBranchPrefix(mapping, makeIssue({ issueType: 'Epic' }))).toBe('ferry/');
+    });
+  });
+
+  describe('mapping prefix — ferry:type label override', () => {
+    const mapping = {
+      Bug: 'bugfix/',
+      Story: 'feature/',
+      hotfix: 'hotfix/',
+      default: 'ferry/',
+    };
+
+    it('label ferry:type:Bug overrides issueType Story', () => {
+      // Label X must match a mapping key — here "Bug" overrides Story's normal prefix
+      const issue = makeIssue({ issueType: 'Story', labels: ['ferry:type:Bug'] });
+      expect(resolveBranchPrefix(mapping, issue)).toBe('bugfix/');
+    });
+
+    it('label ferry:type:hotfix maps to hotfix/ when in mapping', () => {
+      const issue = makeIssue({ issueType: 'Story', labels: ['ferry:type:hotfix'] });
+      expect(resolveBranchPrefix(mapping, issue)).toBe('hotfix/');
+    });
+
+    it('label ferry:type:<X> with unknown X falls through to issueType', () => {
+      const issue = makeIssue({ issueType: 'Bug', labels: ['ferry:type:unknown-type'] });
+      expect(resolveBranchPrefix(mapping, issue)).toBe('bugfix/');
+    });
+
+    it('only the first ferry:type label is used', () => {
+      const extendedMapping = { ...mapping, chore: 'chore/' };
+      const issue = makeIssue({
+        issueType: 'Bug',
+        labels: ['ferry:type:hotfix', 'ferry:type:chore'],
+      });
+      expect(resolveBranchPrefix(extendedMapping, issue)).toBe('hotfix/');
+    });
+
+    it('ignores non-ferry:type labels', () => {
+      const issue = makeIssue({
+        issueType: 'Story',
+        labels: ['ferry:approved', 'ferry:reviewing'],
+      });
+      expect(resolveBranchPrefix(mapping, issue)).toBe('feature/');
+    });
+  });
+
+  describe('mapping prefix — default fallback', () => {
+    it('uses default when neither label nor issueType match', () => {
+      const mapping = { Bug: 'bugfix/', default: 'feature/' };
+      expect(resolveBranchPrefix(mapping, makeIssue({ issueType: 'Spike' }))).toBe('feature/');
+    });
+
+    it('uses default with no labels and unrecognised issueType', () => {
+      const mapping = { default: 'chore/' };
+      expect(resolveBranchPrefix(mapping, makeIssue({ issueType: 'CustomType' }))).toBe('chore/');
+    });
   });
 });

--- a/src/lib/agent-runtime/resolve-git-config.ts
+++ b/src/lib/agent-runtime/resolve-git-config.ts
@@ -4,7 +4,35 @@ import type { FerryConfig } from '../config.js';
 export interface ResolvedGitConfig {
   baseBranch: string;
   targetBranch: string;
-  workingBranchPrefix: string;
+  workingBranchPrefix: string | Record<string, string>;
+}
+
+/**
+ * Resolves the working branch prefix for a given issue.
+ *
+ * Resolution order (mapping case):
+ *   1. ferry:type:<name> label on the issue → mapping[name]
+ *   2. issue.issueType in mapping → mapping[issueType]
+ *   3. mapping.default
+ */
+export function resolveBranchPrefix(
+  prefix: string | Record<string, string>,
+  issue: { issueType: string; labels: string[] },
+): string {
+  if (typeof prefix === 'string') return prefix;
+
+  for (const label of issue.labels) {
+    const match = /^ferry:type:(.+)$/.exec(label);
+    if (match) {
+      const labelType = match[1];
+      if (labelType in prefix) return prefix[labelType];
+      break;
+    }
+  }
+
+  if (issue.issueType in prefix) return prefix[issue.issueType];
+
+  return prefix['default'];
 }
 
 export async function resolveGitConfig(

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -653,6 +653,64 @@ describe('loadFerryConfig', () => {
       expect(() => loadFerryConfig('/repo')).toThrow(FerryError);
     });
 
+    it('accepts a mapping working_branch_prefix with a default key', () => {
+      const mapping = { Bug: 'bugfix/', Story: 'feature/', default: 'ferry/' };
+      mockConfigFile(
+        'ferry.config.json',
+        JSON.stringify({ git: { working_branch_prefix: mapping } }),
+      );
+      const cfg = loadFerryConfig('/repo');
+      expect(cfg.git.working_branch_prefix).toEqual(mapping);
+    });
+
+    it('throws when mapping working_branch_prefix has no default key', () => {
+      mockConfigFile(
+        'ferry.config.json',
+        JSON.stringify({ git: { working_branch_prefix: { Bug: 'bugfix/', Story: 'feature/' } } }),
+      );
+      let thrown: FerryError | null = null;
+      try {
+        loadFerryConfig('/repo');
+      } catch (e) {
+        thrown = e as FerryError;
+      }
+      expect(thrown).toBeInstanceOf(FerryError);
+      const errors = thrown?.context?.errors as string[];
+      expect(errors.some((e) => e.includes('default'))).toBe(true);
+    });
+
+    it('throws when a mapping value is an empty string', () => {
+      mockConfigFile(
+        'ferry.config.json',
+        JSON.stringify({ git: { working_branch_prefix: { Bug: '', default: 'ferry/' } } }),
+      );
+      let thrown: FerryError | null = null;
+      try {
+        loadFerryConfig('/repo');
+      } catch (e) {
+        thrown = e as FerryError;
+      }
+      expect(thrown).toBeInstanceOf(FerryError);
+      const errors = thrown?.context?.errors as string[];
+      expect(errors.some((e) => e.includes('git.working_branch_prefix.Bug'))).toBe(true);
+    });
+
+    it('throws when a mapping value is not a string', () => {
+      mockConfigFile(
+        'ferry.config.json',
+        JSON.stringify({ git: { working_branch_prefix: { Bug: 42, default: 'ferry/' } } }),
+      );
+      expect(() => loadFerryConfig('/repo')).toThrow(FerryError);
+    });
+
+    it('throws when working_branch_prefix is an invalid type (array)', () => {
+      mockConfigFile(
+        'ferry.config.json',
+        JSON.stringify({ git: { working_branch_prefix: ['bugfix/'] } }),
+      );
+      expect(() => loadFerryConfig('/repo')).toThrow(FerryError);
+    });
+
     it('throws on non-string base_branch', () => {
       mockConfigFile('ferry.config.json', JSON.stringify({ git: { base_branch: 42 } }));
       let thrown: FerryError | null = null;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -20,8 +20,12 @@ export interface GitConfig {
   base_branch: string | null;
   /** Branch the PR targets. null = same as base_branch. */
   target_branch: string | null;
-  /** Prefix for working branches created by the Developer. */
-  working_branch_prefix: string;
+  /**
+   * Prefix for working branches created by the Developer.
+   * String → static prefix (e.g. "ferry/").
+   * Mapping → resolved per Jira issue type (requires a "default" key).
+   */
+  working_branch_prefix: string | Record<string, string>;
 }
 
 export interface RefinerWorkflowAgentConfig {
@@ -415,8 +419,28 @@ function validateConfigShape(raw: unknown): ValidationError[] {
         errs.push('git.target_branch: must be a non-empty string or null');
       }
       if (g.working_branch_prefix !== undefined) {
-        if (typeof g.working_branch_prefix !== 'string' || g.working_branch_prefix.length === 0) {
-          errs.push('git.working_branch_prefix: must be a non-empty string');
+        if (typeof g.working_branch_prefix === 'string') {
+          if (g.working_branch_prefix.length === 0) {
+            errs.push('git.working_branch_prefix: must be a non-empty string');
+          }
+        } else if (
+          g.working_branch_prefix !== null &&
+          typeof g.working_branch_prefix === 'object' &&
+          !Array.isArray(g.working_branch_prefix)
+        ) {
+          const mapping = g.working_branch_prefix as Record<string, unknown>;
+          if (!('default' in mapping)) {
+            errs.push('git.working_branch_prefix: mapping must include a "default" key');
+          }
+          for (const [k, v] of Object.entries(mapping)) {
+            if (typeof v !== 'string' || v.length === 0) {
+              errs.push(`git.working_branch_prefix.${k}: must be a non-empty string`);
+            }
+          }
+        } else {
+          errs.push(
+            'git.working_branch_prefix: must be a non-empty string or a mapping object with a "default" key',
+          );
         }
       }
     }
@@ -640,7 +664,11 @@ function mergeWithDefaults(raw: RawConfig): FerryConfig {
       working_branch_prefix:
         typeof g.working_branch_prefix === 'string'
           ? g.working_branch_prefix
-          : DEFAULT_FERRY_CONFIG.git.working_branch_prefix,
+          : g.working_branch_prefix !== null &&
+              typeof g.working_branch_prefix === 'object' &&
+              !Array.isArray(g.working_branch_prefix)
+            ? (g.working_branch_prefix as Record<string, string>)
+            : DEFAULT_FERRY_CONFIG.git.working_branch_prefix,
     },
     ...(labels !== undefined ? { labels } : {}),
     workflow: mergeWorkflow(raw.workflow),


### PR DESCRIPTION
Implements Step 1 of #230.

## Summary

- `git.working_branch_prefix` now accepts `string | Record<string, string>` enabling Conventional Branch naming (`feature/`, `bugfix/`, `chore/`, `hotfix/`)
- Prefix is resolved at runtime by: (1) `ferry:type:<name>` label, (2) Jira issue type, (3) `default` key
- Fixes pre-existing bug in `review-action.ts` that hardcoded `ferry/` prefix instead of reading from config
- All three agents (Developer, Iterator, Reviewer) now use `resolveBranchPrefix`
- Existing consumers are unaffected; string config behaviour unchanged

Step 2 (Refiner classification) is a separate PR per the issue spec.

Closes #230

Generated with [Claude Code](https://claude.ai/code)