### PR TITLE
feat: label override for model/provider per ticket (#237)

### DIFF
--- a/.ferry/dev-action.js
+++ b/.ferry/dev-action.js
@@ -1335,6 +1335,39 @@ function logTypeOverrides(logger, overrides) {
     logger.info("task skip bypassed (ferry:type:enable-task)");
   }
 }
+function logTicketOverrides(logger, overrides) {
+  logTypeOverrides(logger, overrides);
+  if (overrides.modelOverrides) {
+    for (const [phase, mo] of Object.entries(overrides.modelOverrides)) {
+      if (mo?.model) logger.info(`model override (${phase})`, { model: mo.model });
+      if (mo?.provider) logger.info(`provider override (${phase})`, { provider: mo.provider });
+    }
+  }
+  if (overrides.budget) {
+    if (overrides.budget.maxCostEurPerRun !== void 0) {
+      logger.info("budget override: max cost", {
+        maxCostEurPerRun: overrides.budget.maxCostEurPerRun
+      });
+    }
+    if (overrides.budget.maxTokensPerRun !== void 0) {
+      logger.info("budget override: max tokens", {
+        maxTokensPerRun: overrides.budget.maxTokensPerRun
+      });
+    }
+  }
+  if (overrides.skipPhases && overrides.skipPhases.length > 0) {
+    logger.info("phase skip active", { phases: overrides.skipPhases });
+  }
+  if (overrides.thinking !== void 0) {
+    logger.info("thinking override", { thinking: overrides.thinking });
+  }
+  if (overrides.git?.noPr) {
+    logger.info("git override: no-pr (PR creation skipped)");
+  }
+  if (overrides.paused) {
+    logger.warn("ticket is paused (ferry:paused) \u2014 agent will exit without processing");
+  }
+}
 
 // node_modules/universal-user-agent/index.js
 function getUserAgent() {
@@ -5509,6 +5542,307 @@ function filterMcpServers(pool, capabilities, hasLabelsConfig) {
   });
 }
 
