### PR TITLE
feat: label override for git base/target/draft (#241)

### DIFF
--- a/.ferry/agent.js
+++ b/.ferry/agent.js
@@ -553,6 +553,17 @@ function makeCommitProgress(logger, options = {}) {
     return "committed and pushed";
   };
 }
+function remoteBranchExists(branchName, repoRoot) {
+  try {
+    execFileSync("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
+      cwd: repoRoot,
+      stdio: "pipe"
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
 function checkoutExistingBranch(branchName, repoRoot) {
   try {
     execFileSync("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
@@ -5153,7 +5164,7 @@ var GitHubActionsRunner = class {
       return `(error fetching content: ${e.message})`;
     }
   }
-  async createPR(owner, repo, head, base, title, body) {
+  async createPR(owner, repo, head, base, title, body, options) {
     try {
       const { data } = await this.octokit.pulls.create({
         owner,
@@ -5162,7 +5173,7 @@ var GitHubActionsRunner = class {
         base,
         title,
         body,
-        draft: true
+        draft: options?.draft ?? true
       });
       return data.html_url;
     } catch {
@@ -5858,6 +5869,7 @@ function filterMcpServers(pool, capabilities, hasLabelsConfig) {
 var AGENT_PHASES = /* @__PURE__ */ new Set(["refiner", "dev", "review", "iterate"]);
 var PHASES_ORDERED = ["refiner", "dev", "review", "iterate"];
 var LLM_PROVIDERS = /* @__PURE__ */ new Set(["anthropic", "openai", "google"]);
+var BRANCH_NAME_REGEX = /^[a-zA-Z0-9._/-]+$/;
 var LabelConflictError = class extends Error {
   label1;
   label2;
@@ -5937,6 +5949,12 @@ function resolveTicketOverrides(labels, logger, options) {
   let dryRun = false;
   let readOnly = false;
   const skipPhases = [];
+  let baseBranchLabel;
+  let baseBranch;
+  let targetBranchLabel;
+  let targetBranch;
+  let prDraftLabel;
+  let prDraft;
   for (const label of labels) {
     if (!label.startsWith("ferry:")) continue;
     if (isKnownNonOverrideLabel(label)) continue;
@@ -6146,6 +6164,61 @@ function resolveTicketOverrides(labels, logger, options) {
       noPr = true;
       continue;
     }
+    if (label.startsWith("ferry:base/")) {
+      const branch = label.slice("ferry:base/".length);
+      if (!BRANCH_NAME_REGEX.test(branch)) {
+        logger?.warn("invalid branch name in ferry:base label (expected ^[a-zA-Z0-9._/-]+$)", {
+          label
+        });
+        continue;
+      }
+      if (baseBranch !== void 0 && baseBranch !== branch) {
+        throw new LabelConflictError(baseBranchLabel, label, "git.baseBranch");
+      }
+      if (baseBranch === void 0) {
+        baseBranch = branch;
+        baseBranchLabel = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:target/")) {
+      const branch = label.slice("ferry:target/".length);
+      if (!BRANCH_NAME_REGEX.test(branch)) {
+        logger?.warn("invalid branch name in ferry:target label (expected ^[a-zA-Z0-9._/-]+$)", {
+          label
+        });
+        continue;
+      }
+      if (targetBranch !== void 0 && targetBranch !== branch) {
+        throw new LabelConflictError(targetBranchLabel, label, "git.targetBranch");
+      }
+      if (targetBranch === void 0) {
+        targetBranch = branch;
+        targetBranchLabel = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:pr/")) {
+      const suffix = label.slice("ferry:pr/".length);
+      let val;
+      if (suffix === "draft") val = true;
+      else if (suffix === "ready") val = false;
+      if (val === void 0) {
+        logger?.warn("unknown suffix in ferry:pr label (expected draft or ready)", {
+          label,
+          suffix
+        });
+        continue;
+      }
+      if (prDraft !== void 0 && prDraft !== val) {
+        throw new LabelConflictError(prDraftLabel, label, "git.prDraft");
+      }
+      if (prDraft === void 0) {
+        prDraft = val;
+        prDraftLabel = label;
+      }
+      continue;
+    }
     if (label === "ferry:paused") {
       paused = true;
       continue;
@@ -6176,6 +6249,13 @@ function resolveTicketOverrides(labels, logger, options) {
   }
   const hasModelOverrides = Object.keys(modelOverrides).length > 0;
   const hasBudget = budgetMaxCostEur !== void 0 || budgetMaxTokens !== void 0;
+  const hasGit = noPr || baseBranch !== void 0 || targetBranch !== void 0 || prDraft !== void 0;
+  const gitOverride = hasGit ? {
+    ...noPr ? { noPr: true } : {},
+    ...baseBranch !== void 0 ? { baseBranch } : {},
+    ...targetBranch !== void 0 ? { targetBranch } : {},
+    ...prDraft !== void 0 ? { prDraft } : {}
+  } : void 0;
   return {
     ...typeOverrides,
     ...hasModelOverrides ? { modelOverrides } : {},
@@ -6192,7 +6272,7 @@ function resolveTicketOverrides(labels, logger, options) {
     ...noAutoTransition ? { noAutoTransition: true } : {},
     ...thinking !== void 0 ? { thinking } : {},
     ...reviewRubric !== void 0 ? { reviewRubric } : {},
-    ...noPr ? { git: { noPr: true } } : {},
+    ...gitOverride ? { git: gitOverride } : {},
     ...paused ? { paused: true } : {},
     ...dryRun ? { dryRun: true } : {},
     ...readOnly ? { readOnly: true } : {}
@@ -6250,7 +6330,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.git?.baseBranch !== void 0 || overrides.git?.targetBranch !== void 0 || overrides.git?.prDraft !== void 0 || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6265,7 +6345,9 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if (overrides.noAutoTransition) payload.noAutoTransition = true;
   if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
   if (overrides.reviewRubric !== void 0) payload.reviewRubric = overrides.reviewRubric;
-  if (overrides.git?.noPr) payload.git = overrides.git;
+  if (overrides.git !== void 0 && (overrides.git.noPr === true || overrides.git.baseBranch !== void 0 || overrides.git.targetBranch !== void 0 || overrides.git.prDraft !== void 0)) {
+    payload.git = overrides.git;
+  }
   if (overrides.paused) payload.paused = true;
   if (overrides.dryRun) payload.dryRun = true;
   if (overrides.readOnly) payload.readOnly = true;
@@ -9154,8 +9236,10 @@ async function main2(envelope, logger) {
     logger.info("DRY_RUN mode \u2014 no branch push, no PR, no Jira writes");
   }
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT2);
-  const { baseBranch, targetBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
-  const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT2, initialCfg);
+  const resolvedGit = await resolveGitConfig(initialCfg, runner, owner, repo);
+  const ferryCfg = loadFerryConfigFromBaseBranch(resolvedGit.baseBranch, REPO_ROOT2, initialCfg);
+  let baseBranch = resolvedGit.baseBranch;
+  let targetBranch = resolvedGit.targetBranch;
   const devWorkflow = ferryCfg.workflow.agents.developer;
   const configAutoTransition = devWorkflow.auto_transition !== null;
   const issue = await tracker.getIssue(ticketKey);
@@ -9164,6 +9248,7 @@ async function main2(envelope, logger) {
   let forceLabel;
   let noAutoTransition = false;
   let thinkingOverride;
+  let prDraftOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -9172,6 +9257,13 @@ async function main2(envelope, logger) {
     forceLabel = overrides.forceLabel;
     noAutoTransition = overrides.noAutoTransition === true;
     thinkingOverride = overrides.thinking;
+    prDraftOverride = overrides.git?.prDraft;
+    if (overrides.git?.baseBranch !== void 0) {
+      baseBranch = overrides.git.baseBranch;
+    }
+    if (overrides.git?.targetBranch !== void 0) {
+      targetBranch = overrides.git.targetBranch;
+    }
     if (overrides.dryRun === true && !dryRun) {
       dryRun = true;
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
@@ -9183,6 +9275,22 @@ async function main2(envelope, logger) {
         ticketKey,
         buildOverridesAuditComment("developer", eventId, overrides)
       );
+    }
+    if (!dryRun) {
+      if (overrides.git?.baseBranch !== void 0 && !remoteBranchExists(baseBranch, REPO_ROOT2)) {
+        await tracker.postComment(
+          ticketKey,
+          `[ferry:dev:${eventId}] base branch '${baseBranch}' not found on origin \u2014 remove or fix the ferry:base/* label.`
+        );
+        process.exit(1);
+      }
+      if (overrides.git?.targetBranch !== void 0 && !remoteBranchExists(targetBranch, REPO_ROOT2)) {
+        await tracker.postComment(
+          ticketKey,
+          `[ferry:dev:${eventId}] target branch '${targetBranch}' not found on origin \u2014 remove or fix the ferry:target/* label.`
+        );
+        process.exit(1);
+      }
     }
     if (overrides.readOnly === true) {
       logger.info("read-only mode \u2014 developer agent skipped");
@@ -9500,7 +9608,15 @@ ${tree}`,
       validation: done.validation ?? [],
       notes: done.notes ?? []
     });
-    const prUrl = await runner.createPR(owner, repo, branchName, targetBranch, prTitle, prBody);
+    const prUrl = await runner.createPR(
+      owner,
+      repo,
+      branchName,
+      targetBranch,
+      prTitle,
+      prBody,
+      prDraftOverride !== void 0 ? { draft: prDraftOverride } : void 0
+    );
     assertDevOutputContract(resolvedOutcome, { branchPushed, prUrl, verificationNoteWritten });
     if (shouldAutoTransition) {
       await tracker.postTransition(ticketKey, reviewTransitionId);
@@ -10520,8 +10636,9 @@ var REPO_ROOT4 = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main4(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT4);
-  const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
-  const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT4, initialCfg);
+  const resolvedGit = await resolveGitConfig(initialCfg, runner, owner, repo);
+  const ferryCfg = loadFerryConfigFromBaseBranch(resolvedGit.baseBranch, REPO_ROOT4, initialCfg);
+  let baseBranch = resolvedGit.baseBranch;
   const iteratorWorkflow = ferryCfg.workflow.agents.iterator;
   const configAutoTransition = iteratorWorkflow.auto_transition !== null;
   const issue = await tracker.getIssue(ticketKey);
@@ -10541,6 +10658,9 @@ async function main4(envelope, logger) {
     noAutoTransition = overrides.noAutoTransition === true;
     dryRun = overrides.dryRun === true;
     thinkingOverride = overrides.thinking;
+    if (overrides.git?.baseBranch !== void 0) {
+      baseBranch = overrides.git.baseBranch;
+    }
     if (dryRun) {
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
     }
@@ -10551,6 +10671,13 @@ async function main4(envelope, logger) {
         ticketKey,
         buildOverridesAuditComment("iterator", eventId, overrides)
       );
+    }
+    if (!dryRun && overrides.git?.baseBranch !== void 0 && !remoteBranchExists(baseBranch, REPO_ROOT4)) {
+      await tracker.postComment(
+        ticketKey,
+        `[ferry:iter:${eventId}] base branch '${baseBranch}' not found on origin \u2014 remove or fix the ferry:base/* label.`
+      );
+      process.exit(1);
     }
     if (overrides.readOnly === true) {
       logger.info("read-only mode \u2014 iterator agent skipped");

--- a/.github/actions/ferry-run-developer/agent.js
+++ b/.github/actions/ferry-run-developer/agent.js
@@ -553,6 +553,17 @@ function makeCommitProgress(logger, options = {}) {
     return "committed and pushed";
   };
 }
+function remoteBranchExists(branchName, repoRoot) {
+  try {
+    execFileSync("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
+      cwd: repoRoot,
+      stdio: "pipe"
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
 function checkoutExistingBranch(branchName, repoRoot) {
   try {
     execFileSync("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
@@ -5153,7 +5164,7 @@ var GitHubActionsRunner = class {
       return `(error fetching content: ${e.message})`;
     }
   }
-  async createPR(owner, repo, head, base, title, body) {
+  async createPR(owner, repo, head, base, title, body, options) {
     try {
       const { data } = await this.octokit.pulls.create({
         owner,
@@ -5162,7 +5173,7 @@ var GitHubActionsRunner = class {
         base,
         title,
         body,
-        draft: true
+        draft: options?.draft ?? true
       });
       return data.html_url;
     } catch {
@@ -5858,6 +5869,7 @@ function filterMcpServers(pool, capabilities, hasLabelsConfig) {
 var AGENT_PHASES = /* @__PURE__ */ new Set(["refiner", "dev", "review", "iterate"]);
 var PHASES_ORDERED = ["refiner", "dev", "review", "iterate"];
 var LLM_PROVIDERS = /* @__PURE__ */ new Set(["anthropic", "openai", "google"]);
+var BRANCH_NAME_REGEX = /^[a-zA-Z0-9._/-]+$/;
 var LabelConflictError = class extends Error {
   label1;
   label2;
@@ -5937,6 +5949,12 @@ function resolveTicketOverrides(labels, logger, options) {
   let dryRun = false;
   let readOnly = false;
   const skipPhases = [];
+  let baseBranchLabel;
+  let baseBranch;
+  let targetBranchLabel;
+  let targetBranch;
+  let prDraftLabel;
+  let prDraft;
   for (const label of labels) {
     if (!label.startsWith("ferry:")) continue;
     if (isKnownNonOverrideLabel(label)) continue;
@@ -6146,6 +6164,61 @@ function resolveTicketOverrides(labels, logger, options) {
       noPr = true;
       continue;
     }
+    if (label.startsWith("ferry:base/")) {
+      const branch = label.slice("ferry:base/".length);
+      if (!BRANCH_NAME_REGEX.test(branch)) {
+        logger?.warn("invalid branch name in ferry:base label (expected ^[a-zA-Z0-9._/-]+$)", {
+          label
+        });
+        continue;
+      }
+      if (baseBranch !== void 0 && baseBranch !== branch) {
+        throw new LabelConflictError(baseBranchLabel, label, "git.baseBranch");
+      }
+      if (baseBranch === void 0) {
+        baseBranch = branch;
+        baseBranchLabel = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:target/")) {
+      const branch = label.slice("ferry:target/".length);
+      if (!BRANCH_NAME_REGEX.test(branch)) {
+        logger?.warn("invalid branch name in ferry:target label (expected ^[a-zA-Z0-9._/-]+$)", {
+          label
+        });
+        continue;
+      }
+      if (targetBranch !== void 0 && targetBranch !== branch) {
+        throw new LabelConflictError(targetBranchLabel, label, "git.targetBranch");
+      }
+      if (targetBranch === void 0) {
+        targetBranch = branch;
+        targetBranchLabel = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:pr/")) {
+      const suffix = label.slice("ferry:pr/".length);
+      let val;
+      if (suffix === "draft") val = true;
+      else if (suffix === "ready") val = false;
+      if (val === void 0) {
+        logger?.warn("unknown suffix in ferry:pr label (expected draft or ready)", {
+          label,
+          suffix
+        });
+        continue;
+      }
+      if (prDraft !== void 0 && prDraft !== val) {
+        throw new LabelConflictError(prDraftLabel, label, "git.prDraft");
+      }
+      if (prDraft === void 0) {
+        prDraft = val;
+        prDraftLabel = label;
+      }
+      continue;
+    }
     if (label === "ferry:paused") {
       paused = true;
       continue;
@@ -6176,6 +6249,13 @@ function resolveTicketOverrides(labels, logger, options) {
   }
   const hasModelOverrides = Object.keys(modelOverrides).length > 0;
   const hasBudget = budgetMaxCostEur !== void 0 || budgetMaxTokens !== void 0;
+  const hasGit = noPr || baseBranch !== void 0 || targetBranch !== void 0 || prDraft !== void 0;
+  const gitOverride = hasGit ? {
+    ...noPr ? { noPr: true } : {},
+    ...baseBranch !== void 0 ? { baseBranch } : {},
+    ...targetBranch !== void 0 ? { targetBranch } : {},
+    ...prDraft !== void 0 ? { prDraft } : {}
+  } : void 0;
   return {
     ...typeOverrides,
     ...hasModelOverrides ? { modelOverrides } : {},
@@ -6192,7 +6272,7 @@ function resolveTicketOverrides(labels, logger, options) {
     ...noAutoTransition ? { noAutoTransition: true } : {},
     ...thinking !== void 0 ? { thinking } : {},
     ...reviewRubric !== void 0 ? { reviewRubric } : {},
-    ...noPr ? { git: { noPr: true } } : {},
+    ...gitOverride ? { git: gitOverride } : {},
     ...paused ? { paused: true } : {},
     ...dryRun ? { dryRun: true } : {},
     ...readOnly ? { readOnly: true } : {}
@@ -6250,7 +6330,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.git?.baseBranch !== void 0 || overrides.git?.targetBranch !== void 0 || overrides.git?.prDraft !== void 0 || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6265,7 +6345,9 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if (overrides.noAutoTransition) payload.noAutoTransition = true;
   if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
   if (overrides.reviewRubric !== void 0) payload.reviewRubric = overrides.reviewRubric;
-  if (overrides.git?.noPr) payload.git = overrides.git;
+  if (overrides.git !== void 0 && (overrides.git.noPr === true || overrides.git.baseBranch !== void 0 || overrides.git.targetBranch !== void 0 || overrides.git.prDraft !== void 0)) {
+    payload.git = overrides.git;
+  }
   if (overrides.paused) payload.paused = true;
   if (overrides.dryRun) payload.dryRun = true;
   if (overrides.readOnly) payload.readOnly = true;
@@ -9154,8 +9236,10 @@ async function main2(envelope, logger) {
     logger.info("DRY_RUN mode \u2014 no branch push, no PR, no Jira writes");
   }
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT2);
-  const { baseBranch, targetBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
-  const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT2, initialCfg);
+  const resolvedGit = await resolveGitConfig(initialCfg, runner, owner, repo);
+  const ferryCfg = loadFerryConfigFromBaseBranch(resolvedGit.baseBranch, REPO_ROOT2, initialCfg);
+  let baseBranch = resolvedGit.baseBranch;
+  let targetBranch = resolvedGit.targetBranch;
   const devWorkflow = ferryCfg.workflow.agents.developer;
   const configAutoTransition = devWorkflow.auto_transition !== null;
   const issue = await tracker.getIssue(ticketKey);
@@ -9164,6 +9248,7 @@ async function main2(envelope, logger) {
   let forceLabel;
   let noAutoTransition = false;
   let thinkingOverride;
+  let prDraftOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -9172,6 +9257,13 @@ async function main2(envelope, logger) {
     forceLabel = overrides.forceLabel;
     noAutoTransition = overrides.noAutoTransition === true;
     thinkingOverride = overrides.thinking;
+    prDraftOverride = overrides.git?.prDraft;
+    if (overrides.git?.baseBranch !== void 0) {
+      baseBranch = overrides.git.baseBranch;
+    }
+    if (overrides.git?.targetBranch !== void 0) {
+      targetBranch = overrides.git.targetBranch;
+    }
     if (overrides.dryRun === true && !dryRun) {
       dryRun = true;
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
@@ -9183,6 +9275,22 @@ async function main2(envelope, logger) {
         ticketKey,
         buildOverridesAuditComment("developer", eventId, overrides)
       );
+    }
+    if (!dryRun) {
+      if (overrides.git?.baseBranch !== void 0 && !remoteBranchExists(baseBranch, REPO_ROOT2)) {
+        await tracker.postComment(
+          ticketKey,
+          `[ferry:dev:${eventId}] base branch '${baseBranch}' not found on origin \u2014 remove or fix the ferry:base/* label.`
+        );
+        process.exit(1);
+      }
+      if (overrides.git?.targetBranch !== void 0 && !remoteBranchExists(targetBranch, REPO_ROOT2)) {
+        await tracker.postComment(
+          ticketKey,
+          `[ferry:dev:${eventId}] target branch '${targetBranch}' not found on origin \u2014 remove or fix the ferry:target/* label.`
+        );
+        process.exit(1);
+      }
     }
     if (overrides.readOnly === true) {
       logger.info("read-only mode \u2014 developer agent skipped");
@@ -9500,7 +9608,15 @@ ${tree}`,
       validation: done.validation ?? [],
       notes: done.notes ?? []
     });
-    const prUrl = await runner.createPR(owner, repo, branchName, targetBranch, prTitle, prBody);
+    const prUrl = await runner.createPR(
+      owner,
+      repo,
+      branchName,
+      targetBranch,
+      prTitle,
+      prBody,
+      prDraftOverride !== void 0 ? { draft: prDraftOverride } : void 0
+    );
     assertDevOutputContract(resolvedOutcome, { branchPushed, prUrl, verificationNoteWritten });
     if (shouldAutoTransition) {
       await tracker.postTransition(ticketKey, reviewTransitionId);
@@ -10520,8 +10636,9 @@ var REPO_ROOT4 = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main4(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT4);
-  const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
-  const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT4, initialCfg);
+  const resolvedGit = await resolveGitConfig(initialCfg, runner, owner, repo);
+  const ferryCfg = loadFerryConfigFromBaseBranch(resolvedGit.baseBranch, REPO_ROOT4, initialCfg);
+  let baseBranch = resolvedGit.baseBranch;
   const iteratorWorkflow = ferryCfg.workflow.agents.iterator;
   const configAutoTransition = iteratorWorkflow.auto_transition !== null;
   const issue = await tracker.getIssue(ticketKey);
@@ -10541,6 +10658,9 @@ async function main4(envelope, logger) {
     noAutoTransition = overrides.noAutoTransition === true;
     dryRun = overrides.dryRun === true;
     thinkingOverride = overrides.thinking;
+    if (overrides.git?.baseBranch !== void 0) {
+      baseBranch = overrides.git.baseBranch;
+    }
     if (dryRun) {
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
     }
@@ -10551,6 +10671,13 @@ async function main4(envelope, logger) {
         ticketKey,
         buildOverridesAuditComment("iterator", eventId, overrides)
       );
+    }
+    if (!dryRun && overrides.git?.baseBranch !== void 0 && !remoteBranchExists(baseBranch, REPO_ROOT4)) {
+      await tracker.postComment(
+        ticketKey,
+        `[ferry:iter:${eventId}] base branch '${baseBranch}' not found on origin \u2014 remove or fix the ferry:base/* label.`
+      );
+      process.exit(1);
     }
     if (overrides.readOnly === true) {
       logger.info("read-only mode \u2014 iterator agent skipped");

--- a/.github/actions/ferry-run-iterator/agent.js
+++ b/.github/actions/ferry-run-iterator/agent.js
@@ -553,6 +553,17 @@ function makeCommitProgress(logger, options = {}) {
     return "committed and pushed";
   };
 }
+function remoteBranchExists(branchName, repoRoot) {
+  try {
+    execFileSync("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
+      cwd: repoRoot,
+      stdio: "pipe"
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
 function checkoutExistingBranch(branchName, repoRoot) {
   try {
     execFileSync("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
@@ -5153,7 +5164,7 @@ var GitHubActionsRunner = class {
       return `(error fetching content: ${e.message})`;
     }
   }
-  async createPR(owner, repo, head, base, title, body) {
+  async createPR(owner, repo, head, base, title, body, options) {
     try {
       const { data } = await this.octokit.pulls.create({
         owner,
@@ -5162,7 +5173,7 @@ var GitHubActionsRunner = class {
         base,
         title,
         body,
-        draft: true
+        draft: options?.draft ?? true
       });
       return data.html_url;
     } catch {
@@ -5858,6 +5869,7 @@ function filterMcpServers(pool, capabilities, hasLabelsConfig) {
 var AGENT_PHASES = /* @__PURE__ */ new Set(["refiner", "dev", "review", "iterate"]);
 var PHASES_ORDERED = ["refiner", "dev", "review", "iterate"];
 var LLM_PROVIDERS = /* @__PURE__ */ new Set(["anthropic", "openai", "google"]);
+var BRANCH_NAME_REGEX = /^[a-zA-Z0-9._/-]+$/;
 var LabelConflictError = class extends Error {
   label1;
   label2;
@@ -5937,6 +5949,12 @@ function resolveTicketOverrides(labels, logger, options) {
   let dryRun = false;
   let readOnly = false;
   const skipPhases = [];
+  let baseBranchLabel;
+  let baseBranch;
+  let targetBranchLabel;
+  let targetBranch;
+  let prDraftLabel;
+  let prDraft;
   for (const label of labels) {
     if (!label.startsWith("ferry:")) continue;
     if (isKnownNonOverrideLabel(label)) continue;
@@ -6146,6 +6164,61 @@ function resolveTicketOverrides(labels, logger, options) {
       noPr = true;
       continue;
     }
+    if (label.startsWith("ferry:base/")) {
+      const branch = label.slice("ferry:base/".length);
+      if (!BRANCH_NAME_REGEX.test(branch)) {
+        logger?.warn("invalid branch name in ferry:base label (expected ^[a-zA-Z0-9._/-]+$)", {
+          label
+        });
+        continue;
+      }
+      if (baseBranch !== void 0 && baseBranch !== branch) {
+        throw new LabelConflictError(baseBranchLabel, label, "git.baseBranch");
+      }
+      if (baseBranch === void 0) {
+        baseBranch = branch;
+        baseBranchLabel = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:target/")) {
+      const branch = label.slice("ferry:target/".length);
+      if (!BRANCH_NAME_REGEX.test(branch)) {
+        logger?.warn("invalid branch name in ferry:target label (expected ^[a-zA-Z0-9._/-]+$)", {
+          label
+        });
+        continue;
+      }
+      if (targetBranch !== void 0 && targetBranch !== branch) {
+        throw new LabelConflictError(targetBranchLabel, label, "git.targetBranch");
+      }
+      if (targetBranch === void 0) {
+        targetBranch = branch;
+        targetBranchLabel = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:pr/")) {
+      const suffix = label.slice("ferry:pr/".length);
+      let val;
+      if (suffix === "draft") val = true;
+      else if (suffix === "ready") val = false;
+      if (val === void 0) {
+        logger?.warn("unknown suffix in ferry:pr label (expected draft or ready)", {
+          label,
+          suffix
+        });
+        continue;
+      }
+      if (prDraft !== void 0 && prDraft !== val) {
+        throw new LabelConflictError(prDraftLabel, label, "git.prDraft");
+      }
+      if (prDraft === void 0) {
+        prDraft = val;
+        prDraftLabel = label;
+      }
+      continue;
+    }
     if (label === "ferry:paused") {
       paused = true;
       continue;
@@ -6176,6 +6249,13 @@ function resolveTicketOverrides(labels, logger, options) {
   }
   const hasModelOverrides = Object.keys(modelOverrides).length > 0;
   const hasBudget = budgetMaxCostEur !== void 0 || budgetMaxTokens !== void 0;
+  const hasGit = noPr || baseBranch !== void 0 || targetBranch !== void 0 || prDraft !== void 0;
+  const gitOverride = hasGit ? {
+    ...noPr ? { noPr: true } : {},
+    ...baseBranch !== void 0 ? { baseBranch } : {},
+    ...targetBranch !== void 0 ? { targetBranch } : {},
+    ...prDraft !== void 0 ? { prDraft } : {}
+  } : void 0;
   return {
     ...typeOverrides,
     ...hasModelOverrides ? { modelOverrides } : {},
@@ -6192,7 +6272,7 @@ function resolveTicketOverrides(labels, logger, options) {
     ...noAutoTransition ? { noAutoTransition: true } : {},
     ...thinking !== void 0 ? { thinking } : {},
     ...reviewRubric !== void 0 ? { reviewRubric } : {},
-    ...noPr ? { git: { noPr: true } } : {},
+    ...gitOverride ? { git: gitOverride } : {},
     ...paused ? { paused: true } : {},
     ...dryRun ? { dryRun: true } : {},
     ...readOnly ? { readOnly: true } : {}
@@ -6250,7 +6330,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.git?.baseBranch !== void 0 || overrides.git?.targetBranch !== void 0 || overrides.git?.prDraft !== void 0 || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6265,7 +6345,9 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if (overrides.noAutoTransition) payload.noAutoTransition = true;
   if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
   if (overrides.reviewRubric !== void 0) payload.reviewRubric = overrides.reviewRubric;
-  if (overrides.git?.noPr) payload.git = overrides.git;
+  if (overrides.git !== void 0 && (overrides.git.noPr === true || overrides.git.baseBranch !== void 0 || overrides.git.targetBranch !== void 0 || overrides.git.prDraft !== void 0)) {
+    payload.git = overrides.git;
+  }
   if (overrides.paused) payload.paused = true;
   if (overrides.dryRun) payload.dryRun = true;
   if (overrides.readOnly) payload.readOnly = true;
@@ -9154,8 +9236,10 @@ async function main2(envelope, logger) {
     logger.info("DRY_RUN mode \u2014 no branch push, no PR, no Jira writes");
   }
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT2);
-  const { baseBranch, targetBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
-  const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT2, initialCfg);
+  const resolvedGit = await resolveGitConfig(initialCfg, runner, owner, repo);
+  const ferryCfg = loadFerryConfigFromBaseBranch(resolvedGit.baseBranch, REPO_ROOT2, initialCfg);
+  let baseBranch = resolvedGit.baseBranch;
+  let targetBranch = resolvedGit.targetBranch;
   const devWorkflow = ferryCfg.workflow.agents.developer;
   const configAutoTransition = devWorkflow.auto_transition !== null;
   const issue = await tracker.getIssue(ticketKey);
@@ -9164,6 +9248,7 @@ async function main2(envelope, logger) {
   let forceLabel;
   let noAutoTransition = false;
   let thinkingOverride;
+  let prDraftOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -9172,6 +9257,13 @@ async function main2(envelope, logger) {
     forceLabel = overrides.forceLabel;
     noAutoTransition = overrides.noAutoTransition === true;
     thinkingOverride = overrides.thinking;
+    prDraftOverride = overrides.git?.prDraft;
+    if (overrides.git?.baseBranch !== void 0) {
+      baseBranch = overrides.git.baseBranch;
+    }
+    if (overrides.git?.targetBranch !== void 0) {
+      targetBranch = overrides.git.targetBranch;
+    }
     if (overrides.dryRun === true && !dryRun) {
       dryRun = true;
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
@@ -9183,6 +9275,22 @@ async function main2(envelope, logger) {
         ticketKey,
         buildOverridesAuditComment("developer", eventId, overrides)
       );
+    }
+    if (!dryRun) {
+      if (overrides.git?.baseBranch !== void 0 && !remoteBranchExists(baseBranch, REPO_ROOT2)) {
+        await tracker.postComment(
+          ticketKey,
+          `[ferry:dev:${eventId}] base branch '${baseBranch}' not found on origin \u2014 remove or fix the ferry:base/* label.`
+        );
+        process.exit(1);
+      }
+      if (overrides.git?.targetBranch !== void 0 && !remoteBranchExists(targetBranch, REPO_ROOT2)) {
+        await tracker.postComment(
+          ticketKey,
+          `[ferry:dev:${eventId}] target branch '${targetBranch}' not found on origin \u2014 remove or fix the ferry:target/* label.`
+        );
+        process.exit(1);
+      }
     }
     if (overrides.readOnly === true) {
       logger.info("read-only mode \u2014 developer agent skipped");
@@ -9500,7 +9608,15 @@ ${tree}`,
       validation: done.validation ?? [],
       notes: done.notes ?? []
     });
-    const prUrl = await runner.createPR(owner, repo, branchName, targetBranch, prTitle, prBody);
+    const prUrl = await runner.createPR(
+      owner,
+      repo,
+      branchName,
+      targetBranch,
+      prTitle,
+      prBody,
+      prDraftOverride !== void 0 ? { draft: prDraftOverride } : void 0
+    );
     assertDevOutputContract(resolvedOutcome, { branchPushed, prUrl, verificationNoteWritten });
     if (shouldAutoTransition) {
       await tracker.postTransition(ticketKey, reviewTransitionId);
@@ -10520,8 +10636,9 @@ var REPO_ROOT4 = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main4(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT4);
-  const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
-  const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT4, initialCfg);
+  const resolvedGit = await resolveGitConfig(initialCfg, runner, owner, repo);
+  const ferryCfg = loadFerryConfigFromBaseBranch(resolvedGit.baseBranch, REPO_ROOT4, initialCfg);
+  let baseBranch = resolvedGit.baseBranch;
   const iteratorWorkflow = ferryCfg.workflow.agents.iterator;
   const configAutoTransition = iteratorWorkflow.auto_transition !== null;
   const issue = await tracker.getIssue(ticketKey);
@@ -10541,6 +10658,9 @@ async function main4(envelope, logger) {
     noAutoTransition = overrides.noAutoTransition === true;
     dryRun = overrides.dryRun === true;
     thinkingOverride = overrides.thinking;
+    if (overrides.git?.baseBranch !== void 0) {
+      baseBranch = overrides.git.baseBranch;
+    }
     if (dryRun) {
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
     }
@@ -10551,6 +10671,13 @@ async function main4(envelope, logger) {
         ticketKey,
         buildOverridesAuditComment("iterator", eventId, overrides)
       );
+    }
+    if (!dryRun && overrides.git?.baseBranch !== void 0 && !remoteBranchExists(baseBranch, REPO_ROOT4)) {
+      await tracker.postComment(
+        ticketKey,
+        `[ferry:iter:${eventId}] base branch '${baseBranch}' not found on origin \u2014 remove or fix the ferry:base/* label.`
+      );
+      process.exit(1);
     }
     if (overrides.readOnly === true) {
       logger.info("read-only mode \u2014 iterator agent skipped");

--- a/.github/actions/ferry-run-refiner/agent.js
+++ b/.github/actions/ferry-run-refiner/agent.js
@@ -553,6 +553,17 @@ function makeCommitProgress(logger, options = {}) {
     return "committed and pushed";
   };
 }
+function remoteBranchExists(branchName, repoRoot) {
+  try {
+    execFileSync("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
+      cwd: repoRoot,
+      stdio: "pipe"
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
 function checkoutExistingBranch(branchName, repoRoot) {
   try {
     execFileSync("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
@@ -5153,7 +5164,7 @@ var GitHubActionsRunner = class {
       return `(error fetching content: ${e.message})`;
     }
   }
-  async createPR(owner, repo, head, base, title, body) {
+  async createPR(owner, repo, head, base, title, body, options) {
     try {
       const { data } = await this.octokit.pulls.create({
         owner,
@@ -5162,7 +5173,7 @@ var GitHubActionsRunner = class {
         base,
         title,
         body,
-        draft: true
+        draft: options?.draft ?? true
       });
       return data.html_url;
     } catch {
@@ -5858,6 +5869,7 @@ function filterMcpServers(pool, capabilities, hasLabelsConfig) {
 var AGENT_PHASES = /* @__PURE__ */ new Set(["refiner", "dev", "review", "iterate"]);
 var PHASES_ORDERED = ["refiner", "dev", "review", "iterate"];
 var LLM_PROVIDERS = /* @__PURE__ */ new Set(["anthropic", "openai", "google"]);
+var BRANCH_NAME_REGEX = /^[a-zA-Z0-9._/-]+$/;
 var LabelConflictError = class extends Error {
   label1;
   label2;
@@ -5937,6 +5949,12 @@ function resolveTicketOverrides(labels, logger, options) {
   let dryRun = false;
   let readOnly = false;
   const skipPhases = [];
+  let baseBranchLabel;
+  let baseBranch;
+  let targetBranchLabel;
+  let targetBranch;
+  let prDraftLabel;
+  let prDraft;
   for (const label of labels) {
     if (!label.startsWith("ferry:")) continue;
     if (isKnownNonOverrideLabel(label)) continue;
@@ -6146,6 +6164,61 @@ function resolveTicketOverrides(labels, logger, options) {
       noPr = true;
       continue;
     }
+    if (label.startsWith("ferry:base/")) {
+      const branch = label.slice("ferry:base/".length);
+      if (!BRANCH_NAME_REGEX.test(branch)) {
+        logger?.warn("invalid branch name in ferry:base label (expected ^[a-zA-Z0-9._/-]+$)", {
+          label
+        });
+        continue;
+      }
+      if (baseBranch !== void 0 && baseBranch !== branch) {
+        throw new LabelConflictError(baseBranchLabel, label, "git.baseBranch");
+      }
+      if (baseBranch === void 0) {
+        baseBranch = branch;
+        baseBranchLabel = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:target/")) {
+      const branch = label.slice("ferry:target/".length);
+      if (!BRANCH_NAME_REGEX.test(branch)) {
+        logger?.warn("invalid branch name in ferry:target label (expected ^[a-zA-Z0-9._/-]+$)", {
+          label
+        });
+        continue;
+      }
+      if (targetBranch !== void 0 && targetBranch !== branch) {
+        throw new LabelConflictError(targetBranchLabel, label, "git.targetBranch");
+      }
+      if (targetBranch === void 0) {
+        targetBranch = branch;
+        targetBranchLabel = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:pr/")) {
+      const suffix = label.slice("ferry:pr/".length);
+      let val;
+      if (suffix === "draft") val = true;
+      else if (suffix === "ready") val = false;
+      if (val === void 0) {
+        logger?.warn("unknown suffix in ferry:pr label (expected draft or ready)", {
+          label,
+          suffix
+        });
+        continue;
+      }
+      if (prDraft !== void 0 && prDraft !== val) {
+        throw new LabelConflictError(prDraftLabel, label, "git.prDraft");
+      }
+      if (prDraft === void 0) {
+        prDraft = val;
+        prDraftLabel = label;
+      }
+      continue;
+    }
     if (label === "ferry:paused") {
       paused = true;
       continue;
@@ -6176,6 +6249,13 @@ function resolveTicketOverrides(labels, logger, options) {
   }
   const hasModelOverrides = Object.keys(modelOverrides).length > 0;
   const hasBudget = budgetMaxCostEur !== void 0 || budgetMaxTokens !== void 0;
+  const hasGit = noPr || baseBranch !== void 0 || targetBranch !== void 0 || prDraft !== void 0;
+  const gitOverride = hasGit ? {
+    ...noPr ? { noPr: true } : {},
+    ...baseBranch !== void 0 ? { baseBranch } : {},
+    ...targetBranch !== void 0 ? { targetBranch } : {},
+    ...prDraft !== void 0 ? { prDraft } : {}
+  } : void 0;
   return {
     ...typeOverrides,
     ...hasModelOverrides ? { modelOverrides } : {},
@@ -6192,7 +6272,7 @@ function resolveTicketOverrides(labels, logger, options) {
     ...noAutoTransition ? { noAutoTransition: true } : {},
     ...thinking !== void 0 ? { thinking } : {},
     ...reviewRubric !== void 0 ? { reviewRubric } : {},
-    ...noPr ? { git: { noPr: true } } : {},
+    ...gitOverride ? { git: gitOverride } : {},
     ...paused ? { paused: true } : {},
     ...dryRun ? { dryRun: true } : {},
     ...readOnly ? { readOnly: true } : {}
@@ -6250,7 +6330,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.git?.baseBranch !== void 0 || overrides.git?.targetBranch !== void 0 || overrides.git?.prDraft !== void 0 || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6265,7 +6345,9 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if (overrides.noAutoTransition) payload.noAutoTransition = true;
   if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
   if (overrides.reviewRubric !== void 0) payload.reviewRubric = overrides.reviewRubric;
-  if (overrides.git?.noPr) payload.git = overrides.git;
+  if (overrides.git !== void 0 && (overrides.git.noPr === true || overrides.git.baseBranch !== void 0 || overrides.git.targetBranch !== void 0 || overrides.git.prDraft !== void 0)) {
+    payload.git = overrides.git;
+  }
   if (overrides.paused) payload.paused = true;
   if (overrides.dryRun) payload.dryRun = true;
   if (overrides.readOnly) payload.readOnly = true;
@@ -9154,8 +9236,10 @@ async function main2(envelope, logger) {
     logger.info("DRY_RUN mode \u2014 no branch push, no PR, no Jira writes");
   }
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT2);
-  const { baseBranch, targetBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
-  const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT2, initialCfg);
+  const resolvedGit = await resolveGitConfig(initialCfg, runner, owner, repo);
+  const ferryCfg = loadFerryConfigFromBaseBranch(resolvedGit.baseBranch, REPO_ROOT2, initialCfg);
+  let baseBranch = resolvedGit.baseBranch;
+  let targetBranch = resolvedGit.targetBranch;
   const devWorkflow = ferryCfg.workflow.agents.developer;
   const configAutoTransition = devWorkflow.auto_transition !== null;
   const issue = await tracker.getIssue(ticketKey);
@@ -9164,6 +9248,7 @@ async function main2(envelope, logger) {
   let forceLabel;
   let noAutoTransition = false;
   let thinkingOverride;
+  let prDraftOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -9172,6 +9257,13 @@ async function main2(envelope, logger) {
     forceLabel = overrides.forceLabel;
     noAutoTransition = overrides.noAutoTransition === true;
     thinkingOverride = overrides.thinking;
+    prDraftOverride = overrides.git?.prDraft;
+    if (overrides.git?.baseBranch !== void 0) {
+      baseBranch = overrides.git.baseBranch;
+    }
+    if (overrides.git?.targetBranch !== void 0) {
+      targetBranch = overrides.git.targetBranch;
+    }
     if (overrides.dryRun === true && !dryRun) {
       dryRun = true;
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
@@ -9183,6 +9275,22 @@ async function main2(envelope, logger) {
         ticketKey,
         buildOverridesAuditComment("developer", eventId, overrides)
       );
+    }
+    if (!dryRun) {
+      if (overrides.git?.baseBranch !== void 0 && !remoteBranchExists(baseBranch, REPO_ROOT2)) {
+        await tracker.postComment(
+          ticketKey,
+          `[ferry:dev:${eventId}] base branch '${baseBranch}' not found on origin \u2014 remove or fix the ferry:base/* label.`
+        );
+        process.exit(1);
+      }
+      if (overrides.git?.targetBranch !== void 0 && !remoteBranchExists(targetBranch, REPO_ROOT2)) {
+        await tracker.postComment(
+          ticketKey,
+          `[ferry:dev:${eventId}] target branch '${targetBranch}' not found on origin \u2014 remove or fix the ferry:target/* label.`
+        );
+        process.exit(1);
+      }
     }
     if (overrides.readOnly === true) {
       logger.info("read-only mode \u2014 developer agent skipped");
@@ -9500,7 +9608,15 @@ ${tree}`,
       validation: done.validation ?? [],
       notes: done.notes ?? []
     });
-    const prUrl = await runner.createPR(owner, repo, branchName, targetBranch, prTitle, prBody);
+    const prUrl = await runner.createPR(
+      owner,
+      repo,
+      branchName,
+      targetBranch,
+      prTitle,
+      prBody,
+      prDraftOverride !== void 0 ? { draft: prDraftOverride } : void 0
+    );
     assertDevOutputContract(resolvedOutcome, { branchPushed, prUrl, verificationNoteWritten });
     if (shouldAutoTransition) {
       await tracker.postTransition(ticketKey, reviewTransitionId);
@@ -10520,8 +10636,9 @@ var REPO_ROOT4 = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main4(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT4);
-  const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
-  const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT4, initialCfg);
+  const resolvedGit = await resolveGitConfig(initialCfg, runner, owner, repo);
+  const ferryCfg = loadFerryConfigFromBaseBranch(resolvedGit.baseBranch, REPO_ROOT4, initialCfg);
+  let baseBranch = resolvedGit.baseBranch;
   const iteratorWorkflow = ferryCfg.workflow.agents.iterator;
   const configAutoTransition = iteratorWorkflow.auto_transition !== null;
   const issue = await tracker.getIssue(ticketKey);
@@ -10541,6 +10658,9 @@ async function main4(envelope, logger) {
     noAutoTransition = overrides.noAutoTransition === true;
     dryRun = overrides.dryRun === true;
     thinkingOverride = overrides.thinking;
+    if (overrides.git?.baseBranch !== void 0) {
+      baseBranch = overrides.git.baseBranch;
+    }
     if (dryRun) {
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
     }
@@ -10551,6 +10671,13 @@ async function main4(envelope, logger) {
         ticketKey,
         buildOverridesAuditComment("iterator", eventId, overrides)
       );
+    }
+    if (!dryRun && overrides.git?.baseBranch !== void 0 && !remoteBranchExists(baseBranch, REPO_ROOT4)) {
+      await tracker.postComment(
+        ticketKey,
+        `[ferry:iter:${eventId}] base branch '${baseBranch}' not found on origin \u2014 remove or fix the ferry:base/* label.`
+      );
+      process.exit(1);
     }
     if (overrides.readOnly === true) {
       logger.info("read-only mode \u2014 iterator agent skipped");

--- a/.github/actions/ferry-run-reviewer/agent.js
+++ b/.github/actions/ferry-run-reviewer/agent.js
@@ -553,6 +553,17 @@ function makeCommitProgress(logger, options = {}) {
     return "committed and pushed";
   };
 }
+function remoteBranchExists(branchName, repoRoot) {
+  try {
+    execFileSync("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
+      cwd: repoRoot,
+      stdio: "pipe"
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
 function checkoutExistingBranch(branchName, repoRoot) {
   try {
     execFileSync("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
@@ -5153,7 +5164,7 @@ var GitHubActionsRunner = class {
       return `(error fetching content: ${e.message})`;
     }
   }
-  async createPR(owner, repo, head, base, title, body) {
+  async createPR(owner, repo, head, base, title, body, options) {
     try {
       const { data } = await this.octokit.pulls.create({
         owner,
@@ -5162,7 +5173,7 @@ var GitHubActionsRunner = class {
         base,
         title,
         body,
-        draft: true
+        draft: options?.draft ?? true
       });
       return data.html_url;
     } catch {
@@ -5858,6 +5869,7 @@ function filterMcpServers(pool, capabilities, hasLabelsConfig) {
 var AGENT_PHASES = /* @__PURE__ */ new Set(["refiner", "dev", "review", "iterate"]);
 var PHASES_ORDERED = ["refiner", "dev", "review", "iterate"];
 var LLM_PROVIDERS = /* @__PURE__ */ new Set(["anthropic", "openai", "google"]);
+var BRANCH_NAME_REGEX = /^[a-zA-Z0-9._/-]+$/;
 var LabelConflictError = class extends Error {
   label1;
   label2;
@@ -5937,6 +5949,12 @@ function resolveTicketOverrides(labels, logger, options) {
   let dryRun = false;
   let readOnly = false;
   const skipPhases = [];
+  let baseBranchLabel;
+  let baseBranch;
+  let targetBranchLabel;
+  let targetBranch;
+  let prDraftLabel;
+  let prDraft;
   for (const label of labels) {
     if (!label.startsWith("ferry:")) continue;
     if (isKnownNonOverrideLabel(label)) continue;
@@ -6146,6 +6164,61 @@ function resolveTicketOverrides(labels, logger, options) {
       noPr = true;
       continue;
     }
+    if (label.startsWith("ferry:base/")) {
+      const branch = label.slice("ferry:base/".length);
+      if (!BRANCH_NAME_REGEX.test(branch)) {
+        logger?.warn("invalid branch name in ferry:base label (expected ^[a-zA-Z0-9._/-]+$)", {
+          label
+        });
+        continue;
+      }
+      if (baseBranch !== void 0 && baseBranch !== branch) {
+        throw new LabelConflictError(baseBranchLabel, label, "git.baseBranch");
+      }
+      if (baseBranch === void 0) {
+        baseBranch = branch;
+        baseBranchLabel = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:target/")) {
+      const branch = label.slice("ferry:target/".length);
+      if (!BRANCH_NAME_REGEX.test(branch)) {
+        logger?.warn("invalid branch name in ferry:target label (expected ^[a-zA-Z0-9._/-]+$)", {
+          label
+        });
+        continue;
+      }
+      if (targetBranch !== void 0 && targetBranch !== branch) {
+        throw new LabelConflictError(targetBranchLabel, label, "git.targetBranch");
+      }
+      if (targetBranch === void 0) {
+        targetBranch = branch;
+        targetBranchLabel = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:pr/")) {
+      const suffix = label.slice("ferry:pr/".length);
+      let val;
+      if (suffix === "draft") val = true;
+      else if (suffix === "ready") val = false;
+      if (val === void 0) {
+        logger?.warn("unknown suffix in ferry:pr label (expected draft or ready)", {
+          label,
+          suffix
+        });
+        continue;
+      }
+      if (prDraft !== void 0 && prDraft !== val) {
+        throw new LabelConflictError(prDraftLabel, label, "git.prDraft");
+      }
+      if (prDraft === void 0) {
+        prDraft = val;
+        prDraftLabel = label;
+      }
+      continue;
+    }
     if (label === "ferry:paused") {
       paused = true;
       continue;
@@ -6176,6 +6249,13 @@ function resolveTicketOverrides(labels, logger, options) {
   }
   const hasModelOverrides = Object.keys(modelOverrides).length > 0;
   const hasBudget = budgetMaxCostEur !== void 0 || budgetMaxTokens !== void 0;
+  const hasGit = noPr || baseBranch !== void 0 || targetBranch !== void 0 || prDraft !== void 0;
+  const gitOverride = hasGit ? {
+    ...noPr ? { noPr: true } : {},
+    ...baseBranch !== void 0 ? { baseBranch } : {},
+    ...targetBranch !== void 0 ? { targetBranch } : {},
+    ...prDraft !== void 0 ? { prDraft } : {}
+  } : void 0;
   return {
     ...typeOverrides,
     ...hasModelOverrides ? { modelOverrides } : {},
@@ -6192,7 +6272,7 @@ function resolveTicketOverrides(labels, logger, options) {
     ...noAutoTransition ? { noAutoTransition: true } : {},
     ...thinking !== void 0 ? { thinking } : {},
     ...reviewRubric !== void 0 ? { reviewRubric } : {},
-    ...noPr ? { git: { noPr: true } } : {},
+    ...gitOverride ? { git: gitOverride } : {},
     ...paused ? { paused: true } : {},
     ...dryRun ? { dryRun: true } : {},
     ...readOnly ? { readOnly: true } : {}
@@ -6250,7 +6330,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.git?.baseBranch !== void 0 || overrides.git?.targetBranch !== void 0 || overrides.git?.prDraft !== void 0 || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6265,7 +6345,9 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if (overrides.noAutoTransition) payload.noAutoTransition = true;
   if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
   if (overrides.reviewRubric !== void 0) payload.reviewRubric = overrides.reviewRubric;
-  if (overrides.git?.noPr) payload.git = overrides.git;
+  if (overrides.git !== void 0 && (overrides.git.noPr === true || overrides.git.baseBranch !== void 0 || overrides.git.targetBranch !== void 0 || overrides.git.prDraft !== void 0)) {
+    payload.git = overrides.git;
+  }
   if (overrides.paused) payload.paused = true;
   if (overrides.dryRun) payload.dryRun = true;
   if (overrides.readOnly) payload.readOnly = true;
@@ -9154,8 +9236,10 @@ async function main2(envelope, logger) {
     logger.info("DRY_RUN mode \u2014 no branch push, no PR, no Jira writes");
   }
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT2);
-  const { baseBranch, targetBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
-  const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT2, initialCfg);
+  const resolvedGit = await resolveGitConfig(initialCfg, runner, owner, repo);
+  const ferryCfg = loadFerryConfigFromBaseBranch(resolvedGit.baseBranch, REPO_ROOT2, initialCfg);
+  let baseBranch = resolvedGit.baseBranch;
+  let targetBranch = resolvedGit.targetBranch;
   const devWorkflow = ferryCfg.workflow.agents.developer;
   const configAutoTransition = devWorkflow.auto_transition !== null;
   const issue = await tracker.getIssue(ticketKey);
@@ -9164,6 +9248,7 @@ async function main2(envelope, logger) {
   let forceLabel;
   let noAutoTransition = false;
   let thinkingOverride;
+  let prDraftOverride;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -9172,6 +9257,13 @@ async function main2(envelope, logger) {
     forceLabel = overrides.forceLabel;
     noAutoTransition = overrides.noAutoTransition === true;
     thinkingOverride = overrides.thinking;
+    prDraftOverride = overrides.git?.prDraft;
+    if (overrides.git?.baseBranch !== void 0) {
+      baseBranch = overrides.git.baseBranch;
+    }
+    if (overrides.git?.targetBranch !== void 0) {
+      targetBranch = overrides.git.targetBranch;
+    }
     if (overrides.dryRun === true && !dryRun) {
       dryRun = true;
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
@@ -9183,6 +9275,22 @@ async function main2(envelope, logger) {
         ticketKey,
         buildOverridesAuditComment("developer", eventId, overrides)
       );
+    }
+    if (!dryRun) {
+      if (overrides.git?.baseBranch !== void 0 && !remoteBranchExists(baseBranch, REPO_ROOT2)) {
+        await tracker.postComment(
+          ticketKey,
+          `[ferry:dev:${eventId}] base branch '${baseBranch}' not found on origin \u2014 remove or fix the ferry:base/* label.`
+        );
+        process.exit(1);
+      }
+      if (overrides.git?.targetBranch !== void 0 && !remoteBranchExists(targetBranch, REPO_ROOT2)) {
+        await tracker.postComment(
+          ticketKey,
+          `[ferry:dev:${eventId}] target branch '${targetBranch}' not found on origin \u2014 remove or fix the ferry:target/* label.`
+        );
+        process.exit(1);
+      }
     }
     if (overrides.readOnly === true) {
       logger.info("read-only mode \u2014 developer agent skipped");
@@ -9500,7 +9608,15 @@ ${tree}`,
       validation: done.validation ?? [],
       notes: done.notes ?? []
     });
-    const prUrl = await runner.createPR(owner, repo, branchName, targetBranch, prTitle, prBody);
+    const prUrl = await runner.createPR(
+      owner,
+      repo,
+      branchName,
+      targetBranch,
+      prTitle,
+      prBody,
+      prDraftOverride !== void 0 ? { draft: prDraftOverride } : void 0
+    );
     assertDevOutputContract(resolvedOutcome, { branchPushed, prUrl, verificationNoteWritten });
     if (shouldAutoTransition) {
       await tracker.postTransition(ticketKey, reviewTransitionId);
@@ -10520,8 +10636,9 @@ var REPO_ROOT4 = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main4(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT4);
-  const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
-  const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT4, initialCfg);
+  const resolvedGit = await resolveGitConfig(initialCfg, runner, owner, repo);
+  const ferryCfg = loadFerryConfigFromBaseBranch(resolvedGit.baseBranch, REPO_ROOT4, initialCfg);
+  let baseBranch = resolvedGit.baseBranch;
   const iteratorWorkflow = ferryCfg.workflow.agents.iterator;
   const configAutoTransition = iteratorWorkflow.auto_transition !== null;
   const issue = await tracker.getIssue(ticketKey);
@@ -10541,6 +10658,9 @@ async function main4(envelope, logger) {
     noAutoTransition = overrides.noAutoTransition === true;
     dryRun = overrides.dryRun === true;
     thinkingOverride = overrides.thinking;
+    if (overrides.git?.baseBranch !== void 0) {
+      baseBranch = overrides.git.baseBranch;
+    }
     if (dryRun) {
       logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
     }
@@ -10551,6 +10671,13 @@ async function main4(envelope, logger) {
         ticketKey,
         buildOverridesAuditComment("iterator", eventId, overrides)
       );
+    }
+    if (!dryRun && overrides.git?.baseBranch !== void 0 && !remoteBranchExists(baseBranch, REPO_ROOT4)) {
+      await tracker.postComment(
+        ticketKey,
+        `[ferry:iter:${eventId}] base branch '${baseBranch}' not found on origin \u2014 remove or fix the ferry:base/* label.`
+      );
+      process.exit(1);
     }
     if (overrides.readOnly === true) {
       logger.info("read-only mode \u2014 iterator agent skipped");

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -567,6 +567,32 @@ A rubric-override directive is appended at the end of the reviewer's system prom
 | ----------------- | ------------------------------------------------------------------ |
 | `ferry:git/no-pr` | Developer skips PR creation (branch is pushed but no PR is opened) |
 
+##### Per-ticket branch and PR-state overrides (`ferry:base/*`, `ferry:target/*`, `ferry:pr/*`)
+
+Lets a single Jira ticket pick its own base branch, PR target branch, and PR draft state without editing `ferry.config.yaml`.
+
+| Label                   | Effect                                                                                    |
+| ----------------------- | ----------------------------------------------------------------------------------------- |
+| `ferry:base/<branch>`   | Override `git.base_branch` — the branch Ferry creates the `ferry/...` working branch from |
+| `ferry:target/<branch>` | Override `git.target_branch` — the branch the PR is opened against                        |
+| `ferry:pr/draft`        | Open the PR as draft regardless of repo default                                           |
+| `ferry:pr/ready`        | Open the PR as ready-for-review regardless of repo default                                |
+
+**Branch validation:** `<branch>` must match the regex `^[a-zA-Z0-9._/-]+$` (alphanumerics plus `.`, `_`, `/`, `-`). Anything else — spaces, `$`, shell metacharacters, empty string — is rejected as a parse error: the label is logged to stderr and ignored, and no conflict is raised. This is intentional: a typo in the value should not block the ticket.
+
+**Remote existence:** the Developer agent validates that the resolved base and target branches exist on `origin` before branching off them or opening the PR. A missing branch fails loudly with a Jira comment naming the missing branch and a non-zero exit. The Iterator performs the same check for `baseBranch` before merging the base into the working branch.
+
+**Conflict rules:**
+
+- `ferry:pr/draft` + `ferry:pr/ready` on the same ticket → `LabelConflictError` (field `git.prDraft`).
+- Two different `ferry:base/<x>` values → `LabelConflictError` (field `git.baseBranch`).
+- Two different `ferry:target/<x>` values → `LabelConflictError` (field `git.targetBranch`).
+- Identical duplicates (e.g. two `ferry:base/release-1.x` labels) are accepted as vacuous.
+
+**Security:** `ferry:target/<branch>` can theoretically be abused to ship to a protected branch. Ferry only **opens** the PR — it does not merge — so existing GitHub branch protection rules and CODEOWNERS still apply unchanged. Risk is contained at the merge gate; treat the label as a target-branch hint, not a merge authorization.
+
+**Use case (backport):** a ticket fixing a regression on the maintenance branch is labeled `ferry:base/release-1.x` + `ferry:target/release-1.x` + `ferry:pr/ready`. The Developer agent branches off `release-1.x`, opens a ready-for-review PR against `release-1.x`, and the reviewer can merge straight into the maintenance line.
+
 ##### Safety labels
 
 | Label             | Applied by               | Effect                                                                                                                                            |

--- a/src/agents/developer/dev-action.ts
+++ b/src/agents/developer/dev-action.ts
@@ -43,6 +43,7 @@ import {
   buildConflictComment,
   applyDryRunMarker,
   LabelConflictError,
+  remoteBranchExists,
 } from '../../lib/agent-runtime/index.js';
 import { detectTestRunner, repoTree, packageJsonPath, detectPackageManager } from './workspace.js';
 import { assertDevOutputContract } from './outcome-guard.js';
@@ -63,10 +64,13 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
   // Resolve baseBranch before using any config values, then reload config from that branch.
   // On repository_dispatch, actions/checkout resolves to the default branch, not base_branch,
   // so the workspace may contain a stale ferry.config.json.
-  const { baseBranch, targetBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
+  const resolvedGit = await resolveGitConfig(initialCfg, runner, owner, repo);
   // loadFerryConfigFromBaseBranch also fetches origin/<baseBranch>, which makes
   // `git log origin/<base>..HEAD` work correctly later in this function.
-  const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
+  const ferryCfg = loadFerryConfigFromBaseBranch(resolvedGit.baseBranch, REPO_ROOT, initialCfg);
+  // base/target branches may be overridden by ferry:base/* and ferry:target/* labels below.
+  let baseBranch = resolvedGit.baseBranch;
+  let targetBranch = resolvedGit.targetBranch;
 
   const devWorkflow = ferryCfg.workflow.agents.developer;
   const configAutoTransition = devWorkflow.auto_transition !== null;
@@ -79,6 +83,7 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
   let forceLabel: string | undefined;
   let noAutoTransition = false;
   let thinkingOverride: 'on' | 'off' | 'extended' | undefined;
+  let prDraftOverride: boolean | undefined;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true,
@@ -87,6 +92,14 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     forceLabel = overrides.forceLabel;
     noAutoTransition = overrides.noAutoTransition === true;
     thinkingOverride = overrides.thinking;
+    prDraftOverride = overrides.git?.prDraft;
+    // ferry:base/<branch> and ferry:target/<branch> — runtime-validated branch overrides.
+    if (overrides.git?.baseBranch !== undefined) {
+      baseBranch = overrides.git.baseBranch;
+    }
+    if (overrides.git?.targetBranch !== undefined) {
+      targetBranch = overrides.git.targetBranch;
+    }
     // ferry:dry-run label → enable dry-run mode (same gating as FERRY_DRY_RUN env var).
     if (overrides.dryRun === true && !dryRun) {
       dryRun = true;
@@ -99,6 +112,26 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
         ticketKey,
         buildOverridesAuditComment('developer', eventId, overrides),
       );
+    }
+    // Validate overridden base / target branches exist on origin — fail loudly if missing.
+    if (!dryRun) {
+      if (overrides.git?.baseBranch !== undefined && !remoteBranchExists(baseBranch, REPO_ROOT)) {
+        await tracker.postComment(
+          ticketKey,
+          `[ferry:dev:${eventId}] base branch '${baseBranch}' not found on origin — remove or fix the ferry:base/* label.`,
+        );
+        process.exit(1);
+      }
+      if (
+        overrides.git?.targetBranch !== undefined &&
+        !remoteBranchExists(targetBranch, REPO_ROOT)
+      ) {
+        await tracker.postComment(
+          ticketKey,
+          `[ferry:dev:${eventId}] target branch '${targetBranch}' not found on origin — remove or fix the ferry:target/* label.`,
+        );
+        process.exit(1);
+      }
     }
     // ferry:read-only — Developer short-circuits at entry; Refiner runs normally.
     if (overrides.readOnly === true) {
@@ -467,7 +500,15 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
       notes: done.notes ?? [],
     });
 
-    const prUrl = await runner.createPR(owner, repo, branchName, targetBranch, prTitle, prBody);
+    const prUrl = await runner.createPR(
+      owner,
+      repo,
+      branchName,
+      targetBranch,
+      prTitle,
+      prBody,
+      prDraftOverride !== undefined ? { draft: prDraftOverride } : undefined,
+    );
 
     // Output-contract guard: verify all required outputs exist before terminal comment.
     assertDevOutputContract(resolvedOutcome, { branchPushed, prUrl, verificationNoteWritten });

--- a/src/agents/iterator/iterate-action.ts
+++ b/src/agents/iterator/iterate-action.ts
@@ -17,6 +17,7 @@ import {
   buildConflictComment,
   applyDryRunMarker,
   LabelConflictError,
+  remoteBranchExists,
 } from '../../lib/agent-runtime/index.js';
 import {
   requireEnv,
@@ -53,8 +54,10 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
   // Resolve baseBranch before using any config values, then reload config from that branch.
   // On repository_dispatch, actions/checkout resolves to the default branch, not base_branch,
   // so the workspace may contain a stale ferry.config.json.
-  const { baseBranch } = await resolveGitConfig(initialCfg, runner, owner, repo);
-  const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
+  const resolvedGit = await resolveGitConfig(initialCfg, runner, owner, repo);
+  const ferryCfg = loadFerryConfigFromBaseBranch(resolvedGit.baseBranch, REPO_ROOT, initialCfg);
+  // baseBranch may be overridden by the ferry:base/<branch> label below.
+  let baseBranch = resolvedGit.baseBranch;
 
   const iteratorWorkflow = ferryCfg.workflow.agents.iterator;
   const configAutoTransition = iteratorWorkflow.auto_transition !== null;
@@ -80,6 +83,10 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     noAutoTransition = overrides.noAutoTransition === true;
     dryRun = overrides.dryRun === true;
     thinkingOverride = overrides.thinking;
+    // ferry:base/<branch> — runtime-validated base-branch override (Iterator merges from this).
+    if (overrides.git?.baseBranch !== undefined) {
+      baseBranch = overrides.git.baseBranch;
+    }
     if (dryRun) {
       logger.warn('DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.');
     }
@@ -90,6 +97,18 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
         ticketKey,
         buildOverridesAuditComment('iterator', eventId, overrides),
       );
+    }
+    // Validate overridden base branch exists on origin — fail loudly if missing.
+    if (
+      !dryRun &&
+      overrides.git?.baseBranch !== undefined &&
+      !remoteBranchExists(baseBranch, REPO_ROOT)
+    ) {
+      await tracker.postComment(
+        ticketKey,
+        `[ferry:iter:${eventId}] base branch '${baseBranch}' not found on origin — remove or fix the ferry:base/* label.`,
+      );
+      process.exit(1);
     }
     // ferry:read-only — Iterator short-circuits at entry; Refiner runs normally.
     if (overrides.readOnly === true) {

--- a/src/labels/allowlist.ts
+++ b/src/labels/allowlist.ts
@@ -51,6 +51,12 @@ export const LABELS_ALLOWLIST = [
   'ferry:lenient-review',
   'ferry:git/',
   'ferry:git/no-pr',
+  // Git base / target / PR-state overrides (per-ticket; #241)
+  'ferry:base/',
+  'ferry:target/',
+  'ferry:pr/',
+  'ferry:pr/draft',
+  'ferry:pr/ready',
   // Config-label namespace prefixes (handled by resolveCapabilities, not resolveTicketOverrides)
   'ferry:mcp/',
   'ferry:profile/',

--- a/src/lib/agent-runtime/git.ts
+++ b/src/lib/agent-runtime/git.ts
@@ -40,6 +40,23 @@ export function makeCommitProgress(
   };
 }
 
+/**
+ * Returns true when the given branch exists on `origin`.
+ * Used to validate ferry:base/* and ferry:target/* overrides before consuming
+ * them — a missing branch must fail loudly.
+ */
+export function remoteBranchExists(branchName: string, repoRoot: string): boolean {
+  try {
+    execFileSync('git', ['ls-remote', '--exit-code', '--heads', 'origin', branchName], {
+      cwd: repoRoot,
+      stdio: 'pipe',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function checkoutExistingBranch(branchName: string, repoRoot: string): 'ok' | 'not-found' {
   try {
     execFileSync('git', ['ls-remote', '--exit-code', '--heads', 'origin', branchName], {

--- a/src/lib/agent-runtime/index.ts
+++ b/src/lib/agent-runtime/index.ts
@@ -12,6 +12,7 @@ export {
   fetchOriginBranch,
   fetchAndMergeBase,
   checkoutExistingBranch,
+  remoteBranchExists,
 } from './git.js';
 export type { CommitProgressFn } from './git.js';
 export { loadFerryConfigFromBaseBranch } from './config-reload.js';

--- a/src/lib/dispatch/runner/github-actions/index.test.ts
+++ b/src/lib/dispatch/runner/github-actions/index.test.ts
@@ -126,6 +126,32 @@ describe('GitHubActionsRunner', () => {
       expect(mock.pulls.create).toHaveBeenCalledWith(expect.objectContaining({ draft: true }));
     });
 
+    it('opens PR as ready-for-review when options.draft=false', async () => {
+      mock.pulls.create.mockResolvedValue({
+        data: { html_url: 'https://github.com/acme/ferry/pull/100' },
+      });
+      await runner.createPR(OWNER, REPO, 'feature', 'main', 'title', 'body', { draft: false });
+      expect(mock.pulls.create).toHaveBeenCalledWith(expect.objectContaining({ draft: false }));
+    });
+
+    it('opens PR as draft when options.draft=true (explicit)', async () => {
+      mock.pulls.create.mockResolvedValue({
+        data: { html_url: 'https://github.com/acme/ferry/pull/101' },
+      });
+      await runner.createPR(OWNER, REPO, 'feature', 'main', 'title', 'body', { draft: true });
+      expect(mock.pulls.create).toHaveBeenCalledWith(expect.objectContaining({ draft: true }));
+    });
+
+    it('passes the supplied base branch to octokit (target branch override)', async () => {
+      mock.pulls.create.mockResolvedValue({
+        data: { html_url: 'https://github.com/acme/ferry/pull/102' },
+      });
+      await runner.createPR(OWNER, REPO, 'feature', 'release-1.x', 'title', 'body');
+      expect(mock.pulls.create).toHaveBeenCalledWith(
+        expect.objectContaining({ base: 'release-1.x' }),
+      );
+    });
+
     it('returns existing PR url when creation fails (PR already exists)', async () => {
       mock.pulls.create.mockRejectedValue(new Error('Validation Failed'));
       mock.pulls.list.mockResolvedValue({

--- a/src/lib/dispatch/runner/github-actions/index.ts
+++ b/src/lib/dispatch/runner/github-actions/index.ts
@@ -134,6 +134,7 @@ export class GitHubActionsRunner implements CIRunner {
     base: string,
     title: string,
     body: string,
+    options?: { draft?: boolean },
   ): Promise<string> {
     try {
       const { data } = await this.octokit.pulls.create({
@@ -143,7 +144,7 @@ export class GitHubActionsRunner implements CIRunner {
         base,
         title,
         body,
-        draft: true,
+        draft: options?.draft ?? true,
       });
       return data.html_url;
     } catch {

--- a/src/lib/dispatch/runner/types.ts
+++ b/src/lib/dispatch/runner/types.ts
@@ -90,6 +90,7 @@ export interface CIRunner {
     base: string,
     title: string,
     body: string,
+    options?: { draft?: boolean },
   ): Promise<string>;
   /**
    * Promote draft → ready-for-review (GitHub) or remove `Draft:` prefix from

--- a/src/lib/labels/capabilities.ts
+++ b/src/lib/labels/capabilities.ts
@@ -132,14 +132,20 @@ export interface TicketOverrides {
    */
   reviewRubric?: 'strict' | 'lenient';
 
-  // --- ferry:git/* ---
+  // --- ferry:git/* + ferry:base/* + ferry:target/* + ferry:pr/* ---
 
   /**
-   * Git behaviour overrides derived from ferry:git/* labels.
-   * ferry:git/no-pr skips PR creation at the end of a Developer run.
+   * Git behaviour overrides derived from ferry:git/*, ferry:base/*, ferry:target/* and ferry:pr/* labels.
+   * - noPr (ferry:git/no-pr)             — skips PR creation at the end of a Developer run.
+   * - baseBranch (ferry:base/<branch>)   — overrides git.base_branch (the branch Ferry creates ferry/... from).
+   * - targetBranch (ferry:target/<branch>) — overrides git.target_branch (the branch the PR is opened against).
+   * - prDraft (ferry:pr/draft or ferry:pr/ready) — true forces draft, false forces ready-for-review.
    */
   git?: {
     noPr?: boolean;
+    baseBranch?: string;
+    targetBranch?: string;
+    prDraft?: boolean;
   };
 
   // --- ferry:paused (safety) ---

--- a/src/lib/labels/overrides.test.ts
+++ b/src/lib/labels/overrides.test.ts
@@ -530,6 +530,162 @@ describe('resolveTicketOverrides — git overrides (ferry:git/*)', () => {
 });
 
 // ------------------------------------------------------------------
+// ferry:base/<branch> / ferry:target/<branch> / ferry:pr/draft|ready
+// ------------------------------------------------------------------
+
+describe('resolveTicketOverrides — ferry:base/<branch>', () => {
+  it('sets git.baseBranch from ferry:base/release-1.x', () => {
+    const r = resolveTicketOverrides(['ferry:base/release-1.x']);
+    expect(r.git?.baseBranch).toBe('release-1.x');
+  });
+
+  it('accepts slashes inside the branch name (e.g. feat/foo)', () => {
+    const r = resolveTicketOverrides(['ferry:base/feat/foo']);
+    expect(r.git?.baseBranch).toBe('feat/foo');
+  });
+
+  it('accepts dots, underscores, dashes', () => {
+    const r = resolveTicketOverrides(['ferry:base/release_1.2-rc']);
+    expect(r.git?.baseBranch).toBe('release_1.2-rc');
+  });
+
+  it('warns and ignores invalid branch names containing spaces', () => {
+    const { logger, records } = createTestLogger('t', 'test');
+    const r = resolveTicketOverrides(['ferry:base/has space'], logger);
+    expect(r.git?.baseBranch).toBeUndefined();
+    expect(records.some((rec) => rec.level === 'warn')).toBe(true);
+  });
+
+  it('warns and ignores branch names with disallowed chars ($, etc.)', () => {
+    const { logger, records } = createTestLogger('t', 'test');
+    const r = resolveTicketOverrides(['ferry:base/$invalid'], logger);
+    expect(r.git?.baseBranch).toBeUndefined();
+    expect(records.some((rec) => rec.level === 'warn')).toBe(true);
+  });
+
+  it('warns and ignores empty branch name (ferry:base/)', () => {
+    const { logger, records } = createTestLogger('t', 'test');
+    const r = resolveTicketOverrides(['ferry:base/'], logger);
+    expect(r.git?.baseBranch).toBeUndefined();
+    expect(records.some((rec) => rec.level === 'warn')).toBe(true);
+  });
+
+  it('throws LabelConflictError when two different ferry:base/* labels are present', () => {
+    expect(() =>
+      resolveTicketOverrides(['ferry:base/release-1.x', 'ferry:base/release-2.x']),
+    ).toThrow(LabelConflictError);
+  });
+
+  it('does not throw for identical duplicate ferry:base/* labels (vacuous)', () => {
+    const r = resolveTicketOverrides(['ferry:base/release-1.x', 'ferry:base/release-1.x']);
+    expect(r.git?.baseBranch).toBe('release-1.x');
+  });
+
+  it('records correct field name (git.baseBranch) on LabelConflictError', () => {
+    try {
+      resolveTicketOverrides(['ferry:base/a', 'ferry:base/b']);
+      throw new Error('expected throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(LabelConflictError);
+      expect((e as LabelConflictError).field).toBe('git.baseBranch');
+    }
+  });
+});
+
+describe('resolveTicketOverrides — ferry:target/<branch>', () => {
+  it('sets git.targetBranch from ferry:target/release-1.x', () => {
+    const r = resolveTicketOverrides(['ferry:target/release-1.x']);
+    expect(r.git?.targetBranch).toBe('release-1.x');
+  });
+
+  it('accepts slashes inside the branch name', () => {
+    const r = resolveTicketOverrides(['ferry:target/release/v2']);
+    expect(r.git?.targetBranch).toBe('release/v2');
+  });
+
+  it('warns and ignores invalid branch names', () => {
+    const { logger, records } = createTestLogger('t', 'test');
+    const r = resolveTicketOverrides(['ferry:target/has space'], logger);
+    expect(r.git?.targetBranch).toBeUndefined();
+    expect(records.some((rec) => rec.level === 'warn')).toBe(true);
+  });
+
+  it('warns and ignores empty branch name (ferry:target/)', () => {
+    const { logger, records } = createTestLogger('t', 'test');
+    const r = resolveTicketOverrides(['ferry:target/'], logger);
+    expect(r.git?.targetBranch).toBeUndefined();
+    expect(records.some((rec) => rec.level === 'warn')).toBe(true);
+  });
+
+  it('throws LabelConflictError when two different ferry:target/* labels are present', () => {
+    expect(() => resolveTicketOverrides(['ferry:target/main', 'ferry:target/develop'])).toThrow(
+      LabelConflictError,
+    );
+  });
+
+  it('does not throw for identical duplicate ferry:target/* labels (vacuous)', () => {
+    const r = resolveTicketOverrides(['ferry:target/main', 'ferry:target/main']);
+    expect(r.git?.targetBranch).toBe('main');
+  });
+
+  it('records correct field name (git.targetBranch) on LabelConflictError', () => {
+    try {
+      resolveTicketOverrides(['ferry:target/a', 'ferry:target/b']);
+      throw new Error('expected throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(LabelConflictError);
+      expect((e as LabelConflictError).field).toBe('git.targetBranch');
+    }
+  });
+
+  it('does not conflict with ferry:base/<branch> (different fields)', () => {
+    const r = resolveTicketOverrides(['ferry:base/develop', 'ferry:target/release-1.x']);
+    expect(r.git?.baseBranch).toBe('develop');
+    expect(r.git?.targetBranch).toBe('release-1.x');
+  });
+});
+
+describe('resolveTicketOverrides — ferry:pr/draft and ferry:pr/ready', () => {
+  it('sets git.prDraft to true for ferry:pr/draft', () => {
+    const r = resolveTicketOverrides(['ferry:pr/draft']);
+    expect(r.git?.prDraft).toBe(true);
+  });
+
+  it('sets git.prDraft to false for ferry:pr/ready', () => {
+    const r = resolveTicketOverrides(['ferry:pr/ready']);
+    expect(r.git?.prDraft).toBe(false);
+  });
+
+  it('throws LabelConflictError when both ferry:pr/draft and ferry:pr/ready are present', () => {
+    expect(() => resolveTicketOverrides(['ferry:pr/draft', 'ferry:pr/ready'])).toThrow(
+      LabelConflictError,
+    );
+  });
+
+  it('records correct field name (git.prDraft) on LabelConflictError', () => {
+    try {
+      resolveTicketOverrides(['ferry:pr/draft', 'ferry:pr/ready']);
+      throw new Error('expected throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(LabelConflictError);
+      expect((e as LabelConflictError).field).toBe('git.prDraft');
+    }
+  });
+
+  it('does not throw for duplicate identical ferry:pr/draft labels', () => {
+    const r = resolveTicketOverrides(['ferry:pr/draft', 'ferry:pr/draft']);
+    expect(r.git?.prDraft).toBe(true);
+  });
+
+  it('warns on unknown ferry:pr/<other> suffix', () => {
+    const { logger, records } = createTestLogger('t', 'test');
+    const r = resolveTicketOverrides(['ferry:pr/foo'], logger);
+    expect(r.git?.prDraft).toBeUndefined();
+    expect(records.some((rec) => rec.level === 'warn')).toBe(true);
+  });
+});
+
+// ------------------------------------------------------------------
 // ferry:paused (safety)
 // ------------------------------------------------------------------
 
@@ -770,6 +926,22 @@ describe('hasNonDefaultOverrides', () => {
     expect(hasNonDefaultOverrides(resolveTicketOverrides(['ferry:git/no-pr']))).toBe(true);
   });
 
+  it('returns true when git.baseBranch is set', () => {
+    expect(hasNonDefaultOverrides(resolveTicketOverrides(['ferry:base/release-1.x']))).toBe(true);
+  });
+
+  it('returns true when git.targetBranch is set', () => {
+    expect(hasNonDefaultOverrides(resolveTicketOverrides(['ferry:target/release-1.x']))).toBe(true);
+  });
+
+  it('returns true when git.prDraft is set (ferry:pr/draft)', () => {
+    expect(hasNonDefaultOverrides(resolveTicketOverrides(['ferry:pr/draft']))).toBe(true);
+  });
+
+  it('returns true when git.prDraft is set to false (ferry:pr/ready)', () => {
+    expect(hasNonDefaultOverrides(resolveTicketOverrides(['ferry:pr/ready']))).toBe(true);
+  });
+
   it('returns true when paused is set', () => {
     expect(hasNonDefaultOverrides(resolveTicketOverrides(['ferry:paused']))).toBe(true);
   });
@@ -833,6 +1005,44 @@ describe('buildOverridesAuditComment', () => {
     const overrides = resolveTicketOverrides(['ferry:thinking/off']);
     const comment = buildOverridesAuditComment('developer', 'run1', overrides);
     expect(comment).toContain('"thinking":"off"');
+  });
+
+  it('includes git.baseBranch when ferry:base/<branch> is set', () => {
+    const overrides = resolveTicketOverrides(['ferry:base/release-1.x']);
+    const comment = buildOverridesAuditComment('developer', 'run1', overrides);
+    expect(comment).toContain('"baseBranch":"release-1.x"');
+  });
+
+  it('includes git.targetBranch when ferry:target/<branch> is set', () => {
+    const overrides = resolveTicketOverrides(['ferry:target/release-1.x']);
+    const comment = buildOverridesAuditComment('developer', 'run1', overrides);
+    expect(comment).toContain('"targetBranch":"release-1.x"');
+  });
+
+  it('includes git.prDraft=true when ferry:pr/draft is set', () => {
+    const overrides = resolveTicketOverrides(['ferry:pr/draft']);
+    const comment = buildOverridesAuditComment('developer', 'run1', overrides);
+    expect(comment).toContain('"prDraft":true');
+  });
+
+  it('includes git.prDraft=false when ferry:pr/ready is set', () => {
+    const overrides = resolveTicketOverrides(['ferry:pr/ready']);
+    const comment = buildOverridesAuditComment('developer', 'run1', overrides);
+    expect(comment).toContain('"prDraft":false');
+  });
+
+  it('includes all four git fields together in a single audit payload', () => {
+    const overrides = resolveTicketOverrides([
+      'ferry:git/no-pr',
+      'ferry:base/release-1.x',
+      'ferry:target/release-1.x',
+      'ferry:pr/draft',
+    ]);
+    const comment = buildOverridesAuditComment('developer', 'run1', overrides);
+    expect(comment).toContain('"noPr":true');
+    expect(comment).toContain('"baseBranch":"release-1.x"');
+    expect(comment).toContain('"targetBranch":"release-1.x"');
+    expect(comment).toContain('"prDraft":true');
   });
 });
 

--- a/src/lib/labels/overrides.ts
+++ b/src/lib/labels/overrides.ts
@@ -8,6 +8,13 @@ const PHASES_ORDERED: readonly AgentPhase[] = ['refiner', 'dev', 'review', 'iter
 const LLM_PROVIDERS: ReadonlySet<string> = new Set(['anthropic', 'openai', 'google']);
 
 /**
+ * Permitted character set for branch names supplied via ferry:base/* and
+ * ferry:target/* labels. Intentionally narrow — matches the portable subset
+ * of refnames used by GitHub branch protections.
+ */
+const BRANCH_NAME_REGEX = /^[a-zA-Z0-9._/-]+$/;
+
+/**
  * Thrown when two ferry labels on the same ticket set the same override field
  * to contradictory values. Callers should catch this, post a Jira comment explaining
  * the conflict, and exit non-zero.
@@ -145,6 +152,13 @@ export function resolveTicketOverrides(
   let dryRun = false;
   let readOnly = false;
   const skipPhases: AgentPhase[] = [];
+
+  let baseBranchLabel: string | undefined;
+  let baseBranch: string | undefined;
+  let targetBranchLabel: string | undefined;
+  let targetBranch: string | undefined;
+  let prDraftLabel: string | undefined;
+  let prDraft: boolean | undefined;
 
   for (const label of labels) {
     if (!label.startsWith('ferry:')) continue;
@@ -388,6 +402,68 @@ export function resolveTicketOverrides(
       continue;
     }
 
+    // ferry:base/<branch> — override git.base_branch
+    if (label.startsWith('ferry:base/')) {
+      const branch = label.slice('ferry:base/'.length);
+      if (!BRANCH_NAME_REGEX.test(branch)) {
+        logger?.warn('invalid branch name in ferry:base label (expected ^[a-zA-Z0-9._/-]+$)', {
+          label,
+        });
+        continue;
+      }
+      if (baseBranch !== undefined && baseBranch !== branch) {
+        throw new LabelConflictError(baseBranchLabel!, label, 'git.baseBranch');
+      }
+      if (baseBranch === undefined) {
+        baseBranch = branch;
+        baseBranchLabel = label;
+      }
+      continue;
+    }
+
+    // ferry:target/<branch> — override git.target_branch
+    if (label.startsWith('ferry:target/')) {
+      const branch = label.slice('ferry:target/'.length);
+      if (!BRANCH_NAME_REGEX.test(branch)) {
+        logger?.warn('invalid branch name in ferry:target label (expected ^[a-zA-Z0-9._/-]+$)', {
+          label,
+        });
+        continue;
+      }
+      if (targetBranch !== undefined && targetBranch !== branch) {
+        throw new LabelConflictError(targetBranchLabel!, label, 'git.targetBranch');
+      }
+      if (targetBranch === undefined) {
+        targetBranch = branch;
+        targetBranchLabel = label;
+      }
+      continue;
+    }
+
+    // ferry:pr/draft — force PR draft state
+    // ferry:pr/ready — force PR ready-for-review state
+    if (label.startsWith('ferry:pr/')) {
+      const suffix = label.slice('ferry:pr/'.length);
+      let val: boolean | undefined;
+      if (suffix === 'draft') val = true;
+      else if (suffix === 'ready') val = false;
+      if (val === undefined) {
+        logger?.warn('unknown suffix in ferry:pr label (expected draft or ready)', {
+          label,
+          suffix,
+        });
+        continue;
+      }
+      if (prDraft !== undefined && prDraft !== val) {
+        throw new LabelConflictError(prDraftLabel!, label, 'git.prDraft');
+      }
+      if (prDraft === undefined) {
+        prDraft = val;
+        prDraftLabel = label;
+      }
+      continue;
+    }
+
     // ferry:paused
     if (label === 'ferry:paused') {
       paused = true;
@@ -430,6 +506,17 @@ export function resolveTicketOverrides(
   const hasModelOverrides = Object.keys(modelOverrides).length > 0;
   const hasBudget = budgetMaxCostEur !== undefined || budgetMaxTokens !== undefined;
 
+  const hasGit =
+    noPr || baseBranch !== undefined || targetBranch !== undefined || prDraft !== undefined;
+  const gitOverride = hasGit
+    ? {
+        ...(noPr ? { noPr: true } : {}),
+        ...(baseBranch !== undefined ? { baseBranch } : {}),
+        ...(targetBranch !== undefined ? { targetBranch } : {}),
+        ...(prDraft !== undefined ? { prDraft } : {}),
+      }
+    : undefined;
+
   return {
     ...typeOverrides,
     ...(hasModelOverrides ? { modelOverrides } : {}),
@@ -448,7 +535,7 @@ export function resolveTicketOverrides(
     ...(noAutoTransition ? { noAutoTransition: true } : {}),
     ...(thinking !== undefined ? { thinking } : {}),
     ...(reviewRubric !== undefined ? { reviewRubric } : {}),
-    ...(noPr ? { git: { noPr: true } } : {}),
+    ...(gitOverride ? { git: gitOverride } : {}),
     ...(paused ? { paused: true } : {}),
     ...(dryRun ? { dryRun: true } : {}),
     ...(readOnly ? { readOnly: true } : {}),
@@ -544,6 +631,9 @@ export function hasNonDefaultOverrides(overrides: TicketOverrides): boolean {
     overrides.thinking !== undefined ||
     overrides.reviewRubric !== undefined ||
     overrides.git?.noPr === true ||
+    overrides.git?.baseBranch !== undefined ||
+    overrides.git?.targetBranch !== undefined ||
+    overrides.git?.prDraft !== undefined ||
     overrides.paused === true ||
     overrides.dryRun === true ||
     overrides.readOnly === true
@@ -577,7 +667,15 @@ export function buildOverridesAuditComment(
   if (overrides.noAutoTransition) payload.noAutoTransition = true;
   if (overrides.thinking !== undefined) payload.thinking = overrides.thinking;
   if (overrides.reviewRubric !== undefined) payload.reviewRubric = overrides.reviewRubric;
-  if (overrides.git?.noPr) payload.git = overrides.git;
+  if (
+    overrides.git !== undefined &&
+    (overrides.git.noPr === true ||
+      overrides.git.baseBranch !== undefined ||
+      overrides.git.targetBranch !== undefined ||
+      overrides.git.prDraft !== undefined)
+  ) {
+    payload.git = overrides.git;
+  }
   if (overrides.paused) payload.paused = true;
   if (overrides.dryRun) payload.dryRun = true;
   if (overrides.readOnly) payload.readOnly = true;


### PR DESCRIPTION
Closes #241

> Stacked on #281 → #278 → #277. After upstream PRs merge, re-target to `main`.

## Summary

- Adds `ferry:base/<branch>` and `ferry:target/<branch>` overrides for git.base_branch / git.target_branch.
- Adds `ferry:pr/draft` / `ferry:pr/ready` to override the PR draft state.
- Branch name validated against `^[a-zA-Z0-9._/-]+$`; remote existence checked at runtime by Developer (and Iterator for baseBranch).
- Conflicts on draft/ready and on duplicate base/target values fail loudly via `LabelConflictError`.

## Test plan

- [x] All 1594 tests pass (`npm test`) — +35 new tests over the 1559 baseline
- [x] TypeScript typecheck passes
- [x] 30 new tests in `overrides.test.ts` (parsing, regex rejection, conflicts, audit payload)
- [x] 4 new tests in `runner/github-actions/index.test.ts` covering `createPR({ draft, base })`
- [x] `hasNonDefaultOverrides` updated to cover the three new `git.*` fields
- [x] Bundle rebuilt (`npm run build:ferry`)

Generated with [Claude Code](https://claude.ai/code)