### PR TITLE
feat: label override for thinking / review rubric (#240)

### DIFF
--- a/.ferry/agent.js
+++ b/.ferry/agent.js
@@ -1403,6 +1403,9 @@ function logTicketOverrides(logger, overrides) {
   if (overrides.thinking !== void 0) {
     logger.info("thinking override", { thinking: overrides.thinking });
   }
+  if (overrides.reviewRubric !== void 0) {
+    logger.info("review rubric override", { reviewRubric: overrides.reviewRubric });
+  }
   if (overrides.git?.noPr) {
     logger.info("git override: no-pr (PR creation skipped)");
   }
@@ -5926,6 +5929,8 @@ function resolveTicketOverrides(labels, logger, options) {
   let maxTokens;
   let thinkingLabel;
   let thinking;
+  let reviewRubricLabel;
+  let reviewRubric;
   let noPr = false;
   let paused = false;
   let noAutoTransition = false;
@@ -6107,14 +6112,33 @@ function resolveTicketOverrides(labels, logger, options) {
       noAutoTransition = true;
       continue;
     }
-    if (label === "ferry:thinking/on" || label === "ferry:thinking/off") {
-      const val = label === "ferry:thinking/on" ? "on" : "off";
+    if (label.startsWith("ferry:thinking/")) {
+      const suffix = label.slice("ferry:thinking/".length);
+      let val;
+      if (suffix === "on") val = "on";
+      else if (suffix === "off") val = "off";
+      else if (suffix === "extended") val = "extended";
+      if (val === void 0) {
+        logger?.warn("unknown suffix in ferry:thinking label", { label, suffix });
+        continue;
+      }
       if (thinking !== void 0 && thinking !== val) {
         throw new LabelConflictError(thinkingLabel, label, "thinking");
       }
       if (thinking === void 0) {
         thinking = val;
         thinkingLabel = label;
+      }
+      continue;
+    }
+    if (label === "ferry:strict-review" || label === "ferry:lenient-review") {
+      const val = label === "ferry:strict-review" ? "strict" : "lenient";
+      if (reviewRubric !== void 0 && reviewRubric !== val) {
+        throw new LabelConflictError(reviewRubricLabel, label, "reviewRubric");
+      }
+      if (reviewRubric === void 0) {
+        reviewRubric = val;
+        reviewRubricLabel = label;
       }
       continue;
     }
@@ -6167,6 +6191,7 @@ function resolveTicketOverrides(labels, logger, options) {
     ...skipPhases.length > 0 ? { skipPhases } : {},
     ...noAutoTransition ? { noAutoTransition: true } : {},
     ...thinking !== void 0 ? { thinking } : {},
+    ...reviewRubric !== void 0 ? { reviewRubric } : {},
     ...noPr ? { git: { noPr: true } } : {},
     ...paused ? { paused: true } : {},
     ...dryRun ? { dryRun: true } : {},
@@ -6225,7 +6250,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6239,6 +6264,7 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if ((overrides.skipPhases?.length ?? 0) > 0) payload.skipPhases = overrides.skipPhases;
   if (overrides.noAutoTransition) payload.noAutoTransition = true;
   if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
+  if (overrides.reviewRubric !== void 0) payload.reviewRubric = overrides.reviewRubric;
   if (overrides.git?.noPr) payload.git = overrides.git;
   if (overrides.paused) payload.paused = true;
   if (overrides.dryRun) payload.dryRun = true;
@@ -7912,7 +7938,8 @@ function createAnthropicAgentLoop(opts) {
         max_tokens: maxTokens,
         system: systemBlocks,
         tools: effectiveTools,
-        messages
+        messages,
+        ...opts.thinking !== void 0 ? { thinking: opts.thinking } : {}
       };
       const response = hasHttp ? await anthropic.beta.messages.create({
         ...baseParams,
@@ -8818,6 +8845,33 @@ function createGoogleAgentLoop(opts) {
   };
 }
 
+// src/lib/llm/thinking.ts
+var THINKING_BUDGET_ON = 2e3;
+var THINKING_BUDGET_EXTENDED = 8e3;
+function thinkingParamFromOverride(thinking) {
+  switch (thinking) {
+    case "extended":
+      return { type: "enabled", budget_tokens: THINKING_BUDGET_EXTENDED };
+    case "on":
+      return { type: "enabled", budget_tokens: THINKING_BUDGET_ON };
+    case "off":
+      return { type: "disabled" };
+    default:
+      return void 0;
+  }
+}
+function resolveThinkingForProvider(thinking, provider, logger) {
+  if (thinking === void 0) return void 0;
+  if (provider !== "anthropic") {
+    logger?.warn("ferry:thinking label set but provider is not anthropic \u2014 ignoring", {
+      provider,
+      thinking
+    });
+    return void 0;
+  }
+  return thinkingParamFromOverride(thinking);
+}
+
 // src/lib/llm/agent-loop/index.ts
 function requireEnv3(key) {
   const val = process.env[key];
@@ -8829,6 +8883,7 @@ function requireEnv3(key) {
 function createAgentLoop(opts) {
   if (opts.provider === "anthropic") {
     const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
+    const thinking = resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
     return createAnthropicAgentLoop({
       ...auth2,
       model: opts.model,
@@ -8840,9 +8895,11 @@ function createAgentLoop(opts) {
       maxTokens: opts.maxTokens,
       maxCostEur: opts.maxCostEur,
       compactWindow: opts.compactWindow,
+      thinking,
       logger: opts.logger
     });
   }
+  resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
   if (opts.provider === "openai") {
     const apiKey = requireEnv3("FERRY_OPENAI_KEY");
     return createOpenAIAgentLoop({
@@ -9106,6 +9163,7 @@ async function main2(envelope, logger) {
   let typeOverride;
   let forceLabel;
   let noAutoTransition = false;
+  let thinkingOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -9113,6 +9171,7 @@ async function main2(envelope, logger) {
     typeOverride = overrides.typeOverride;
     forceLabel = overrides.forceLabel;
     noAutoTransition = overrides.noAutoTransition === true;
+    thinkingOverride = overrides.thinking;
     if (overrides.dryRun === true && !dryRun) {
       dryRun = true;
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
@@ -9263,6 +9322,7 @@ ${tree}`,
     maxInputTokens: effectiveCfg.limits.max_tokens_per_run,
     maxTokens: effectiveCfg.limits.max_tokens_per_message,
     maxCostEur: effectiveCfg.limits.max_cost_eur_per_run,
+    thinking: thinkingOverride,
     executeTool,
     commitProgress: makeCommitProgress(logger, { dryRun }),
     spawnSubagent: (task) => loop.run({

--- a/.ferry/agent.js
+++ b/.ferry/agent.js
@@ -9580,7 +9580,8 @@ function createAnthropicToolCallLoop(opts) {
           max_tokens: maxTokens,
           system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
           tools: anthropicTools,
-          messages
+          messages,
+          ...opts.thinking !== void 0 ? { thinking: opts.thinking } : {}
         });
         inputTokens += response.usage.input_tokens;
         outputTokens += response.usage.output_tokens;
@@ -9986,8 +9987,10 @@ function createToolCallLoop(opts) {
   if (opts.provider === "anthropic") {
     const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
     const client = new Anthropic4(auth2);
-    return createAnthropicToolCallLoop({ client, model: opts.model });
+    const thinking = resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
+    return createAnthropicToolCallLoop({ client, model: opts.model, thinking });
   }
+  resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
   if (opts.provider === "openai") {
     const apiKey = requireEnv4("FERRY_OPENAI_KEY");
     return createOpenAIToolCallLoop({ apiKey, model: opts.model });
@@ -10149,6 +10152,38 @@ async function runReviewLoop(opts) {
   };
 }
 
+// src/agents/reviewer/rubric.ts
+var STRICT_DIRECTIVE = [
+  "## Rubric override \u2014 strict",
+  "",
+  "For this review, apply a STRICTER bar than usual:",
+  "",
+  "- Block on any missing test coverage for new/changed behaviour.",
+  "- Block on missing edge-case handling, error paths, or input validation.",
+  "- Block on weak naming, dead code, or unreachable branches.",
+  "- Block on incomplete documentation when public APIs change.",
+  "- Approve only when every acceptance criterion is fully satisfied with concrete evidence."
+].join("\n");
+var LENIENT_DIRECTIVE = [
+  "## Rubric override \u2014 lenient",
+  "",
+  "For this review, apply a MORE PERMISSIVE bar than usual:",
+  "",
+  "- Approve when the acceptance criteria are met, even if minor polish is missing.",
+  "- Treat naming nits, non-blocking style issues, and stylistic preferences as comments \u2014 not blockers.",
+  "- Block only on: failing tests, unimplemented ACs, merge conflicts, committed build artefacts, or security regressions.",
+  '- Prefer "approve with comments" over "request changes" when issues are non-blocking.'
+].join("\n");
+function applyRubricToPrompt(basePrompt, rubric) {
+  if (rubric === void 0) return basePrompt;
+  const directive = rubric === "strict" ? STRICT_DIRECTIVE : LENIENT_DIRECTIVE;
+  return `${basePrompt}
+
+---
+
+${directive}`;
+}
+
 // src/agents/reviewer/changes-guard.ts
 function countPriorIterations(existingComments) {
   return existingComments.filter(
@@ -10173,6 +10208,8 @@ async function main3(envelope, logger) {
   let autoApprove = false;
   let noAutoTransition = false;
   let dryRun = false;
+  let thinkingOverride;
+  let reviewRubricOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10181,6 +10218,8 @@ async function main3(envelope, logger) {
     autoApprove = overrides.skipPhases?.includes("review") === true;
     noAutoTransition = overrides.noAutoTransition === true;
     dryRun = overrides.dryRun === true;
+    thinkingOverride = overrides.thinking;
+    reviewRubricOverride = overrides.reviewRubric;
     if (dryRun) {
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
     }
@@ -10327,11 +10366,12 @@ async function main3(envelope, logger) {
     "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
     "When you have enough information, call finish_review."
   ].filter((l) => l !== null).join("\n");
-  const system = buildSystem("review", REPO_ROOT3, {
+  const baseSystem = buildSystem("review", REPO_ROOT3, {
     extraParts: [loadOptionalPrompt("review-comment", REPO_ROOT3)],
     separator: "\n\n---\n\n"
   });
-  const loop = createToolCallLoop({ provider, model });
+  const system = applyRubricToPrompt(baseSystem, reviewRubricOverride);
+  const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
   const {
     result: review,
     inputTokens,
@@ -10491,6 +10531,7 @@ async function main4(envelope, logger) {
   let labelMaxIterations;
   let noAutoTransition = false;
   let dryRun = false;
+  let thinkingOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10499,6 +10540,7 @@ async function main4(envelope, logger) {
     labelMaxIterations = overrides.maxIterations;
     noAutoTransition = overrides.noAutoTransition === true;
     dryRun = overrides.dryRun === true;
+    thinkingOverride = overrides.thinking;
     if (dryRun) {
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
     }
@@ -10653,6 +10695,7 @@ ${existingLog}` : "",
     maxInputTokens: effectiveCfg.limits.max_tokens_per_run,
     maxTokens: effectiveCfg.limits.max_tokens_per_message,
     maxCostEur: effectiveCfg.limits.max_cost_eur_per_run,
+    thinking: thinkingOverride,
     executeTool,
     commitProgress: makeCommitProgress(logger),
     logger

--- a/.github/actions/ferry-run-developer/agent.js
+++ b/.github/actions/ferry-run-developer/agent.js
@@ -1403,6 +1403,9 @@ function logTicketOverrides(logger, overrides) {
   if (overrides.thinking !== void 0) {
     logger.info("thinking override", { thinking: overrides.thinking });
   }
+  if (overrides.reviewRubric !== void 0) {
+    logger.info("review rubric override", { reviewRubric: overrides.reviewRubric });
+  }
   if (overrides.git?.noPr) {
     logger.info("git override: no-pr (PR creation skipped)");
   }
@@ -5926,6 +5929,8 @@ function resolveTicketOverrides(labels, logger, options) {
   let maxTokens;
   let thinkingLabel;
   let thinking;
+  let reviewRubricLabel;
+  let reviewRubric;
   let noPr = false;
   let paused = false;
   let noAutoTransition = false;
@@ -6107,14 +6112,33 @@ function resolveTicketOverrides(labels, logger, options) {
       noAutoTransition = true;
       continue;
     }
-    if (label === "ferry:thinking/on" || label === "ferry:thinking/off") {
-      const val = label === "ferry:thinking/on" ? "on" : "off";
+    if (label.startsWith("ferry:thinking/")) {
+      const suffix = label.slice("ferry:thinking/".length);
+      let val;
+      if (suffix === "on") val = "on";
+      else if (suffix === "off") val = "off";
+      else if (suffix === "extended") val = "extended";
+      if (val === void 0) {
+        logger?.warn("unknown suffix in ferry:thinking label", { label, suffix });
+        continue;
+      }
       if (thinking !== void 0 && thinking !== val) {
         throw new LabelConflictError(thinkingLabel, label, "thinking");
       }
       if (thinking === void 0) {
         thinking = val;
         thinkingLabel = label;
+      }
+      continue;
+    }
+    if (label === "ferry:strict-review" || label === "ferry:lenient-review") {
+      const val = label === "ferry:strict-review" ? "strict" : "lenient";
+      if (reviewRubric !== void 0 && reviewRubric !== val) {
+        throw new LabelConflictError(reviewRubricLabel, label, "reviewRubric");
+      }
+      if (reviewRubric === void 0) {
+        reviewRubric = val;
+        reviewRubricLabel = label;
       }
       continue;
     }
@@ -6167,6 +6191,7 @@ function resolveTicketOverrides(labels, logger, options) {
     ...skipPhases.length > 0 ? { skipPhases } : {},
     ...noAutoTransition ? { noAutoTransition: true } : {},
     ...thinking !== void 0 ? { thinking } : {},
+    ...reviewRubric !== void 0 ? { reviewRubric } : {},
     ...noPr ? { git: { noPr: true } } : {},
     ...paused ? { paused: true } : {},
     ...dryRun ? { dryRun: true } : {},
@@ -6225,7 +6250,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6239,6 +6264,7 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if ((overrides.skipPhases?.length ?? 0) > 0) payload.skipPhases = overrides.skipPhases;
   if (overrides.noAutoTransition) payload.noAutoTransition = true;
   if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
+  if (overrides.reviewRubric !== void 0) payload.reviewRubric = overrides.reviewRubric;
   if (overrides.git?.noPr) payload.git = overrides.git;
   if (overrides.paused) payload.paused = true;
   if (overrides.dryRun) payload.dryRun = true;
@@ -7912,7 +7938,8 @@ function createAnthropicAgentLoop(opts) {
         max_tokens: maxTokens,
         system: systemBlocks,
         tools: effectiveTools,
-        messages
+        messages,
+        ...opts.thinking !== void 0 ? { thinking: opts.thinking } : {}
       };
       const response = hasHttp ? await anthropic.beta.messages.create({
         ...baseParams,
@@ -8818,6 +8845,33 @@ function createGoogleAgentLoop(opts) {
   };
 }
 
+// src/lib/llm/thinking.ts
+var THINKING_BUDGET_ON = 2e3;
+var THINKING_BUDGET_EXTENDED = 8e3;
+function thinkingParamFromOverride(thinking) {
+  switch (thinking) {
+    case "extended":
+      return { type: "enabled", budget_tokens: THINKING_BUDGET_EXTENDED };
+    case "on":
+      return { type: "enabled", budget_tokens: THINKING_BUDGET_ON };
+    case "off":
+      return { type: "disabled" };
+    default:
+      return void 0;
+  }
+}
+function resolveThinkingForProvider(thinking, provider, logger) {
+  if (thinking === void 0) return void 0;
+  if (provider !== "anthropic") {
+    logger?.warn("ferry:thinking label set but provider is not anthropic \u2014 ignoring", {
+      provider,
+      thinking
+    });
+    return void 0;
+  }
+  return thinkingParamFromOverride(thinking);
+}
+
 // src/lib/llm/agent-loop/index.ts
 function requireEnv3(key) {
   const val = process.env[key];
@@ -8829,6 +8883,7 @@ function requireEnv3(key) {
 function createAgentLoop(opts) {
   if (opts.provider === "anthropic") {
     const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
+    const thinking = resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
     return createAnthropicAgentLoop({
       ...auth2,
       model: opts.model,
@@ -8840,9 +8895,11 @@ function createAgentLoop(opts) {
       maxTokens: opts.maxTokens,
       maxCostEur: opts.maxCostEur,
       compactWindow: opts.compactWindow,
+      thinking,
       logger: opts.logger
     });
   }
+  resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
   if (opts.provider === "openai") {
     const apiKey = requireEnv3("FERRY_OPENAI_KEY");
     return createOpenAIAgentLoop({
@@ -9106,6 +9163,7 @@ async function main2(envelope, logger) {
   let typeOverride;
   let forceLabel;
   let noAutoTransition = false;
+  let thinkingOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -9113,6 +9171,7 @@ async function main2(envelope, logger) {
     typeOverride = overrides.typeOverride;
     forceLabel = overrides.forceLabel;
     noAutoTransition = overrides.noAutoTransition === true;
+    thinkingOverride = overrides.thinking;
     if (overrides.dryRun === true && !dryRun) {
       dryRun = true;
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
@@ -9263,6 +9322,7 @@ ${tree}`,
     maxInputTokens: effectiveCfg.limits.max_tokens_per_run,
     maxTokens: effectiveCfg.limits.max_tokens_per_message,
     maxCostEur: effectiveCfg.limits.max_cost_eur_per_run,
+    thinking: thinkingOverride,
     executeTool,
     commitProgress: makeCommitProgress(logger, { dryRun }),
     spawnSubagent: (task) => loop.run({

--- a/.github/actions/ferry-run-developer/agent.js
+++ b/.github/actions/ferry-run-developer/agent.js
@@ -9580,7 +9580,8 @@ function createAnthropicToolCallLoop(opts) {
           max_tokens: maxTokens,
           system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
           tools: anthropicTools,
-          messages
+          messages,
+          ...opts.thinking !== void 0 ? { thinking: opts.thinking } : {}
         });
         inputTokens += response.usage.input_tokens;
         outputTokens += response.usage.output_tokens;
@@ -9986,8 +9987,10 @@ function createToolCallLoop(opts) {
   if (opts.provider === "anthropic") {
     const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
     const client = new Anthropic4(auth2);
-    return createAnthropicToolCallLoop({ client, model: opts.model });
+    const thinking = resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
+    return createAnthropicToolCallLoop({ client, model: opts.model, thinking });
   }
+  resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
   if (opts.provider === "openai") {
     const apiKey = requireEnv4("FERRY_OPENAI_KEY");
     return createOpenAIToolCallLoop({ apiKey, model: opts.model });
@@ -10149,6 +10152,38 @@ async function runReviewLoop(opts) {
   };
 }
 
+// src/agents/reviewer/rubric.ts
+var STRICT_DIRECTIVE = [
+  "## Rubric override \u2014 strict",
+  "",
+  "For this review, apply a STRICTER bar than usual:",
+  "",
+  "- Block on any missing test coverage for new/changed behaviour.",
+  "- Block on missing edge-case handling, error paths, or input validation.",
+  "- Block on weak naming, dead code, or unreachable branches.",
+  "- Block on incomplete documentation when public APIs change.",
+  "- Approve only when every acceptance criterion is fully satisfied with concrete evidence."
+].join("\n");
+var LENIENT_DIRECTIVE = [
+  "## Rubric override \u2014 lenient",
+  "",
+  "For this review, apply a MORE PERMISSIVE bar than usual:",
+  "",
+  "- Approve when the acceptance criteria are met, even if minor polish is missing.",
+  "- Treat naming nits, non-blocking style issues, and stylistic preferences as comments \u2014 not blockers.",
+  "- Block only on: failing tests, unimplemented ACs, merge conflicts, committed build artefacts, or security regressions.",
+  '- Prefer "approve with comments" over "request changes" when issues are non-blocking.'
+].join("\n");
+function applyRubricToPrompt(basePrompt, rubric) {
+  if (rubric === void 0) return basePrompt;
+  const directive = rubric === "strict" ? STRICT_DIRECTIVE : LENIENT_DIRECTIVE;
+  return `${basePrompt}
+
+---
+
+${directive}`;
+}
+
 // src/agents/reviewer/changes-guard.ts
 function countPriorIterations(existingComments) {
   return existingComments.filter(
@@ -10173,6 +10208,8 @@ async function main3(envelope, logger) {
   let autoApprove = false;
   let noAutoTransition = false;
   let dryRun = false;
+  let thinkingOverride;
+  let reviewRubricOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10181,6 +10218,8 @@ async function main3(envelope, logger) {
     autoApprove = overrides.skipPhases?.includes("review") === true;
     noAutoTransition = overrides.noAutoTransition === true;
     dryRun = overrides.dryRun === true;
+    thinkingOverride = overrides.thinking;
+    reviewRubricOverride = overrides.reviewRubric;
     if (dryRun) {
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
     }
@@ -10327,11 +10366,12 @@ async function main3(envelope, logger) {
     "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
     "When you have enough information, call finish_review."
   ].filter((l) => l !== null).join("\n");
-  const system = buildSystem("review", REPO_ROOT3, {
+  const baseSystem = buildSystem("review", REPO_ROOT3, {
     extraParts: [loadOptionalPrompt("review-comment", REPO_ROOT3)],
     separator: "\n\n---\n\n"
   });
-  const loop = createToolCallLoop({ provider, model });
+  const system = applyRubricToPrompt(baseSystem, reviewRubricOverride);
+  const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
   const {
     result: review,
     inputTokens,
@@ -10491,6 +10531,7 @@ async function main4(envelope, logger) {
   let labelMaxIterations;
   let noAutoTransition = false;
   let dryRun = false;
+  let thinkingOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10499,6 +10540,7 @@ async function main4(envelope, logger) {
     labelMaxIterations = overrides.maxIterations;
     noAutoTransition = overrides.noAutoTransition === true;
     dryRun = overrides.dryRun === true;
+    thinkingOverride = overrides.thinking;
     if (dryRun) {
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
     }
@@ -10653,6 +10695,7 @@ ${existingLog}` : "",
     maxInputTokens: effectiveCfg.limits.max_tokens_per_run,
     maxTokens: effectiveCfg.limits.max_tokens_per_message,
     maxCostEur: effectiveCfg.limits.max_cost_eur_per_run,
+    thinking: thinkingOverride,
     executeTool,
     commitProgress: makeCommitProgress(logger),
     logger

--- a/.github/actions/ferry-run-iterator/agent.js
+++ b/.github/actions/ferry-run-iterator/agent.js
@@ -1403,6 +1403,9 @@ function logTicketOverrides(logger, overrides) {
   if (overrides.thinking !== void 0) {
     logger.info("thinking override", { thinking: overrides.thinking });
   }
+  if (overrides.reviewRubric !== void 0) {
+    logger.info("review rubric override", { reviewRubric: overrides.reviewRubric });
+  }
   if (overrides.git?.noPr) {
     logger.info("git override: no-pr (PR creation skipped)");
   }
@@ -5926,6 +5929,8 @@ function resolveTicketOverrides(labels, logger, options) {
   let maxTokens;
   let thinkingLabel;
   let thinking;
+  let reviewRubricLabel;
+  let reviewRubric;
   let noPr = false;
   let paused = false;
   let noAutoTransition = false;
@@ -6107,14 +6112,33 @@ function resolveTicketOverrides(labels, logger, options) {
       noAutoTransition = true;
       continue;
     }
-    if (label === "ferry:thinking/on" || label === "ferry:thinking/off") {
-      const val = label === "ferry:thinking/on" ? "on" : "off";
+    if (label.startsWith("ferry:thinking/")) {
+      const suffix = label.slice("ferry:thinking/".length);
+      let val;
+      if (suffix === "on") val = "on";
+      else if (suffix === "off") val = "off";
+      else if (suffix === "extended") val = "extended";
+      if (val === void 0) {
+        logger?.warn("unknown suffix in ferry:thinking label", { label, suffix });
+        continue;
+      }
       if (thinking !== void 0 && thinking !== val) {
         throw new LabelConflictError(thinkingLabel, label, "thinking");
       }
       if (thinking === void 0) {
         thinking = val;
         thinkingLabel = label;
+      }
+      continue;
+    }
+    if (label === "ferry:strict-review" || label === "ferry:lenient-review") {
+      const val = label === "ferry:strict-review" ? "strict" : "lenient";
+      if (reviewRubric !== void 0 && reviewRubric !== val) {
+        throw new LabelConflictError(reviewRubricLabel, label, "reviewRubric");
+      }
+      if (reviewRubric === void 0) {
+        reviewRubric = val;
+        reviewRubricLabel = label;
       }
       continue;
     }
@@ -6167,6 +6191,7 @@ function resolveTicketOverrides(labels, logger, options) {
     ...skipPhases.length > 0 ? { skipPhases } : {},
     ...noAutoTransition ? { noAutoTransition: true } : {},
     ...thinking !== void 0 ? { thinking } : {},
+    ...reviewRubric !== void 0 ? { reviewRubric } : {},
     ...noPr ? { git: { noPr: true } } : {},
     ...paused ? { paused: true } : {},
     ...dryRun ? { dryRun: true } : {},
@@ -6225,7 +6250,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6239,6 +6264,7 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if ((overrides.skipPhases?.length ?? 0) > 0) payload.skipPhases = overrides.skipPhases;
   if (overrides.noAutoTransition) payload.noAutoTransition = true;
   if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
+  if (overrides.reviewRubric !== void 0) payload.reviewRubric = overrides.reviewRubric;
   if (overrides.git?.noPr) payload.git = overrides.git;
   if (overrides.paused) payload.paused = true;
   if (overrides.dryRun) payload.dryRun = true;
@@ -7912,7 +7938,8 @@ function createAnthropicAgentLoop(opts) {
         max_tokens: maxTokens,
         system: systemBlocks,
         tools: effectiveTools,
-        messages
+        messages,
+        ...opts.thinking !== void 0 ? { thinking: opts.thinking } : {}
       };
       const response = hasHttp ? await anthropic.beta.messages.create({
         ...baseParams,
@@ -8818,6 +8845,33 @@ function createGoogleAgentLoop(opts) {
   };
 }
 
+// src/lib/llm/thinking.ts
+var THINKING_BUDGET_ON = 2e3;
+var THINKING_BUDGET_EXTENDED = 8e3;
+function thinkingParamFromOverride(thinking) {
+  switch (thinking) {
+    case "extended":
+      return { type: "enabled", budget_tokens: THINKING_BUDGET_EXTENDED };
+    case "on":
+      return { type: "enabled", budget_tokens: THINKING_BUDGET_ON };
+    case "off":
+      return { type: "disabled" };
+    default:
+      return void 0;
+  }
+}
+function resolveThinkingForProvider(thinking, provider, logger) {
+  if (thinking === void 0) return void 0;
+  if (provider !== "anthropic") {
+    logger?.warn("ferry:thinking label set but provider is not anthropic \u2014 ignoring", {
+      provider,
+      thinking
+    });
+    return void 0;
+  }
+  return thinkingParamFromOverride(thinking);
+}
+
 // src/lib/llm/agent-loop/index.ts
 function requireEnv3(key) {
   const val = process.env[key];
@@ -8829,6 +8883,7 @@ function requireEnv3(key) {
 function createAgentLoop(opts) {
   if (opts.provider === "anthropic") {
     const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
+    const thinking = resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
     return createAnthropicAgentLoop({
       ...auth2,
       model: opts.model,
@@ -8840,9 +8895,11 @@ function createAgentLoop(opts) {
       maxTokens: opts.maxTokens,
       maxCostEur: opts.maxCostEur,
       compactWindow: opts.compactWindow,
+      thinking,
       logger: opts.logger
     });
   }
+  resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
   if (opts.provider === "openai") {
     const apiKey = requireEnv3("FERRY_OPENAI_KEY");
     return createOpenAIAgentLoop({
@@ -9106,6 +9163,7 @@ async function main2(envelope, logger) {
   let typeOverride;
   let forceLabel;
   let noAutoTransition = false;
+  let thinkingOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -9113,6 +9171,7 @@ async function main2(envelope, logger) {
     typeOverride = overrides.typeOverride;
     forceLabel = overrides.forceLabel;
     noAutoTransition = overrides.noAutoTransition === true;
+    thinkingOverride = overrides.thinking;
     if (overrides.dryRun === true && !dryRun) {
       dryRun = true;
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
@@ -9263,6 +9322,7 @@ ${tree}`,
     maxInputTokens: effectiveCfg.limits.max_tokens_per_run,
     maxTokens: effectiveCfg.limits.max_tokens_per_message,
     maxCostEur: effectiveCfg.limits.max_cost_eur_per_run,
+    thinking: thinkingOverride,
     executeTool,
     commitProgress: makeCommitProgress(logger, { dryRun }),
     spawnSubagent: (task) => loop.run({
@@ -9520,7 +9580,8 @@ function createAnthropicToolCallLoop(opts) {
           max_tokens: maxTokens,
           system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
           tools: anthropicTools,
-          messages
+          messages,
+          ...opts.thinking !== void 0 ? { thinking: opts.thinking } : {}
         });
         inputTokens += response.usage.input_tokens;
         outputTokens += response.usage.output_tokens;
@@ -9926,8 +9987,10 @@ function createToolCallLoop(opts) {
   if (opts.provider === "anthropic") {
     const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
     const client = new Anthropic4(auth2);
-    return createAnthropicToolCallLoop({ client, model: opts.model });
+    const thinking = resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
+    return createAnthropicToolCallLoop({ client, model: opts.model, thinking });
   }
+  resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
   if (opts.provider === "openai") {
     const apiKey = requireEnv4("FERRY_OPENAI_KEY");
     return createOpenAIToolCallLoop({ apiKey, model: opts.model });
@@ -10089,6 +10152,38 @@ async function runReviewLoop(opts) {
   };
 }
 
+// src/agents/reviewer/rubric.ts
+var STRICT_DIRECTIVE = [
+  "## Rubric override \u2014 strict",
+  "",
+  "For this review, apply a STRICTER bar than usual:",
+  "",
+  "- Block on any missing test coverage for new/changed behaviour.",
+  "- Block on missing edge-case handling, error paths, or input validation.",
+  "- Block on weak naming, dead code, or unreachable branches.",
+  "- Block on incomplete documentation when public APIs change.",
+  "- Approve only when every acceptance criterion is fully satisfied with concrete evidence."
+].join("\n");
+var LENIENT_DIRECTIVE = [
+  "## Rubric override \u2014 lenient",
+  "",
+  "For this review, apply a MORE PERMISSIVE bar than usual:",
+  "",
+  "- Approve when the acceptance criteria are met, even if minor polish is missing.",
+  "- Treat naming nits, non-blocking style issues, and stylistic preferences as comments \u2014 not blockers.",
+  "- Block only on: failing tests, unimplemented ACs, merge conflicts, committed build artefacts, or security regressions.",
+  '- Prefer "approve with comments" over "request changes" when issues are non-blocking.'
+].join("\n");
+function applyRubricToPrompt(basePrompt, rubric) {
+  if (rubric === void 0) return basePrompt;
+  const directive = rubric === "strict" ? STRICT_DIRECTIVE : LENIENT_DIRECTIVE;
+  return `${basePrompt}
+
+---
+
+${directive}`;
+}
+
 // src/agents/reviewer/changes-guard.ts
 function countPriorIterations(existingComments) {
   return existingComments.filter(
@@ -10113,6 +10208,8 @@ async function main3(envelope, logger) {
   let autoApprove = false;
   let noAutoTransition = false;
   let dryRun = false;
+  let thinkingOverride;
+  let reviewRubricOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10121,6 +10218,8 @@ async function main3(envelope, logger) {
     autoApprove = overrides.skipPhases?.includes("review") === true;
     noAutoTransition = overrides.noAutoTransition === true;
     dryRun = overrides.dryRun === true;
+    thinkingOverride = overrides.thinking;
+    reviewRubricOverride = overrides.reviewRubric;
     if (dryRun) {
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
     }
@@ -10267,11 +10366,12 @@ async function main3(envelope, logger) {
     "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
     "When you have enough information, call finish_review."
   ].filter((l) => l !== null).join("\n");
-  const system = buildSystem("review", REPO_ROOT3, {
+  const baseSystem = buildSystem("review", REPO_ROOT3, {
     extraParts: [loadOptionalPrompt("review-comment", REPO_ROOT3)],
     separator: "\n\n---\n\n"
   });
-  const loop = createToolCallLoop({ provider, model });
+  const system = applyRubricToPrompt(baseSystem, reviewRubricOverride);
+  const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
   const {
     result: review,
     inputTokens,
@@ -10431,6 +10531,7 @@ async function main4(envelope, logger) {
   let labelMaxIterations;
   let noAutoTransition = false;
   let dryRun = false;
+  let thinkingOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10439,6 +10540,7 @@ async function main4(envelope, logger) {
     labelMaxIterations = overrides.maxIterations;
     noAutoTransition = overrides.noAutoTransition === true;
     dryRun = overrides.dryRun === true;
+    thinkingOverride = overrides.thinking;
     if (dryRun) {
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
     }
@@ -10593,6 +10695,7 @@ ${existingLog}` : "",
     maxInputTokens: effectiveCfg.limits.max_tokens_per_run,
     maxTokens: effectiveCfg.limits.max_tokens_per_message,
     maxCostEur: effectiveCfg.limits.max_cost_eur_per_run,
+    thinking: thinkingOverride,
     executeTool,
     commitProgress: makeCommitProgress(logger),
     logger

--- a/.github/actions/ferry-run-refiner/agent.js
+++ b/.github/actions/ferry-run-refiner/agent.js
@@ -1403,6 +1403,9 @@ function logTicketOverrides(logger, overrides) {
   if (overrides.thinking !== void 0) {
     logger.info("thinking override", { thinking: overrides.thinking });
   }
+  if (overrides.reviewRubric !== void 0) {
+    logger.info("review rubric override", { reviewRubric: overrides.reviewRubric });
+  }
   if (overrides.git?.noPr) {
     logger.info("git override: no-pr (PR creation skipped)");
   }
@@ -5926,6 +5929,8 @@ function resolveTicketOverrides(labels, logger, options) {
   let maxTokens;
   let thinkingLabel;
   let thinking;
+  let reviewRubricLabel;
+  let reviewRubric;
   let noPr = false;
   let paused = false;
   let noAutoTransition = false;
@@ -6107,14 +6112,33 @@ function resolveTicketOverrides(labels, logger, options) {
       noAutoTransition = true;
       continue;
     }
-    if (label === "ferry:thinking/on" || label === "ferry:thinking/off") {
-      const val = label === "ferry:thinking/on" ? "on" : "off";
+    if (label.startsWith("ferry:thinking/")) {
+      const suffix = label.slice("ferry:thinking/".length);
+      let val;
+      if (suffix === "on") val = "on";
+      else if (suffix === "off") val = "off";
+      else if (suffix === "extended") val = "extended";
+      if (val === void 0) {
+        logger?.warn("unknown suffix in ferry:thinking label", { label, suffix });
+        continue;
+      }
       if (thinking !== void 0 && thinking !== val) {
         throw new LabelConflictError(thinkingLabel, label, "thinking");
       }
       if (thinking === void 0) {
         thinking = val;
         thinkingLabel = label;
+      }
+      continue;
+    }
+    if (label === "ferry:strict-review" || label === "ferry:lenient-review") {
+      const val = label === "ferry:strict-review" ? "strict" : "lenient";
+      if (reviewRubric !== void 0 && reviewRubric !== val) {
+        throw new LabelConflictError(reviewRubricLabel, label, "reviewRubric");
+      }
+      if (reviewRubric === void 0) {
+        reviewRubric = val;
+        reviewRubricLabel = label;
       }
       continue;
     }
@@ -6167,6 +6191,7 @@ function resolveTicketOverrides(labels, logger, options) {
     ...skipPhases.length > 0 ? { skipPhases } : {},
     ...noAutoTransition ? { noAutoTransition: true } : {},
     ...thinking !== void 0 ? { thinking } : {},
+    ...reviewRubric !== void 0 ? { reviewRubric } : {},
     ...noPr ? { git: { noPr: true } } : {},
     ...paused ? { paused: true } : {},
     ...dryRun ? { dryRun: true } : {},
@@ -6225,7 +6250,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6239,6 +6264,7 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if ((overrides.skipPhases?.length ?? 0) > 0) payload.skipPhases = overrides.skipPhases;
   if (overrides.noAutoTransition) payload.noAutoTransition = true;
   if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
+  if (overrides.reviewRubric !== void 0) payload.reviewRubric = overrides.reviewRubric;
   if (overrides.git?.noPr) payload.git = overrides.git;
   if (overrides.paused) payload.paused = true;
   if (overrides.dryRun) payload.dryRun = true;
@@ -7912,7 +7938,8 @@ function createAnthropicAgentLoop(opts) {
         max_tokens: maxTokens,
         system: systemBlocks,
         tools: effectiveTools,
-        messages
+        messages,
+        ...opts.thinking !== void 0 ? { thinking: opts.thinking } : {}
       };
       const response = hasHttp ? await anthropic.beta.messages.create({
         ...baseParams,
@@ -8818,6 +8845,33 @@ function createGoogleAgentLoop(opts) {
   };
 }
 
+// src/lib/llm/thinking.ts
+var THINKING_BUDGET_ON = 2e3;
+var THINKING_BUDGET_EXTENDED = 8e3;
+function thinkingParamFromOverride(thinking) {
+  switch (thinking) {
+    case "extended":
+      return { type: "enabled", budget_tokens: THINKING_BUDGET_EXTENDED };
+    case "on":
+      return { type: "enabled", budget_tokens: THINKING_BUDGET_ON };
+    case "off":
+      return { type: "disabled" };
+    default:
+      return void 0;
+  }
+}
+function resolveThinkingForProvider(thinking, provider, logger) {
+  if (thinking === void 0) return void 0;
+  if (provider !== "anthropic") {
+    logger?.warn("ferry:thinking label set but provider is not anthropic \u2014 ignoring", {
+      provider,
+      thinking
+    });
+    return void 0;
+  }
+  return thinkingParamFromOverride(thinking);
+}
+
 // src/lib/llm/agent-loop/index.ts
 function requireEnv3(key) {
   const val = process.env[key];
@@ -8829,6 +8883,7 @@ function requireEnv3(key) {
 function createAgentLoop(opts) {
   if (opts.provider === "anthropic") {
     const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
+    const thinking = resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
     return createAnthropicAgentLoop({
       ...auth2,
       model: opts.model,
@@ -8840,9 +8895,11 @@ function createAgentLoop(opts) {
       maxTokens: opts.maxTokens,
       maxCostEur: opts.maxCostEur,
       compactWindow: opts.compactWindow,
+      thinking,
       logger: opts.logger
     });
   }
+  resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
   if (opts.provider === "openai") {
     const apiKey = requireEnv3("FERRY_OPENAI_KEY");
     return createOpenAIAgentLoop({
@@ -9106,6 +9163,7 @@ async function main2(envelope, logger) {
   let typeOverride;
   let forceLabel;
   let noAutoTransition = false;
+  let thinkingOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -9113,6 +9171,7 @@ async function main2(envelope, logger) {
     typeOverride = overrides.typeOverride;
     forceLabel = overrides.forceLabel;
     noAutoTransition = overrides.noAutoTransition === true;
+    thinkingOverride = overrides.thinking;
     if (overrides.dryRun === true && !dryRun) {
       dryRun = true;
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
@@ -9263,6 +9322,7 @@ ${tree}`,
     maxInputTokens: effectiveCfg.limits.max_tokens_per_run,
     maxTokens: effectiveCfg.limits.max_tokens_per_message,
     maxCostEur: effectiveCfg.limits.max_cost_eur_per_run,
+    thinking: thinkingOverride,
     executeTool,
     commitProgress: makeCommitProgress(logger, { dryRun }),
     spawnSubagent: (task) => loop.run({
@@ -9520,7 +9580,8 @@ function createAnthropicToolCallLoop(opts) {
           max_tokens: maxTokens,
           system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
           tools: anthropicTools,
-          messages
+          messages,
+          ...opts.thinking !== void 0 ? { thinking: opts.thinking } : {}
         });
         inputTokens += response.usage.input_tokens;
         outputTokens += response.usage.output_tokens;
@@ -9926,8 +9987,10 @@ function createToolCallLoop(opts) {
   if (opts.provider === "anthropic") {
     const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
     const client = new Anthropic4(auth2);
-    return createAnthropicToolCallLoop({ client, model: opts.model });
+    const thinking = resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
+    return createAnthropicToolCallLoop({ client, model: opts.model, thinking });
   }
+  resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
   if (opts.provider === "openai") {
     const apiKey = requireEnv4("FERRY_OPENAI_KEY");
     return createOpenAIToolCallLoop({ apiKey, model: opts.model });
@@ -10089,6 +10152,38 @@ async function runReviewLoop(opts) {
   };
 }
 
+// src/agents/reviewer/rubric.ts
+var STRICT_DIRECTIVE = [
+  "## Rubric override \u2014 strict",
+  "",
+  "For this review, apply a STRICTER bar than usual:",
+  "",
+  "- Block on any missing test coverage for new/changed behaviour.",
+  "- Block on missing edge-case handling, error paths, or input validation.",
+  "- Block on weak naming, dead code, or unreachable branches.",
+  "- Block on incomplete documentation when public APIs change.",
+  "- Approve only when every acceptance criterion is fully satisfied with concrete evidence."
+].join("\n");
+var LENIENT_DIRECTIVE = [
+  "## Rubric override \u2014 lenient",
+  "",
+  "For this review, apply a MORE PERMISSIVE bar than usual:",
+  "",
+  "- Approve when the acceptance criteria are met, even if minor polish is missing.",
+  "- Treat naming nits, non-blocking style issues, and stylistic preferences as comments \u2014 not blockers.",
+  "- Block only on: failing tests, unimplemented ACs, merge conflicts, committed build artefacts, or security regressions.",
+  '- Prefer "approve with comments" over "request changes" when issues are non-blocking.'
+].join("\n");
+function applyRubricToPrompt(basePrompt, rubric) {
+  if (rubric === void 0) return basePrompt;
+  const directive = rubric === "strict" ? STRICT_DIRECTIVE : LENIENT_DIRECTIVE;
+  return `${basePrompt}
+
+---
+
+${directive}`;
+}
+
 // src/agents/reviewer/changes-guard.ts
 function countPriorIterations(existingComments) {
   return existingComments.filter(
@@ -10113,6 +10208,8 @@ async function main3(envelope, logger) {
   let autoApprove = false;
   let noAutoTransition = false;
   let dryRun = false;
+  let thinkingOverride;
+  let reviewRubricOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10121,6 +10218,8 @@ async function main3(envelope, logger) {
     autoApprove = overrides.skipPhases?.includes("review") === true;
     noAutoTransition = overrides.noAutoTransition === true;
     dryRun = overrides.dryRun === true;
+    thinkingOverride = overrides.thinking;
+    reviewRubricOverride = overrides.reviewRubric;
     if (dryRun) {
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
     }
@@ -10267,11 +10366,12 @@ async function main3(envelope, logger) {
     "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
     "When you have enough information, call finish_review."
   ].filter((l) => l !== null).join("\n");
-  const system = buildSystem("review", REPO_ROOT3, {
+  const baseSystem = buildSystem("review", REPO_ROOT3, {
     extraParts: [loadOptionalPrompt("review-comment", REPO_ROOT3)],
     separator: "\n\n---\n\n"
   });
-  const loop = createToolCallLoop({ provider, model });
+  const system = applyRubricToPrompt(baseSystem, reviewRubricOverride);
+  const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
   const {
     result: review,
     inputTokens,
@@ -10431,6 +10531,7 @@ async function main4(envelope, logger) {
   let labelMaxIterations;
   let noAutoTransition = false;
   let dryRun = false;
+  let thinkingOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10439,6 +10540,7 @@ async function main4(envelope, logger) {
     labelMaxIterations = overrides.maxIterations;
     noAutoTransition = overrides.noAutoTransition === true;
     dryRun = overrides.dryRun === true;
+    thinkingOverride = overrides.thinking;
     if (dryRun) {
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
     }
@@ -10593,6 +10695,7 @@ ${existingLog}` : "",
     maxInputTokens: effectiveCfg.limits.max_tokens_per_run,
     maxTokens: effectiveCfg.limits.max_tokens_per_message,
     maxCostEur: effectiveCfg.limits.max_cost_eur_per_run,
+    thinking: thinkingOverride,
     executeTool,
     commitProgress: makeCommitProgress(logger),
     logger

--- a/.github/actions/ferry-run-reviewer/agent.js
+++ b/.github/actions/ferry-run-reviewer/agent.js
@@ -1403,6 +1403,9 @@ function logTicketOverrides(logger, overrides) {
   if (overrides.thinking !== void 0) {
     logger.info("thinking override", { thinking: overrides.thinking });
   }
+  if (overrides.reviewRubric !== void 0) {
+    logger.info("review rubric override", { reviewRubric: overrides.reviewRubric });
+  }
   if (overrides.git?.noPr) {
     logger.info("git override: no-pr (PR creation skipped)");
   }
@@ -5926,6 +5929,8 @@ function resolveTicketOverrides(labels, logger, options) {
   let maxTokens;
   let thinkingLabel;
   let thinking;
+  let reviewRubricLabel;
+  let reviewRubric;
   let noPr = false;
   let paused = false;
   let noAutoTransition = false;
@@ -6107,14 +6112,33 @@ function resolveTicketOverrides(labels, logger, options) {
       noAutoTransition = true;
       continue;
     }
-    if (label === "ferry:thinking/on" || label === "ferry:thinking/off") {
-      const val = label === "ferry:thinking/on" ? "on" : "off";
+    if (label.startsWith("ferry:thinking/")) {
+      const suffix = label.slice("ferry:thinking/".length);
+      let val;
+      if (suffix === "on") val = "on";
+      else if (suffix === "off") val = "off";
+      else if (suffix === "extended") val = "extended";
+      if (val === void 0) {
+        logger?.warn("unknown suffix in ferry:thinking label", { label, suffix });
+        continue;
+      }
       if (thinking !== void 0 && thinking !== val) {
         throw new LabelConflictError(thinkingLabel, label, "thinking");
       }
       if (thinking === void 0) {
         thinking = val;
         thinkingLabel = label;
+      }
+      continue;
+    }
+    if (label === "ferry:strict-review" || label === "ferry:lenient-review") {
+      const val = label === "ferry:strict-review" ? "strict" : "lenient";
+      if (reviewRubric !== void 0 && reviewRubric !== val) {
+        throw new LabelConflictError(reviewRubricLabel, label, "reviewRubric");
+      }
+      if (reviewRubric === void 0) {
+        reviewRubric = val;
+        reviewRubricLabel = label;
       }
       continue;
     }
@@ -6167,6 +6191,7 @@ function resolveTicketOverrides(labels, logger, options) {
     ...skipPhases.length > 0 ? { skipPhases } : {},
     ...noAutoTransition ? { noAutoTransition: true } : {},
     ...thinking !== void 0 ? { thinking } : {},
+    ...reviewRubric !== void 0 ? { reviewRubric } : {},
     ...noPr ? { git: { noPr: true } } : {},
     ...paused ? { paused: true } : {},
     ...dryRun ? { dryRun: true } : {},
@@ -6225,7 +6250,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6239,6 +6264,7 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if ((overrides.skipPhases?.length ?? 0) > 0) payload.skipPhases = overrides.skipPhases;
   if (overrides.noAutoTransition) payload.noAutoTransition = true;
   if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
+  if (overrides.reviewRubric !== void 0) payload.reviewRubric = overrides.reviewRubric;
   if (overrides.git?.noPr) payload.git = overrides.git;
   if (overrides.paused) payload.paused = true;
   if (overrides.dryRun) payload.dryRun = true;
@@ -7912,7 +7938,8 @@ function createAnthropicAgentLoop(opts) {
         max_tokens: maxTokens,
         system: systemBlocks,
         tools: effectiveTools,
-        messages
+        messages,
+        ...opts.thinking !== void 0 ? { thinking: opts.thinking } : {}
       };
       const response = hasHttp ? await anthropic.beta.messages.create({
         ...baseParams,
@@ -8818,6 +8845,33 @@ function createGoogleAgentLoop(opts) {
   };
 }
 
+// src/lib/llm/thinking.ts
+var THINKING_BUDGET_ON = 2e3;
+var THINKING_BUDGET_EXTENDED = 8e3;
+function thinkingParamFromOverride(thinking) {
+  switch (thinking) {
+    case "extended":
+      return { type: "enabled", budget_tokens: THINKING_BUDGET_EXTENDED };
+    case "on":
+      return { type: "enabled", budget_tokens: THINKING_BUDGET_ON };
+    case "off":
+      return { type: "disabled" };
+    default:
+      return void 0;
+  }
+}
+function resolveThinkingForProvider(thinking, provider, logger) {
+  if (thinking === void 0) return void 0;
+  if (provider !== "anthropic") {
+    logger?.warn("ferry:thinking label set but provider is not anthropic \u2014 ignoring", {
+      provider,
+      thinking
+    });
+    return void 0;
+  }
+  return thinkingParamFromOverride(thinking);
+}
+
 // src/lib/llm/agent-loop/index.ts
 function requireEnv3(key) {
   const val = process.env[key];
@@ -8829,6 +8883,7 @@ function requireEnv3(key) {
 function createAgentLoop(opts) {
   if (opts.provider === "anthropic") {
     const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
+    const thinking = resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
     return createAnthropicAgentLoop({
       ...auth2,
       model: opts.model,
@@ -8840,9 +8895,11 @@ function createAgentLoop(opts) {
       maxTokens: opts.maxTokens,
       maxCostEur: opts.maxCostEur,
       compactWindow: opts.compactWindow,
+      thinking,
       logger: opts.logger
     });
   }
+  resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
   if (opts.provider === "openai") {
     const apiKey = requireEnv3("FERRY_OPENAI_KEY");
     return createOpenAIAgentLoop({
@@ -9106,6 +9163,7 @@ async function main2(envelope, logger) {
   let typeOverride;
   let forceLabel;
   let noAutoTransition = false;
+  let thinkingOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -9113,6 +9171,7 @@ async function main2(envelope, logger) {
     typeOverride = overrides.typeOverride;
     forceLabel = overrides.forceLabel;
     noAutoTransition = overrides.noAutoTransition === true;
+    thinkingOverride = overrides.thinking;
     if (overrides.dryRun === true && !dryRun) {
       dryRun = true;
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
@@ -9263,6 +9322,7 @@ ${tree}`,
     maxInputTokens: effectiveCfg.limits.max_tokens_per_run,
     maxTokens: effectiveCfg.limits.max_tokens_per_message,
     maxCostEur: effectiveCfg.limits.max_cost_eur_per_run,
+    thinking: thinkingOverride,
     executeTool,
     commitProgress: makeCommitProgress(logger, { dryRun }),
     spawnSubagent: (task) => loop.run({
@@ -9520,7 +9580,8 @@ function createAnthropicToolCallLoop(opts) {
           max_tokens: maxTokens,
           system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
           tools: anthropicTools,
-          messages
+          messages,
+          ...opts.thinking !== void 0 ? { thinking: opts.thinking } : {}
         });
         inputTokens += response.usage.input_tokens;
         outputTokens += response.usage.output_tokens;
@@ -9926,8 +9987,10 @@ function createToolCallLoop(opts) {
   if (opts.provider === "anthropic") {
     const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
     const client = new Anthropic4(auth2);
-    return createAnthropicToolCallLoop({ client, model: opts.model });
+    const thinking = resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
+    return createAnthropicToolCallLoop({ client, model: opts.model, thinking });
   }
+  resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
   if (opts.provider === "openai") {
     const apiKey = requireEnv4("FERRY_OPENAI_KEY");
     return createOpenAIToolCallLoop({ apiKey, model: opts.model });
@@ -10089,6 +10152,38 @@ async function runReviewLoop(opts) {
   };
 }
 
+// src/agents/reviewer/rubric.ts
+var STRICT_DIRECTIVE = [
+  "## Rubric override \u2014 strict",
+  "",
+  "For this review, apply a STRICTER bar than usual:",
+  "",
+  "- Block on any missing test coverage for new/changed behaviour.",
+  "- Block on missing edge-case handling, error paths, or input validation.",
+  "- Block on weak naming, dead code, or unreachable branches.",
+  "- Block on incomplete documentation when public APIs change.",
+  "- Approve only when every acceptance criterion is fully satisfied with concrete evidence."
+].join("\n");
+var LENIENT_DIRECTIVE = [
+  "## Rubric override \u2014 lenient",
+  "",
+  "For this review, apply a MORE PERMISSIVE bar than usual:",
+  "",
+  "- Approve when the acceptance criteria are met, even if minor polish is missing.",
+  "- Treat naming nits, non-blocking style issues, and stylistic preferences as comments \u2014 not blockers.",
+  "- Block only on: failing tests, unimplemented ACs, merge conflicts, committed build artefacts, or security regressions.",
+  '- Prefer "approve with comments" over "request changes" when issues are non-blocking.'
+].join("\n");
+function applyRubricToPrompt(basePrompt, rubric) {
+  if (rubric === void 0) return basePrompt;
+  const directive = rubric === "strict" ? STRICT_DIRECTIVE : LENIENT_DIRECTIVE;
+  return `${basePrompt}
+
+---
+
+${directive}`;
+}
+
 // src/agents/reviewer/changes-guard.ts
 function countPriorIterations(existingComments) {
   return existingComments.filter(
@@ -10113,6 +10208,8 @@ async function main3(envelope, logger) {
   let autoApprove = false;
   let noAutoTransition = false;
   let dryRun = false;
+  let thinkingOverride;
+  let reviewRubricOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10121,6 +10218,8 @@ async function main3(envelope, logger) {
     autoApprove = overrides.skipPhases?.includes("review") === true;
     noAutoTransition = overrides.noAutoTransition === true;
     dryRun = overrides.dryRun === true;
+    thinkingOverride = overrides.thinking;
+    reviewRubricOverride = overrides.reviewRubric;
     if (dryRun) {
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
     }
@@ -10267,11 +10366,12 @@ async function main3(envelope, logger) {
     "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
     "When you have enough information, call finish_review."
   ].filter((l) => l !== null).join("\n");
-  const system = buildSystem("review", REPO_ROOT3, {
+  const baseSystem = buildSystem("review", REPO_ROOT3, {
     extraParts: [loadOptionalPrompt("review-comment", REPO_ROOT3)],
     separator: "\n\n---\n\n"
   });
-  const loop = createToolCallLoop({ provider, model });
+  const system = applyRubricToPrompt(baseSystem, reviewRubricOverride);
+  const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
   const {
     result: review,
     inputTokens,
@@ -10431,6 +10531,7 @@ async function main4(envelope, logger) {
   let labelMaxIterations;
   let noAutoTransition = false;
   let dryRun = false;
+  let thinkingOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10439,6 +10540,7 @@ async function main4(envelope, logger) {
     labelMaxIterations = overrides.maxIterations;
     noAutoTransition = overrides.noAutoTransition === true;
     dryRun = overrides.dryRun === true;
+    thinkingOverride = overrides.thinking;
     if (dryRun) {
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
     }
@@ -10593,6 +10695,7 @@ ${existingLog}` : "",
     maxInputTokens: effectiveCfg.limits.max_tokens_per_run,
     maxTokens: effectiveCfg.limits.max_tokens_per_message,
     maxCostEur: effectiveCfg.limits.max_cost_eur_per_run,
+    thinking: thinkingOverride,
     executeTool,
     commitProgress: makeCommitProgress(logger),
     logger

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -521,10 +521,10 @@ Disable Ferry's automatic Jira column moves (FR18, FR24, FR28) for this ticket o
 
 Let a Jira ticket run Ferry without producing side effects — to validate prompts, MCP wiring, or rough token spend before committing real work.
 
-| Label             | Effect                                                                                                                                                                                                                                       |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Label             | Effect                                                                                                                                                                                                                                        |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ferry:dry-run`   | Run every phase but suppress all external writes: no branch push, no PR creation, no Jira label / transition / sub-task writes. The audit comment still posts, prefixed with `[dry-run]` so consumers can spot it in the Jira comment stream. |
-| `ferry:read-only` | Refiner runs normally; Developer / Reviewer / Iterator short-circuit at entry with a single `[ferry:<role>:<run-id>] read-only: agent skipped` audit comment and exit cleanly. Useful for "what would Ferry plan for this ticket?".            |
+| `ferry:read-only` | Refiner runs normally; Developer / Reviewer / Iterator short-circuit at entry with a single `[ferry:<role>:<run-id>] read-only: agent skipped` audit comment and exit cleanly. Useful for "what would Ferry plan for this ticket?".           |
 
 **LLM cost warning:** `ferry:dry-run` only suppresses **external** side effects. LLM calls still happen and **token cost is still incurred**. Each agent logs a `DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.` warning at start. Use `ferry:read-only` to also skip Developer / Reviewer / Iterator LLM calls — only the Refiner pays tokens.
 
@@ -536,12 +536,30 @@ Let a Jira ticket run Ferry without producing side effects — to validate promp
 
 ##### Extended thinking (`ferry:thinking/*`)
 
-| Label                | Effect                                                         |
-| -------------------- | -------------------------------------------------------------- |
-| `ferry:thinking/on`  | Enable extended-thinking mode for this ticket (Anthropic only) |
-| `ferry:thinking/off` | Disable extended-thinking mode                                 |
+| Label                     | Effect                                                                                 |
+| ------------------------- | -------------------------------------------------------------------------------------- |
+| `ferry:thinking/on`       | Enable extended-thinking mode for this ticket with the default budget (Anthropic only) |
+| `ferry:thinking/extended` | Enable extended-thinking mode with a larger budget for complex tasks (Anthropic only)  |
+| `ferry:thinking/off`      | Force-disable extended-thinking mode even if repo defaults enable it                   |
 
-**Conflict rule:** `ferry:thinking/on` and `ferry:thinking/off` on the same ticket is a conflict.
+**Anthropic-only:** these labels are only honoured when the resolved provider for the agent is `anthropic`. With `openai` or `google` the flag is ignored at invoke time and the agent logs a `ferry:thinking/* label set but provider is not anthropic — ignoring` warning to stderr. The override stays visible in the audit comment so the user's intent is recorded.
+
+**Budgets:** `on` uses a conservative `budget_tokens` for routine reasoning; `extended` uses a larger budget appropriate for complex refactors or analyses. Both budgets are below the call's `max_tokens` so the SDK accepts them. See [Anthropic extended thinking](https://docs.claude.com/en/docs/build-with-claude/extended-thinking).
+
+**Conflict rule:** any two of `ferry:thinking/on`, `ferry:thinking/extended`, `ferry:thinking/off` on the same ticket is a conflict — the Refiner / Developer / Reviewer / Iterator throws `LabelConflictError`, posts a conflict-audit comment, and exits non-zero.
+
+##### Reviewer rubric (`ferry:strict-review`, `ferry:lenient-review`)
+
+| Label                  | Effect                                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `ferry:strict-review`  | Reviewer applies a stricter rubric: blocks on missing tests, edge cases, weak naming, incomplete docs              |
+| `ferry:lenient-review` | Reviewer applies a more permissive rubric: blocks only on failing tests, unimplemented ACs, conflicts, or security |
+
+A rubric-override directive is appended at the end of the reviewer's system prompt (after `prompts/review.md` and any optional `prompts/review-comment.md` overlay) so it takes precedence over earlier instructions about review strictness.
+
+**Conflict rule:** `ferry:strict-review` + `ferry:lenient-review` on the same ticket is a conflict — the Reviewer throws `LabelConflictError`, posts a conflict-audit comment, and exits non-zero.
+
+**Use case:** a complex refactor gets `ferry:thinking/extended` + `ferry:strict-review` — Ferry takes its time and the Reviewer holds the bar high. A trivial copy change gets `ferry:thinking/off` + `ferry:lenient-review` — fast and cheap.
 
 ##### Git overrides (`ferry:git/*`)
 

--- a/src/agents/developer/dev-action.ts
+++ b/src/agents/developer/dev-action.ts
@@ -78,6 +78,7 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
   let typeOverride: string | undefined;
   let forceLabel: string | undefined;
   let noAutoTransition = false;
+  let thinkingOverride: 'on' | 'off' | 'extended' | undefined;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true,
@@ -85,6 +86,7 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     typeOverride = overrides.typeOverride;
     forceLabel = overrides.forceLabel;
     noAutoTransition = overrides.noAutoTransition === true;
+    thinkingOverride = overrides.thinking;
     // ferry:dry-run label → enable dry-run mode (same gating as FERRY_DRY_RUN env var).
     if (overrides.dryRun === true && !dryRun) {
       dryRun = true;
@@ -252,6 +254,7 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     maxInputTokens: effectiveCfg.limits.max_tokens_per_run,
     maxTokens: effectiveCfg.limits.max_tokens_per_message,
     maxCostEur: effectiveCfg.limits.max_cost_eur_per_run,
+    thinking: thinkingOverride,
     executeTool,
     commitProgress: makeCommitProgress(logger, { dryRun }),
     spawnSubagent: (task) =>

--- a/src/agents/iterator/iterate-action.ts
+++ b/src/agents/iterator/iterate-action.ts
@@ -70,6 +70,7 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
   let labelMaxIterations: number | undefined;
   let noAutoTransition = false;
   let dryRun = false;
+  let thinkingOverride: 'on' | 'off' | 'extended' | undefined;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true,
@@ -78,6 +79,7 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     labelMaxIterations = overrides.maxIterations;
     noAutoTransition = overrides.noAutoTransition === true;
     dryRun = overrides.dryRun === true;
+    thinkingOverride = overrides.thinking;
     if (dryRun) {
       logger.warn('DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.');
     }
@@ -264,6 +266,7 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     maxInputTokens: effectiveCfg.limits.max_tokens_per_run,
     maxTokens: effectiveCfg.limits.max_tokens_per_message,
     maxCostEur: effectiveCfg.limits.max_cost_eur_per_run,
+    thinking: thinkingOverride,
     executeTool,
     commitProgress: makeCommitProgress(logger),
     logger,

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -3,6 +3,7 @@ import { delimitUntrusted } from '../../lib/llm/delimit-untrusted.js';
 import { checkIdempotencyMarker } from '../../lib/io/idempotency.js';
 import { gateCi } from './ci-gate.js';
 import { detectMergeConflicts, buildFileList, runReviewLoop } from './review-loop.js';
+import { applyRubricToPrompt } from './rubric.js';
 import {
   resolveCapabilities,
   resolveTicketOverrides,
@@ -55,6 +56,8 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
   let autoApprove = false;
   let noAutoTransition = false;
   let dryRun = false;
+  let thinkingOverride: 'on' | 'off' | 'extended' | undefined;
+  let reviewRubricOverride: 'strict' | 'lenient' | undefined;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true,
@@ -63,6 +66,8 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     autoApprove = overrides.skipPhases?.includes('review') === true;
     noAutoTransition = overrides.noAutoTransition === true;
     dryRun = overrides.dryRun === true;
+    thinkingOverride = overrides.thinking;
+    reviewRubricOverride = overrides.reviewRubric;
     if (dryRun) {
       logger.warn('DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.');
     }
@@ -249,11 +254,12 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     .filter((l) => l !== null)
     .join('\n');
 
-  const system = buildSystem('review', REPO_ROOT, {
+  const baseSystem = buildSystem('review', REPO_ROOT, {
     extraParts: [loadOptionalPrompt('review-comment', REPO_ROOT)],
     separator: '\n\n---\n\n',
   });
-  const loop = createToolCallLoop({ provider, model });
+  const system = applyRubricToPrompt(baseSystem, reviewRubricOverride);
+  const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
 
   const {
     result: review,

--- a/src/agents/reviewer/rubric.test.ts
+++ b/src/agents/reviewer/rubric.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { applyRubricToPrompt } from './rubric.js';
+
+const BASE = 'You are a reviewer. Review the PR.';
+
+describe('applyRubricToPrompt', () => {
+  it('returns the base prompt unchanged when rubric is undefined', () => {
+    expect(applyRubricToPrompt(BASE, undefined)).toBe(BASE);
+  });
+
+  it('appends the strict directive when rubric is "strict"', () => {
+    const out = applyRubricToPrompt(BASE, 'strict');
+    expect(out).toContain(BASE);
+    expect(out).toMatch(/Rubric override — strict/);
+    expect(out).toMatch(/STRICTER bar/);
+  });
+
+  it('appends the lenient directive when rubric is "lenient"', () => {
+    const out = applyRubricToPrompt(BASE, 'lenient');
+    expect(out).toContain(BASE);
+    expect(out).toMatch(/Rubric override — lenient/);
+    expect(out).toMatch(/MORE PERMISSIVE bar/);
+  });
+
+  it('strict and lenient produce different prompts', () => {
+    expect(applyRubricToPrompt(BASE, 'strict')).not.toBe(applyRubricToPrompt(BASE, 'lenient'));
+  });
+
+  it('the directive is appended at the end (after the base prompt)', () => {
+    const out = applyRubricToPrompt(BASE, 'strict');
+    expect(out.indexOf(BASE)).toBeLessThan(out.indexOf('Rubric override'));
+  });
+
+  it('produces a prompt that contains a horizontal-rule separator', () => {
+    const out = applyRubricToPrompt(BASE, 'strict');
+    expect(out).toContain('\n---\n');
+  });
+});

--- a/src/agents/reviewer/rubric.ts
+++ b/src/agents/reviewer/rubric.ts
@@ -1,0 +1,54 @@
+/**
+ * Reviewer rubric overlay — appended to the base reviewer system prompt when
+ * `ferry:strict-review` or `ferry:lenient-review` is on the ticket.
+ *
+ * Kept short and append-only (not a base-prompt swap) so the rubric overlay
+ * composes with the existing `prompts/review.md` and any optional
+ * `prompts/review-comment.md` overlay. The directive is the LAST section of the
+ * system prompt — it overrides earlier instructions about review strictness.
+ */
+
+import type { TicketOverrides } from '../../lib/agent-runtime/index.js';
+
+const STRICT_DIRECTIVE = [
+  '## Rubric override — strict',
+  '',
+  'For this review, apply a STRICTER bar than usual:',
+  '',
+  '- Block on any missing test coverage for new/changed behaviour.',
+  '- Block on missing edge-case handling, error paths, or input validation.',
+  '- Block on weak naming, dead code, or unreachable branches.',
+  '- Block on incomplete documentation when public APIs change.',
+  '- Approve only when every acceptance criterion is fully satisfied with concrete evidence.',
+].join('\n');
+
+const LENIENT_DIRECTIVE = [
+  '## Rubric override — lenient',
+  '',
+  'For this review, apply a MORE PERMISSIVE bar than usual:',
+  '',
+  '- Approve when the acceptance criteria are met, even if minor polish is missing.',
+  '- Treat naming nits, non-blocking style issues, and stylistic preferences as comments — not blockers.',
+  '- Block only on: failing tests, unimplemented ACs, merge conflicts, committed build artefacts, or security regressions.',
+  '- Prefer "approve with comments" over "request changes" when issues are non-blocking.',
+].join('\n');
+
+/**
+ * Appends a rubric-override directive to the reviewer system prompt.
+ *
+ * - `rubric === 'strict'`  → appends the strict directive.
+ * - `rubric === 'lenient'` → appends the lenient directive.
+ * - `rubric === undefined` → returns `basePrompt` unchanged.
+ *
+ * The directive is appended (not substituted) so it composes with the base
+ * prompt and any optional overlay. It is placed last, so it wins when it
+ * disagrees with earlier sections.
+ */
+export function applyRubricToPrompt(
+  basePrompt: string,
+  rubric: TicketOverrides['reviewRubric'],
+): string {
+  if (rubric === undefined) return basePrompt;
+  const directive = rubric === 'strict' ? STRICT_DIRECTIVE : LENIENT_DIRECTIVE;
+  return `${basePrompt}\n\n---\n\n${directive}`;
+}

--- a/src/labels/allowlist.ts
+++ b/src/labels/allowlist.ts
@@ -46,6 +46,9 @@ export const LABELS_ALLOWLIST = [
   'ferry:thinking/',
   'ferry:thinking/on',
   'ferry:thinking/off',
+  'ferry:thinking/extended',
+  'ferry:strict-review',
+  'ferry:lenient-review',
   'ferry:git/',
   'ferry:git/no-pr',
   // Config-label namespace prefixes (handled by resolveCapabilities, not resolveTicketOverrides)

--- a/src/lib/agent-runtime/labels.ts
+++ b/src/lib/agent-runtime/labels.ts
@@ -65,6 +65,10 @@ export function logTicketOverrides(logger: Logger, overrides: TicketOverrides): 
     logger.info('thinking override', { thinking: overrides.thinking });
   }
 
+  if (overrides.reviewRubric !== undefined) {
+    logger.info('review rubric override', { reviewRubric: overrides.reviewRubric });
+  }
+
   if (overrides.git?.noPr) {
     logger.info('git override: no-pr (PR creation skipped)');
   }

--- a/src/lib/labels/capabilities.ts
+++ b/src/lib/labels/capabilities.ts
@@ -112,9 +112,25 @@ export interface TicketOverrides {
 
   /**
    * Extended-thinking mode override.
-   * ferry:thinking/on enables thinking; ferry:thinking/off disables it.
+   * - `ferry:thinking/on` enables thinking with the default budget.
+   * - `ferry:thinking/extended` enables thinking with a larger budget for complex tasks.
+   * - `ferry:thinking/off` force-disables thinking even if repo defaults enable it.
+   *
+   * Anthropic-only — non-Anthropic providers ignore the flag with a stderr warning
+   * at invocation time (not at resolution time, so the override stays visible in the audit).
    */
-  thinking?: 'on' | 'off';
+  thinking?: 'on' | 'off' | 'extended';
+
+  // --- ferry:strict-review / ferry:lenient-review ---
+
+  /**
+   * Reviewer rubric override for this ticket.
+   * - `ferry:strict-review` → 'strict' — Reviewer applies a stricter rubric (blocks more easily).
+   * - `ferry:lenient-review` → 'lenient' — Reviewer applies a more permissive rubric (passes more easily).
+   *
+   * Consumed when assembling the Reviewer's prompt; ignored by other agents.
+   */
+  reviewRubric?: 'strict' | 'lenient';
 
   // --- ferry:git/* ---
 

--- a/src/lib/labels/overrides.test.ts
+++ b/src/lib/labels/overrides.test.ts
@@ -425,8 +425,28 @@ describe('resolveTicketOverrides — thinking mode (ferry:thinking/*)', () => {
     expect(resolveTicketOverrides(['ferry:thinking/off']).thinking).toBe('off');
   });
 
+  it('sets thinking to "extended" for ferry:thinking/extended', () => {
+    expect(resolveTicketOverrides(['ferry:thinking/extended']).thinking).toBe('extended');
+  });
+
   it('throws LabelConflictError when ferry:thinking/on and ferry:thinking/off both present', () => {
     expect(() => resolveTicketOverrides(['ferry:thinking/on', 'ferry:thinking/off'])).toThrow(
+      LabelConflictError,
+    );
+  });
+
+  it('throws LabelConflictError when ferry:thinking/extended and ferry:thinking/off both present', () => {
+    try {
+      resolveTicketOverrides(['ferry:thinking/extended', 'ferry:thinking/off']);
+      throw new Error('expected LabelConflictError');
+    } catch (e) {
+      expect(e).toBeInstanceOf(LabelConflictError);
+      expect((e as LabelConflictError).field).toBe('thinking');
+    }
+  });
+
+  it('throws LabelConflictError when ferry:thinking/extended and ferry:thinking/on both present', () => {
+    expect(() => resolveTicketOverrides(['ferry:thinking/extended', 'ferry:thinking/on'])).toThrow(
       LabelConflictError,
     );
   });
@@ -434,6 +454,63 @@ describe('resolveTicketOverrides — thinking mode (ferry:thinking/*)', () => {
   it('does not throw when the same thinking label appears twice', () => {
     expect(() => resolveTicketOverrides(['ferry:thinking/on', 'ferry:thinking/on'])).not.toThrow();
     expect(resolveTicketOverrides(['ferry:thinking/on', 'ferry:thinking/on']).thinking).toBe('on');
+  });
+
+  it('does not throw when ferry:thinking/extended appears twice', () => {
+    expect(() =>
+      resolveTicketOverrides(['ferry:thinking/extended', 'ferry:thinking/extended']),
+    ).not.toThrow();
+    expect(
+      resolveTicketOverrides(['ferry:thinking/extended', 'ferry:thinking/extended']).thinking,
+    ).toBe('extended');
+  });
+
+  it('logs a warning and ignores an unknown ferry:thinking/<unknown> suffix', () => {
+    const { logger, records } = createTestLogger('t', 'test');
+    const r = resolveTicketOverrides(['ferry:thinking/foo'], logger);
+    expect(r.thinking).toBeUndefined();
+    expect(records.some((rec) => rec.level === 'warn')).toBe(true);
+  });
+});
+
+// ------------------------------------------------------------------
+// ferry:strict-review / ferry:lenient-review (reviewer rubric)
+// ------------------------------------------------------------------
+
+describe('resolveTicketOverrides — reviewer rubric (ferry:strict-review / ferry:lenient-review)', () => {
+  it('sets reviewRubric to "strict" for ferry:strict-review', () => {
+    expect(resolveTicketOverrides(['ferry:strict-review']).reviewRubric).toBe('strict');
+  });
+
+  it('sets reviewRubric to "lenient" for ferry:lenient-review', () => {
+    expect(resolveTicketOverrides(['ferry:lenient-review']).reviewRubric).toBe('lenient');
+  });
+
+  it('reviewRubric is undefined when no rubric label is present', () => {
+    expect(resolveTicketOverrides([]).reviewRubric).toBeUndefined();
+  });
+
+  it('throws LabelConflictError when both strict and lenient review labels are present', () => {
+    try {
+      resolveTicketOverrides(['ferry:strict-review', 'ferry:lenient-review']);
+      throw new Error('expected LabelConflictError');
+    } catch (e) {
+      expect(e).toBeInstanceOf(LabelConflictError);
+      expect((e as LabelConflictError).field).toBe('reviewRubric');
+    }
+  });
+
+  it('does not throw when the same rubric label appears twice', () => {
+    expect(() =>
+      resolveTicketOverrides(['ferry:strict-review', 'ferry:strict-review']),
+    ).not.toThrow();
+    expect(
+      resolveTicketOverrides(['ferry:strict-review', 'ferry:strict-review']).reviewRubric,
+    ).toBe('strict');
+  });
+
+  it('hasNonDefaultOverrides returns true when reviewRubric is set', () => {
+    expect(hasNonDefaultOverrides(resolveTicketOverrides(['ferry:strict-review']))).toBe(true);
   });
 });
 
@@ -743,6 +820,19 @@ describe('buildOverridesAuditComment', () => {
     const overrides = resolveTicketOverrides(['ferry:no-auto-transition']);
     const comment = buildOverridesAuditComment('developer', 'r1', overrides);
     expect(comment).toContain('"noAutoTransition":true');
+  });
+
+  it('includes thinking and reviewRubric when both are set', () => {
+    const overrides = resolveTicketOverrides(['ferry:thinking/extended', 'ferry:strict-review']);
+    const comment = buildOverridesAuditComment('reviewer', 'run1', overrides);
+    expect(comment).toContain('"thinking":"extended"');
+    expect(comment).toContain('"reviewRubric":"strict"');
+  });
+
+  it('includes thinking when set to "off"', () => {
+    const overrides = resolveTicketOverrides(['ferry:thinking/off']);
+    const comment = buildOverridesAuditComment('developer', 'run1', overrides);
+    expect(comment).toContain('"thinking":"off"');
   });
 });
 

--- a/src/lib/labels/overrides.ts
+++ b/src/lib/labels/overrides.ts
@@ -93,7 +93,8 @@ export interface ResolveOverridesOptions {
  * - ferry:budget/*             — cost / token budget overrides
  * - ferry:skip/phase           — phase skip (refiner | dev | review | iter | iterate)
  * - ferry:no-auto-transition   — disable FR18 / FR24 / FR28 auto-transitions
- * - ferry:thinking/on|off      — extended-thinking toggle
+ * - ferry:thinking/on|off|extended — extended-thinking toggle (Anthropic-only at invoke time)
+ * - ferry:strict-review|lenient-review — Reviewer rubric override
  * - ferry:git/no-pr            — skip PR creation
  * - ferry:paused               — safety pause flag
  *
@@ -133,7 +134,10 @@ export function resolveTicketOverrides(
   let maxTokens: number | undefined;
 
   let thinkingLabel: string | undefined;
-  let thinking: 'on' | 'off' | undefined;
+  let thinking: 'on' | 'off' | 'extended' | undefined;
+
+  let reviewRubricLabel: string | undefined;
+  let reviewRubric: 'strict' | 'lenient' | undefined;
 
   let noPr = false;
   let paused = false;
@@ -344,15 +348,36 @@ export function resolveTicketOverrides(
       continue;
     }
 
-    // ferry:thinking/on | ferry:thinking/off
-    if (label === 'ferry:thinking/on' || label === 'ferry:thinking/off') {
-      const val: 'on' | 'off' = label === 'ferry:thinking/on' ? 'on' : 'off';
+    // ferry:thinking/on | ferry:thinking/off | ferry:thinking/extended
+    if (label.startsWith('ferry:thinking/')) {
+      const suffix = label.slice('ferry:thinking/'.length);
+      let val: 'on' | 'off' | 'extended' | undefined;
+      if (suffix === 'on') val = 'on';
+      else if (suffix === 'off') val = 'off';
+      else if (suffix === 'extended') val = 'extended';
+      if (val === undefined) {
+        logger?.warn('unknown suffix in ferry:thinking label', { label, suffix });
+        continue;
+      }
       if (thinking !== undefined && thinking !== val) {
         throw new LabelConflictError(thinkingLabel!, label, 'thinking');
       }
       if (thinking === undefined) {
         thinking = val;
         thinkingLabel = label;
+      }
+      continue;
+    }
+
+    // ferry:strict-review | ferry:lenient-review — reviewer rubric override
+    if (label === 'ferry:strict-review' || label === 'ferry:lenient-review') {
+      const val: 'strict' | 'lenient' = label === 'ferry:strict-review' ? 'strict' : 'lenient';
+      if (reviewRubric !== undefined && reviewRubric !== val) {
+        throw new LabelConflictError(reviewRubricLabel!, label, 'reviewRubric');
+      }
+      if (reviewRubric === undefined) {
+        reviewRubric = val;
+        reviewRubricLabel = label;
       }
       continue;
     }
@@ -422,6 +447,7 @@ export function resolveTicketOverrides(
     ...(skipPhases.length > 0 ? { skipPhases } : {}),
     ...(noAutoTransition ? { noAutoTransition: true } : {}),
     ...(thinking !== undefined ? { thinking } : {}),
+    ...(reviewRubric !== undefined ? { reviewRubric } : {}),
     ...(noPr ? { git: { noPr: true } } : {}),
     ...(paused ? { paused: true } : {}),
     ...(dryRun ? { dryRun: true } : {}),
@@ -516,6 +542,7 @@ export function hasNonDefaultOverrides(overrides: TicketOverrides): boolean {
     (overrides.skipPhases?.length ?? 0) > 0 ||
     overrides.noAutoTransition === true ||
     overrides.thinking !== undefined ||
+    overrides.reviewRubric !== undefined ||
     overrides.git?.noPr === true ||
     overrides.paused === true ||
     overrides.dryRun === true ||
@@ -549,6 +576,7 @@ export function buildOverridesAuditComment(
   if ((overrides.skipPhases?.length ?? 0) > 0) payload.skipPhases = overrides.skipPhases;
   if (overrides.noAutoTransition) payload.noAutoTransition = true;
   if (overrides.thinking !== undefined) payload.thinking = overrides.thinking;
+  if (overrides.reviewRubric !== undefined) payload.reviewRubric = overrides.reviewRubric;
   if (overrides.git?.noPr) payload.git = overrides.git;
   if (overrides.paused) payload.paused = true;
   if (overrides.dryRun) payload.dryRun = true;

--- a/src/lib/llm/agent-loop/anthropic.ts
+++ b/src/lib/llm/agent-loop/anthropic.ts
@@ -25,6 +25,7 @@ import type {
 import { isStdioMcpServer, isHttpMcpServer } from './types.js';
 import { compactOldToolResults } from './compact.js';
 import { computeCostEur } from '../pricing.js';
+import type { ThinkingParam } from '../thinking.js';
 
 // Tools kept available in commit-and-stop mode (>=85% budget used).
 const COMMIT_AND_STOP_TOOL_NAMES = new Set([
@@ -142,6 +143,8 @@ export function createAnthropicAgentLoop(opts: {
   maxTokens?: number;
   maxCostEur?: number;
   compactWindow?: number;
+  /** Optional extended-thinking config; passed through to messages.create when set. */
+  thinking?: ThinkingParam;
   logger?: Logger;
 }): AgentLoop {
   const anthropic =
@@ -366,6 +369,7 @@ export function createAnthropicAgentLoop(opts: {
         system: systemBlocks,
         tools: effectiveTools,
         messages,
+        ...(opts.thinking !== undefined ? { thinking: opts.thinking } : {}),
       };
 
       const response: ApiResponse = hasHttp

--- a/src/lib/llm/agent-loop/index.ts
+++ b/src/lib/llm/agent-loop/index.ts
@@ -3,7 +3,9 @@ import { resolveAnthropicAuth } from '../anthropic-auth.js';
 import { createAnthropicAgentLoop } from './anthropic.js';
 import { createOpenAIAgentLoop } from './openai.js';
 import { createGoogleAgentLoop } from './google.js';
+import { resolveThinkingForProvider } from '../thinking.js';
 import type { AgentLoop } from './types.js';
+import type { TicketOverrides } from '../../labels/capabilities.js';
 
 export type {
   AgentLoop,
@@ -38,6 +40,8 @@ export interface CreateAgentLoopOpts {
   maxTokens?: number;
   maxCostEur?: number;
   compactWindow?: number;
+  /** Extended-thinking override from the ferry:thinking/{on,off,extended} label — Anthropic-only, ignored elsewhere. */
+  thinking?: TicketOverrides['thinking'];
   logger?: import('../../logger/index.js').Logger;
 }
 
@@ -52,6 +56,7 @@ function requireEnv(key: string): string {
 export function createAgentLoop(opts: CreateAgentLoopOpts): AgentLoop {
   if (opts.provider === 'anthropic') {
     const auth = resolveAnthropicAuth({ apiKeyEnv: 'ANTHROPIC_API_KEY' });
+    const thinking = resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
     return createAnthropicAgentLoop({
       ...auth,
       model: opts.model,
@@ -63,9 +68,14 @@ export function createAgentLoop(opts: CreateAgentLoopOpts): AgentLoop {
       maxTokens: opts.maxTokens,
       maxCostEur: opts.maxCostEur,
       compactWindow: opts.compactWindow,
+      thinking,
       logger: opts.logger,
     });
   }
+
+  // Non-Anthropic providers: emit the "ignored — non-Anthropic provider" warning
+  // when a thinking override is set, then fall through without passing the param.
+  resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
 
   if (opts.provider === 'openai') {
     const apiKey = requireEnv('FERRY_OPENAI_KEY');

--- a/src/lib/llm/thinking.test.ts
+++ b/src/lib/llm/thinking.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  thinkingParamFromOverride,
+  resolveThinkingForProvider,
+  THINKING_BUDGET_ON,
+  THINKING_BUDGET_EXTENDED,
+} from './thinking.js';
+import { createTestLogger } from '../logger/index.js';
+
+describe('thinkingParamFromOverride', () => {
+  it('returns undefined when override is undefined', () => {
+    expect(thinkingParamFromOverride(undefined)).toBeUndefined();
+  });
+
+  it('maps "on" to enabled with default budget', () => {
+    expect(thinkingParamFromOverride('on')).toEqual({
+      type: 'enabled',
+      budget_tokens: THINKING_BUDGET_ON,
+    });
+  });
+
+  it('maps "extended" to enabled with the larger budget', () => {
+    expect(thinkingParamFromOverride('extended')).toEqual({
+      type: 'enabled',
+      budget_tokens: THINKING_BUDGET_EXTENDED,
+    });
+  });
+
+  it('maps "off" to disabled', () => {
+    expect(thinkingParamFromOverride('off')).toEqual({ type: 'disabled' });
+  });
+
+  it('extended budget is greater than on budget', () => {
+    expect(THINKING_BUDGET_EXTENDED).toBeGreaterThan(THINKING_BUDGET_ON);
+  });
+
+  it('SDK minimum: budget_tokens >= 1024 for enabled', () => {
+    expect(THINKING_BUDGET_ON).toBeGreaterThanOrEqual(1024);
+    expect(THINKING_BUDGET_EXTENDED).toBeGreaterThanOrEqual(1024);
+  });
+});
+
+describe('resolveThinkingForProvider', () => {
+  it('returns undefined when no thinking override is set, regardless of provider', () => {
+    expect(resolveThinkingForProvider(undefined, 'anthropic')).toBeUndefined();
+    expect(resolveThinkingForProvider(undefined, 'openai')).toBeUndefined();
+    expect(resolveThinkingForProvider(undefined, 'google')).toBeUndefined();
+  });
+
+  it('returns the SDK param for anthropic provider when override is "on"', () => {
+    expect(resolveThinkingForProvider('on', 'anthropic')).toEqual({
+      type: 'enabled',
+      budget_tokens: THINKING_BUDGET_ON,
+    });
+  });
+
+  it('returns the SDK param for anthropic provider when override is "extended"', () => {
+    expect(resolveThinkingForProvider('extended', 'anthropic')).toEqual({
+      type: 'enabled',
+      budget_tokens: THINKING_BUDGET_EXTENDED,
+    });
+  });
+
+  it('returns the SDK param for anthropic provider when override is "off"', () => {
+    expect(resolveThinkingForProvider('off', 'anthropic')).toEqual({ type: 'disabled' });
+  });
+
+  it('returns undefined and warns when provider is openai (non-Anthropic)', () => {
+    const { logger, records } = createTestLogger('t', 'test');
+    expect(resolveThinkingForProvider('extended', 'openai', logger)).toBeUndefined();
+    expect(records.some((r) => r.level === 'warn')).toBe(true);
+  });
+
+  it('returns undefined and warns when provider is google (non-Anthropic)', () => {
+    const { logger, records } = createTestLogger('t', 'test');
+    expect(resolveThinkingForProvider('on', 'google', logger)).toBeUndefined();
+    expect(records.some((r) => r.level === 'warn')).toBe(true);
+  });
+
+  it('does not warn when there is no override (even for non-Anthropic providers)', () => {
+    const { logger, records } = createTestLogger('t', 'test');
+    resolveThinkingForProvider(undefined, 'openai', logger);
+    expect(records.filter((r) => r.level === 'warn')).toHaveLength(0);
+  });
+});

--- a/src/lib/llm/thinking.ts
+++ b/src/lib/llm/thinking.ts
@@ -1,0 +1,82 @@
+/**
+ * Helpers for translating the ferry:thinking/{on,off,extended} label override
+ * into an Anthropic Messages API `thinking` parameter (or a no-op when unset).
+ *
+ * Anthropic SDK shape (from `@anthropic-ai/sdk/resources/messages.js`):
+ *   thinking?:
+ *     | { type: 'enabled'; budget_tokens: number; display?: 'summarized' | 'omitted' | null }
+ *     | { type: 'disabled' }
+ *     | { type: 'adaptive'; display?: 'summarized' | 'omitted' | null }
+ *
+ * See https://docs.claude.com/en/docs/build-with-claude/extended-thinking
+ */
+import type { Logger } from '../logger/index.js';
+import type { TicketOverrides } from '../labels/capabilities.js';
+
+/**
+ * Anthropic Messages API `thinking` parameter value.
+ *
+ * - `{ type: 'enabled', budget_tokens }` — extended thinking on, with a budget
+ * - `{ type: 'disabled' }`               — extended thinking off (forces off)
+ * - `undefined`                          — leave the default (model-dependent)
+ */
+export type ThinkingParam =
+  | { type: 'enabled'; budget_tokens: number }
+  | { type: 'disabled' }
+  | undefined;
+
+/**
+ * Budget-token defaults for the two enabled modes.
+ *
+ * `on` is the conservative default (≥1024 is the SDK minimum).
+ * `extended` provides a larger budget for complex refactors / analyses.
+ * Both budgets must be smaller than the call's `max_tokens` — the caller is
+ * responsible for ensuring that.
+ */
+export const THINKING_BUDGET_ON = 2_000;
+export const THINKING_BUDGET_EXTENDED = 8_000;
+
+/**
+ * Translates a `TicketOverrides.thinking` value into the Anthropic SDK's
+ * `thinking` parameter.
+ *
+ * Returns `undefined` when no override is set, leaving the model's default
+ * behaviour in place.
+ */
+export function thinkingParamFromOverride(thinking: TicketOverrides['thinking']): ThinkingParam {
+  switch (thinking) {
+    case 'extended':
+      return { type: 'enabled', budget_tokens: THINKING_BUDGET_EXTENDED };
+    case 'on':
+      return { type: 'enabled', budget_tokens: THINKING_BUDGET_ON };
+    case 'off':
+      return { type: 'disabled' };
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Resolves the `thinking` override for a given provider. Anthropic-only —
+ * when the override is set but the provider is not `anthropic`, logs a
+ * warning to the supplied logger (stderr via the logger sink) and returns
+ * `undefined` so the invoker silently no-ops.
+ *
+ * The override is NOT removed from `TicketOverrides`; suppression happens
+ * here, at invoke time, so the audit comment still reflects the user's intent.
+ */
+export function resolveThinkingForProvider(
+  thinking: TicketOverrides['thinking'],
+  provider: string,
+  logger?: Logger,
+): ThinkingParam {
+  if (thinking === undefined) return undefined;
+  if (provider !== 'anthropic') {
+    logger?.warn('ferry:thinking label set but provider is not anthropic — ignoring', {
+      provider,
+      thinking,
+    });
+    return undefined;
+  }
+  return thinkingParamFromOverride(thinking);
+}

--- a/src/lib/llm/tool-loop/anthropic.test.ts
+++ b/src/lib/llm/tool-loop/anthropic.test.ts
@@ -174,4 +174,49 @@ describe('createAnthropicToolCallLoop', () => {
     expect(out.usage.inputTokens).toBe(300);
     expect(out.usage.outputTokens).toBe(100);
   });
+
+  describe('thinking parameter wiring', () => {
+    function makeSpyClient(): { client: Anthropic; create: ReturnType<typeof vi.fn> } {
+      const create = vi.fn().mockImplementation(async () => ({
+        stop_reason: 'tool_use',
+        content: [{ type: 'tool_use', id: 'tu1', name: 'finish', input: { result: 'ok' } }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }));
+      const client = { messages: { create } } as unknown as Anthropic;
+      return { client, create };
+    }
+
+    it('does not pass `thinking` to messages.create when no override is set', async () => {
+      const { client, create } = makeSpyClient();
+      const loop = createAnthropicToolCallLoop({ client, model: 'claude-test' });
+      await loop.run(baseRunOpts);
+      expect(create).toHaveBeenCalledOnce();
+      const callArgs = create.mock.calls[0][0] as Record<string, unknown>;
+      expect('thinking' in callArgs).toBe(false);
+    });
+
+    it('passes `thinking: { type: "enabled", budget_tokens: ... }` for on/extended', async () => {
+      const { client, create } = makeSpyClient();
+      const loop = createAnthropicToolCallLoop({
+        client,
+        model: 'claude-test',
+        thinking: { type: 'enabled', budget_tokens: 8000 },
+      });
+      await loop.run(baseRunOpts);
+      const callArgs = create.mock.calls[0][0] as Record<string, unknown>;
+      expect(callArgs.thinking).toEqual({ type: 'enabled', budget_tokens: 8000 });
+    });
+
+    it('passes `thinking: { type: "disabled" }` when override is off', async () => {
+      const { client, create } = makeSpyClient();
+      const loop = createAnthropicToolCallLoop({
+        client,
+        model: 'claude-test',
+        thinking: { type: 'disabled' },
+      });
+      await loop.run(baseRunOpts);
+      const callArgs = create.mock.calls[0][0] as Record<string, unknown>;
+      expect(callArgs.thinking).toEqual({ type: 'disabled' });
+    });
+  });
 });

--- a/src/lib/llm/tool-loop/anthropic.ts
+++ b/src/lib/llm/tool-loop/anthropic.ts
@@ -8,10 +8,13 @@ import { FerryError } from '../../errors/index.js';
 import { emitDebug } from '../debug-log.js';
 import { createLogger } from '../../logger/index.js';
 import type { ToolCallLoop, ToolLoopRunOpts, ToolLoopResult } from './types.js';
+import type { ThinkingParam } from '../thinking.js';
 
 export function createAnthropicToolCallLoop(opts: {
   client: Anthropic;
   model: string;
+  /** Optional extended-thinking config; passed through to messages.create when set. */
+  thinking?: ThinkingParam;
 }): ToolCallLoop {
   return {
     async run<T>(runOpts: ToolLoopRunOpts<T>): Promise<ToolLoopResult<T>> {
@@ -62,6 +65,7 @@ export function createAnthropicToolCallLoop(opts: {
           system: [{ type: 'text', text: system, cache_control: { type: 'ephemeral' } }],
           tools: anthropicTools,
           messages,
+          ...(opts.thinking !== undefined ? { thinking: opts.thinking } : {}),
         });
 
         inputTokens += response.usage.input_tokens;

--- a/src/lib/llm/tool-loop/index.ts
+++ b/src/lib/llm/tool-loop/index.ts
@@ -4,7 +4,10 @@ import { resolveAnthropicAuth } from '../anthropic-auth.js';
 import { createAnthropicToolCallLoop } from './anthropic.js';
 import { createOpenAIToolCallLoop } from './openai.js';
 import { createGoogleToolCallLoop } from './google.js';
+import { resolveThinkingForProvider } from '../thinking.js';
 import type { ToolCallLoop } from './types.js';
+import type { TicketOverrides } from '../../labels/capabilities.js';
+import type { Logger } from '../../logger/index.js';
 
 function requireEnv(key: string): string {
   const val = process.env[key];
@@ -14,12 +17,24 @@ function requireEnv(key: string): string {
   return val;
 }
 
-export function createToolCallLoop(opts: { provider: string; model: string }): ToolCallLoop {
+export function createToolCallLoop(opts: {
+  provider: string;
+  model: string;
+  /** Extended-thinking override from the ferry:thinking/{on,off,extended} label — Anthropic-only, ignored elsewhere. */
+  thinking?: TicketOverrides['thinking'];
+  /** Logger used to emit the "ignored — non-Anthropic provider" warning. */
+  logger?: Logger;
+}): ToolCallLoop {
   if (opts.provider === 'anthropic') {
     const auth = resolveAnthropicAuth({ apiKeyEnv: 'ANTHROPIC_API_KEY' });
     const client = new Anthropic(auth);
-    return createAnthropicToolCallLoop({ client, model: opts.model });
+    const thinking = resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
+    return createAnthropicToolCallLoop({ client, model: opts.model, thinking });
   }
+
+  // Non-Anthropic providers: still call the resolver so the stderr warning is emitted
+  // when a thinking override is set, then fall through without passing the param.
+  resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
 
   if (opts.provider === 'openai') {
     const apiKey = requireEnv('FERRY_OPENAI_KEY');


### PR DESCRIPTION
Closes #240

> Stacked on #278 → #277. After upstream PRs merge, re-target to `main`.

## Summary

- Adds `ferry:thinking/extended` (extends existing `thinking` override; foundation already supported `on` / `off`).
- Adds `ferry:strict-review` / `ferry:lenient-review` to override the Reviewer rubric (new `TicketOverrides.reviewRubric` field).
- Wires the Anthropic SDK `thinking` parameter through both the agent-loop (Developer / Iterator) and the tool-loop (Reviewer); shape verified against `@anthropic-ai/sdk` 0.95.2.
- Non-Anthropic providers ignore the thinking flag with a stderr warning (`ferry:thinking label set but provider is not anthropic — ignoring`); the override stays in `TicketOverrides` so the audit comment still reflects the user's intent.
- Conflict pairs fail loudly via `LabelConflictError`:
  - `thinking`: any two of `on` / `off` / `extended`
  - `reviewRubric`: `strict` + `lenient`
- Reviewer rubric is implemented as an append-only directive (`applyRubricToPrompt`) at the end of the reviewer system prompt — composes with `prompts/review.md` and any `review-comment.md` overlay.
- `docs/CONFIGURATION.md`: new section for thinking / rubric labels, Anthropic-only note, conflict rules.

## Test plan

- [x] All 1559 tests pass (`npm test`)
- [x] TypeScript typecheck passes (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] Prettier check passes (`npm run format:check`)
- [x] 31 new tests added (10 in `overrides.test.ts`, 12 in `thinking.test.ts`, 6 in `rubric.test.ts`, 3 in `anthropic.test.ts`)
- [x] Anthropic invoker test asserts SDK `thinking` parameter wiring for on/extended/off + absence
- [x] Reviewer rubric prompt assembly tested (strict ≠ lenient, undefined returns base unchanged)
- [x] Bundle rebuilt (`npm run build:ferry`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)