+// src/lib/labels/overrides.ts
+var AGENT_PHASES = /* @__PURE__ */ new Set(["refiner", "dev", "review", "iterate"]);
+var PHASES_ORDERED = ["refiner", "dev", "review", "iterate"];
+var LLM_PROVIDERS = /* @__PURE__ */ new Set(["anthropic", "openai", "google"]);
+var LabelConflictError = class extends Error {
+  label1;
+  label2;
+  field;
+  constructor(label1, label2, field) {
+    super(`Conflicting ferry labels for "${field}": "${label1}" and "${label2}"`);
+    this.name = "LabelConflictError";
+    this.label1 = label1;
+    this.label2 = label2;
+    this.field = field;
+  }
+};
+function parsePositiveFloat(s) {
+  const n = Number(s);
+  return Number.isFinite(n) && n > 0 ? n : void 0;
+}
+function parsePositiveInt(s) {
+  const n = Number(s);
+  return Number.isInteger(n) && n > 0 ? n : void 0;
+}
+var MCP_LABEL_PREFIX = "ferry:mcp/";
+var PROFILE_LABEL_PREFIX = "ferry:profile/";
+var KNOWN_STATUS_LABELS = /* @__PURE__ */ new Set([
+  "ferry:refining",
+  "ferry:developing",
+  "ferry:reviewing",
+  "ferry:iterating",
+  "ferry:ready",
+  "ferry:approved",
+  "ferry:cancelled",
+  "ferry:blocked",
+  "ferry:spend-cap",
+  "ferry:audit-log:active"
+]);
+function isKnownNonOverrideLabel(label) {
+  if (isBuiltinTypeLabel(label)) return true;
+  if (KNOWN_STATUS_LABELS.has(label)) return true;
+  if (label.startsWith("ferry:cost-estimate:")) return true;
+  if (label.startsWith(MCP_LABEL_PREFIX)) return true;
+  if (label.startsWith(PROFILE_LABEL_PREFIX)) return true;
+  return false;
+}
+function resolveTicketOverrides(labels, logger) {
+  const typeOverrides = resolveTypeOverrides(labels);
+  const modelOverrides = {};
+  const modelSources = {};
+  const providerSources = {};
+  let blanketModel;
+  let blanketModelSource;
+  let blanketProvider;
+  let blanketProviderSource;
+  let budgetMaxCostLabel;
+  let budgetMaxTokensLabel;
+  let budgetMaxCostEur;
+  let budgetMaxTokens;
+  let thinkingLabel;
+  let thinking;
+  let noPr = false;
+  let paused = false;
+  const skipPhases = [];
+  for (const label of labels) {
+    if (!label.startsWith("ferry:")) continue;
+    if (isKnownNonOverrideLabel(label)) continue;
+    if (label.startsWith("ferry:model/")) {
+      const rest = label.slice("ferry:model/".length);
+      if (!rest) {
+        logger?.warn("malformed ferry:model label (empty model name)", { label });
+        continue;
+      }
+      const slashIdx = rest.indexOf("/");
+      if (slashIdx < 0) {
+        if (blanketModelSource !== void 0) {
+          throw new LabelConflictError(blanketModelSource, label, "model");
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
+        continue;
+      }
+      const firstSegment = rest.slice(0, slashIdx);
+      const remainder = rest.slice(slashIdx + 1);
+      if (AGENT_PHASES.has(firstSegment)) {
+        const p = firstSegment;
+        if (!remainder) {
+          logger?.warn("empty model-id in ferry:model label", { label });
+          continue;
+        }
+        if (modelSources[p] !== void 0) {
+          throw new LabelConflictError(modelSources[p], label, `model.${firstSegment}`);
+        }
+        modelSources[p] = label;
+        modelOverrides[p] = { ...modelOverrides[p], model: remainder };
+      } else {
+        if (blanketModelSource !== void 0) {
+          throw new LabelConflictError(blanketModelSource, label, "model");
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:provider/")) {
+      const parts = label.slice("ferry:provider/".length).split("/");
+      if (parts.length === 1) {
+        const provider2 = parts[0];
+        if (!LLM_PROVIDERS.has(provider2)) {
+          logger?.warn("unknown provider in blanket ferry:provider label", { label, provider: provider2 });
+          continue;
+        }
+        if (blanketProviderSource !== void 0) {
+          throw new LabelConflictError(blanketProviderSource, label, "provider");
+        }
+        blanketProvider = provider2;
+        blanketProviderSource = label;
+        continue;
+      }
+      if (parts.length !== 2) {
+        logger?.warn(
+          "malformed ferry:provider label (expected ferry:provider/<provider> or ferry:provider/<phase>/<provider>)",
+          { label }
+        );
+        continue;
+      }
+      const [phase, provider] = parts;
+      if (!AGENT_PHASES.has(phase)) {
+        logger?.warn("unknown phase in ferry:provider label", { label, phase });
+        continue;
+      }
+      if (!LLM_PROVIDERS.has(provider)) {
+        logger?.warn("unknown provider in ferry:provider label", { label, provider });
+        continue;
+      }
+      const p = phase;
+      if (providerSources[p] !== void 0) {
+        throw new LabelConflictError(providerSources[p], label, `provider.${phase}`);
+      }
+      providerSources[p] = label;
+      modelOverrides[p] = {
+        ...modelOverrides[p],
+        provider
+      };
+      continue;
+    }
+    if (label.startsWith("ferry:budget/max-cost/")) {
+      const raw = label.slice("ferry:budget/max-cost/".length);
+      const val = parsePositiveFloat(raw);
+      if (val === void 0) {
+        logger?.warn("invalid cost value in ferry:budget/max-cost label", { label });
+        continue;
+      }
+      if (budgetMaxCostLabel !== void 0) {
+        throw new LabelConflictError(budgetMaxCostLabel, label, "budget.maxCostEurPerRun");
+      }
+      budgetMaxCostLabel = label;
+      budgetMaxCostEur = val;
+      continue;
+    }
+    if (label.startsWith("ferry:budget/max-tokens/")) {
+      const raw = label.slice("ferry:budget/max-tokens/".length);
+      const val = parsePositiveInt(raw);
+      if (val === void 0) {
+        logger?.warn("invalid token count in ferry:budget/max-tokens label", { label });
+        continue;
+      }
+      if (budgetMaxTokensLabel !== void 0) {
+        throw new LabelConflictError(budgetMaxTokensLabel, label, "budget.maxTokensPerRun");
+      }
+      budgetMaxTokensLabel = label;
+      budgetMaxTokens = val;
+      continue;
+    }
+    if (label.startsWith("ferry:skip/")) {
+      const phase = label.slice("ferry:skip/".length);
+      if (!AGENT_PHASES.has(phase)) {
+        logger?.warn("unknown phase in ferry:skip label", { label, phase });
+        continue;
+      }
+      const p = phase;
+      if (!skipPhases.includes(p)) skipPhases.push(p);
+      continue;
+    }
+    if (label === "ferry:thinking/on" || label === "ferry:thinking/off") {
+      const val = label === "ferry:thinking/on" ? "on" : "off";
+      if (thinking !== void 0 && thinking !== val) {
+        throw new LabelConflictError(thinkingLabel, label, "thinking");
+      }
+      if (thinking === void 0) {
+        thinking = val;
+        thinkingLabel = label;
+      }
+      continue;
+    }
+    if (label === "ferry:git/no-pr") {
+      noPr = true;
+      continue;
+    }
+    if (label === "ferry:paused") {
+      paused = true;
+      continue;
+    }
+    logger?.warn("unknown ferry override label ignored", { label });
+  }
+  if (blanketModel !== void 0) {
+    for (const phase of PHASES_ORDERED) {
+      if (modelSources[phase] === void 0) {
+        modelOverrides[phase] = { ...modelOverrides[phase], model: blanketModel };
+      }
+    }
+  }
+  if (blanketProvider !== void 0) {
+    for (const phase of PHASES_ORDERED) {
+      if (providerSources[phase] === void 0) {
+        modelOverrides[phase] = { ...modelOverrides[phase], provider: blanketProvider };
+      }
+    }
+  }
+  const hasModelOverrides = Object.keys(modelOverrides).length > 0;
+  const hasBudget = budgetMaxCostEur !== void 0 || budgetMaxTokens !== void 0;
+  return {
+    ...typeOverrides,
+    ...hasModelOverrides ? { modelOverrides } : {},
+    ...hasBudget ? {
+      budget: {
+        ...budgetMaxCostEur !== void 0 ? { maxCostEurPerRun: budgetMaxCostEur } : {},
+        ...budgetMaxTokens !== void 0 ? { maxTokensPerRun: budgetMaxTokens } : {}
+      }
+    } : {},
+    ...skipPhases.length > 0 ? { skipPhases } : {},
+    ...thinking !== void 0 ? { thinking } : {},
+    ...noPr ? { git: { noPr: true } } : {},
+    ...paused ? { paused: true } : {}
+  };
+}
+function applyTicketOverrides(cfg, overrides) {
+  if (!overrides.modelOverrides && !overrides.budget) return cfg;
+  const models = { ...cfg.models };
+  const limits = { ...cfg.limits };
+  const mo = overrides.modelOverrides;
+  if (mo) {
+    if (mo.refiner) {
+      models.refiner = {
+        provider: mo.refiner.provider ?? models.refiner.provider,
+        model: mo.refiner.model ?? models.refiner.model
+      };
+    }
+    if (mo.dev) {
+      models.dev = {
+        provider: mo.dev.provider ?? models.dev.provider,
+        model: mo.dev.model ?? models.dev.model
+      };
+    }
+    if (mo.review) {
+      models.review = {
+        provider: mo.review.provider ?? models.review.provider,
+        model: mo.review.model ?? models.review.model
+      };
+    }
+    if (mo.iterate) {
+      models.iterate = {
+        provider: mo.iterate.provider ?? models.iterate.provider,
+        model: mo.iterate.model ?? models.iterate.model
+      };
+    }
+  }
+  if (overrides.budget) {
+    if (overrides.budget.maxCostEurPerRun !== void 0) {
+      limits.max_cost_eur_per_run = overrides.budget.maxCostEurPerRun;
+    }
+    if (overrides.budget.maxTokensPerRun !== void 0) {
+      limits.max_tokens_per_run = overrides.budget.maxTokensPerRun;
+    }
+  }
+  return { ...cfg, models, limits };
+}
+function hasNonDefaultOverrides(overrides) {
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true;
+}
+function buildOverridesAuditComment(role, runId, overrides) {
+  const payload = {};
+  if (overrides.bypassTaskSkip) payload.bypassTaskSkip = true;
+  if (overrides.typeOverride !== void 0) payload.typeOverride = overrides.typeOverride;
+  if (overrides.modelOverrides !== void 0) payload.modelOverrides = overrides.modelOverrides;
+  if (overrides.budget !== void 0) payload.budget = overrides.budget;
+  if ((overrides.skipPhases?.length ?? 0) > 0) payload.skipPhases = overrides.skipPhases;
+  if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
+  if (overrides.git?.noPr) payload.git = overrides.git;
+  if (overrides.paused) payload.paused = true;
+  return `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+}
+function buildConflictComment(role, runId, err) {
+  return [
+    `[ferry:${role}:${runId}] label conflict \u2014 remove one of the contradicting labels and re-trigger:`,
+    `  field: ${err.field}`,
+    `  label 1: ${err.label1}`,
+    `  label 2: ${err.label2}`
+  ].join("\n");
+}
+
 // src/lib/dry-run.ts
 function isDryRun() {
   return process.env.FERRY_DRY_RUN === "1" || process.env.FERRY_DRY_RUN === "true";
@@ -7552,20 +7886,40 @@ async function main(envelope, logger) {
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT);
   const { baseBranch, targetBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
-  const { provider: devProvider } = ferryCfg.models.dev;
   const devWorkflow = ferryCfg.workflow.agents.developer;
   const shouldAutoTransition = devWorkflow.auto_transition !== null;
   const reviewTransitionId = dryRun || !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
   const jiraBaseUrl = requireEnv("FERRY_JIRA_BASE_URL");
   const issue = await tracker.getIssue(ticketKey);
-  const typeOverrides = resolveTypeOverrides(issue.labels);
-  logTypeOverrides(logger, typeOverrides);
+  let effectiveCfg = ferryCfg;
+  let typeOverride;
+  let forceLabel;
+  try {
+    const overrides = resolveTicketOverrides(issue.labels, logger);
+    typeOverride = overrides.typeOverride;
+    forceLabel = overrides.forceLabel;
+    effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
+    logTicketOverrides(logger, overrides);
+    if (hasNonDefaultOverrides(overrides)) {
+      await tracker.postComment(
+        ticketKey,
+        buildOverridesAuditComment("developer", eventId, overrides)
+      );
+    }
+  } catch (err) {
+    if (err instanceof LabelConflictError) {
+      await tracker.postComment(ticketKey, buildConflictComment("developer", eventId, err));
+      process.exit(1);
+    }
+    throw err;
+  }
+  const { provider: devProvider } = effectiveCfg.models.dev;
   const labels = issue.labels.join(", ");
   const comments = issue.comments.map((c) => `Comment: ${c}`).join("\n");
   const ticketBlock = buildTicketBlock(ticketKey, issue, {
     labels,
     comments,
-    typeOverride: typeOverrides.typeOverride
+    typeOverride
   });
   const subtasks = await tracker.getSubtasks(ticketKey);
   const testRunner = detectTestRunner(packageJsonPath(REPO_ROOT));
@@ -7576,8 +7930,8 @@ async function main(envelope, logger) {
 
 ${pkgManagerHint}`] : []
   });
-  const model = ferryCfg.models.dev.model;
-  const branchName = `${resolveBranchPrefix(ferryCfg.git.working_branch_prefix, issue)}${ticketKey}`;
+  const model = effectiveCfg.models.dev.model;
+  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
   configureFerryGitUser(REPO_ROOT);
   let resumeContext = "";
   let branchHeadSha = "";
@@ -7649,8 +8003,8 @@ ${tree}`,
   ].join("\n");
   const secretScan = makeSecretScan(REPO_ROOT);
   const mcpPool = loadMcpServers();
-  const capabilities = resolveCapabilities(issue.labels, ferryCfg.labels);
-  const hasLabelsConfig = ferryCfg.labels !== void 0;
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
+  const hasLabelsConfig = effectiveCfg.labels !== void 0;
   const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
   logCapabilities(logger, capabilities);
   if (mcpServers.length > 0) {
@@ -7661,9 +8015,9 @@ ${tree}`,
   loop = createAgentLoop({
     provider: devProvider,
     model,
-    maxIterations: ferryCfg.limits.max_agent_iterations,
-    maxInputTokens: ferryCfg.limits.max_tokens_per_run,
-    maxTokens: ferryCfg.limits.max_tokens_per_message,
+    maxIterations: effectiveCfg.limits.max_agent_iterations,
+    maxInputTokens: effectiveCfg.limits.max_tokens_per_run,
+    maxTokens: effectiveCfg.limits.max_tokens_per_message,
     executeTool,
     commitProgress: makeCommitProgress(logger, { dryRun }),
     spawnSubagent: (task) => loop.run({
@@ -7835,8 +8189,8 @@ ${tree}`,
       await tracker.postTransition(ticketKey, reviewTransitionId);
     }
     const transitionNote = shouldAutoTransition ? " Moved to Review." : "";
-    const forceOverrideName = typeOverrides.forceLabel?.split(":").at(-1);
-    const overrideNote = typeOverrides.typeOverride ? ` [type override: ${JSON.stringify({ issuetype: typeOverrides.typeOverride, issuetype_raw: issue.issueType, override: forceOverrideName })}]` : "";
+    const forceOverrideName = forceLabel?.split(":").at(-1);
+    const overrideNote = typeOverride ? ` [type override: ${JSON.stringify({ issuetype: typeOverride, issuetype_raw: issue.issueType, override: forceOverrideName })}]` : "";
     const terminalComment = resolvedOutcome === "already_satisfied" ? `${idempotencyMarker} Spec already satisfied \u2014 verification PR: ${prUrl}.${transitionNote}${overrideNote}` : `${idempotencyMarker} Implementation complete \u2014 PR: ${prUrl}.${transitionNote}${overrideNote}`;
     await tracker.postComment(ticketKey, terminalComment);
   } catch (err) {

--- a/.ferry/iterate-action.js
+++ b/.ferry/iterate-action.js
@@ -3188,6 +3188,39 @@ function logTypeOverrides(logger, overrides) {
     logger.info("task skip bypassed (ferry:type:enable-task)");
   }
 }
+function logTicketOverrides(logger, overrides) {
+  logTypeOverrides(logger, overrides);
+  if (overrides.modelOverrides) {
+    for (const [phase, mo] of Object.entries(overrides.modelOverrides)) {
+      if (mo?.model) logger.info(`model override (${phase})`, { model: mo.model });
+      if (mo?.provider) logger.info(`provider override (${phase})`, { provider: mo.provider });
+    }
+  }
+  if (overrides.budget) {
+    if (overrides.budget.maxCostEurPerRun !== void 0) {
+      logger.info("budget override: max cost", {
+        maxCostEurPerRun: overrides.budget.maxCostEurPerRun
+      });
+    }
+    if (overrides.budget.maxTokensPerRun !== void 0) {
+      logger.info("budget override: max tokens", {
+        maxTokensPerRun: overrides.budget.maxTokensPerRun
+      });
+    }
+  }
+  if (overrides.skipPhases && overrides.skipPhases.length > 0) {
+    logger.info("phase skip active", { phases: overrides.skipPhases });
+  }
+  if (overrides.thinking !== void 0) {
+    logger.info("thinking override", { thinking: overrides.thinking });
+  }
+  if (overrides.git?.noPr) {
+    logger.info("git override: no-pr (PR creation skipped)");
+  }
+  if (overrides.paused) {
+    logger.warn("ticket is paused (ferry:paused) \u2014 agent will exit without processing");
+  }
+}
 
 // node_modules/universal-user-agent/index.js
 function getUserAgent() {
@@ -7362,6 +7395,307 @@ function filterMcpServers(pool, capabilities, hasLabelsConfig) {
   });
 }
 
+// src/lib/labels/overrides.ts
+var AGENT_PHASES = /* @__PURE__ */ new Set(["refiner", "dev", "review", "iterate"]);
+var PHASES_ORDERED = ["refiner", "dev", "review", "iterate"];
+var LLM_PROVIDERS = /* @__PURE__ */ new Set(["anthropic", "openai", "google"]);
+var LabelConflictError = class extends Error {
+  label1;
+  label2;
+  field;
+  constructor(label1, label2, field) {
+    super(`Conflicting ferry labels for "${field}": "${label1}" and "${label2}"`);
+    this.name = "LabelConflictError";
+    this.label1 = label1;
+    this.label2 = label2;
+    this.field = field;
+  }
+};
+function parsePositiveFloat(s) {
+  const n = Number(s);
+  return Number.isFinite(n) && n > 0 ? n : void 0;
+}
+function parsePositiveInt(s) {
+  const n = Number(s);
+  return Number.isInteger(n) && n > 0 ? n : void 0;
+}
+var MCP_LABEL_PREFIX = "ferry:mcp/";
+var PROFILE_LABEL_PREFIX = "ferry:profile/";
+var KNOWN_STATUS_LABELS = /* @__PURE__ */ new Set([
+  "ferry:refining",
+  "ferry:developing",
+  "ferry:reviewing",
+  "ferry:iterating",
+  "ferry:ready",
+  "ferry:approved",
+  "ferry:cancelled",
+  "ferry:blocked",
+  "ferry:spend-cap",
+  "ferry:audit-log:active"
+]);
+function isKnownNonOverrideLabel(label) {
+  if (isBuiltinTypeLabel(label)) return true;
+  if (KNOWN_STATUS_LABELS.has(label)) return true;
+  if (label.startsWith("ferry:cost-estimate:")) return true;
+  if (label.startsWith(MCP_LABEL_PREFIX)) return true;
+  if (label.startsWith(PROFILE_LABEL_PREFIX)) return true;
+  return false;
+}
+function resolveTicketOverrides(labels, logger) {
+  const typeOverrides = resolveTypeOverrides(labels);
+  const modelOverrides = {};
+  const modelSources = {};
+  const providerSources = {};
+  let blanketModel;
+  let blanketModelSource;
+  let blanketProvider;
+  let blanketProviderSource;
+  let budgetMaxCostLabel;
+  let budgetMaxTokensLabel;
+  let budgetMaxCostEur;
+  let budgetMaxTokens;
+  let thinkingLabel;
+  let thinking;
+  let noPr = false;
+  let paused = false;
+  const skipPhases = [];
+  for (const label of labels) {
+    if (!label.startsWith("ferry:")) continue;
+    if (isKnownNonOverrideLabel(label)) continue;
+    if (label.startsWith("ferry:model/")) {
+      const rest = label.slice("ferry:model/".length);
+      if (!rest) {
+        logger?.warn("malformed ferry:model label (empty model name)", { label });
+        continue;
+      }
+      const slashIdx = rest.indexOf("/");
+      if (slashIdx < 0) {
+        if (blanketModelSource !== void 0) {
+          throw new LabelConflictError(blanketModelSource, label, "model");
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
+        continue;
+      }
+      const firstSegment = rest.slice(0, slashIdx);
+      const remainder = rest.slice(slashIdx + 1);
+      if (AGENT_PHASES.has(firstSegment)) {
+        const p = firstSegment;
+        if (!remainder) {
+          logger?.warn("empty model-id in ferry:model label", { label });
+          continue;
+        }
+        if (modelSources[p] !== void 0) {
+          throw new LabelConflictError(modelSources[p], label, `model.${firstSegment}`);
+        }
+        modelSources[p] = label;
+        modelOverrides[p] = { ...modelOverrides[p], model: remainder };
+      } else {
+        if (blanketModelSource !== void 0) {
+          throw new LabelConflictError(blanketModelSource, label, "model");
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:provider/")) {
+      const parts = label.slice("ferry:provider/".length).split("/");
+      if (parts.length === 1) {
+        const provider2 = parts[0];
+        if (!LLM_PROVIDERS.has(provider2)) {
+          logger?.warn("unknown provider in blanket ferry:provider label", { label, provider: provider2 });
+          continue;
+        }
+        if (blanketProviderSource !== void 0) {
+          throw new LabelConflictError(blanketProviderSource, label, "provider");
+        }
+        blanketProvider = provider2;
+        blanketProviderSource = label;
+        continue;
+      }
+      if (parts.length !== 2) {
+        logger?.warn(
+          "malformed ferry:provider label (expected ferry:provider/<provider> or ferry:provider/<phase>/<provider>)",
+          { label }
+        );
+        continue;
+      }
+      const [phase, provider] = parts;
+      if (!AGENT_PHASES.has(phase)) {
+        logger?.warn("unknown phase in ferry:provider label", { label, phase });
+        continue;
+      }
+      if (!LLM_PROVIDERS.has(provider)) {
+        logger?.warn("unknown provider in ferry:provider label", { label, provider });
+        continue;
+      }
+      const p = phase;
+      if (providerSources[p] !== void 0) {
+        throw new LabelConflictError(providerSources[p], label, `provider.${phase}`);
+      }
+      providerSources[p] = label;
+      modelOverrides[p] = {
+        ...modelOverrides[p],
+        provider
+      };
+      continue;
+    }
+    if (label.startsWith("ferry:budget/max-cost/")) {
+      const raw = label.slice("ferry:budget/max-cost/".length);
+      const val = parsePositiveFloat(raw);
+      if (val === void 0) {
+        logger?.warn("invalid cost value in ferry:budget/max-cost label", { label });
+        continue;
+      }
+      if (budgetMaxCostLabel !== void 0) {
+        throw new LabelConflictError(budgetMaxCostLabel, label, "budget.maxCostEurPerRun");
+      }
+      budgetMaxCostLabel = label;
+      budgetMaxCostEur = val;
+      continue;
+    }
+    if (label.startsWith("ferry:budget/max-tokens/")) {
+      const raw = label.slice("ferry:budget/max-tokens/".length);
+      const val = parsePositiveInt(raw);
+      if (val === void 0) {
+        logger?.warn("invalid token count in ferry:budget/max-tokens label", { label });
+        continue;
+      }
+      if (budgetMaxTokensLabel !== void 0) {
+        throw new LabelConflictError(budgetMaxTokensLabel, label, "budget.maxTokensPerRun");
+      }
+      budgetMaxTokensLabel = label;
+      budgetMaxTokens = val;
+      continue;
+    }
+    if (label.startsWith("ferry:skip/")) {
+      const phase = label.slice("ferry:skip/".length);
+      if (!AGENT_PHASES.has(phase)) {
+        logger?.warn("unknown phase in ferry:skip label", { label, phase });
+        continue;
+      }
+      const p = phase;
+      if (!skipPhases.includes(p)) skipPhases.push(p);
+      continue;
+    }
+    if (label === "ferry:thinking/on" || label === "ferry:thinking/off") {
+      const val = label === "ferry:thinking/on" ? "on" : "off";
+      if (thinking !== void 0 && thinking !== val) {
+        throw new LabelConflictError(thinkingLabel, label, "thinking");
+      }
+      if (thinking === void 0) {
+        thinking = val;
+        thinkingLabel = label;
+      }
+      continue;
+    }
+    if (label === "ferry:git/no-pr") {
+      noPr = true;
+      continue;
+    }
+    if (label === "ferry:paused") {
+      paused = true;
+      continue;
+    }
+    logger?.warn("unknown ferry override label ignored", { label });
+  }
+  if (blanketModel !== void 0) {
+    for (const phase of PHASES_ORDERED) {
+      if (modelSources[phase] === void 0) {
+        modelOverrides[phase] = { ...modelOverrides[phase], model: blanketModel };
+      }
+    }
+  }
+  if (blanketProvider !== void 0) {
+    for (const phase of PHASES_ORDERED) {
+      if (providerSources[phase] === void 0) {
+        modelOverrides[phase] = { ...modelOverrides[phase], provider: blanketProvider };
+      }
+    }
+  }
+  const hasModelOverrides = Object.keys(modelOverrides).length > 0;
+  const hasBudget = budgetMaxCostEur !== void 0 || budgetMaxTokens !== void 0;
+  return {
+    ...typeOverrides,
+    ...hasModelOverrides ? { modelOverrides } : {},
+    ...hasBudget ? {
+      budget: {
+        ...budgetMaxCostEur !== void 0 ? { maxCostEurPerRun: budgetMaxCostEur } : {},
+        ...budgetMaxTokens !== void 0 ? { maxTokensPerRun: budgetMaxTokens } : {}
+      }
+    } : {},
+    ...skipPhases.length > 0 ? { skipPhases } : {},
+    ...thinking !== void 0 ? { thinking } : {},
+    ...noPr ? { git: { noPr: true } } : {},
+    ...paused ? { paused: true } : {}
+  };
+}
+function applyTicketOverrides(cfg, overrides) {
+  if (!overrides.modelOverrides && !overrides.budget) return cfg;
+  const models = { ...cfg.models };
+  const limits = { ...cfg.limits };
+  const mo = overrides.modelOverrides;
+  if (mo) {
+    if (mo.refiner) {
+      models.refiner = {
+        provider: mo.refiner.provider ?? models.refiner.provider,
+        model: mo.refiner.model ?? models.refiner.model
+      };
+    }
+    if (mo.dev) {
+      models.dev = {
+        provider: mo.dev.provider ?? models.dev.provider,
+        model: mo.dev.model ?? models.dev.model
+      };
+    }
+    if (mo.review) {
+      models.review = {
+        provider: mo.review.provider ?? models.review.provider,
+        model: mo.review.model ?? models.review.model
+      };
+    }
+    if (mo.iterate) {
+      models.iterate = {
+        provider: mo.iterate.provider ?? models.iterate.provider,
+        model: mo.iterate.model ?? models.iterate.model
+      };
+    }
+  }
+  if (overrides.budget) {
+    if (overrides.budget.maxCostEurPerRun !== void 0) {
+      limits.max_cost_eur_per_run = overrides.budget.maxCostEurPerRun;
+    }
+    if (overrides.budget.maxTokensPerRun !== void 0) {
+      limits.max_tokens_per_run = overrides.budget.maxTokensPerRun;
+    }
+  }
+  return { ...cfg, models, limits };
+}
+function hasNonDefaultOverrides(overrides) {
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true;
+}
+function buildOverridesAuditComment(role, runId, overrides) {
+  const payload = {};
+  if (overrides.bypassTaskSkip) payload.bypassTaskSkip = true;
+  if (overrides.typeOverride !== void 0) payload.typeOverride = overrides.typeOverride;
+  if (overrides.modelOverrides !== void 0) payload.modelOverrides = overrides.modelOverrides;
+  if (overrides.budget !== void 0) payload.budget = overrides.budget;
+  if ((overrides.skipPhases?.length ?? 0) > 0) payload.skipPhases = overrides.skipPhases;
+  if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
+  if (overrides.git?.noPr) payload.git = overrides.git;
+  if (overrides.paused) payload.paused = true;
+  return `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+}
+function buildConflictComment(role, runId, err) {
+  return [
+    `[ferry:${role}:${runId}] label conflict \u2014 remove one of the contradicting labels and re-trigger:`,
+    `  field: ${err.field}`,
+    `  label 1: ${err.label1}`,
+    `  label 2: ${err.label2}`
+  ].join("\n");
+}
+
 // src/agents/iterator/iterate-action.ts
 var REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main(envelope, logger) {
@@ -7369,27 +7703,45 @@ async function main(envelope, logger) {
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT);
   const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
-  const { provider: iterProvider, model } = ferryCfg.models.iterate;
   const iteratorWorkflow = ferryCfg.workflow.agents.iterator;
   const shouldAutoTransition = iteratorWorkflow.auto_transition !== null;
   const reviewTransitionId = shouldAutoTransition ? requireEnv2("FERRY_REVIEW_TRANSITION_ID") : "";
   const issue = await tracker.getIssue(ticketKey);
   const existingComments = issue.comments;
+  let effectiveCfg = ferryCfg;
+  let typeOverride;
+  try {
+    const overrides = resolveTicketOverrides(issue.labels, logger);
+    typeOverride = overrides.typeOverride;
+    effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
+    logTicketOverrides(logger, overrides);
+    if (hasNonDefaultOverrides(overrides)) {
+      await tracker.postComment(
+        ticketKey,
+        buildOverridesAuditComment("iterator", eventId, overrides)
+      );
+    }
+  } catch (err) {
+    if (err instanceof LabelConflictError) {
+      await tracker.postComment(ticketKey, buildConflictComment("iterator", eventId, err));
+      process.exit(1);
+    }
+    throw err;
+  }
+  const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
-  const capabilities = resolveCapabilities(issue.labels, ferryCfg.labels);
-  const hasLabelsConfig = ferryCfg.labels !== void 0;
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
+  const hasLabelsConfig = effectiveCfg.labels !== void 0;
   const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
-  const typeOverrides = resolveTypeOverrides(issue.labels);
   logCapabilities(logger, capabilities);
-  logTypeOverrides(logger, typeOverrides);
   const priorIterations = existingComments.filter(
     (c) => c.includes("[ferry:iterator:") && c.includes("complete. Pushed fixes to PR#")
   ).length;
   checkIterationCap(
     { iteration: priorIterations, hasFindings: true },
-    ferryCfg.limits.max_iterations
+    effectiveCfg.limits.max_iterations
   );
-  const branchName = `${resolveBranchPrefix(ferryCfg.git.working_branch_prefix, issue)}${ticketKey}`;
+  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
   const prs = await runner.listPRsForBranch(owner, repo, branchName);
   if (prs.length === 0) {
     const eventMarker = byEventId("iterator", eventId);
@@ -7467,7 +7819,7 @@ async function main(envelope, logger) {
     encoding: "utf8"
   }).trim();
   const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    typeOverride: typeOverrides.typeOverride
+    typeOverride
   });
   const initialPrompt = [
     "## Jira Ticket",
@@ -7487,9 +7839,9 @@ ${existingLog}` : "",
   const loop = createAgentLoop({
     provider: iterProvider,
     model,
-    maxIterations: ferryCfg.limits.max_agent_iterations,
-    maxInputTokens: ferryCfg.limits.max_tokens_per_run,
-    maxTokens: ferryCfg.limits.max_tokens_per_message,
+    maxIterations: effectiveCfg.limits.max_agent_iterations,
+    maxInputTokens: effectiveCfg.limits.max_tokens_per_run,
+    maxTokens: effectiveCfg.limits.max_tokens_per_message,
     executeTool,
     commitProgress: makeCommitProgress(logger),
     logger

--- a/.ferry/refiner-action.js
+++ b/.ferry/refiner-action.js
@@ -1236,6 +1236,52 @@ function loadFerryConfigFromBaseBranch(baseBranch, repoRoot, fallback) {
   return parseFerryConfigJson(jsonContent);
 }
 
+// src/lib/agent-runtime/labels.ts
+function logTypeOverrides(logger, overrides) {
+  if (overrides.typeOverride) {
+    logger.info("type override active", {
+      override: overrides.forceLabel,
+      effectiveType: overrides.typeOverride
+    });
+  }
+  if (overrides.bypassTaskSkip) {
+    logger.info("task skip bypassed (ferry:type:enable-task)");
+  }
+}
+function logTicketOverrides(logger, overrides) {
+  logTypeOverrides(logger, overrides);
+  if (overrides.modelOverrides) {
+    for (const [phase, mo] of Object.entries(overrides.modelOverrides)) {
+      if (mo?.model) logger.info(`model override (${phase})`, { model: mo.model });
+      if (mo?.provider) logger.info(`provider override (${phase})`, { provider: mo.provider });
+    }
+  }
+  if (overrides.budget) {
+    if (overrides.budget.maxCostEurPerRun !== void 0) {
+      logger.info("budget override: max cost", {
+        maxCostEurPerRun: overrides.budget.maxCostEurPerRun
+      });
+    }
+    if (overrides.budget.maxTokensPerRun !== void 0) {
+      logger.info("budget override: max tokens", {
+        maxTokensPerRun: overrides.budget.maxTokensPerRun
+      });
+    }
+  }
+  if (overrides.skipPhases && overrides.skipPhases.length > 0) {
+    logger.info("phase skip active", { phases: overrides.skipPhases });
+  }
+  if (overrides.thinking !== void 0) {
+    logger.info("thinking override", { thinking: overrides.thinking });
+  }
+  if (overrides.git?.noPr) {
+    logger.info("git override: no-pr (PR creation skipped)");
+  }
+  if (overrides.paused) {
+    logger.warn("ticket is paused (ferry:paused) \u2014 agent will exit without processing");
+  }
+}
+
 // node_modules/universal-user-agent/index.js
 function getUserAgent() {
   if (typeof navigator === "object" && "userAgent" in navigator) {
@@ -5323,6 +5369,324 @@ var BUILTIN_TYPE_LABELS = /* @__PURE__ */ new Set([
   ENABLE_TASK_LABEL,
   ...Object.keys(FORCE_TYPE_LABELS)
 ]);
+function resolveTypeOverrides(labels) {
+  let bypassTaskSkip = false;
+  let typeOverride;
+  let forceLabel;
+  for (const label of labels) {
+    if (label === ENABLE_TASK_LABEL) {
+      bypassTaskSkip = true;
+    } else if (Object.prototype.hasOwnProperty.call(FORCE_TYPE_LABELS, label)) {
+      typeOverride = FORCE_TYPE_LABELS[label];
+      forceLabel = label;
+    }
+  }
+  return { bypassTaskSkip, typeOverride, forceLabel };
+}
+function isBuiltinTypeLabel(label) {
+  return BUILTIN_TYPE_LABELS.has(label);
+}
+
+// src/lib/labels/overrides.ts
+var AGENT_PHASES = /* @__PURE__ */ new Set(["refiner", "dev", "review", "iterate"]);
+var PHASES_ORDERED = ["refiner", "dev", "review", "iterate"];
+var LLM_PROVIDERS = /* @__PURE__ */ new Set(["anthropic", "openai", "google"]);
+var LabelConflictError = class extends Error {
+  label1;
+  label2;
+  field;
+  constructor(label1, label2, field) {
+    super(`Conflicting ferry labels for "${field}": "${label1}" and "${label2}"`);
+    this.name = "LabelConflictError";
+    this.label1 = label1;
+    this.label2 = label2;
+    this.field = field;
+  }
+};
+function parsePositiveFloat(s) {
+  const n = Number(s);
+  return Number.isFinite(n) && n > 0 ? n : void 0;
+}
+function parsePositiveInt(s) {
+  const n = Number(s);
+  return Number.isInteger(n) && n > 0 ? n : void 0;
+}
+var MCP_LABEL_PREFIX = "ferry:mcp/";
+var PROFILE_LABEL_PREFIX = "ferry:profile/";
+var KNOWN_STATUS_LABELS = /* @__PURE__ */ new Set([
+  "ferry:refining",
+  "ferry:developing",
+  "ferry:reviewing",
+  "ferry:iterating",
+  "ferry:ready",
+  "ferry:approved",
+  "ferry:cancelled",
+  "ferry:blocked",
+  "ferry:spend-cap",
+  "ferry:audit-log:active"
+]);
+function isKnownNonOverrideLabel(label) {
+  if (isBuiltinTypeLabel(label)) return true;
+  if (KNOWN_STATUS_LABELS.has(label)) return true;
+  if (label.startsWith("ferry:cost-estimate:")) return true;
+  if (label.startsWith(MCP_LABEL_PREFIX)) return true;
+  if (label.startsWith(PROFILE_LABEL_PREFIX)) return true;
+  return false;
+}
+function resolveTicketOverrides(labels, logger) {
+  const typeOverrides = resolveTypeOverrides(labels);
+  const modelOverrides = {};
+  const modelSources = {};
+  const providerSources = {};
+  let blanketModel;
+  let blanketModelSource;
+  let blanketProvider;
+  let blanketProviderSource;
+  let budgetMaxCostLabel;
+  let budgetMaxTokensLabel;
+  let budgetMaxCostEur;
+  let budgetMaxTokens;
+  let thinkingLabel;
+  let thinking;
+  let noPr = false;
+  let paused = false;
+  const skipPhases = [];
+  for (const label of labels) {
+    if (!label.startsWith("ferry:")) continue;
+    if (isKnownNonOverrideLabel(label)) continue;
+    if (label.startsWith("ferry:model/")) {
+      const rest = label.slice("ferry:model/".length);
+      if (!rest) {
+        logger?.warn("malformed ferry:model label (empty model name)", { label });
+        continue;
+      }
+      const slashIdx = rest.indexOf("/");
+      if (slashIdx < 0) {
+        if (blanketModelSource !== void 0) {
+          throw new LabelConflictError(blanketModelSource, label, "model");
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
+        continue;
+      }
+      const firstSegment = rest.slice(0, slashIdx);
+      const remainder = rest.slice(slashIdx + 1);
+      if (AGENT_PHASES.has(firstSegment)) {
+        const p = firstSegment;
+        if (!remainder) {
+          logger?.warn("empty model-id in ferry:model label", { label });
+          continue;
+        }
+        if (modelSources[p] !== void 0) {
+          throw new LabelConflictError(modelSources[p], label, `model.${firstSegment}`);
+        }
+        modelSources[p] = label;
+        modelOverrides[p] = { ...modelOverrides[p], model: remainder };
+      } else {
+        if (blanketModelSource !== void 0) {
+          throw new LabelConflictError(blanketModelSource, label, "model");
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:provider/")) {
+      const parts = label.slice("ferry:provider/".length).split("/");
+      if (parts.length === 1) {
+        const provider2 = parts[0];
+        if (!LLM_PROVIDERS.has(provider2)) {
+          logger?.warn("unknown provider in blanket ferry:provider label", { label, provider: provider2 });
+          continue;
+        }
+        if (blanketProviderSource !== void 0) {
+          throw new LabelConflictError(blanketProviderSource, label, "provider");
+        }
+        blanketProvider = provider2;
+        blanketProviderSource = label;
+        continue;
+      }
+      if (parts.length !== 2) {
+        logger?.warn(
+          "malformed ferry:provider label (expected ferry:provider/<provider> or ferry:provider/<phase>/<provider>)",
+          { label }
+        );
+        continue;
+      }
+      const [phase, provider] = parts;
+      if (!AGENT_PHASES.has(phase)) {
+        logger?.warn("unknown phase in ferry:provider label", { label, phase });
+        continue;
+      }
+      if (!LLM_PROVIDERS.has(provider)) {
+        logger?.warn("unknown provider in ferry:provider label", { label, provider });
+        continue;
+      }
+      const p = phase;
+      if (providerSources[p] !== void 0) {
+        throw new LabelConflictError(providerSources[p], label, `provider.${phase}`);
+      }
+      providerSources[p] = label;
+      modelOverrides[p] = {
+        ...modelOverrides[p],
+        provider
+      };
+      continue;
+    }
+    if (label.startsWith("ferry:budget/max-cost/")) {
+      const raw = label.slice("ferry:budget/max-cost/".length);
+      const val = parsePositiveFloat(raw);
+      if (val === void 0) {
+        logger?.warn("invalid cost value in ferry:budget/max-cost label", { label });
+        continue;
+      }
+      if (budgetMaxCostLabel !== void 0) {
+        throw new LabelConflictError(budgetMaxCostLabel, label, "budget.maxCostEurPerRun");
+      }
+      budgetMaxCostLabel = label;
+      budgetMaxCostEur = val;
+      continue;
+    }
+    if (label.startsWith("ferry:budget/max-tokens/")) {
+      const raw = label.slice("ferry:budget/max-tokens/".length);
+      const val = parsePositiveInt(raw);
+      if (val === void 0) {
+        logger?.warn("invalid token count in ferry:budget/max-tokens label", { label });
+        continue;
+      }
+      if (budgetMaxTokensLabel !== void 0) {
+        throw new LabelConflictError(budgetMaxTokensLabel, label, "budget.maxTokensPerRun");
+      }
+      budgetMaxTokensLabel = label;
+      budgetMaxTokens = val;
+      continue;
+    }
+    if (label.startsWith("ferry:skip/")) {
+      const phase = label.slice("ferry:skip/".length);
+      if (!AGENT_PHASES.has(phase)) {
+        logger?.warn("unknown phase in ferry:skip label", { label, phase });
+        continue;
+      }
+      const p = phase;
+      if (!skipPhases.includes(p)) skipPhases.push(p);
+      continue;
+    }
+    if (label === "ferry:thinking/on" || label === "ferry:thinking/off") {
+      const val = label === "ferry:thinking/on" ? "on" : "off";
+      if (thinking !== void 0 && thinking !== val) {
+        throw new LabelConflictError(thinkingLabel, label, "thinking");
+      }
+      if (thinking === void 0) {
+        thinking = val;
+        thinkingLabel = label;
+      }
+      continue;
+    }
+    if (label === "ferry:git/no-pr") {
+      noPr = true;
+      continue;
+    }
+    if (label === "ferry:paused") {
+      paused = true;
+      continue;
+    }
+    logger?.warn("unknown ferry override label ignored", { label });
+  }
+  if (blanketModel !== void 0) {
+    for (const phase of PHASES_ORDERED) {
+      if (modelSources[phase] === void 0) {
+        modelOverrides[phase] = { ...modelOverrides[phase], model: blanketModel };
+      }
+    }
+  }
+  if (blanketProvider !== void 0) {
+    for (const phase of PHASES_ORDERED) {
+      if (providerSources[phase] === void 0) {
+        modelOverrides[phase] = { ...modelOverrides[phase], provider: blanketProvider };
+      }
+    }
+  }
+  const hasModelOverrides = Object.keys(modelOverrides).length > 0;
+  const hasBudget = budgetMaxCostEur !== void 0 || budgetMaxTokens !== void 0;
+  return {
+    ...typeOverrides,
+    ...hasModelOverrides ? { modelOverrides } : {},
+    ...hasBudget ? {
+      budget: {
+        ...budgetMaxCostEur !== void 0 ? { maxCostEurPerRun: budgetMaxCostEur } : {},
+        ...budgetMaxTokens !== void 0 ? { maxTokensPerRun: budgetMaxTokens } : {}
+      }
+    } : {},
+    ...skipPhases.length > 0 ? { skipPhases } : {},
+    ...thinking !== void 0 ? { thinking } : {},
+    ...noPr ? { git: { noPr: true } } : {},
+    ...paused ? { paused: true } : {}
+  };
+}
+function applyTicketOverrides(cfg, overrides) {
+  if (!overrides.modelOverrides && !overrides.budget) return cfg;
+  const models = { ...cfg.models };
+  const limits = { ...cfg.limits };
+  const mo = overrides.modelOverrides;
+  if (mo) {
+    if (mo.refiner) {
+      models.refiner = {
+        provider: mo.refiner.provider ?? models.refiner.provider,
+        model: mo.refiner.model ?? models.refiner.model
+      };
+    }
+    if (mo.dev) {
+      models.dev = {
+        provider: mo.dev.provider ?? models.dev.provider,
+        model: mo.dev.model ?? models.dev.model
+      };
+    }
+    if (mo.review) {
+      models.review = {
+        provider: mo.review.provider ?? models.review.provider,
+        model: mo.review.model ?? models.review.model
+      };
+    }
+    if (mo.iterate) {
+      models.iterate = {
+        provider: mo.iterate.provider ?? models.iterate.provider,
+        model: mo.iterate.model ?? models.iterate.model
+      };
+    }
+  }
+  if (overrides.budget) {
+    if (overrides.budget.maxCostEurPerRun !== void 0) {
+      limits.max_cost_eur_per_run = overrides.budget.maxCostEurPerRun;
+    }
+    if (overrides.budget.maxTokensPerRun !== void 0) {
+      limits.max_tokens_per_run = overrides.budget.maxTokensPerRun;
+    }
+  }
+  return { ...cfg, models, limits };
+}
+function hasNonDefaultOverrides(overrides) {
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true;
+}
+function buildOverridesAuditComment(role, runId, overrides) {
+  const payload = {};
+  if (overrides.bypassTaskSkip) payload.bypassTaskSkip = true;
+  if (overrides.typeOverride !== void 0) payload.typeOverride = overrides.typeOverride;
+  if (overrides.modelOverrides !== void 0) payload.modelOverrides = overrides.modelOverrides;
+  if (overrides.budget !== void 0) payload.budget = overrides.budget;
+  if ((overrides.skipPhases?.length ?? 0) > 0) payload.skipPhases = overrides.skipPhases;
+  if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
+  if (overrides.git?.noPr) payload.git = overrides.git;
+  if (overrides.paused) payload.paused = true;
+  return `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+}
+function buildConflictComment(role, runId, err) {
+  return [
+    `[ferry:${role}:${runId}] label conflict \u2014 remove one of the contradicting labels and re-trigger:`,
+    `  field: ${err.field}`,
+    `  label 1: ${err.label1}`,
+    `  label 2: ${err.label2}`
+  ].join("\n");
+}
 
 // src/agents/refiner/refine.ts
 import { createRequire as createRequire3 } from "module";
@@ -5838,10 +6202,30 @@ async function run(envelope, deps) {
   });
 }
 async function main(envelope, logger) {
+  const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT);
   const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
-  const route = ferryCfg.models.refiner;
+  const issueForLabels = await tracker.getIssue(ticketKey);
+  let effectiveCfg = ferryCfg;
+  try {
+    const overrides = resolveTicketOverrides(issueForLabels.labels, logger);
+    logTicketOverrides(logger, overrides);
+    effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
+    if (hasNonDefaultOverrides(overrides)) {
+      await tracker.postComment(
+        ticketKey,
+        buildOverridesAuditComment("refiner", eventId, overrides)
+      );
+    }
+  } catch (err) {
+    if (err instanceof LabelConflictError) {
+      await tracker.postComment(ticketKey, buildConflictComment("refiner", eventId, err));
+      process.exit(1);
+    }
+    throw err;
+  }
+  const route = effectiveCfg.models.refiner;
   const callLlm = createLlmCall(route);
   await run(envelope, { tracker, callLlm, logger });
 }

--- a/.ferry/review-action.js
+++ b/.ferry/review-action.js
@@ -1845,6 +1845,39 @@ function logTypeOverrides(logger, overrides) {
     logger.info("task skip bypassed (ferry:type:enable-task)");
   }
 }
+function logTicketOverrides(logger, overrides) {
+  logTypeOverrides(logger, overrides);
+  if (overrides.modelOverrides) {
+    for (const [phase, mo] of Object.entries(overrides.modelOverrides)) {
+      if (mo?.model) logger.info(`model override (${phase})`, { model: mo.model });
+      if (mo?.provider) logger.info(`provider override (${phase})`, { provider: mo.provider });
+    }
+  }
+  if (overrides.budget) {
+    if (overrides.budget.maxCostEurPerRun !== void 0) {
+      logger.info("budget override: max cost", {
+        maxCostEurPerRun: overrides.budget.maxCostEurPerRun
+      });
+    }
+    if (overrides.budget.maxTokensPerRun !== void 0) {
+      logger.info("budget override: max tokens", {
+        maxTokensPerRun: overrides.budget.maxTokensPerRun
+      });
+    }
+  }
+  if (overrides.skipPhases && overrides.skipPhases.length > 0) {
+    logger.info("phase skip active", { phases: overrides.skipPhases });
+  }
+  if (overrides.thinking !== void 0) {
+    logger.info("thinking override", { thinking: overrides.thinking });
+  }
+  if (overrides.git?.noPr) {
+    logger.info("git override: no-pr (PR creation skipped)");
+  }
+  if (overrides.paused) {
+    logger.warn("ticket is paused (ferry:paused) \u2014 agent will exit without processing");
+  }
+}
 
 // node_modules/universal-user-agent/index.js
 function getUserAgent() {
@@ -6009,6 +6042,307 @@ function resolveCapabilities(ticketLabels, configLabels, logger) {
   };
 }
 
+// src/lib/labels/overrides.ts
+var AGENT_PHASES = /* @__PURE__ */ new Set(["refiner", "dev", "review", "iterate"]);
+var PHASES_ORDERED = ["refiner", "dev", "review", "iterate"];
+var LLM_PROVIDERS = /* @__PURE__ */ new Set(["anthropic", "openai", "google"]);
+var LabelConflictError = class extends Error {
+  label1;
+  label2;
+  field;
+  constructor(label1, label2, field) {
+    super(`Conflicting ferry labels for "${field}": "${label1}" and "${label2}"`);
+    this.name = "LabelConflictError";
+    this.label1 = label1;
+    this.label2 = label2;
+    this.field = field;
+  }
+};
+function parsePositiveFloat(s) {
+  const n = Number(s);
+  return Number.isFinite(n) && n > 0 ? n : void 0;
+}
+function parsePositiveInt(s) {
+  const n = Number(s);
+  return Number.isInteger(n) && n > 0 ? n : void 0;
+}
+var MCP_LABEL_PREFIX = "ferry:mcp/";
+var PROFILE_LABEL_PREFIX = "ferry:profile/";
+var KNOWN_STATUS_LABELS = /* @__PURE__ */ new Set([
+  "ferry:refining",
+  "ferry:developing",
+  "ferry:reviewing",
+  "ferry:iterating",
+  "ferry:ready",
+  "ferry:approved",
+  "ferry:cancelled",
+  "ferry:blocked",
+  "ferry:spend-cap",
+  "ferry:audit-log:active"
+]);
+function isKnownNonOverrideLabel(label) {
+  if (isBuiltinTypeLabel(label)) return true;
+  if (KNOWN_STATUS_LABELS.has(label)) return true;
+  if (label.startsWith("ferry:cost-estimate:")) return true;
+  if (label.startsWith(MCP_LABEL_PREFIX)) return true;
+  if (label.startsWith(PROFILE_LABEL_PREFIX)) return true;
+  return false;
+}
+function resolveTicketOverrides(labels, logger) {
+  const typeOverrides = resolveTypeOverrides(labels);
+  const modelOverrides = {};
+  const modelSources = {};
+  const providerSources = {};
+  let blanketModel;
+  let blanketModelSource;
+  let blanketProvider;
+  let blanketProviderSource;
+  let budgetMaxCostLabel;
+  let budgetMaxTokensLabel;
+  let budgetMaxCostEur;
+  let budgetMaxTokens;
+  let thinkingLabel;
+  let thinking;
+  let noPr = false;
+  let paused = false;
+  const skipPhases = [];
+  for (const label of labels) {
+    if (!label.startsWith("ferry:")) continue;
+    if (isKnownNonOverrideLabel(label)) continue;
+    if (label.startsWith("ferry:model/")) {
+      const rest = label.slice("ferry:model/".length);
+      if (!rest) {
+        logger?.warn("malformed ferry:model label (empty model name)", { label });
+        continue;
+      }
+      const slashIdx = rest.indexOf("/");
+      if (slashIdx < 0) {
+        if (blanketModelSource !== void 0) {
+          throw new LabelConflictError(blanketModelSource, label, "model");
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
+        continue;
+      }
+      const firstSegment = rest.slice(0, slashIdx);
+      const remainder = rest.slice(slashIdx + 1);
+      if (AGENT_PHASES.has(firstSegment)) {
+        const p = firstSegment;
+        if (!remainder) {
+          logger?.warn("empty model-id in ferry:model label", { label });
+          continue;
+        }
+        if (modelSources[p] !== void 0) {
+          throw new LabelConflictError(modelSources[p], label, `model.${firstSegment}`);
+        }
+        modelSources[p] = label;
+        modelOverrides[p] = { ...modelOverrides[p], model: remainder };
+      } else {
+        if (blanketModelSource !== void 0) {
+          throw new LabelConflictError(blanketModelSource, label, "model");
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:provider/")) {
+      const parts = label.slice("ferry:provider/".length).split("/");
+      if (parts.length === 1) {
+        const provider2 = parts[0];
+        if (!LLM_PROVIDERS.has(provider2)) {
+          logger?.warn("unknown provider in blanket ferry:provider label", { label, provider: provider2 });
+          continue;
+        }
+        if (blanketProviderSource !== void 0) {
+          throw new LabelConflictError(blanketProviderSource, label, "provider");
+        }
+        blanketProvider = provider2;
+        blanketProviderSource = label;
+        continue;
+      }
+      if (parts.length !== 2) {
+        logger?.warn(
+          "malformed ferry:provider label (expected ferry:provider/<provider> or ferry:provider/<phase>/<provider>)",
+          { label }
+        );
+        continue;
+      }
+      const [phase, provider] = parts;
+      if (!AGENT_PHASES.has(phase)) {
+        logger?.warn("unknown phase in ferry:provider label", { label, phase });
+        continue;
+      }
+      if (!LLM_PROVIDERS.has(provider)) {
+        logger?.warn("unknown provider in ferry:provider label", { label, provider });
+        continue;
+      }
+      const p = phase;
+      if (providerSources[p] !== void 0) {
+        throw new LabelConflictError(providerSources[p], label, `provider.${phase}`);
+      }
+      providerSources[p] = label;
+      modelOverrides[p] = {
+        ...modelOverrides[p],
+        provider
+      };
+      continue;
+    }
+    if (label.startsWith("ferry:budget/max-cost/")) {
+      const raw = label.slice("ferry:budget/max-cost/".length);
+      const val = parsePositiveFloat(raw);
+      if (val === void 0) {
+        logger?.warn("invalid cost value in ferry:budget/max-cost label", { label });
+        continue;
+      }
+      if (budgetMaxCostLabel !== void 0) {
+        throw new LabelConflictError(budgetMaxCostLabel, label, "budget.maxCostEurPerRun");
+      }
+      budgetMaxCostLabel = label;
+      budgetMaxCostEur = val;
+      continue;
+    }
+    if (label.startsWith("ferry:budget/max-tokens/")) {
+      const raw = label.slice("ferry:budget/max-tokens/".length);
+      const val = parsePositiveInt(raw);
+      if (val === void 0) {
+        logger?.warn("invalid token count in ferry:budget/max-tokens label", { label });
+        continue;
+      }
+      if (budgetMaxTokensLabel !== void 0) {
+        throw new LabelConflictError(budgetMaxTokensLabel, label, "budget.maxTokensPerRun");
+      }
+      budgetMaxTokensLabel = label;
+      budgetMaxTokens = val;
+      continue;
+    }
+    if (label.startsWith("ferry:skip/")) {
+      const phase = label.slice("ferry:skip/".length);
+      if (!AGENT_PHASES.has(phase)) {
+        logger?.warn("unknown phase in ferry:skip label", { label, phase });
+        continue;
+      }
+      const p = phase;
+      if (!skipPhases.includes(p)) skipPhases.push(p);
+      continue;
+    }
+    if (label === "ferry:thinking/on" || label === "ferry:thinking/off") {
+      const val = label === "ferry:thinking/on" ? "on" : "off";
+      if (thinking !== void 0 && thinking !== val) {
+        throw new LabelConflictError(thinkingLabel, label, "thinking");
+      }
+      if (thinking === void 0) {
+        thinking = val;
+        thinkingLabel = label;
+      }
+      continue;
+    }
+    if (label === "ferry:git/no-pr") {
+      noPr = true;
+      continue;
+    }
+    if (label === "ferry:paused") {
+      paused = true;
+      continue;
+    }
+    logger?.warn("unknown ferry override label ignored", { label });
+  }
+  if (blanketModel !== void 0) {
+    for (const phase of PHASES_ORDERED) {
+      if (modelSources[phase] === void 0) {
+        modelOverrides[phase] = { ...modelOverrides[phase], model: blanketModel };
+      }
+    }
+  }
+  if (blanketProvider !== void 0) {
+    for (const phase of PHASES_ORDERED) {
+      if (providerSources[phase] === void 0) {
+        modelOverrides[phase] = { ...modelOverrides[phase], provider: blanketProvider };
+      }
+    }
+  }
+  const hasModelOverrides = Object.keys(modelOverrides).length > 0;
+  const hasBudget = budgetMaxCostEur !== void 0 || budgetMaxTokens !== void 0;
+  return {
+    ...typeOverrides,
+    ...hasModelOverrides ? { modelOverrides } : {},
+    ...hasBudget ? {
+      budget: {
+        ...budgetMaxCostEur !== void 0 ? { maxCostEurPerRun: budgetMaxCostEur } : {},
+        ...budgetMaxTokens !== void 0 ? { maxTokensPerRun: budgetMaxTokens } : {}
+      }
+    } : {},
+    ...skipPhases.length > 0 ? { skipPhases } : {},
+    ...thinking !== void 0 ? { thinking } : {},
+    ...noPr ? { git: { noPr: true } } : {},
+    ...paused ? { paused: true } : {}
+  };
+}
+function applyTicketOverrides(cfg, overrides) {
+  if (!overrides.modelOverrides && !overrides.budget) return cfg;
+  const models = { ...cfg.models };
+  const limits = { ...cfg.limits };
+  const mo = overrides.modelOverrides;
+  if (mo) {
+    if (mo.refiner) {
+      models.refiner = {
+        provider: mo.refiner.provider ?? models.refiner.provider,
+        model: mo.refiner.model ?? models.refiner.model
+      };
+    }
+    if (mo.dev) {
+      models.dev = {
+        provider: mo.dev.provider ?? models.dev.provider,
+        model: mo.dev.model ?? models.dev.model
+      };
+    }
+    if (mo.review) {
+      models.review = {
+        provider: mo.review.provider ?? models.review.provider,
+        model: mo.review.model ?? models.review.model
+      };
+    }
+    if (mo.iterate) {
+      models.iterate = {
+        provider: mo.iterate.provider ?? models.iterate.provider,
+        model: mo.iterate.model ?? models.iterate.model
+      };
+    }
+  }
+  if (overrides.budget) {
+    if (overrides.budget.maxCostEurPerRun !== void 0) {
+      limits.max_cost_eur_per_run = overrides.budget.maxCostEurPerRun;
+    }
+    if (overrides.budget.maxTokensPerRun !== void 0) {
+      limits.max_tokens_per_run = overrides.budget.maxTokensPerRun;
+    }
+  }
+  return { ...cfg, models, limits };
+}
+function hasNonDefaultOverrides(overrides) {
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true;
+}
+function buildOverridesAuditComment(role, runId, overrides) {
+  const payload = {};
+  if (overrides.bypassTaskSkip) payload.bypassTaskSkip = true;
+  if (overrides.typeOverride !== void 0) payload.typeOverride = overrides.typeOverride;
+  if (overrides.modelOverrides !== void 0) payload.modelOverrides = overrides.modelOverrides;
+  if (overrides.budget !== void 0) payload.budget = overrides.budget;
+  if ((overrides.skipPhases?.length ?? 0) > 0) payload.skipPhases = overrides.skipPhases;
+  if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
+  if (overrides.git?.noPr) payload.git = overrides.git;
+  if (overrides.paused) payload.paused = true;
+  return `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+}
+function buildConflictComment(role, runId, err) {
+  return [
+    `[ferry:${role}:${runId}] label conflict \u2014 remove one of the contradicting labels and re-trigger:`,
+    `  field: ${err.field}`,
+    `  label 1: ${err.label1}`,
+    `  label 2: ${err.label2}`
+  ].join("\n");
+}
+
 // src/agents/reviewer/changes-guard.ts
 function countPriorIterations(existingComments) {
   return existingComments.filter(
@@ -6023,7 +6357,6 @@ async function main(envelope, logger) {
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT);
   const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
-  const { provider, model } = ferryCfg.models.review;
   const reviewerWorkflow = ferryCfg.workflow.agents.reviewer;
   const shouldTransitionChanges = reviewerWorkflow.auto_transition_changes !== null;
   const shouldTransitionApprove = reviewerWorkflow.auto_transition_approve !== null;
@@ -6031,11 +6364,30 @@ async function main(envelope, logger) {
   const approveTransitionId = shouldTransitionApprove ? requireEnv2("FERRY_APPROVE_TRANSITION_ID") : "";
   const issue = await tracker.getIssue(ticketKey);
   const existingComments = issue.comments;
-  const capabilities = resolveCapabilities(issue.labels, ferryCfg.labels, logger);
+  let effectiveCfg = ferryCfg;
+  let typeOverride;
+  try {
+    const overrides = resolveTicketOverrides(issue.labels, logger);
+    typeOverride = overrides.typeOverride;
+    effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
+    logTicketOverrides(logger, overrides);
+    if (hasNonDefaultOverrides(overrides)) {
+      await tracker.postComment(
+        ticketKey,
+        buildOverridesAuditComment("reviewer", eventId, overrides)
+      );
+    }
+  } catch (err) {
+    if (err instanceof LabelConflictError) {
+      await tracker.postComment(ticketKey, buildConflictComment("reviewer", eventId, err));
+      process.exit(1);
+    }
+    throw err;
+  }
+  const { provider, model } = effectiveCfg.models.review;
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels, logger);
   logCapabilities(logger, capabilities);
-  const typeOverrides = resolveTypeOverrides(issue.labels);
-  logTypeOverrides(logger, typeOverrides);
-  const branchName = `${resolveBranchPrefix(ferryCfg.git.working_branch_prefix, issue)}${ticketKey}`;
+  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
   const prs = await runner.listPRsForBranch(owner, repo, branchName);
   if (prs.length === 0) {
     const errorMarker = byEventId("reviewer", eventId);
@@ -6096,7 +6448,7 @@ async function main(envelope, logger) {
   const commits = await runner.listPRCommits({ owner, repo, prNumber });
   const commitLog = commits.map((c) => `${c.sha.slice(0, 7)} ${c.message.split("\n")[0]}`).join("\n");
   const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    typeOverride: typeOverrides.typeOverride
+    typeOverride
   });
   const mergeConflictWarning = hasMergeConflicts ? `
 \u26A0\uFE0F  MERGE CONFLICTS DETECTED \u2014 mergeable=${String(mergeable)}${conflictedFiles.length > 0 ? `, conflicted files: ${conflictedFiles.join(", ")}` : ""}` : "";
@@ -6140,8 +6492,8 @@ async function main(envelope, logger) {
     owner,
     repo,
     headSha,
-    maxIterations: ferryCfg.limits.reviewer_max_iterations,
-    maxTokens: ferryCfg.limits.reviewer_max_tokens,
+    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
+    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
     logger
   });
   logger.info("reviewed", {
@@ -6181,7 +6533,7 @@ async function main(envelope, logger) {
     }
   } else {
     const priorIterations = countPriorIterations(existingComments);
-    const cap = ferryCfg.limits.max_iterations;
+    const cap = effectiveCfg.limits.max_iterations;
     const capReached = priorIterations >= cap;
     await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
     if (!capReached) {

--- a/.github/actions/ferry-run-developer/dev-action.js
+++ b/.github/actions/ferry-run-developer/dev-action.js
@@ -1335,6 +1335,39 @@ function logTypeOverrides(logger, overrides) {
     logger.info("task skip bypassed (ferry:type:enable-task)");
   }
 }
+function logTicketOverrides(logger, overrides) {
+  logTypeOverrides(logger, overrides);
+  if (overrides.modelOverrides) {
+    for (const [phase, mo] of Object.entries(overrides.modelOverrides)) {
+      if (mo?.model) logger.info(`model override (${phase})`, { model: mo.model });
+      if (mo?.provider) logger.info(`provider override (${phase})`, { provider: mo.provider });
+    }
+  }
+  if (overrides.budget) {
+    if (overrides.budget.maxCostEurPerRun !== void 0) {
+      logger.info("budget override: max cost", {
+        maxCostEurPerRun: overrides.budget.maxCostEurPerRun
+      });
+    }
+    if (overrides.budget.maxTokensPerRun !== void 0) {
+      logger.info("budget override: max tokens", {
+        maxTokensPerRun: overrides.budget.maxTokensPerRun
+      });
+    }
+  }
+  if (overrides.skipPhases && overrides.skipPhases.length > 0) {
+    logger.info("phase skip active", { phases: overrides.skipPhases });
+  }
+  if (overrides.thinking !== void 0) {
+    logger.info("thinking override", { thinking: overrides.thinking });
+  }
+  if (overrides.git?.noPr) {
+    logger.info("git override: no-pr (PR creation skipped)");
+  }
+  if (overrides.paused) {
+    logger.warn("ticket is paused (ferry:paused) \u2014 agent will exit without processing");
+  }
+}
 
 // node_modules/universal-user-agent/index.js
 function getUserAgent() {
@@ -5509,6 +5542,307 @@ function filterMcpServers(pool, capabilities, hasLabelsConfig) {
   });
 }
 
+// src/lib/labels/overrides.ts
+var AGENT_PHASES = /* @__PURE__ */ new Set(["refiner", "dev", "review", "iterate"]);
+var PHASES_ORDERED = ["refiner", "dev", "review", "iterate"];
+var LLM_PROVIDERS = /* @__PURE__ */ new Set(["anthropic", "openai", "google"]);
+var LabelConflictError = class extends Error {
+  label1;
+  label2;
+  field;
+  constructor(label1, label2, field) {
+    super(`Conflicting ferry labels for "${field}": "${label1}" and "${label2}"`);
+    this.name = "LabelConflictError";
+    this.label1 = label1;
+    this.label2 = label2;
+    this.field = field;
+  }
+};
+function parsePositiveFloat(s) {
+  const n = Number(s);
+  return Number.isFinite(n) && n > 0 ? n : void 0;
+}
+function parsePositiveInt(s) {
+  const n = Number(s);
+  return Number.isInteger(n) && n > 0 ? n : void 0;
+}
+var MCP_LABEL_PREFIX = "ferry:mcp/";
+var PROFILE_LABEL_PREFIX = "ferry:profile/";
+var KNOWN_STATUS_LABELS = /* @__PURE__ */ new Set([
+  "ferry:refining",
+  "ferry:developing",
+  "ferry:reviewing",
+  "ferry:iterating",
+  "ferry:ready",
+  "ferry:approved",
+  "ferry:cancelled",
+  "ferry:blocked",
+  "ferry:spend-cap",
+  "ferry:audit-log:active"
+]);
+function isKnownNonOverrideLabel(label) {
+  if (isBuiltinTypeLabel(label)) return true;
+  if (KNOWN_STATUS_LABELS.has(label)) return true;
+  if (label.startsWith("ferry:cost-estimate:")) return true;
+  if (label.startsWith(MCP_LABEL_PREFIX)) return true;
+  if (label.startsWith(PROFILE_LABEL_PREFIX)) return true;
+  return false;
+}
+function resolveTicketOverrides(labels, logger) {
+  const typeOverrides = resolveTypeOverrides(labels);
+  const modelOverrides = {};
+  const modelSources = {};
+  const providerSources = {};
+  let blanketModel;
+  let blanketModelSource;
+  let blanketProvider;
+  let blanketProviderSource;
+  let budgetMaxCostLabel;
+  let budgetMaxTokensLabel;
+  let budgetMaxCostEur;
+  let budgetMaxTokens;
+  let thinkingLabel;
+  let thinking;
+  let noPr = false;
+  let paused = false;
+  const skipPhases = [];
+  for (const label of labels) {
+    if (!label.startsWith("ferry:")) continue;
+    if (isKnownNonOverrideLabel(label)) continue;
+    if (label.startsWith("ferry:model/")) {
+      const rest = label.slice("ferry:model/".length);
+      if (!rest) {
+        logger?.warn("malformed ferry:model label (empty model name)", { label });
+        continue;
+      }
+      const slashIdx = rest.indexOf("/");
+      if (slashIdx < 0) {
+        if (blanketModelSource !== void 0) {
+          throw new LabelConflictError(blanketModelSource, label, "model");
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
+        continue;
+      }
+      const firstSegment = rest.slice(0, slashIdx);
+      const remainder = rest.slice(slashIdx + 1);
+      if (AGENT_PHASES.has(firstSegment)) {
+        const p = firstSegment;
+        if (!remainder) {
+          logger?.warn("empty model-id in ferry:model label", { label });
+          continue;
+        }
+        if (modelSources[p] !== void 0) {
+          throw new LabelConflictError(modelSources[p], label, `model.${firstSegment}`);
+        }
+        modelSources[p] = label;
+        modelOverrides[p] = { ...modelOverrides[p], model: remainder };
+      } else {
+        if (blanketModelSource !== void 0) {
+          throw new LabelConflictError(blanketModelSource, label, "model");
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:provider/")) {
+      const parts = label.slice("ferry:provider/".length).split("/");
+      if (parts.length === 1) {
+        const provider2 = parts[0];
+        if (!LLM_PROVIDERS.has(provider2)) {
+          logger?.warn("unknown provider in blanket ferry:provider label", { label, provider: provider2 });
+          continue;
+        }
+        if (blanketProviderSource !== void 0) {
+          throw new LabelConflictError(blanketProviderSource, label, "provider");
+        }
+        blanketProvider = provider2;
+        blanketProviderSource = label;
+        continue;
+      }
+      if (parts.length !== 2) {
+        logger?.warn(
+          "malformed ferry:provider label (expected ferry:provider/<provider> or ferry:provider/<phase>/<provider>)",
+          { label }
+        );
+        continue;
+      }
+      const [phase, provider] = parts;
+      if (!AGENT_PHASES.has(phase)) {
+        logger?.warn("unknown phase in ferry:provider label", { label, phase });
+        continue;
+      }
+      if (!LLM_PROVIDERS.has(provider)) {
+        logger?.warn("unknown provider in ferry:provider label", { label, provider });
+        continue;
+      }
+      const p = phase;
+      if (providerSources[p] !== void 0) {
+        throw new LabelConflictError(providerSources[p], label, `provider.${phase}`);
+      }
+      providerSources[p] = label;
+      modelOverrides[p] = {
+        ...modelOverrides[p],
+        provider
+      };
+      continue;
+    }
+    if (label.startsWith("ferry:budget/max-cost/")) {
+      const raw = label.slice("ferry:budget/max-cost/".length);
+      const val = parsePositiveFloat(raw);
+      if (val === void 0) {
+        logger?.warn("invalid cost value in ferry:budget/max-cost label", { label });
+        continue;
+      }
+      if (budgetMaxCostLabel !== void 0) {
+        throw new LabelConflictError(budgetMaxCostLabel, label, "budget.maxCostEurPerRun");
+      }
+      budgetMaxCostLabel = label;
+      budgetMaxCostEur = val;
+      continue;
+    }
+    if (label.startsWith("ferry:budget/max-tokens/")) {
+      const raw = label.slice("ferry:budget/max-tokens/".length);
+      const val = parsePositiveInt(raw);
+      if (val === void 0) {
+        logger?.warn("invalid token count in ferry:budget/max-tokens label", { label });
+        continue;
+      }
+      if (budgetMaxTokensLabel !== void 0) {
+        throw new LabelConflictError(budgetMaxTokensLabel, label, "budget.maxTokensPerRun");
+      }
+      budgetMaxTokensLabel = label;
+      budgetMaxTokens = val;
+      continue;
+    }
+    if (label.startsWith("ferry:skip/")) {
+      const phase = label.slice("ferry:skip/".length);
+      if (!AGENT_PHASES.has(phase)) {
+        logger?.warn("unknown phase in ferry:skip label", { label, phase });
+        continue;
+      }
+      const p = phase;
+      if (!skipPhases.includes(p)) skipPhases.push(p);
+      continue;
+    }
+    if (label === "ferry:thinking/on" || label === "ferry:thinking/off") {
+      const val = label === "ferry:thinking/on" ? "on" : "off";
+      if (thinking !== void 0 && thinking !== val) {
+        throw new LabelConflictError(thinkingLabel, label, "thinking");
+      }
+      if (thinking === void 0) {
+        thinking = val;
+        thinkingLabel = label;
+      }
+      continue;
+    }
+    if (label === "ferry:git/no-pr") {
+      noPr = true;
+      continue;
+    }
+    if (label === "ferry:paused") {
+      paused = true;
+      continue;
+    }
+    logger?.warn("unknown ferry override label ignored", { label });
+  }
+  if (blanketModel !== void 0) {
+    for (const phase of PHASES_ORDERED) {
+      if (modelSources[phase] === void 0) {
+        modelOverrides[phase] = { ...modelOverrides[phase], model: blanketModel };
+      }
+    }
+  }
+  if (blanketProvider !== void 0) {
+    for (const phase of PHASES_ORDERED) {
+      if (providerSources[phase] === void 0) {
+        modelOverrides[phase] = { ...modelOverrides[phase], provider: blanketProvider };
+      }
+    }
+  }
+  const hasModelOverrides = Object.keys(modelOverrides).length > 0;
+  const hasBudget = budgetMaxCostEur !== void 0 || budgetMaxTokens !== void 0;
+  return {
+    ...typeOverrides,
+    ...hasModelOverrides ? { modelOverrides } : {},
+    ...hasBudget ? {
+      budget: {
+        ...budgetMaxCostEur !== void 0 ? { maxCostEurPerRun: budgetMaxCostEur } : {},
+        ...budgetMaxTokens !== void 0 ? { maxTokensPerRun: budgetMaxTokens } : {}
+      }
+    } : {},
+    ...skipPhases.length > 0 ? { skipPhases } : {},
+    ...thinking !== void 0 ? { thinking } : {},
+    ...noPr ? { git: { noPr: true } } : {},
+    ...paused ? { paused: true } : {}
+  };
+}
+function applyTicketOverrides(cfg, overrides) {
+  if (!overrides.modelOverrides && !overrides.budget) return cfg;
+  const models = { ...cfg.models };
+  const limits = { ...cfg.limits };
+  const mo = overrides.modelOverrides;
+  if (mo) {
+    if (mo.refiner) {
+      models.refiner = {
+        provider: mo.refiner.provider ?? models.refiner.provider,
+        model: mo.refiner.model ?? models.refiner.model
+      };
+    }
+    if (mo.dev) {
+      models.dev = {
+        provider: mo.dev.provider ?? models.dev.provider,
+        model: mo.dev.model ?? models.dev.model
+      };
+    }
+    if (mo.review) {
+      models.review = {
+        provider: mo.review.provider ?? models.review.provider,
+        model: mo.review.model ?? models.review.model
+      };
+    }
+    if (mo.iterate) {
+      models.iterate = {
+        provider: mo.iterate.provider ?? models.iterate.provider,
+        model: mo.iterate.model ?? models.iterate.model
+      };
+    }
+  }
+  if (overrides.budget) {
+    if (overrides.budget.maxCostEurPerRun !== void 0) {
+      limits.max_cost_eur_per_run = overrides.budget.maxCostEurPerRun;
+    }
+    if (overrides.budget.maxTokensPerRun !== void 0) {
+      limits.max_tokens_per_run = overrides.budget.maxTokensPerRun;
+    }
+  }
+  return { ...cfg, models, limits };
+}
+function hasNonDefaultOverrides(overrides) {
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true;
+}
+function buildOverridesAuditComment(role, runId, overrides) {
+  const payload = {};
+  if (overrides.bypassTaskSkip) payload.bypassTaskSkip = true;
+  if (overrides.typeOverride !== void 0) payload.typeOverride = overrides.typeOverride;
+  if (overrides.modelOverrides !== void 0) payload.modelOverrides = overrides.modelOverrides;
+  if (overrides.budget !== void 0) payload.budget = overrides.budget;
+  if ((overrides.skipPhases?.length ?? 0) > 0) payload.skipPhases = overrides.skipPhases;
+  if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
+  if (overrides.git?.noPr) payload.git = overrides.git;
+  if (overrides.paused) payload.paused = true;
+  return `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+}
+function buildConflictComment(role, runId, err) {
+  return [
+    `[ferry:${role}:${runId}] label conflict \u2014 remove one of the contradicting labels and re-trigger:`,
+    `  field: ${err.field}`,
+    `  label 1: ${err.label1}`,
+    `  label 2: ${err.label2}`
+  ].join("\n");
+}
+
 // src/lib/dry-run.ts
 function isDryRun() {
   return process.env.FERRY_DRY_RUN === "1" || process.env.FERRY_DRY_RUN === "true";
@@ -7552,20 +7886,40 @@ async function main(envelope, logger) {
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT);
   const { baseBranch, targetBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
-  const { provider: devProvider } = ferryCfg.models.dev;
   const devWorkflow = ferryCfg.workflow.agents.developer;
   const shouldAutoTransition = devWorkflow.auto_transition !== null;
   const reviewTransitionId = dryRun || !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
   const jiraBaseUrl = requireEnv("FERRY_JIRA_BASE_URL");
   const issue = await tracker.getIssue(ticketKey);
-  const typeOverrides = resolveTypeOverrides(issue.labels);
-  logTypeOverrides(logger, typeOverrides);
+  let effectiveCfg = ferryCfg;
+  let typeOverride;
+  let forceLabel;
+  try {
+    const overrides = resolveTicketOverrides(issue.labels, logger);
+    typeOverride = overrides.typeOverride;
+    forceLabel = overrides.forceLabel;
+    effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
+    logTicketOverrides(logger, overrides);
+    if (hasNonDefaultOverrides(overrides)) {
+      await tracker.postComment(
+        ticketKey,
+        buildOverridesAuditComment("developer", eventId, overrides)
+      );
+    }
+  } catch (err) {
+    if (err instanceof LabelConflictError) {
+      await tracker.postComment(ticketKey, buildConflictComment("developer", eventId, err));
+      process.exit(1);
+    }
+    throw err;
+  }
+  const { provider: devProvider } = effectiveCfg.models.dev;
   const labels = issue.labels.join(", ");
   const comments = issue.comments.map((c) => `Comment: ${c}`).join("\n");
   const ticketBlock = buildTicketBlock(ticketKey, issue, {
     labels,
     comments,
-    typeOverride: typeOverrides.typeOverride
+    typeOverride
   });
   const subtasks = await tracker.getSubtasks(ticketKey);
   const testRunner = detectTestRunner(packageJsonPath(REPO_ROOT));
@@ -7576,8 +7930,8 @@ async function main(envelope, logger) {
 
 ${pkgManagerHint}`] : []
   });
-  const model = ferryCfg.models.dev.model;
-  const branchName = `${resolveBranchPrefix(ferryCfg.git.working_branch_prefix, issue)}${ticketKey}`;
+  const model = effectiveCfg.models.dev.model;
+  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
   configureFerryGitUser(REPO_ROOT);
   let resumeContext = "";
   let branchHeadSha = "";
@@ -7649,8 +8003,8 @@ ${tree}`,
   ].join("\n");
   const secretScan = makeSecretScan(REPO_ROOT);
   const mcpPool = loadMcpServers();
-  const capabilities = resolveCapabilities(issue.labels, ferryCfg.labels);
-  const hasLabelsConfig = ferryCfg.labels !== void 0;
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
+  const hasLabelsConfig = effectiveCfg.labels !== void 0;
   const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
   logCapabilities(logger, capabilities);
   if (mcpServers.length > 0) {
@@ -7661,9 +8015,9 @@ ${tree}`,
   loop = createAgentLoop({
     provider: devProvider,
     model,
-    maxIterations: ferryCfg.limits.max_agent_iterations,
-    maxInputTokens: ferryCfg.limits.max_tokens_per_run,
-    maxTokens: ferryCfg.limits.max_tokens_per_message,
+    maxIterations: effectiveCfg.limits.max_agent_iterations,
+    maxInputTokens: effectiveCfg.limits.max_tokens_per_run,
+    maxTokens: effectiveCfg.limits.max_tokens_per_message,
     executeTool,
     commitProgress: makeCommitProgress(logger, { dryRun }),
     spawnSubagent: (task) => loop.run({
@@ -7835,8 +8189,8 @@ ${tree}`,
       await tracker.postTransition(ticketKey, reviewTransitionId);
     }
     const transitionNote = shouldAutoTransition ? " Moved to Review." : "";
-    const forceOverrideName = typeOverrides.forceLabel?.split(":").at(-1);
-    const overrideNote = typeOverrides.typeOverride ? ` [type override: ${JSON.stringify({ issuetype: typeOverrides.typeOverride, issuetype_raw: issue.issueType, override: forceOverrideName })}]` : "";
+    const forceOverrideName = forceLabel?.split(":").at(-1);
+    const overrideNote = typeOverride ? ` [type override: ${JSON.stringify({ issuetype: typeOverride, issuetype_raw: issue.issueType, override: forceOverrideName })}]` : "";
     const terminalComment = resolvedOutcome === "already_satisfied" ? `${idempotencyMarker} Spec already satisfied \u2014 verification PR: ${prUrl}.${transitionNote}${overrideNote}` : `${idempotencyMarker} Implementation complete \u2014 PR: ${prUrl}.${transitionNote}${overrideNote}`;
     await tracker.postComment(ticketKey, terminalComment);
   } catch (err) {

--- a/.github/actions/ferry-run-iterator/iterate-action.js
+++ b/.github/actions/ferry-run-iterator/iterate-action.js
@@ -3188,6 +3188,39 @@ function logTypeOverrides(logger, overrides) {
     logger.info("task skip bypassed (ferry:type:enable-task)");
   }
 }
+function logTicketOverrides(logger, overrides) {
+  logTypeOverrides(logger, overrides);
+  if (overrides.modelOverrides) {
+    for (const [phase, mo] of Object.entries(overrides.modelOverrides)) {
+      if (mo?.model) logger.info(`model override (${phase})`, { model: mo.model });
+      if (mo?.provider) logger.info(`provider override (${phase})`, { provider: mo.provider });
+    }
+  }
+  if (overrides.budget) {
+    if (overrides.budget.maxCostEurPerRun !== void 0) {
+      logger.info("budget override: max cost", {
+        maxCostEurPerRun: overrides.budget.maxCostEurPerRun
+      });
+    }
+    if (overrides.budget.maxTokensPerRun !== void 0) {
+      logger.info("budget override: max tokens", {
+        maxTokensPerRun: overrides.budget.maxTokensPerRun
+      });
+    }
+  }
+  if (overrides.skipPhases && overrides.skipPhases.length > 0) {
+    logger.info("phase skip active", { phases: overrides.skipPhases });
+  }
+  if (overrides.thinking !== void 0) {
+    logger.info("thinking override", { thinking: overrides.thinking });
+  }
+  if (overrides.git?.noPr) {
+    logger.info("git override: no-pr (PR creation skipped)");
+  }
+  if (overrides.paused) {
+    logger.warn("ticket is paused (ferry:paused) \u2014 agent will exit without processing");
+  }
+}
 
 // node_modules/universal-user-agent/index.js
 function getUserAgent() {
@@ -7362,6 +7395,307 @@ function filterMcpServers(pool, capabilities, hasLabelsConfig) {
   });
 }
 
+// src/lib/labels/overrides.ts
+var AGENT_PHASES = /* @__PURE__ */ new Set(["refiner", "dev", "review", "iterate"]);
+var PHASES_ORDERED = ["refiner", "dev", "review", "iterate"];
+var LLM_PROVIDERS = /* @__PURE__ */ new Set(["anthropic", "openai", "google"]);
+var LabelConflictError = class extends Error {
+  label1;
+  label2;
+  field;
+  constructor(label1, label2, field) {
+    super(`Conflicting ferry labels for "${field}": "${label1}" and "${label2}"`);
+    this.name = "LabelConflictError";
+    this.label1 = label1;
+    this.label2 = label2;
+    this.field = field;
+  }
+};
+function parsePositiveFloat(s) {
+  const n = Number(s);
+  return Number.isFinite(n) && n > 0 ? n : void 0;
+}
+function parsePositiveInt(s) {
+  const n = Number(s);
+  return Number.isInteger(n) && n > 0 ? n : void 0;
+}
+var MCP_LABEL_PREFIX = "ferry:mcp/";
+var PROFILE_LABEL_PREFIX = "ferry:profile/";
+var KNOWN_STATUS_LABELS = /* @__PURE__ */ new Set([
+  "ferry:refining",
+  "ferry:developing",
+  "ferry:reviewing",
+  "ferry:iterating",
+  "ferry:ready",
+  "ferry:approved",
+  "ferry:cancelled",
+  "ferry:blocked",
+  "ferry:spend-cap",
+  "ferry:audit-log:active"
+]);
+function isKnownNonOverrideLabel(label) {
+  if (isBuiltinTypeLabel(label)) return true;
+  if (KNOWN_STATUS_LABELS.has(label)) return true;
+  if (label.startsWith("ferry:cost-estimate:")) return true;
+  if (label.startsWith(MCP_LABEL_PREFIX)) return true;
+  if (label.startsWith(PROFILE_LABEL_PREFIX)) return true;
+  return false;
+}
+function resolveTicketOverrides(labels, logger) {
+  const typeOverrides = resolveTypeOverrides(labels);
+  const modelOverrides = {};
+  const modelSources = {};
+  const providerSources = {};
+  let blanketModel;
+  let blanketModelSource;
+  let blanketProvider;
+  let blanketProviderSource;
+  let budgetMaxCostLabel;
+  let budgetMaxTokensLabel;
+  let budgetMaxCostEur;
+  let budgetMaxTokens;
+  let thinkingLabel;
+  let thinking;
+  let noPr = false;
+  let paused = false;
+  const skipPhases = [];
+  for (const label of labels) {
+    if (!label.startsWith("ferry:")) continue;
+    if (isKnownNonOverrideLabel(label)) continue;
+    if (label.startsWith("ferry:model/")) {
+      const rest = label.slice("ferry:model/".length);
+      if (!rest) {
+        logger?.warn("malformed ferry:model label (empty model name)", { label });
+        continue;
+      }
+      const slashIdx = rest.indexOf("/");
+      if (slashIdx < 0) {
+        if (blanketModelSource !== void 0) {
+          throw new LabelConflictError(blanketModelSource, label, "model");
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
+        continue;
+      }
+      const firstSegment = rest.slice(0, slashIdx);
+      const remainder = rest.slice(slashIdx + 1);
+      if (AGENT_PHASES.has(firstSegment)) {
+        const p = firstSegment;
+        if (!remainder) {
+          logger?.warn("empty model-id in ferry:model label", { label });
+          continue;
+        }
+        if (modelSources[p] !== void 0) {
+          throw new LabelConflictError(modelSources[p], label, `model.${firstSegment}`);
+        }
+        modelSources[p] = label;
+        modelOverrides[p] = { ...modelOverrides[p], model: remainder };
+      } else {
+        if (blanketModelSource !== void 0) {
+          throw new LabelConflictError(blanketModelSource, label, "model");
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:provider/")) {
+      const parts = label.slice("ferry:provider/".length).split("/");
+      if (parts.length === 1) {
+        const provider2 = parts[0];
+        if (!LLM_PROVIDERS.has(provider2)) {
+          logger?.warn("unknown provider in blanket ferry:provider label", { label, provider: provider2 });
+          continue;
+        }
+        if (blanketProviderSource !== void 0) {
+          throw new LabelConflictError(blanketProviderSource, label, "provider");
+        }
+        blanketProvider = provider2;
+        blanketProviderSource = label;
+        continue;
+      }
+      if (parts.length !== 2) {
+        logger?.warn(
+          "malformed ferry:provider label (expected ferry:provider/<provider> or ferry:provider/<phase>/<provider>)",
+          { label }
+        );
+        continue;
+      }
+      const [phase, provider] = parts;
+      if (!AGENT_PHASES.has(phase)) {
+        logger?.warn("unknown phase in ferry:provider label", { label, phase });
+        continue;
+      }
+      if (!LLM_PROVIDERS.has(provider)) {
+        logger?.warn("unknown provider in ferry:provider label", { label, provider });
+        continue;
+      }
+      const p = phase;
+      if (providerSources[p] !== void 0) {
+        throw new LabelConflictError(providerSources[p], label, `provider.${phase}`);
+      }
+      providerSources[p] = label;
+      modelOverrides[p] = {
+        ...modelOverrides[p],
+        provider
+      };
+      continue;
+    }
+    if (label.startsWith("ferry:budget/max-cost/")) {
+      const raw = label.slice("ferry:budget/max-cost/".length);
+      const val = parsePositiveFloat(raw);
+      if (val === void 0) {
+        logger?.warn("invalid cost value in ferry:budget/max-cost label", { label });
+        continue;
+      }
+      if (budgetMaxCostLabel !== void 0) {
+        throw new LabelConflictError(budgetMaxCostLabel, label, "budget.maxCostEurPerRun");
+      }
+      budgetMaxCostLabel = label;
+      budgetMaxCostEur = val;
+      continue;
+    }
+    if (label.startsWith("ferry:budget/max-tokens/")) {
+      const raw = label.slice("ferry:budget/max-tokens/".length);
+      const val = parsePositiveInt(raw);
+      if (val === void 0) {
+        logger?.warn("invalid token count in ferry:budget/max-tokens label", { label });
+        continue;
+      }
+      if (budgetMaxTokensLabel !== void 0) {
+        throw new LabelConflictError(budgetMaxTokensLabel, label, "budget.maxTokensPerRun");
+      }
+      budgetMaxTokensLabel = label;
+      budgetMaxTokens = val;
+      continue;
+    }
+    if (label.startsWith("ferry:skip/")) {
+      const phase = label.slice("ferry:skip/".length);
+      if (!AGENT_PHASES.has(phase)) {
+        logger?.warn("unknown phase in ferry:skip label", { label, phase });
+        continue;
+      }
+      const p = phase;
+      if (!skipPhases.includes(p)) skipPhases.push(p);
+      continue;
+    }
+    if (label === "ferry:thinking/on" || label === "ferry:thinking/off") {
+      const val = label === "ferry:thinking/on" ? "on" : "off";
+      if (thinking !== void 0 && thinking !== val) {
+        throw new LabelConflictError(thinkingLabel, label, "thinking");
+      }
+      if (thinking === void 0) {
+        thinking = val;
+        thinkingLabel = label;
+      }
+      continue;
+    }
+    if (label === "ferry:git/no-pr") {
+      noPr = true;
+      continue;
+    }
+    if (label === "ferry:paused") {
+      paused = true;
+      continue;
+    }
+    logger?.warn("unknown ferry override label ignored", { label });
+  }
+  if (blanketModel !== void 0) {
+    for (const phase of PHASES_ORDERED) {
+      if (modelSources[phase] === void 0) {
+        modelOverrides[phase] = { ...modelOverrides[phase], model: blanketModel };
+      }
+    }
+  }
+  if (blanketProvider !== void 0) {
+    for (const phase of PHASES_ORDERED) {
+      if (providerSources[phase] === void 0) {
+        modelOverrides[phase] = { ...modelOverrides[phase], provider: blanketProvider };
+      }
+    }
+  }
+  const hasModelOverrides = Object.keys(modelOverrides).length > 0;
+  const hasBudget = budgetMaxCostEur !== void 0 || budgetMaxTokens !== void 0;
+  return {
+    ...typeOverrides,
+    ...hasModelOverrides ? { modelOverrides } : {},
+    ...hasBudget ? {
+      budget: {
+        ...budgetMaxCostEur !== void 0 ? { maxCostEurPerRun: budgetMaxCostEur } : {},
+        ...budgetMaxTokens !== void 0 ? { maxTokensPerRun: budgetMaxTokens } : {}
+      }
+    } : {},
+    ...skipPhases.length > 0 ? { skipPhases } : {},
+    ...thinking !== void 0 ? { thinking } : {},
+    ...noPr ? { git: { noPr: true } } : {},
+    ...paused ? { paused: true } : {}
+  };
+}
+function applyTicketOverrides(cfg, overrides) {
+  if (!overrides.modelOverrides && !overrides.budget) return cfg;
+  const models = { ...cfg.models };
+  const limits = { ...cfg.limits };
+  const mo = overrides.modelOverrides;
+  if (mo) {
+    if (mo.refiner) {
+      models.refiner = {
+        provider: mo.refiner.provider ?? models.refiner.provider,
+        model: mo.refiner.model ?? models.refiner.model
+      };
+    }
+    if (mo.dev) {
+      models.dev = {
+        provider: mo.dev.provider ?? models.dev.provider,
+        model: mo.dev.model ?? models.dev.model
+      };
+    }
+    if (mo.review) {
+      models.review = {
+        provider: mo.review.provider ?? models.review.provider,
+        model: mo.review.model ?? models.review.model
+      };
+    }
+    if (mo.iterate) {
+      models.iterate = {
+        provider: mo.iterate.provider ?? models.iterate.provider,
+        model: mo.iterate.model ?? models.iterate.model
+      };
+    }
+  }
+  if (overrides.budget) {
+    if (overrides.budget.maxCostEurPerRun !== void 0) {
+      limits.max_cost_eur_per_run = overrides.budget.maxCostEurPerRun;
+    }
+    if (overrides.budget.maxTokensPerRun !== void 0) {
+      limits.max_tokens_per_run = overrides.budget.maxTokensPerRun;
+    }
+  }
+  return { ...cfg, models, limits };
+}
+function hasNonDefaultOverrides(overrides) {
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true;
+}
+function buildOverridesAuditComment(role, runId, overrides) {
+  const payload = {};
+  if (overrides.bypassTaskSkip) payload.bypassTaskSkip = true;
+  if (overrides.typeOverride !== void 0) payload.typeOverride = overrides.typeOverride;
+  if (overrides.modelOverrides !== void 0) payload.modelOverrides = overrides.modelOverrides;
+  if (overrides.budget !== void 0) payload.budget = overrides.budget;
+  if ((overrides.skipPhases?.length ?? 0) > 0) payload.skipPhases = overrides.skipPhases;
+  if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
+  if (overrides.git?.noPr) payload.git = overrides.git;
+  if (overrides.paused) payload.paused = true;
+  return `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+}
+function buildConflictComment(role, runId, err) {
+  return [
+    `[ferry:${role}:${runId}] label conflict \u2014 remove one of the contradicting labels and re-trigger:`,
+    `  field: ${err.field}`,
+    `  label 1: ${err.label1}`,
+    `  label 2: ${err.label2}`
+  ].join("\n");
+}
+
 // src/agents/iterator/iterate-action.ts
 var REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main(envelope, logger) {
@@ -7369,27 +7703,45 @@ async function main(envelope, logger) {
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT);
   const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
-  const { provider: iterProvider, model } = ferryCfg.models.iterate;
   const iteratorWorkflow = ferryCfg.workflow.agents.iterator;
   const shouldAutoTransition = iteratorWorkflow.auto_transition !== null;
   const reviewTransitionId = shouldAutoTransition ? requireEnv2("FERRY_REVIEW_TRANSITION_ID") : "";
   const issue = await tracker.getIssue(ticketKey);
   const existingComments = issue.comments;
+  let effectiveCfg = ferryCfg;
+  let typeOverride;
+  try {
+    const overrides = resolveTicketOverrides(issue.labels, logger);
+    typeOverride = overrides.typeOverride;
+    effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
+    logTicketOverrides(logger, overrides);
+    if (hasNonDefaultOverrides(overrides)) {
+      await tracker.postComment(
+        ticketKey,
+        buildOverridesAuditComment("iterator", eventId, overrides)
+      );
+    }
+  } catch (err) {
+    if (err instanceof LabelConflictError) {
+      await tracker.postComment(ticketKey, buildConflictComment("iterator", eventId, err));
+      process.exit(1);
+    }
+    throw err;
+  }
+  const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
-  const capabilities = resolveCapabilities(issue.labels, ferryCfg.labels);
-  const hasLabelsConfig = ferryCfg.labels !== void 0;
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
+  const hasLabelsConfig = effectiveCfg.labels !== void 0;
   const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
-  const typeOverrides = resolveTypeOverrides(issue.labels);
   logCapabilities(logger, capabilities);
-  logTypeOverrides(logger, typeOverrides);
   const priorIterations = existingComments.filter(
     (c) => c.includes("[ferry:iterator:") && c.includes("complete. Pushed fixes to PR#")
   ).length;
   checkIterationCap(
     { iteration: priorIterations, hasFindings: true },
-    ferryCfg.limits.max_iterations
+    effectiveCfg.limits.max_iterations
   );
-  const branchName = `${resolveBranchPrefix(ferryCfg.git.working_branch_prefix, issue)}${ticketKey}`;
+  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
   const prs = await runner.listPRsForBranch(owner, repo, branchName);
   if (prs.length === 0) {
     const eventMarker = byEventId("iterator", eventId);
@@ -7467,7 +7819,7 @@ async function main(envelope, logger) {
     encoding: "utf8"
   }).trim();
   const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    typeOverride: typeOverrides.typeOverride
+    typeOverride
   });
   const initialPrompt = [
     "## Jira Ticket",
@@ -7487,9 +7839,9 @@ ${existingLog}` : "",
   const loop = createAgentLoop({
     provider: iterProvider,
     model,
-    maxIterations: ferryCfg.limits.max_agent_iterations,
-    maxInputTokens: ferryCfg.limits.max_tokens_per_run,
-    maxTokens: ferryCfg.limits.max_tokens_per_message,
+    maxIterations: effectiveCfg.limits.max_agent_iterations,
+    maxInputTokens: effectiveCfg.limits.max_tokens_per_run,
+    maxTokens: effectiveCfg.limits.max_tokens_per_message,
     executeTool,
     commitProgress: makeCommitProgress(logger),
     logger

--- a/.github/actions/ferry-run-refiner/refiner-action.js
+++ b/.github/actions/ferry-run-refiner/refiner-action.js
@@ -1236,6 +1236,52 @@ function loadFerryConfigFromBaseBranch(baseBranch, repoRoot, fallback) {
   return parseFerryConfigJson(jsonContent);
 }
 
+// src/lib/agent-runtime/labels.ts
+function logTypeOverrides(logger, overrides) {
+  if (overrides.typeOverride) {
+    logger.info("type override active", {
+      override: overrides.forceLabel,
+      effectiveType: overrides.typeOverride
+    });
+  }
+  if (overrides.bypassTaskSkip) {
+    logger.info("task skip bypassed (ferry:type:enable-task)");
+  }
+}
+function logTicketOverrides(logger, overrides) {
+  logTypeOverrides(logger, overrides);
+  if (overrides.modelOverrides) {
+    for (const [phase, mo] of Object.entries(overrides.modelOverrides)) {
+      if (mo?.model) logger.info(`model override (${phase})`, { model: mo.model });
+      if (mo?.provider) logger.info(`provider override (${phase})`, { provider: mo.provider });
+    }
+  }
+  if (overrides.budget) {
+    if (overrides.budget.maxCostEurPerRun !== void 0) {
+      logger.info("budget override: max cost", {
+        maxCostEurPerRun: overrides.budget.maxCostEurPerRun
+      });
+    }
+    if (overrides.budget.maxTokensPerRun !== void 0) {
+      logger.info("budget override: max tokens", {
+        maxTokensPerRun: overrides.budget.maxTokensPerRun
+      });
+    }
+  }
+  if (overrides.skipPhases && overrides.skipPhases.length > 0) {
+    logger.info("phase skip active", { phases: overrides.skipPhases });
+  }
+  if (overrides.thinking !== void 0) {
+    logger.info("thinking override", { thinking: overrides.thinking });
+  }
+  if (overrides.git?.noPr) {
+    logger.info("git override: no-pr (PR creation skipped)");
+  }
+  if (overrides.paused) {
+    logger.warn("ticket is paused (ferry:paused) \u2014 agent will exit without processing");
+  }
+}
+
 // node_modules/universal-user-agent/index.js
 function getUserAgent() {
   if (typeof navigator === "object" && "userAgent" in navigator) {
@@ -5323,6 +5369,324 @@ var BUILTIN_TYPE_LABELS = /* @__PURE__ */ new Set([
   ENABLE_TASK_LABEL,
   ...Object.keys(FORCE_TYPE_LABELS)
 ]);
+function resolveTypeOverrides(labels) {
+  let bypassTaskSkip = false;
+  let typeOverride;
+  let forceLabel;
+  for (const label of labels) {
+    if (label === ENABLE_TASK_LABEL) {
+      bypassTaskSkip = true;
+    } else if (Object.prototype.hasOwnProperty.call(FORCE_TYPE_LABELS, label)) {
+      typeOverride = FORCE_TYPE_LABELS[label];
+      forceLabel = label;
+    }
+  }
+  return { bypassTaskSkip, typeOverride, forceLabel };
+}
+function isBuiltinTypeLabel(label) {
+  return BUILTIN_TYPE_LABELS.has(label);
+}
+
+// src/lib/labels/overrides.ts
+var AGENT_PHASES = /* @__PURE__ */ new Set(["refiner", "dev", "review", "iterate"]);
+var PHASES_ORDERED = ["refiner", "dev", "review", "iterate"];
+var LLM_PROVIDERS = /* @__PURE__ */ new Set(["anthropic", "openai", "google"]);
+var LabelConflictError = class extends Error {
+  label1;
+  label2;
+  field;
+  constructor(label1, label2, field) {
+    super(`Conflicting ferry labels for "${field}": "${label1}" and "${label2}"`);
+    this.name = "LabelConflictError";
+    this.label1 = label1;
+    this.label2 = label2;
+    this.field = field;
+  }
+};
+function parsePositiveFloat(s) {
+  const n = Number(s);
+  return Number.isFinite(n) && n > 0 ? n : void 0;
+}
+function parsePositiveInt(s) {
+  const n = Number(s);
+  return Number.isInteger(n) && n > 0 ? n : void 0;
+}
+var MCP_LABEL_PREFIX = "ferry:mcp/";
+var PROFILE_LABEL_PREFIX = "ferry:profile/";
+var KNOWN_STATUS_LABELS = /* @__PURE__ */ new Set([
+  "ferry:refining",
+  "ferry:developing",
+  "ferry:reviewing",
+  "ferry:iterating",
+  "ferry:ready",
+  "ferry:approved",
+  "ferry:cancelled",
+  "ferry:blocked",
+  "ferry:spend-cap",
+  "ferry:audit-log:active"
+]);
+function isKnownNonOverrideLabel(label) {
+  if (isBuiltinTypeLabel(label)) return true;
+  if (KNOWN_STATUS_LABELS.has(label)) return true;
+  if (label.startsWith("ferry:cost-estimate:")) return true;
+  if (label.startsWith(MCP_LABEL_PREFIX)) return true;
+  if (label.startsWith(PROFILE_LABEL_PREFIX)) return true;
+  return false;
+}
+function resolveTicketOverrides(labels, logger) {
+  const typeOverrides = resolveTypeOverrides(labels);
+  const modelOverrides = {};
+  const modelSources = {};
+  const providerSources = {};
+  let blanketModel;
+  let blanketModelSource;
+  let blanketProvider;
+  let blanketProviderSource;
+  let budgetMaxCostLabel;
+  let budgetMaxTokensLabel;
+  let budgetMaxCostEur;
+  let budgetMaxTokens;
+  let thinkingLabel;
+  let thinking;
+  let noPr = false;
+  let paused = false;
+  const skipPhases = [];
+  for (const label of labels) {
+    if (!label.startsWith("ferry:")) continue;
+    if (isKnownNonOverrideLabel(label)) continue;
+    if (label.startsWith("ferry:model/")) {
+      const rest = label.slice("ferry:model/".length);
+      if (!rest) {
+        logger?.warn("malformed ferry:model label (empty model name)", { label });
+        continue;
+      }
+      const slashIdx = rest.indexOf("/");
+      if (slashIdx < 0) {
+        if (blanketModelSource !== void 0) {
+          throw new LabelConflictError(blanketModelSource, label, "model");
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
+        continue;
+      }
+      const firstSegment = rest.slice(0, slashIdx);
+      const remainder = rest.slice(slashIdx + 1);
+      if (AGENT_PHASES.has(firstSegment)) {
+        const p = firstSegment;
+        if (!remainder) {
+          logger?.warn("empty model-id in ferry:model label", { label });
+          continue;
+        }
+        if (modelSources[p] !== void 0) {
+          throw new LabelConflictError(modelSources[p], label, `model.${firstSegment}`);
+        }
+        modelSources[p] = label;
+        modelOverrides[p] = { ...modelOverrides[p], model: remainder };
+      } else {
+        if (blanketModelSource !== void 0) {
+          throw new LabelConflictError(blanketModelSource, label, "model");
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:provider/")) {
+      const parts = label.slice("ferry:provider/".length).split("/");
+      if (parts.length === 1) {
+        const provider2 = parts[0];
+        if (!LLM_PROVIDERS.has(provider2)) {
+          logger?.warn("unknown provider in blanket ferry:provider label", { label, provider: provider2 });
+          continue;
+        }
+        if (blanketProviderSource !== void 0) {
+          throw new LabelConflictError(blanketProviderSource, label, "provider");
+        }
+        blanketProvider = provider2;
+        blanketProviderSource = label;
+        continue;
+      }
+      if (parts.length !== 2) {
+        logger?.warn(
+          "malformed ferry:provider label (expected ferry:provider/<provider> or ferry:provider/<phase>/<provider>)",
+          { label }
+        );
+        continue;
+      }
+      const [phase, provider] = parts;
+      if (!AGENT_PHASES.has(phase)) {
+        logger?.warn("unknown phase in ferry:provider label", { label, phase });
+        continue;
+      }
+      if (!LLM_PROVIDERS.has(provider)) {
+        logger?.warn("unknown provider in ferry:provider label", { label, provider });
+        continue;
+      }
+      const p = phase;
+      if (providerSources[p] !== void 0) {
+        throw new LabelConflictError(providerSources[p], label, `provider.${phase}`);
+      }
+      providerSources[p] = label;
+      modelOverrides[p] = {
+        ...modelOverrides[p],
+        provider
+      };
+      continue;
+    }
+    if (label.startsWith("ferry:budget/max-cost/")) {
+      const raw = label.slice("ferry:budget/max-cost/".length);
+      const val = parsePositiveFloat(raw);
+      if (val === void 0) {
+        logger?.warn("invalid cost value in ferry:budget/max-cost label", { label });
+        continue;
+      }
+      if (budgetMaxCostLabel !== void 0) {
+        throw new LabelConflictError(budgetMaxCostLabel, label, "budget.maxCostEurPerRun");
+      }
+      budgetMaxCostLabel = label;
+      budgetMaxCostEur = val;
+      continue;
+    }
+    if (label.startsWith("ferry:budget/max-tokens/")) {
+      const raw = label.slice("ferry:budget/max-tokens/".length);
+      const val = parsePositiveInt(raw);
+      if (val === void 0) {
+        logger?.warn("invalid token count in ferry:budget/max-tokens label", { label });
+        continue;
+      }
+      if (budgetMaxTokensLabel !== void 0) {
+        throw new LabelConflictError(budgetMaxTokensLabel, label, "budget.maxTokensPerRun");
+      }
+      budgetMaxTokensLabel = label;
+      budgetMaxTokens = val;
+      continue;
+    }
+    if (label.startsWith("ferry:skip/")) {
+      const phase = label.slice("ferry:skip/".length);
+      if (!AGENT_PHASES.has(phase)) {
+        logger?.warn("unknown phase in ferry:skip label", { label, phase });
+        continue;
+      }
+      const p = phase;
+      if (!skipPhases.includes(p)) skipPhases.push(p);
+      continue;
+    }
+    if (label === "ferry:thinking/on" || label === "ferry:thinking/off") {
+      const val = label === "ferry:thinking/on" ? "on" : "off";
+      if (thinking !== void 0 && thinking !== val) {
+        throw new LabelConflictError(thinkingLabel, label, "thinking");
+      }
+      if (thinking === void 0) {
+        thinking = val;
+        thinkingLabel = label;
+      }
+      continue;
+    }
+    if (label === "ferry:git/no-pr") {
+      noPr = true;
+      continue;
+    }
+    if (label === "ferry:paused") {
+      paused = true;
+      continue;
+    }
+    logger?.warn("unknown ferry override label ignored", { label });
+  }
+  if (blanketModel !== void 0) {
+    for (const phase of PHASES_ORDERED) {
+      if (modelSources[phase] === void 0) {
+        modelOverrides[phase] = { ...modelOverrides[phase], model: blanketModel };
+      }
+    }
+  }
+  if (blanketProvider !== void 0) {
+    for (const phase of PHASES_ORDERED) {
+      if (providerSources[phase] === void 0) {
+        modelOverrides[phase] = { ...modelOverrides[phase], provider: blanketProvider };
+      }
+    }
+  }
+  const hasModelOverrides = Object.keys(modelOverrides).length > 0;
+  const hasBudget = budgetMaxCostEur !== void 0 || budgetMaxTokens !== void 0;
+  return {
+    ...typeOverrides,
+    ...hasModelOverrides ? { modelOverrides } : {},
+    ...hasBudget ? {
+      budget: {
+        ...budgetMaxCostEur !== void 0 ? { maxCostEurPerRun: budgetMaxCostEur } : {},
+        ...budgetMaxTokens !== void 0 ? { maxTokensPerRun: budgetMaxTokens } : {}
+      }
+    } : {},
+    ...skipPhases.length > 0 ? { skipPhases } : {},
+    ...thinking !== void 0 ? { thinking } : {},
+    ...noPr ? { git: { noPr: true } } : {},
+    ...paused ? { paused: true } : {}
+  };
+}
+function applyTicketOverrides(cfg, overrides) {
+  if (!overrides.modelOverrides && !overrides.budget) return cfg;
+  const models = { ...cfg.models };
+  const limits = { ...cfg.limits };
+  const mo = overrides.modelOverrides;
+  if (mo) {
+    if (mo.refiner) {
+      models.refiner = {
+        provider: mo.refiner.provider ?? models.refiner.provider,
+        model: mo.refiner.model ?? models.refiner.model
+      };
+    }
+    if (mo.dev) {
+      models.dev = {
+        provider: mo.dev.provider ?? models.dev.provider,
+        model: mo.dev.model ?? models.dev.model
+      };
+    }
+    if (mo.review) {
+      models.review = {
+        provider: mo.review.provider ?? models.review.provider,
+        model: mo.review.model ?? models.review.model
+      };
+    }
+    if (mo.iterate) {
+      models.iterate = {
+        provider: mo.iterate.provider ?? models.iterate.provider,
+        model: mo.iterate.model ?? models.iterate.model
+      };
+    }
+  }
+  if (overrides.budget) {
+    if (overrides.budget.maxCostEurPerRun !== void 0) {
+      limits.max_cost_eur_per_run = overrides.budget.maxCostEurPerRun;
+    }
+    if (overrides.budget.maxTokensPerRun !== void 0) {
+      limits.max_tokens_per_run = overrides.budget.maxTokensPerRun;
+    }
+  }
+  return { ...cfg, models, limits };
+}
+function hasNonDefaultOverrides(overrides) {
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true;
+}
+function buildOverridesAuditComment(role, runId, overrides) {
+  const payload = {};
+  if (overrides.bypassTaskSkip) payload.bypassTaskSkip = true;
+  if (overrides.typeOverride !== void 0) payload.typeOverride = overrides.typeOverride;
+  if (overrides.modelOverrides !== void 0) payload.modelOverrides = overrides.modelOverrides;
+  if (overrides.budget !== void 0) payload.budget = overrides.budget;
+  if ((overrides.skipPhases?.length ?? 0) > 0) payload.skipPhases = overrides.skipPhases;
+  if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
+  if (overrides.git?.noPr) payload.git = overrides.git;
+  if (overrides.paused) payload.paused = true;
+  return `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+}
+function buildConflictComment(role, runId, err) {
+  return [
+    `[ferry:${role}:${runId}] label conflict \u2014 remove one of the contradicting labels and re-trigger:`,
+    `  field: ${err.field}`,
+    `  label 1: ${err.label1}`,
+    `  label 2: ${err.label2}`
+  ].join("\n");
+}
 
 // src/agents/refiner/refine.ts
 import { createRequire as createRequire3 } from "module";
@@ -5838,10 +6202,30 @@ async function run(envelope, deps) {
   });
 }
 async function main(envelope, logger) {
+  const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT);
   const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
-  const route = ferryCfg.models.refiner;
+  const issueForLabels = await tracker.getIssue(ticketKey);
+  let effectiveCfg = ferryCfg;
+  try {
+    const overrides = resolveTicketOverrides(issueForLabels.labels, logger);
+    logTicketOverrides(logger, overrides);
+    effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
+    if (hasNonDefaultOverrides(overrides)) {
+      await tracker.postComment(
+        ticketKey,
+        buildOverridesAuditComment("refiner", eventId, overrides)
+      );
+    }
+  } catch (err) {
+    if (err instanceof LabelConflictError) {
+      await tracker.postComment(ticketKey, buildConflictComment("refiner", eventId, err));
+      process.exit(1);
+    }
+    throw err;
+  }
+  const route = effectiveCfg.models.refiner;
   const callLlm = createLlmCall(route);
   await run(envelope, { tracker, callLlm, logger });
 }

--- a/.github/actions/ferry-run-reviewer/review-action.js
+++ b/.github/actions/ferry-run-reviewer/review-action.js
@@ -1845,6 +1845,39 @@ function logTypeOverrides(logger, overrides) {
     logger.info("task skip bypassed (ferry:type:enable-task)");
   }
 }
+function logTicketOverrides(logger, overrides) {
+  logTypeOverrides(logger, overrides);
+  if (overrides.modelOverrides) {
+    for (const [phase, mo] of Object.entries(overrides.modelOverrides)) {
+      if (mo?.model) logger.info(`model override (${phase})`, { model: mo.model });
+      if (mo?.provider) logger.info(`provider override (${phase})`, { provider: mo.provider });
+    }
+  }
+  if (overrides.budget) {
+    if (overrides.budget.maxCostEurPerRun !== void 0) {
+      logger.info("budget override: max cost", {
+        maxCostEurPerRun: overrides.budget.maxCostEurPerRun
+      });
+    }
+    if (overrides.budget.maxTokensPerRun !== void 0) {
+      logger.info("budget override: max tokens", {
+        maxTokensPerRun: overrides.budget.maxTokensPerRun
+      });
+    }
+  }
+  if (overrides.skipPhases && overrides.skipPhases.length > 0) {
+    logger.info("phase skip active", { phases: overrides.skipPhases });
+  }
+  if (overrides.thinking !== void 0) {
+    logger.info("thinking override", { thinking: overrides.thinking });
+  }
+  if (overrides.git?.noPr) {
+    logger.info("git override: no-pr (PR creation skipped)");
+  }
+  if (overrides.paused) {
+    logger.warn("ticket is paused (ferry:paused) \u2014 agent will exit without processing");
+  }
+}
 
 // node_modules/universal-user-agent/index.js
 function getUserAgent() {
@@ -6009,6 +6042,307 @@ function resolveCapabilities(ticketLabels, configLabels, logger) {
   };
 }
 
+// src/lib/labels/overrides.ts
+var AGENT_PHASES = /* @__PURE__ */ new Set(["refiner", "dev", "review", "iterate"]);
+var PHASES_ORDERED = ["refiner", "dev", "review", "iterate"];
+var LLM_PROVIDERS = /* @__PURE__ */ new Set(["anthropic", "openai", "google"]);
+var LabelConflictError = class extends Error {
+  label1;
+  label2;
+  field;
+  constructor(label1, label2, field) {
+    super(`Conflicting ferry labels for "${field}": "${label1}" and "${label2}"`);
+    this.name = "LabelConflictError";
+    this.label1 = label1;
+    this.label2 = label2;
+    this.field = field;
+  }
+};
+function parsePositiveFloat(s) {
+  const n = Number(s);
+  return Number.isFinite(n) && n > 0 ? n : void 0;
+}
+function parsePositiveInt(s) {
+  const n = Number(s);
+  return Number.isInteger(n) && n > 0 ? n : void 0;
+}
+var MCP_LABEL_PREFIX = "ferry:mcp/";
+var PROFILE_LABEL_PREFIX = "ferry:profile/";
+var KNOWN_STATUS_LABELS = /* @__PURE__ */ new Set([
+  "ferry:refining",
+  "ferry:developing",
+  "ferry:reviewing",
+  "ferry:iterating",
+  "ferry:ready",
+  "ferry:approved",
+  "ferry:cancelled",
+  "ferry:blocked",
+  "ferry:spend-cap",
+  "ferry:audit-log:active"
+]);
+function isKnownNonOverrideLabel(label) {
+  if (isBuiltinTypeLabel(label)) return true;
+  if (KNOWN_STATUS_LABELS.has(label)) return true;
+  if (label.startsWith("ferry:cost-estimate:")) return true;
+  if (label.startsWith(MCP_LABEL_PREFIX)) return true;
+  if (label.startsWith(PROFILE_LABEL_PREFIX)) return true;
+  return false;
+}
+function resolveTicketOverrides(labels, logger) {
+  const typeOverrides = resolveTypeOverrides(labels);
+  const modelOverrides = {};
+  const modelSources = {};
+  const providerSources = {};
+  let blanketModel;
+  let blanketModelSource;
+  let blanketProvider;
+  let blanketProviderSource;
+  let budgetMaxCostLabel;
+  let budgetMaxTokensLabel;
+  let budgetMaxCostEur;
+  let budgetMaxTokens;
+  let thinkingLabel;
+  let thinking;
+  let noPr = false;
+  let paused = false;
+  const skipPhases = [];
+  for (const label of labels) {
+    if (!label.startsWith("ferry:")) continue;
+    if (isKnownNonOverrideLabel(label)) continue;
+    if (label.startsWith("ferry:model/")) {
+      const rest = label.slice("ferry:model/".length);
+      if (!rest) {
+        logger?.warn("malformed ferry:model label (empty model name)", { label });
+        continue;
+      }
+      const slashIdx = rest.indexOf("/");
+      if (slashIdx < 0) {
+        if (blanketModelSource !== void 0) {
+          throw new LabelConflictError(blanketModelSource, label, "model");
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
+        continue;
+      }
+      const firstSegment = rest.slice(0, slashIdx);
+      const remainder = rest.slice(slashIdx + 1);
+      if (AGENT_PHASES.has(firstSegment)) {
+        const p = firstSegment;
+        if (!remainder) {
+          logger?.warn("empty model-id in ferry:model label", { label });
+          continue;
+        }
+        if (modelSources[p] !== void 0) {
+          throw new LabelConflictError(modelSources[p], label, `model.${firstSegment}`);
+        }
+        modelSources[p] = label;
+        modelOverrides[p] = { ...modelOverrides[p], model: remainder };
+      } else {
+        if (blanketModelSource !== void 0) {
+          throw new LabelConflictError(blanketModelSource, label, "model");
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:provider/")) {
+      const parts = label.slice("ferry:provider/".length).split("/");
+      if (parts.length === 1) {
+        const provider2 = parts[0];
+        if (!LLM_PROVIDERS.has(provider2)) {
+          logger?.warn("unknown provider in blanket ferry:provider label", { label, provider: provider2 });
+          continue;
+        }
+        if (blanketProviderSource !== void 0) {
+          throw new LabelConflictError(blanketProviderSource, label, "provider");
+        }
+        blanketProvider = provider2;
+        blanketProviderSource = label;
+        continue;
+      }
+      if (parts.length !== 2) {
+        logger?.warn(
+          "malformed ferry:provider label (expected ferry:provider/<provider> or ferry:provider/<phase>/<provider>)",
+          { label }
+        );
+        continue;
+      }
+      const [phase, provider] = parts;
+      if (!AGENT_PHASES.has(phase)) {
+        logger?.warn("unknown phase in ferry:provider label", { label, phase });
+        continue;
+      }
+      if (!LLM_PROVIDERS.has(provider)) {
+        logger?.warn("unknown provider in ferry:provider label", { label, provider });
+        continue;
+      }
+      const p = phase;
+      if (providerSources[p] !== void 0) {
+        throw new LabelConflictError(providerSources[p], label, `provider.${phase}`);
+      }
+      providerSources[p] = label;
+      modelOverrides[p] = {
+        ...modelOverrides[p],
+        provider
+      };
+      continue;
+    }
+    if (label.startsWith("ferry:budget/max-cost/")) {
+      const raw = label.slice("ferry:budget/max-cost/".length);
+      const val = parsePositiveFloat(raw);
+      if (val === void 0) {
+        logger?.warn("invalid cost value in ferry:budget/max-cost label", { label });
+        continue;
+      }
+      if (budgetMaxCostLabel !== void 0) {
+        throw new LabelConflictError(budgetMaxCostLabel, label, "budget.maxCostEurPerRun");
+      }
+      budgetMaxCostLabel = label;
+      budgetMaxCostEur = val;
+      continue;
+    }
+    if (label.startsWith("ferry:budget/max-tokens/")) {
+      const raw = label.slice("ferry:budget/max-tokens/".length);
+      const val = parsePositiveInt(raw);
+      if (val === void 0) {
+        logger?.warn("invalid token count in ferry:budget/max-tokens label", { label });
+        continue;
+      }
+      if (budgetMaxTokensLabel !== void 0) {
+        throw new LabelConflictError(budgetMaxTokensLabel, label, "budget.maxTokensPerRun");
+      }
+      budgetMaxTokensLabel = label;
+      budgetMaxTokens = val;
+      continue;
+    }
+    if (label.startsWith("ferry:skip/")) {
+      const phase = label.slice("ferry:skip/".length);
+      if (!AGENT_PHASES.has(phase)) {
+        logger?.warn("unknown phase in ferry:skip label", { label, phase });
+        continue;
+      }
+      const p = phase;
+      if (!skipPhases.includes(p)) skipPhases.push(p);
+      continue;
+    }
+    if (label === "ferry:thinking/on" || label === "ferry:thinking/off") {
+      const val = label === "ferry:thinking/on" ? "on" : "off";
+      if (thinking !== void 0 && thinking !== val) {
+        throw new LabelConflictError(thinkingLabel, label, "thinking");
+      }
+      if (thinking === void 0) {
+        thinking = val;
+        thinkingLabel = label;
+      }
+      continue;
+    }
+    if (label === "ferry:git/no-pr") {
+      noPr = true;
+      continue;
+    }
+    if (label === "ferry:paused") {
+      paused = true;
+      continue;
+    }
+    logger?.warn("unknown ferry override label ignored", { label });
+  }
+  if (blanketModel !== void 0) {
+    for (const phase of PHASES_ORDERED) {
+      if (modelSources[phase] === void 0) {
+        modelOverrides[phase] = { ...modelOverrides[phase], model: blanketModel };
+      }
+    }
+  }
+  if (blanketProvider !== void 0) {
+    for (const phase of PHASES_ORDERED) {
+      if (providerSources[phase] === void 0) {
+        modelOverrides[phase] = { ...modelOverrides[phase], provider: blanketProvider };
+      }
+    }
+  }
+  const hasModelOverrides = Object.keys(modelOverrides).length > 0;
+  const hasBudget = budgetMaxCostEur !== void 0 || budgetMaxTokens !== void 0;
+  return {
+    ...typeOverrides,
+    ...hasModelOverrides ? { modelOverrides } : {},
+    ...hasBudget ? {
+      budget: {
+        ...budgetMaxCostEur !== void 0 ? { maxCostEurPerRun: budgetMaxCostEur } : {},
+        ...budgetMaxTokens !== void 0 ? { maxTokensPerRun: budgetMaxTokens } : {}
+      }
+    } : {},
+    ...skipPhases.length > 0 ? { skipPhases } : {},
+    ...thinking !== void 0 ? { thinking } : {},
+    ...noPr ? { git: { noPr: true } } : {},
+    ...paused ? { paused: true } : {}
+  };
+}
+function applyTicketOverrides(cfg, overrides) {
+  if (!overrides.modelOverrides && !overrides.budget) return cfg;
+  const models = { ...cfg.models };
+  const limits = { ...cfg.limits };
+  const mo = overrides.modelOverrides;
+  if (mo) {
+    if (mo.refiner) {
+      models.refiner = {
+        provider: mo.refiner.provider ?? models.refiner.provider,
+        model: mo.refiner.model ?? models.refiner.model
+      };
+    }
+    if (mo.dev) {
+      models.dev = {
+        provider: mo.dev.provider ?? models.dev.provider,
+        model: mo.dev.model ?? models.dev.model
+      };
+    }
+    if (mo.review) {
+      models.review = {
+        provider: mo.review.provider ?? models.review.provider,
+        model: mo.review.model ?? models.review.model
+      };
+    }
+    if (mo.iterate) {
+      models.iterate = {
+        provider: mo.iterate.provider ?? models.iterate.provider,
+        model: mo.iterate.model ?? models.iterate.model
+      };
+    }
+  }
+  if (overrides.budget) {
+    if (overrides.budget.maxCostEurPerRun !== void 0) {
+      limits.max_cost_eur_per_run = overrides.budget.maxCostEurPerRun;
+    }
+    if (overrides.budget.maxTokensPerRun !== void 0) {
+      limits.max_tokens_per_run = overrides.budget.maxTokensPerRun;
+    }
+  }
+  return { ...cfg, models, limits };
+}
+function hasNonDefaultOverrides(overrides) {
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true;
+}
+function buildOverridesAuditComment(role, runId, overrides) {
+  const payload = {};
+  if (overrides.bypassTaskSkip) payload.bypassTaskSkip = true;
+  if (overrides.typeOverride !== void 0) payload.typeOverride = overrides.typeOverride;
+  if (overrides.modelOverrides !== void 0) payload.modelOverrides = overrides.modelOverrides;
+  if (overrides.budget !== void 0) payload.budget = overrides.budget;
+  if ((overrides.skipPhases?.length ?? 0) > 0) payload.skipPhases = overrides.skipPhases;
+  if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
+  if (overrides.git?.noPr) payload.git = overrides.git;
+  if (overrides.paused) payload.paused = true;
+  return `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+}
+function buildConflictComment(role, runId, err) {
+  return [
+    `[ferry:${role}:${runId}] label conflict \u2014 remove one of the contradicting labels and re-trigger:`,
+    `  field: ${err.field}`,
+    `  label 1: ${err.label1}`,
+    `  label 2: ${err.label2}`
+  ].join("\n");
+}
+
 // src/agents/reviewer/changes-guard.ts
 function countPriorIterations(existingComments) {
   return existingComments.filter(
@@ -6023,7 +6357,6 @@ async function main(envelope, logger) {
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT);
   const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
-  const { provider, model } = ferryCfg.models.review;
   const reviewerWorkflow = ferryCfg.workflow.agents.reviewer;
   const shouldTransitionChanges = reviewerWorkflow.auto_transition_changes !== null;
   const shouldTransitionApprove = reviewerWorkflow.auto_transition_approve !== null;
@@ -6031,11 +6364,30 @@ async function main(envelope, logger) {
   const approveTransitionId = shouldTransitionApprove ? requireEnv2("FERRY_APPROVE_TRANSITION_ID") : "";
   const issue = await tracker.getIssue(ticketKey);
   const existingComments = issue.comments;
-  const capabilities = resolveCapabilities(issue.labels, ferryCfg.labels, logger);
+  let effectiveCfg = ferryCfg;
+  let typeOverride;
+  try {
+    const overrides = resolveTicketOverrides(issue.labels, logger);
+    typeOverride = overrides.typeOverride;
+    effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
+    logTicketOverrides(logger, overrides);
+    if (hasNonDefaultOverrides(overrides)) {
+      await tracker.postComment(
+        ticketKey,
+        buildOverridesAuditComment("reviewer", eventId, overrides)
+      );
+    }
+  } catch (err) {
+    if (err instanceof LabelConflictError) {
+      await tracker.postComment(ticketKey, buildConflictComment("reviewer", eventId, err));
+      process.exit(1);
+    }
+    throw err;
+  }
+  const { provider, model } = effectiveCfg.models.review;
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels, logger);
   logCapabilities(logger, capabilities);
-  const typeOverrides = resolveTypeOverrides(issue.labels);
-  logTypeOverrides(logger, typeOverrides);
-  const branchName = `${resolveBranchPrefix(ferryCfg.git.working_branch_prefix, issue)}${ticketKey}`;
+  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
   const prs = await runner.listPRsForBranch(owner, repo, branchName);
   if (prs.length === 0) {
     const errorMarker = byEventId("reviewer", eventId);
@@ -6096,7 +6448,7 @@ async function main(envelope, logger) {
   const commits = await runner.listPRCommits({ owner, repo, prNumber });
   const commitLog = commits.map((c) => `${c.sha.slice(0, 7)} ${c.message.split("\n")[0]}`).join("\n");
   const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    typeOverride: typeOverrides.typeOverride
+    typeOverride
   });
   const mergeConflictWarning = hasMergeConflicts ? `
 \u26A0\uFE0F  MERGE CONFLICTS DETECTED \u2014 mergeable=${String(mergeable)}${conflictedFiles.length > 0 ? `, conflicted files: ${conflictedFiles.join(", ")}` : ""}` : "";
@@ -6140,8 +6492,8 @@ async function main(envelope, logger) {
     owner,
     repo,
     headSha,
-    maxIterations: ferryCfg.limits.reviewer_max_iterations,
-    maxTokens: ferryCfg.limits.reviewer_max_tokens,
+    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
+    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
     logger
   });
   logger.info("reviewed", {
@@ -6181,7 +6533,7 @@ async function main(envelope, logger) {
     }
   } else {
     const priorIterations = countPriorIterations(existingComments);
-    const cap = ferryCfg.limits.max_iterations;
+    const cap = effectiveCfg.limits.max_iterations;
     const capReached = priorIterations >= cap;
     await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
     if (!capReached) {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -435,18 +435,28 @@ When one or more override labels are present, the agent posts an audit comment i
 
 ##### Model and provider (`ferry:model/*`, `ferry:provider/*`)
 
-Override the model or provider for a specific agent phase without touching `ferry.config.yaml`.
+Override the model or provider for any or all agent phases without touching `ferry.config.yaml`.
 
-| Label pattern                       | Example                           | Effect                                                 |
-| ----------------------------------- | --------------------------------- | ------------------------------------------------------ |
-| `ferry:model/<phase>/<model-id>`    | `ferry:model/dev/claude-opus-4-7` | Use `claude-opus-4-7` for the Developer on this ticket |
-| `ferry:model/<phase>/<model-id>`    | `ferry:model/review/gpt-4o`       | Use `gpt-4o` for the Reviewer on this ticket           |
-| `ferry:provider/<phase>/<provider>` | `ferry:provider/dev/openai`       | Use the `openai` provider for the Developer            |
+| Label pattern                       | Example                           | Effect                                                                      |
+| ----------------------------------- | --------------------------------- | --------------------------------------------------------------------------- |
+| `ferry:model/<model-id>`            | `ferry:model/claude-opus-4-7`     | Use `claude-opus-4-7` for **all four agents** on this ticket                |
+| `ferry:model/<phase>/<model-id>`    | `ferry:model/dev/claude-opus-4-7` | Use `claude-opus-4-7` for the Developer only                                |
+| `ferry:model/<phase>/<model-id>`    | `ferry:model/review/gpt-4o`       | Use `gpt-4o` for the Reviewer only                                          |
+| `ferry:provider/<provider>`         | `ferry:provider/openai`           | Switch to the `openai` provider for **all four agents** — model from config |
+| `ferry:provider/<phase>/<provider>` | `ferry:provider/dev/openai`       | Switch to the `openai` provider for the Developer only                      |
 
 Valid `<phase>` values: `refiner`, `dev`, `review`, `iterate`.
 Valid `<provider>` values: `anthropic`, `openai`, `google`.
+`<model-id>` is a free string passed to the provider SDK (e.g. `claude-opus-4-7`, `gpt-4o`, or an org-scoped name like `openai/gpt-4o`).
 
-**Conflict rule:** two labels that set the model (or provider) for the same phase to different values are a conflict — the agent posts a Jira comment explaining the conflict and exits non-zero. Remove the conflicting label and re-trigger.
+**Conflict rules:**
+
+- `ferry:model/<x>` (blanket) + `ferry:model/dev/<y>` (per-phase) — no conflict; per-phase wins for Dev, blanket applies to the other three agents.
+- `ferry:model/dev/<x>` + `ferry:model/dev/<y>` (two per-phase labels for the same phase) — conflict; the agent posts a Jira comment and exits non-zero.
+- Two blanket model labels (`ferry:model/<x>` + `ferry:model/<y>`) — conflict.
+- Same rules apply to provider labels.
+
+**Use case:** keep Sonnet as the repo default; tag the two hardest tickets of the sprint with `ferry:model/claude-opus-4-7` so they get higher-quality output while routine work stays cheap.
 
 ##### Budget (`ferry:budget/*`)
 

--- a/src/agents/developer/dev-action.ts
+++ b/src/agents/developer/dev-action.ts
@@ -13,7 +13,7 @@ import {
   makeCommitProgress,
   makeSecretScan,
   logCapabilities,
-  logTypeOverrides,
+  logTicketOverrides,
   createGitHubContext,
   resolveGitConfig,
   resolveBranchPrefix,
@@ -36,7 +36,12 @@ import type { AgentLoop } from '../../lib/llm/agent-loop/types.js';
 import {
   resolveCapabilities,
   filterMcpServers,
-  resolveTypeOverrides,
+  resolveTicketOverrides,
+  applyTicketOverrides,
+  hasNonDefaultOverrides,
+  buildOverridesAuditComment,
+  buildConflictComment,
+  LabelConflictError,
 } from '../../lib/agent-runtime/index.js';
 import { detectTestRunner, repoTree, packageJsonPath, detectPackageManager } from './workspace.js';
 import { assertDevOutputContract } from './outcome-guard.js';
@@ -62,7 +67,6 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   // `git log origin/<base>..HEAD` work correctly later in this function.
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
 
-  const { provider: devProvider } = ferryCfg.models.dev;
   const devWorkflow = ferryCfg.workflow.agents.developer;
   const shouldAutoTransition = devWorkflow.auto_transition !== null;
   const reviewTransitionId =
@@ -70,14 +74,38 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const jiraBaseUrl = requireEnv('FERRY_JIRA_BASE_URL');
 
   const issue = await tracker.getIssue(ticketKey);
-  const typeOverrides = resolveTypeOverrides(issue.labels);
-  logTypeOverrides(logger, typeOverrides);
+
+  // Resolve label overrides (model/provider/budget/…) — Jira labels take highest precedence.
+  let effectiveCfg = ferryCfg;
+  let typeOverride: string | undefined;
+  let forceLabel: string | undefined;
+  try {
+    const overrides = resolveTicketOverrides(issue.labels, logger);
+    typeOverride = overrides.typeOverride;
+    forceLabel = overrides.forceLabel;
+    effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
+    logTicketOverrides(logger, overrides);
+    if (hasNonDefaultOverrides(overrides)) {
+      await tracker.postComment(
+        ticketKey,
+        buildOverridesAuditComment('developer', eventId, overrides),
+      );
+    }
+  } catch (err) {
+    if (err instanceof LabelConflictError) {
+      await tracker.postComment(ticketKey, buildConflictComment('developer', eventId, err));
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  const { provider: devProvider } = effectiveCfg.models.dev;
   const labels = issue.labels.join(', ');
   const comments = issue.comments.map((c) => `Comment: ${c}`).join('\n');
   const ticketBlock = buildTicketBlock(ticketKey, issue, {
     labels,
     comments,
-    typeOverride: typeOverrides.typeOverride,
+    typeOverride,
   });
 
   const subtasks = await tracker.getSubtasks(ticketKey);
@@ -88,10 +116,10 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const system = buildSystem('dev', REPO_ROOT, {
     extraParts: pkgManagerHint ? [`## Detected package manager\n\n${pkgManagerHint}`] : [],
   });
-  const model = ferryCfg.models.dev.model;
+  const model = effectiveCfg.models.dev.model;
 
   // Branch is determined upfront from the ticket key so restarts resume the same branch.
-  const branchName = `${resolveBranchPrefix(ferryCfg.git.working_branch_prefix, issue)}${ticketKey}`;
+  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
 
   configureFerryGitUser(REPO_ROOT);
 
@@ -168,8 +196,8 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
 
   const secretScan = makeSecretScan(REPO_ROOT);
   const mcpPool = loadMcpServers();
-  const capabilities = resolveCapabilities(issue.labels, ferryCfg.labels);
-  const hasLabelsConfig = ferryCfg.labels !== undefined;
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
+  const hasLabelsConfig = effectiveCfg.labels !== undefined;
   const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
 
   logCapabilities(logger, capabilities);
@@ -183,9 +211,9 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   loop = createAgentLoop({
     provider: devProvider,
     model,
-    maxIterations: ferryCfg.limits.max_agent_iterations,
-    maxInputTokens: ferryCfg.limits.max_tokens_per_run,
-    maxTokens: ferryCfg.limits.max_tokens_per_message,
+    maxIterations: effectiveCfg.limits.max_agent_iterations,
+    maxInputTokens: effectiveCfg.limits.max_tokens_per_run,
+    maxTokens: effectiveCfg.limits.max_tokens_per_message,
     executeTool,
     commitProgress: makeCommitProgress(logger, { dryRun }),
     spawnSubagent: (task) =>
@@ -389,9 +417,9 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
     }
     const transitionNote = shouldAutoTransition ? ' Moved to Review.' : '';
 
-    const forceOverrideName = typeOverrides.forceLabel?.split(':').at(-1);
-    const overrideNote = typeOverrides.typeOverride
-      ? ` [type override: ${JSON.stringify({ issuetype: typeOverrides.typeOverride, issuetype_raw: issue.issueType, override: forceOverrideName })}]`
+    const forceOverrideName = forceLabel?.split(':').at(-1);
+    const overrideNote = typeOverride
+      ? ` [type override: ${JSON.stringify({ issuetype: typeOverride, issuetype_raw: issue.issueType, override: forceOverrideName })}]`
       : '';
 
     const terminalComment =

--- a/src/agents/iterator/iterate-action.ts
+++ b/src/agents/iterator/iterate-action.ts
@@ -10,7 +10,12 @@ import { formatCommitMessage } from './prompt.js';
 import {
   resolveCapabilities,
   filterMcpServers,
-  resolveTypeOverrides,
+  resolveTicketOverrides,
+  applyTicketOverrides,
+  hasNonDefaultOverrides,
+  buildOverridesAuditComment,
+  buildConflictComment,
+  LabelConflictError,
 } from '../../lib/agent-runtime/index.js';
 import {
   requireEnv,
@@ -23,7 +28,7 @@ import {
   makeCommitProgress,
   makeSecretScan,
   logCapabilities,
-  logTypeOverrides,
+  logTicketOverrides,
   fetchAndMergeBase,
   checkoutExistingBranch,
   createGitHubContext,
@@ -50,7 +55,6 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
 
-  const { provider: iterProvider, model } = ferryCfg.models.iterate;
   const iteratorWorkflow = ferryCfg.workflow.agents.iterator;
   const shouldAutoTransition = iteratorWorkflow.auto_transition !== null;
   const reviewTransitionId = shouldAutoTransition ? requireEnv('FERRY_REVIEW_TRANSITION_ID') : '';
@@ -58,25 +62,46 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const issue = await tracker.getIssue(ticketKey);
   const existingComments = issue.comments;
 
+  // Resolve label overrides (model/provider/budget/…) — Jira labels take highest precedence.
   // Labels are re-read from Jira on each iterate-action invocation (each review→iterate cycle),
   // so a label added between iterations takes effect on the next cycle.
+  let effectiveCfg = ferryCfg;
+  let typeOverride: string | undefined;
+  try {
+    const overrides = resolveTicketOverrides(issue.labels, logger);
+    typeOverride = overrides.typeOverride;
+    effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
+    logTicketOverrides(logger, overrides);
+    if (hasNonDefaultOverrides(overrides)) {
+      await tracker.postComment(
+        ticketKey,
+        buildOverridesAuditComment('iterator', eventId, overrides),
+      );
+    }
+  } catch (err) {
+    if (err instanceof LabelConflictError) {
+      await tracker.postComment(ticketKey, buildConflictComment('iterator', eventId, err));
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
-  const capabilities = resolveCapabilities(issue.labels, ferryCfg.labels);
-  const hasLabelsConfig = ferryCfg.labels !== undefined;
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
+  const hasLabelsConfig = effectiveCfg.labels !== undefined;
   const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
 
-  const typeOverrides = resolveTypeOverrides(issue.labels);
   logCapabilities(logger, capabilities);
-  logTypeOverrides(logger, typeOverrides);
 
   const priorIterations = existingComments.filter(
     (c) => c.includes('[ferry:iterator:') && c.includes('complete. Pushed fixes to PR#'),
   ).length;
   checkIterationCap(
     { iteration: priorIterations, hasFindings: true },
-    ferryCfg.limits.max_iterations,
+    effectiveCfg.limits.max_iterations,
   );
-  const branchName = `${resolveBranchPrefix(ferryCfg.git.working_branch_prefix, issue)}${ticketKey}`;
+  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
   const prs = await runner.listPRsForBranch(owner, repo, branchName);
 
   if (prs.length === 0) {
@@ -173,7 +198,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   }).trim();
 
   const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    typeOverride: typeOverrides.typeOverride,
+    typeOverride,
   });
 
   const initialPrompt = [
@@ -198,9 +223,9 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const loop = createAgentLoop({
     provider: iterProvider,
     model,
-    maxIterations: ferryCfg.limits.max_agent_iterations,
-    maxInputTokens: ferryCfg.limits.max_tokens_per_run,
-    maxTokens: ferryCfg.limits.max_tokens_per_message,
+    maxIterations: effectiveCfg.limits.max_agent_iterations,
+    maxInputTokens: effectiveCfg.limits.max_tokens_per_run,
+    maxTokens: effectiveCfg.limits.max_tokens_per_message,
     executeTool,
     commitProgress: makeCommitProgress(logger),
     logger,

--- a/src/agents/iterator/iterate-action.ts
+++ b/src/agents/iterator/iterate-action.ts
@@ -65,7 +65,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   // Resolve label overrides (model/provider/budget/…) — Jira labels take highest precedence.
   // Labels are re-read from Jira on each iterate-action invocation (each review→iterate cycle),
   // so a label added between iterations takes effect on the next cycle.
-  let effectiveCfg = ferryCfg;
+  let effectiveCfg: typeof ferryCfg;
   let typeOverride: string | undefined;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger);

--- a/src/agents/refiner/refiner-action.ts
+++ b/src/agents/refiner/refiner-action.ts
@@ -8,6 +8,13 @@ import {
   resolveGitConfig,
   loadFerryConfigFromBaseBranch,
   writeStepSummary,
+  resolveTicketOverrides,
+  applyTicketOverrides,
+  hasNonDefaultOverrides,
+  buildOverridesAuditComment,
+  buildConflictComment,
+  LabelConflictError,
+  logTicketOverrides,
 } from '../../lib/agent-runtime/index.js';
 import type { Logger } from '../../lib/agent-runtime/index.js';
 import { runRefiner } from './refine.js';
@@ -169,11 +176,34 @@ export async function run(envelope: EventEnvelopeV1, deps: RefinerActionDeps): P
 }
 
 async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
+  const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT);
   // Reload config from base_branch — the workspace may contain the default branch's config.
   const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
-  const route = ferryCfg.models.refiner;
+
+  // Resolve label overrides (model/provider/budget/…) before creating the LLM call.
+  const issueForLabels = await tracker.getIssue(ticketKey);
+  let effectiveCfg = ferryCfg;
+  try {
+    const overrides = resolveTicketOverrides(issueForLabels.labels, logger);
+    logTicketOverrides(logger, overrides);
+    effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
+    if (hasNonDefaultOverrides(overrides)) {
+      await tracker.postComment(
+        ticketKey,
+        buildOverridesAuditComment('refiner', eventId, overrides),
+      );
+    }
+  } catch (err) {
+    if (err instanceof LabelConflictError) {
+      await tracker.postComment(ticketKey, buildConflictComment('refiner', eventId, err));
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  const route = effectiveCfg.models.refiner;
   const callLlm: LlmCall = createLlmCall(route);
   await run(envelope, { tracker, callLlm, logger });
 }

--- a/src/agents/refiner/refiner-action.ts
+++ b/src/agents/refiner/refiner-action.ts
@@ -184,7 +184,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
 
   // Resolve label overrides (model/provider/budget/…) before creating the LLM call.
   const issueForLabels = await tracker.getIssue(ticketKey);
-  let effectiveCfg = ferryCfg;
+  let effectiveCfg;
   try {
     const overrides = resolveTicketOverrides(issueForLabels.labels, logger);
     logTicketOverrides(logger, overrides);

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -3,7 +3,15 @@ import { delimitUntrusted } from '../../lib/llm/delimit-untrusted.js';
 import { checkIdempotencyMarker } from '../../lib/io/idempotency.js';
 import { gateCi } from './ci-gate.js';
 import { detectMergeConflicts, buildFileList, runReviewLoop } from './review-loop.js';
-import { resolveCapabilities, resolveTypeOverrides } from '../../lib/agent-runtime/index.js';
+import {
+  resolveCapabilities,
+  resolveTicketOverrides,
+  applyTicketOverrides,
+  hasNonDefaultOverrides,
+  buildOverridesAuditComment,
+  buildConflictComment,
+  LabelConflictError,
+} from '../../lib/agent-runtime/index.js';
 import {
   requireEnv,
   appendOutput,
@@ -16,7 +24,7 @@ import {
   resolveBranchPrefix,
   loadFerryConfigFromBaseBranch,
   logCapabilities,
-  logTypeOverrides,
+  logTicketOverrides,
   byEventId,
   byPrHeadSha,
   runAgent,
@@ -34,7 +42,6 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   // Reload config from base_branch — the workspace may contain the default branch's config.
   const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
-  const { provider, model } = ferryCfg.models.review;
   const reviewerWorkflow = ferryCfg.workflow.agents.reviewer;
   const shouldTransitionChanges = reviewerWorkflow.auto_transition_changes !== null;
   const shouldTransitionApprove = reviewerWorkflow.auto_transition_approve !== null;
@@ -46,14 +53,35 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const issue = await tracker.getIssue(ticketKey);
   const existingComments = issue.comments;
 
-  const capabilities = resolveCapabilities(issue.labels, ferryCfg.labels, logger);
+  // Resolve label overrides (model/provider/budget/…) — Jira labels take highest precedence.
+  let effectiveCfg = ferryCfg;
+  let typeOverride: string | undefined;
+  try {
+    const overrides = resolveTicketOverrides(issue.labels, logger);
+    typeOverride = overrides.typeOverride;
+    effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
+    logTicketOverrides(logger, overrides);
+    if (hasNonDefaultOverrides(overrides)) {
+      await tracker.postComment(
+        ticketKey,
+        buildOverridesAuditComment('reviewer', eventId, overrides),
+      );
+    }
+  } catch (err) {
+    if (err instanceof LabelConflictError) {
+      await tracker.postComment(ticketKey, buildConflictComment('reviewer', eventId, err));
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  const { provider, model } = effectiveCfg.models.review;
+
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels, logger);
   logCapabilities(logger, capabilities);
 
-  const typeOverrides = resolveTypeOverrides(issue.labels);
-  logTypeOverrides(logger, typeOverrides);
-
   // Find PR for this ticket's branch
-  const branchName = `${resolveBranchPrefix(ferryCfg.git.working_branch_prefix, issue)}${ticketKey}`;
+  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
   const prs = await runner.listPRsForBranch(owner, repo, branchName);
 
   if (prs.length === 0) {
@@ -132,7 +160,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
     .join('\n');
 
   const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    typeOverride: typeOverrides.typeOverride,
+    typeOverride,
   });
 
   const mergeConflictWarning = hasMergeConflicts
@@ -183,8 +211,8 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
     owner,
     repo,
     headSha,
-    maxIterations: ferryCfg.limits.reviewer_max_iterations,
-    maxTokens: ferryCfg.limits.reviewer_max_tokens,
+    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
+    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
     logger,
   });
 
@@ -226,7 +254,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
     }
   } else {
     const priorIterations = countPriorIterations(existingComments);
-    const cap = ferryCfg.limits.max_iterations;
+    const cap = effectiveCfg.limits.max_iterations;
     const capReached = priorIterations >= cap;
 
     await runner.commentOnPR({ owner, repo, prNumber }, review.comment);

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -54,7 +54,7 @@ async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const existingComments = issue.comments;
 
   // Resolve label overrides (model/provider/budget/…) — Jira labels take highest precedence.
-  let effectiveCfg = ferryCfg;
+  let effectiveCfg: typeof ferryCfg;
   let typeOverride: string | undefined;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger);

--- a/src/lib/labels/overrides.test.ts
+++ b/src/lib/labels/overrides.test.ts
@@ -113,16 +113,52 @@ describe('resolveTicketOverrides — model overrides (ferry:model/*)', () => {
     expect(err?.field).toBe('model.dev');
   });
 
-  it('logs a warning and ignores malformed ferry:model label (no phase)', () => {
-    const { logger, records } = createTestLogger('t', 'test');
-    const r = resolveTicketOverrides(['ferry:model/notamodel'], logger);
-    expect(r.modelOverrides).toBeUndefined();
-    expect(records.some((rec) => rec.level === 'warn')).toBe(true);
+  it('treats ferry:model/<name> (no slash) as a blanket model override for all phases', () => {
+    const r = resolveTicketOverrides(['ferry:model/claude-opus-4-7']);
+    expect(r.modelOverrides?.refiner?.model).toBe('claude-opus-4-7');
+    expect(r.modelOverrides?.dev?.model).toBe('claude-opus-4-7');
+    expect(r.modelOverrides?.review?.model).toBe('claude-opus-4-7');
+    expect(r.modelOverrides?.iterate?.model).toBe('claude-opus-4-7');
   });
 
-  it('logs a warning and ignores unknown phase in ferry:model label', () => {
+  it('treats ferry:model/<non-phase>/<rest> as blanket model with full rest as name', () => {
+    const r = resolveTicketOverrides(['ferry:model/openai/gpt-4o']);
+    expect(r.modelOverrides?.refiner?.model).toBe('openai/gpt-4o');
+    expect(r.modelOverrides?.dev?.model).toBe('openai/gpt-4o');
+    expect(r.modelOverrides?.review?.model).toBe('openai/gpt-4o');
+    expect(r.modelOverrides?.iterate?.model).toBe('openai/gpt-4o');
+  });
+
+  it('blanket model applies only to phases without a per-phase override (per-phase wins)', () => {
+    const r = resolveTicketOverrides([
+      'ferry:model/claude-opus-4-7',
+      'ferry:model/dev/claude-sonnet-4-6',
+    ]);
+    expect(r.modelOverrides?.dev?.model).toBe('claude-sonnet-4-6');
+    expect(r.modelOverrides?.refiner?.model).toBe('claude-opus-4-7');
+    expect(r.modelOverrides?.review?.model).toBe('claude-opus-4-7');
+    expect(r.modelOverrides?.iterate?.model).toBe('claude-opus-4-7');
+  });
+
+  it('throws LabelConflictError when two blanket model labels conflict', () => {
+    expect(() =>
+      resolveTicketOverrides(['ferry:model/claude-opus-4-7', 'ferry:model/gpt-4o']),
+    ).toThrow(LabelConflictError);
+  });
+
+  it('includes field "model" (not "model.<phase>") in LabelConflictError for blanket conflict', () => {
+    let err: LabelConflictError | undefined;
+    try {
+      resolveTicketOverrides(['ferry:model/model-a', 'ferry:model/model-b']);
+    } catch (e) {
+      err = e as LabelConflictError;
+    }
+    expect(err?.field).toBe('model');
+  });
+
+  it('logs a warning and ignores malformed ferry:model label (empty name)', () => {
     const { logger, records } = createTestLogger('t', 'test');
-    const r = resolveTicketOverrides(['ferry:model/badphase/some-model'], logger);
+    const r = resolveTicketOverrides(['ferry:model/'], logger);
     expect(r.modelOverrides).toBeUndefined();
     expect(records.some((rec) => rec.level === 'warn')).toBe(true);
   });
@@ -162,6 +198,45 @@ describe('resolveTicketOverrides — provider overrides (ferry:provider/*)', () 
   it('logs a warning and ignores unknown provider', () => {
     const { logger, records } = createTestLogger('t', 'test');
     const r = resolveTicketOverrides(['ferry:provider/dev/notaprovider'], logger);
+    expect(r.modelOverrides).toBeUndefined();
+    expect(records.some((rec) => rec.level === 'warn')).toBe(true);
+  });
+
+  it('treats ferry:provider/<provider> (one segment) as a blanket provider for all phases', () => {
+    const r = resolveTicketOverrides(['ferry:provider/openai']);
+    expect(r.modelOverrides?.refiner?.provider).toBe('openai');
+    expect(r.modelOverrides?.dev?.provider).toBe('openai');
+    expect(r.modelOverrides?.review?.provider).toBe('openai');
+    expect(r.modelOverrides?.iterate?.provider).toBe('openai');
+  });
+
+  it('blanket provider applies only to phases without a per-phase provider override (per-phase wins)', () => {
+    const r = resolveTicketOverrides(['ferry:provider/openai', 'ferry:provider/dev/google']);
+    expect(r.modelOverrides?.dev?.provider).toBe('google');
+    expect(r.modelOverrides?.refiner?.provider).toBe('openai');
+    expect(r.modelOverrides?.review?.provider).toBe('openai');
+    expect(r.modelOverrides?.iterate?.provider).toBe('openai');
+  });
+
+  it('throws LabelConflictError when two blanket provider labels conflict', () => {
+    expect(() =>
+      resolveTicketOverrides(['ferry:provider/openai', 'ferry:provider/anthropic']),
+    ).toThrow(LabelConflictError);
+  });
+
+  it('includes field "provider" in LabelConflictError for blanket provider conflict', () => {
+    let err: LabelConflictError | undefined;
+    try {
+      resolveTicketOverrides(['ferry:provider/openai', 'ferry:provider/google']);
+    } catch (e) {
+      err = e as LabelConflictError;
+    }
+    expect(err?.field).toBe('provider');
+  });
+
+  it('logs a warning and ignores unknown provider in blanket ferry:provider label', () => {
+    const { logger, records } = createTestLogger('t', 'test');
+    const r = resolveTicketOverrides(['ferry:provider/notaprovider'], logger);
     expect(r.modelOverrides).toBeUndefined();
     expect(records.some((rec) => rec.level === 'warn')).toBe(true);
   });
@@ -450,6 +525,40 @@ describe('applyTicketOverrides', () => {
     expect(cfg.models.dev.model).toBe('dev-model');
     expect(cfg.models.review.model).toBe('review-model');
     expect(cfg.models.iterate.model).toBe('iter-model');
+  });
+
+  it('applies a blanket model override to all four phases', () => {
+    const overrides = resolveTicketOverrides(['ferry:model/claude-opus-4-7']);
+    const cfg = applyTicketOverrides(BASE_CFG, overrides);
+    expect(cfg.models.refiner.model).toBe('claude-opus-4-7');
+    expect(cfg.models.dev.model).toBe('claude-opus-4-7');
+    expect(cfg.models.review.model).toBe('claude-opus-4-7');
+    expect(cfg.models.iterate.model).toBe('claude-opus-4-7');
+    // providers unchanged
+    expect(cfg.models.dev.provider).toBe(BASE_CFG.models.dev.provider);
+  });
+
+  it('blanket model + per-phase model: per-phase wins for that phase, blanket fills the rest', () => {
+    const overrides = resolveTicketOverrides([
+      'ferry:model/claude-opus-4-7',
+      'ferry:model/dev/claude-sonnet-4-6',
+    ]);
+    const cfg = applyTicketOverrides(BASE_CFG, overrides);
+    expect(cfg.models.dev.model).toBe('claude-sonnet-4-6');
+    expect(cfg.models.refiner.model).toBe('claude-opus-4-7');
+    expect(cfg.models.review.model).toBe('claude-opus-4-7');
+    expect(cfg.models.iterate.model).toBe('claude-opus-4-7');
+  });
+
+  it('applies a blanket provider override to all four phases', () => {
+    const overrides = resolveTicketOverrides(['ferry:provider/openai']);
+    const cfg = applyTicketOverrides(BASE_CFG, overrides);
+    expect(cfg.models.refiner.provider).toBe('openai');
+    expect(cfg.models.dev.provider).toBe('openai');
+    expect(cfg.models.review.provider).toBe('openai');
+    expect(cfg.models.iterate.provider).toBe('openai');
+    // models unchanged
+    expect(cfg.models.dev.model).toBe(BASE_CFG.models.dev.model);
   });
 });
 

--- a/src/lib/labels/overrides.ts
+++ b/src/lib/labels/overrides.ts
@@ -4,6 +4,7 @@ import { resolveTypeOverrides, isBuiltinTypeLabel } from './capabilities.js';
 import type { TicketOverrides, AgentPhase, PhaseModelOverride } from './capabilities.js';
 
 const AGENT_PHASES: ReadonlySet<string> = new Set(['refiner', 'dev', 'review', 'iterate']);
+const PHASES_ORDERED: readonly AgentPhase[] = ['refiner', 'dev', 'review', 'iterate'];
 const LLM_PROVIDERS: ReadonlySet<string> = new Set(['anthropic', 'openai', 'google']);
 
 /**
@@ -87,6 +88,11 @@ export function resolveTicketOverrides(labels: string[], logger?: Logger): Ticke
   const modelSources: Partial<Record<AgentPhase, string>> = {};
   const providerSources: Partial<Record<AgentPhase, string>> = {};
 
+  let blanketModel: string | undefined;
+  let blanketModelSource: string | undefined;
+  let blanketProvider: 'anthropic' | 'openai' | 'google' | undefined;
+  let blanketProviderSource: string | undefined;
+
   let budgetMaxCostLabel: string | undefined;
   let budgetMaxTokensLabel: string | undefined;
   let budgetMaxCostEur: number | undefined;
@@ -103,41 +109,71 @@ export function resolveTicketOverrides(labels: string[], logger?: Logger): Ticke
     if (!label.startsWith('ferry:')) continue;
     if (isKnownNonOverrideLabel(label)) continue;
 
-    // ferry:model/<phase>/<model-id>
+    // ferry:model/<name>              — blanket: override model for all agent phases
+    // ferry:model/<phase>/<model-id>  — per-phase: override model for a specific phase only
     if (label.startsWith('ferry:model/')) {
       const rest = label.slice('ferry:model/'.length);
+      if (!rest) {
+        logger?.warn('malformed ferry:model label (empty model name)', { label });
+        continue;
+      }
       const slashIdx = rest.indexOf('/');
-      if (slashIdx < 1) {
-        logger?.warn('malformed ferry:model label (expected ferry:model/<phase>/<model-id>)', {
-          label,
-        });
+      if (slashIdx < 0) {
+        // Blanket form: ferry:model/<name> — no slash, applies to all phases
+        if (blanketModelSource !== undefined) {
+          throw new LabelConflictError(blanketModelSource, label, 'model');
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
         continue;
       }
-      const phase = rest.slice(0, slashIdx);
-      const modelId = rest.slice(slashIdx + 1);
-      if (!AGENT_PHASES.has(phase)) {
-        logger?.warn('unknown phase in ferry:model label', { label, phase });
-        continue;
+      const firstSegment = rest.slice(0, slashIdx);
+      const remainder = rest.slice(slashIdx + 1);
+      if (AGENT_PHASES.has(firstSegment)) {
+        // Per-phase form: ferry:model/<phase>/<model-id>
+        const p = firstSegment as AgentPhase;
+        if (!remainder) {
+          logger?.warn('empty model-id in ferry:model label', { label });
+          continue;
+        }
+        if (modelSources[p] !== undefined) {
+          throw new LabelConflictError(modelSources[p]!, label, `model.${firstSegment}`);
+        }
+        modelSources[p] = label;
+        modelOverrides[p] = { ...modelOverrides[p], model: remainder };
+      } else {
+        // Non-phase first segment: blanket model with org/model slash in name
+        // e.g. ferry:model/openai/gpt-4o → blanket model "openai/gpt-4o"
+        if (blanketModelSource !== undefined) {
+          throw new LabelConflictError(blanketModelSource, label, 'model');
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
       }
-      if (!modelId) {
-        logger?.warn('empty model-id in ferry:model label', { label });
-        continue;
-      }
-      const p = phase as AgentPhase;
-      if (modelSources[p] !== undefined) {
-        throw new LabelConflictError(modelSources[p]!, label, `model.${phase}`);
-      }
-      modelSources[p] = label;
-      modelOverrides[p] = { ...modelOverrides[p], model: modelId };
       continue;
     }
 
-    // ferry:provider/<phase>/<provider>
+    // ferry:provider/<provider>              — blanket: switch provider for all agent phases
+    // ferry:provider/<phase>/<provider>      — per-phase: switch provider for one phase only
     if (label.startsWith('ferry:provider/')) {
       const parts = label.slice('ferry:provider/'.length).split('/');
+      if (parts.length === 1) {
+        // Blanket form: ferry:provider/<provider>
+        const provider = parts[0];
+        if (!LLM_PROVIDERS.has(provider)) {
+          logger?.warn('unknown provider in blanket ferry:provider label', { label, provider });
+          continue;
+        }
+        if (blanketProviderSource !== undefined) {
+          throw new LabelConflictError(blanketProviderSource, label, 'provider');
+        }
+        blanketProvider = provider as 'anthropic' | 'openai' | 'google';
+        blanketProviderSource = label;
+        continue;
+      }
       if (parts.length !== 2) {
         logger?.warn(
-          'malformed ferry:provider label (expected ferry:provider/<phase>/<provider>)',
+          'malformed ferry:provider label (expected ferry:provider/<provider> or ferry:provider/<phase>/<provider>)',
           { label },
         );
         continue;
@@ -234,6 +270,23 @@ export function resolveTicketOverrides(labels: string[], logger?: Logger): Ticke
 
     // Unrecognised ferry:* label in override namespace — log and ignore
     logger?.warn('unknown ferry override label ignored', { label });
+  }
+
+  // Apply blanket model/provider to phases not already overridden per-phase.
+  // Per-phase labels take precedence: blanket only fills phases with no explicit per-phase override.
+  if (blanketModel !== undefined) {
+    for (const phase of PHASES_ORDERED) {
+      if (modelSources[phase] === undefined) {
+        modelOverrides[phase] = { ...modelOverrides[phase], model: blanketModel };
+      }
+    }
+  }
+  if (blanketProvider !== undefined) {
+    for (const phase of PHASES_ORDERED) {
+      if (providerSources[phase] === undefined) {
+        modelOverrides[phase] = { ...modelOverrides[phase], provider: blanketProvider };
+      }
+    }
   }
 
   const hasModelOverrides = Object.keys(modelOverrides).length > 0;


### PR DESCRIPTION
Implements issue #237: label-based LLM model/provider overrides per Jira ticket.

## Summary
- Add blanket `ferry:model/<name>` and `ferry:provider/<name>` label forms that apply to all four agents
- Per-phase labels take precedence over blanket when both appear on the same ticket
- Wire `resolveTicketOverrides` + `applyTicketOverrides` into all four agent actions so label-sourced model and provider overrides actually affect LLM call routing
- Each agent posts a Jira audit comment listing resolved overrides when any non-default override is active
- Exit non-zero with a conflict comment on `LabelConflictError`
- Update docs/CONFIGURATION.md with full label table, conflict rules, and use-case example

Closes #237

Generated with [Claude Code](https://claude.ai/code)