### PR TITLE
feat(runner): GitLab adapter (experimental) (#212)

### DIFF
--- a/.ferry/agent.js
+++ b/.ferry/agent.js
@@ -5202,8 +5202,249 @@ var GitHubActionsRunner = class {
   }
 };
 
+// src/lib/dispatch/runner/gitlab/index.ts
+var MAX_CONTENT_CHARS_DEFAULT2 = 4e4;
+var DRAFT_PREFIX = "Draft: ";
+var GitLabRunner = class {
+  constructor(token, defaultOwner, defaultRepo, opts = {}) {
+    this.defaultOwner = defaultOwner;
+    this.defaultRepo = defaultRepo;
+    this.authHeader = `Bearer ${token}`;
+    this.apiBase = (opts.apiBase ?? "https://gitlab.com/api/v4").replace(/\/+$/, "");
+    this.pipelineTriggerToken = opts.pipelineTriggerToken;
+    this.triggerRef = opts.triggerRef ?? "main";
+  }
+  defaultOwner;
+  defaultRepo;
+  authHeader;
+  apiBase;
+  pipelineTriggerToken;
+  triggerRef;
+  // ── Internals ────────────────────────────────────────────────────────────
+  projectPath(owner, repo) {
+    return encodeURIComponent(`${owner}/${repo}`);
+  }
+  baseHeaders(extra) {
+    return { Authorization: this.authHeader, Accept: "application/json", ...extra };
+  }
+  async request(method, path7, init = {}) {
+    const headers = this.baseHeaders(init.headers);
+    let body;
+    if (init.rawBody !== void 0) {
+      body = init.rawBody;
+    } else if (init.body !== void 0) {
+      headers["Content-Type"] = "application/json";
+      body = JSON.stringify(init.body);
+    }
+    const url = `${this.apiBase}${path7}`;
+    const response = await fetch(url, { method, headers, body });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new FerryError("transient", {
+        reason: "gitlab-request-failed",
+        method,
+        path: path7,
+        status: response.status,
+        body: text.slice(0, 500)
+      });
+    }
+    if (response.status === 204) return void 0;
+    return await response.json();
+  }
+  async getProject(owner, repo) {
+    return this.request("GET", `/projects/${this.projectPath(owner, repo)}`);
+  }
+  // ── CIRunner methods ─────────────────────────────────────────────────────
+  async dispatch(phase, payload) {
+    const route = PHASE_TO_WORKFLOW[phase];
+    if (!route) throw new Error(`Unknown phase for dispatch: ${phase}`);
+    if (!this.pipelineTriggerToken) {
+      throw new FerryError("state-invariant", {
+        reason: "missing-pipeline-trigger-token",
+        env: "FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN"
+      });
+    }
+    const form = new URLSearchParams();
+    form.set("token", this.pipelineTriggerToken);
+    form.set("ref", this.triggerRef);
+    form.set("variables[FERRY_DISPATCH_TYPE]", route.dispatchType);
+    form.set("variables[FERRY_ENVELOPE_PAYLOAD]", JSON.stringify(payload));
+    const url = `${this.apiBase}/projects/${this.projectPath(this.defaultOwner, this.defaultRepo)}/trigger/pipeline`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: form.toString()
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new FerryError("transient", {
+        reason: "gitlab-pipeline-trigger-failed",
+        status: response.status,
+        body: text.slice(0, 500)
+      });
+    }
+  }
+  async getRepoDefaultBranch(owner, repo) {
+    const project = await this.getProject(owner, repo);
+    return project.default_branch;
+  }
+  async listPRsForBranch(owner, repo, branch) {
+    const path7 = `/projects/${this.projectPath(owner, repo)}/merge_requests?state=opened&source_branch=${encodeURIComponent(branch)}&per_page=1`;
+    const mrs = await this.request("GET", path7);
+    return mrs.map((mr) => this.toPR(mr));
+  }
+  async getPR(prRef) {
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}`;
+    const mr = await this.request("GET", path7);
+    return this.toPR(mr);
+  }
+  async listPRFiles(prRef) {
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/changes`;
+    const data = await this.request("GET", path7);
+    return data.changes.map((c) => ({
+      filename: c.new_path || c.old_path,
+      status: c.new_file ? "added" : c.deleted_file ? "removed" : c.renamed_file ? "renamed" : "modified",
+      additions: countDiffLines(c.diff, "+"),
+      deletions: countDiffLines(c.diff, "-"),
+      patch: c.diff || void 0
+    }));
+  }
+  async listPRCommits(prRef) {
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/commits?per_page=50`;
+    const commits = await this.request("GET", path7);
+    return commits.map((c) => ({ sha: c.id, message: c.message }));
+  }
+  async getCommitStatus(owner, repo, sha) {
+    const path7 = `/projects/${this.projectPath(owner, repo)}/pipelines?sha=${encodeURIComponent(sha)}&per_page=1&order_by=id&sort=desc`;
+    const pipelines = await this.request("GET", path7);
+    if (pipelines.length === 0) return "pending";
+    return collapsePipelineStatus(pipelines[0].status);
+  }
+  async getFileContent(owner, repo, path7, ref) {
+    try {
+      const url = `${this.apiBase}/projects/${this.projectPath(owner, repo)}/repository/files/${encodeURIComponent(path7)}/raw?ref=${encodeURIComponent(ref)}`;
+      const response = await fetch(url, { method: "GET", headers: this.baseHeaders() });
+      if (!response.ok) {
+        return `(error fetching content: HTTP ${response.status})`;
+      }
+      const text = await response.text();
+      const maxChars = parseInt(process.env.FERRY_FILE_DISPLAY_CHARS ?? "", 10) || MAX_CONTENT_CHARS_DEFAULT2;
+      return text.length > maxChars ? text.slice(0, maxChars) + "\n... (truncated)" : text;
+    } catch (e) {
+      return `(error fetching content: ${e.message})`;
+    }
+  }
+  async createPR(owner, repo, head, base, title, body) {
+    const draftTitle = title.startsWith(DRAFT_PREFIX) ? title : `${DRAFT_PREFIX}${title}`;
+    const path7 = `/projects/${this.projectPath(owner, repo)}/merge_requests`;
+    try {
+      const mr = await this.request("POST", path7, {
+        body: {
+          source_branch: head,
+          target_branch: base,
+          title: draftTitle,
+          description: body
+        }
+      });
+      return mr.web_url;
+    } catch {
+      const existing = await this.listPRsForBranch(owner, repo, head);
+      if (existing.length > 0) {
+        const mr = await this.request(
+          "GET",
+          `/projects/${this.projectPath(owner, repo)}/merge_requests/${existing[0].number}`
+        );
+        return mr.web_url;
+      }
+      throw new Error(`Failed to create or find MR for source branch ${head}`);
+    }
+  }
+  async markPRReadyForReview(owner, repo, prNumber) {
+    const mr = await this.request(
+      "GET",
+      `/projects/${this.projectPath(owner, repo)}/merge_requests/${prNumber}`
+    );
+    if (!mr.title.startsWith(DRAFT_PREFIX)) return;
+    const newTitle = mr.title.slice(DRAFT_PREFIX.length);
+    await this.request(
+      "PUT",
+      `/projects/${this.projectPath(owner, repo)}/merge_requests/${prNumber}`,
+      {
+        body: { title: newTitle }
+      }
+    );
+  }
+  async commentOnPR(prRef, body) {
+    await this.request(
+      "POST",
+      `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/notes`,
+      { body: { body } }
+    );
+  }
+  async addLabelsToPR(prRef, labels) {
+    if (labels.length === 0) return;
+    await this.request(
+      "PUT",
+      `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}`,
+      { body: { add_labels: labels.join(",") } }
+    );
+  }
+  async removeLabelFromPR(prRef, label) {
+    await this.request(
+      "PUT",
+      `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}`,
+      { body: { remove_labels: label } }
+    );
+  }
+  async listPRComments(prRef, count) {
+    const perPage = Math.min(Math.max(count, 1), 100);
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/notes?sort=desc&order_by=created_at&per_page=${perPage}`;
+    const notes = await this.request("GET", path7);
+    return notes.map((n) => ({ id: n.id, body: n.body ?? "" }));
+  }
+  // ── Helpers ──────────────────────────────────────────────────────────────
+  toPR(mr) {
+    const conflict = mr.has_conflicts === true || typeof mr.detailed_merge_status === "string" && mr.detailed_merge_status.includes("conflict");
+    const mergeable = conflict === true ? false : mr.has_conflicts === false ? true : null;
+    return {
+      number: mr.iid,
+      title: mr.title,
+      baseRef: mr.target_branch,
+      headRef: mr.source_branch,
+      headSha: mr.sha,
+      mergeable
+    };
+  }
+};
+function countDiffLines(diff, prefix) {
+  if (!diff) return 0;
+  let count = 0;
+  for (const line of diff.split("\n")) {
+    if (line.startsWith(prefix) && !line.startsWith(prefix.repeat(3))) count += 1;
+  }
+  return count;
+}
+function collapsePipelineStatus(status) {
+  switch (status) {
+    case "success":
+    case "skipped":
+    case "manual":
+      return "green";
+    case "failed":
+      return "red";
+    case "canceled":
+      return "red";
+    case "created":
+    case "waiting_for_resource":
+    case "preparing":
+    case "pending":
+    case "running":
+    case "scheduled":
+      return "pending";
+  }
+}
+
 // src/lib/dispatch/runner/factory.ts
-var GITLAB_TRACKING_ISSUE = "https://github.com/big-emotion/ferry/issues/210";
 function resolveForgeFromEnv() {
   const raw = (process.env.FERRY_FORGE ?? "").trim().toLowerCase();
   if (raw === "" || raw === "github") return "github";
@@ -5220,9 +5461,10 @@ function createRunnerFromEnv(token, owner, repo) {
     case "github":
       return new GitHubActionsRunner(token, owner, repo);
     case "gitlab":
-      throw new FerryError("state-invariant", {
-        reason: "gitlab-runner-not-implemented",
-        tracking: GITLAB_TRACKING_ISSUE
+      return new GitLabRunner(token, owner, repo, {
+        apiBase: process.env.FERRY_GITLAB_API_BASE,
+        pipelineTriggerToken: process.env.FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN,
+        triggerRef: process.env.FERRY_GITLAB_TRIGGER_REF
       });
   }
 }

--- a/.github/actions/ferry-run-developer/agent.js
+++ b/.github/actions/ferry-run-developer/agent.js
@@ -5202,8 +5202,249 @@ var GitHubActionsRunner = class {
   }
 };
 
+// src/lib/dispatch/runner/gitlab/index.ts
+var MAX_CONTENT_CHARS_DEFAULT2 = 4e4;
+var DRAFT_PREFIX = "Draft: ";
+var GitLabRunner = class {
+  constructor(token, defaultOwner, defaultRepo, opts = {}) {
+    this.defaultOwner = defaultOwner;
+    this.defaultRepo = defaultRepo;
+    this.authHeader = `Bearer ${token}`;
+    this.apiBase = (opts.apiBase ?? "https://gitlab.com/api/v4").replace(/\/+$/, "");
+    this.pipelineTriggerToken = opts.pipelineTriggerToken;
+    this.triggerRef = opts.triggerRef ?? "main";
+  }
+  defaultOwner;
+  defaultRepo;
+  authHeader;
+  apiBase;
+  pipelineTriggerToken;
+  triggerRef;
+  // ── Internals ────────────────────────────────────────────────────────────
+  projectPath(owner, repo) {
+    return encodeURIComponent(`${owner}/${repo}`);
+  }
+  baseHeaders(extra) {
+    return { Authorization: this.authHeader, Accept: "application/json", ...extra };
+  }
+  async request(method, path7, init = {}) {
+    const headers = this.baseHeaders(init.headers);
+    let body;
+    if (init.rawBody !== void 0) {
+      body = init.rawBody;
+    } else if (init.body !== void 0) {
+      headers["Content-Type"] = "application/json";
+      body = JSON.stringify(init.body);
+    }
+    const url = `${this.apiBase}${path7}`;
+    const response = await fetch(url, { method, headers, body });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new FerryError("transient", {
+        reason: "gitlab-request-failed",
+        method,
+        path: path7,
+        status: response.status,
+        body: text.slice(0, 500)
+      });
+    }
+    if (response.status === 204) return void 0;
+    return await response.json();
+  }
+  async getProject(owner, repo) {
+    return this.request("GET", `/projects/${this.projectPath(owner, repo)}`);
+  }
+  // ── CIRunner methods ─────────────────────────────────────────────────────
+  async dispatch(phase, payload) {
+    const route = PHASE_TO_WORKFLOW[phase];
+    if (!route) throw new Error(`Unknown phase for dispatch: ${phase}`);
+    if (!this.pipelineTriggerToken) {
+      throw new FerryError("state-invariant", {
+        reason: "missing-pipeline-trigger-token",
+        env: "FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN"
+      });
+    }
+    const form = new URLSearchParams();
+    form.set("token", this.pipelineTriggerToken);
+    form.set("ref", this.triggerRef);
+    form.set("variables[FERRY_DISPATCH_TYPE]", route.dispatchType);
+    form.set("variables[FERRY_ENVELOPE_PAYLOAD]", JSON.stringify(payload));
+    const url = `${this.apiBase}/projects/${this.projectPath(this.defaultOwner, this.defaultRepo)}/trigger/pipeline`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: form.toString()
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new FerryError("transient", {
+        reason: "gitlab-pipeline-trigger-failed",
+        status: response.status,
+        body: text.slice(0, 500)
+      });
+    }
+  }
+  async getRepoDefaultBranch(owner, repo) {
+    const project = await this.getProject(owner, repo);
+    return project.default_branch;
+  }
+  async listPRsForBranch(owner, repo, branch) {
+    const path7 = `/projects/${this.projectPath(owner, repo)}/merge_requests?state=opened&source_branch=${encodeURIComponent(branch)}&per_page=1`;
+    const mrs = await this.request("GET", path7);
+    return mrs.map((mr) => this.toPR(mr));
+  }
+  async getPR(prRef) {
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}`;
+    const mr = await this.request("GET", path7);
+    return this.toPR(mr);
+  }
+  async listPRFiles(prRef) {
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/changes`;
+    const data = await this.request("GET", path7);
+    return data.changes.map((c) => ({
+      filename: c.new_path || c.old_path,
+      status: c.new_file ? "added" : c.deleted_file ? "removed" : c.renamed_file ? "renamed" : "modified",
+      additions: countDiffLines(c.diff, "+"),
+      deletions: countDiffLines(c.diff, "-"),
+      patch: c.diff || void 0
+    }));
+  }
+  async listPRCommits(prRef) {
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/commits?per_page=50`;
+    const commits = await this.request("GET", path7);
+    return commits.map((c) => ({ sha: c.id, message: c.message }));
+  }
+  async getCommitStatus(owner, repo, sha) {
+    const path7 = `/projects/${this.projectPath(owner, repo)}/pipelines?sha=${encodeURIComponent(sha)}&per_page=1&order_by=id&sort=desc`;
+    const pipelines = await this.request("GET", path7);
+    if (pipelines.length === 0) return "pending";
+    return collapsePipelineStatus(pipelines[0].status);
+  }
+  async getFileContent(owner, repo, path7, ref) {
+    try {
+      const url = `${this.apiBase}/projects/${this.projectPath(owner, repo)}/repository/files/${encodeURIComponent(path7)}/raw?ref=${encodeURIComponent(ref)}`;
+      const response = await fetch(url, { method: "GET", headers: this.baseHeaders() });
+      if (!response.ok) {
+        return `(error fetching content: HTTP ${response.status})`;
+      }
+      const text = await response.text();
+      const maxChars = parseInt(process.env.FERRY_FILE_DISPLAY_CHARS ?? "", 10) || MAX_CONTENT_CHARS_DEFAULT2;
+      return text.length > maxChars ? text.slice(0, maxChars) + "\n... (truncated)" : text;
+    } catch (e) {
+      return `(error fetching content: ${e.message})`;
+    }
+  }
+  async createPR(owner, repo, head, base, title, body) {
+    const draftTitle = title.startsWith(DRAFT_PREFIX) ? title : `${DRAFT_PREFIX}${title}`;
+    const path7 = `/projects/${this.projectPath(owner, repo)}/merge_requests`;
+    try {
+      const mr = await this.request("POST", path7, {
+        body: {
+          source_branch: head,
+          target_branch: base,
+          title: draftTitle,
+          description: body
+        }
+      });
+      return mr.web_url;
+    } catch {
+      const existing = await this.listPRsForBranch(owner, repo, head);
+      if (existing.length > 0) {
+        const mr = await this.request(
+          "GET",
+          `/projects/${this.projectPath(owner, repo)}/merge_requests/${existing[0].number}`
+        );
+        return mr.web_url;
+      }
+      throw new Error(`Failed to create or find MR for source branch ${head}`);
+    }
+  }
+  async markPRReadyForReview(owner, repo, prNumber) {
+    const mr = await this.request(
+      "GET",
+      `/projects/${this.projectPath(owner, repo)}/merge_requests/${prNumber}`
+    );
+    if (!mr.title.startsWith(DRAFT_PREFIX)) return;
+    const newTitle = mr.title.slice(DRAFT_PREFIX.length);
+    await this.request(
+      "PUT",
+      `/projects/${this.projectPath(owner, repo)}/merge_requests/${prNumber}`,
+      {
+        body: { title: newTitle }
+      }
+    );
+  }
+  async commentOnPR(prRef, body) {
+    await this.request(
+      "POST",
+      `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/notes`,
+      { body: { body } }
+    );
+  }
+  async addLabelsToPR(prRef, labels) {
+    if (labels.length === 0) return;
+    await this.request(
+      "PUT",
+      `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}`,
+      { body: { add_labels: labels.join(",") } }
+    );
+  }
+  async removeLabelFromPR(prRef, label) {
+    await this.request(
+      "PUT",
+      `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}`,
+      { body: { remove_labels: label } }
+    );
+  }
+  async listPRComments(prRef, count) {
+    const perPage = Math.min(Math.max(count, 1), 100);
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/notes?sort=desc&order_by=created_at&per_page=${perPage}`;
+    const notes = await this.request("GET", path7);
+    return notes.map((n) => ({ id: n.id, body: n.body ?? "" }));
+  }
+  // ── Helpers ──────────────────────────────────────────────────────────────
+  toPR(mr) {
+    const conflict = mr.has_conflicts === true || typeof mr.detailed_merge_status === "string" && mr.detailed_merge_status.includes("conflict");
+    const mergeable = conflict === true ? false : mr.has_conflicts === false ? true : null;
+    return {
+      number: mr.iid,
+      title: mr.title,
+      baseRef: mr.target_branch,
+      headRef: mr.source_branch,
+      headSha: mr.sha,
+      mergeable
+    };
+  }
+};
+function countDiffLines(diff, prefix) {
+  if (!diff) return 0;
+  let count = 0;
+  for (const line of diff.split("\n")) {
+    if (line.startsWith(prefix) && !line.startsWith(prefix.repeat(3))) count += 1;
+  }
+  return count;
+}
+function collapsePipelineStatus(status) {
+  switch (status) {
+    case "success":
+    case "skipped":
+    case "manual":
+      return "green";
+    case "failed":
+      return "red";
+    case "canceled":
+      return "red";
+    case "created":
+    case "waiting_for_resource":
+    case "preparing":
+    case "pending":
+    case "running":
+    case "scheduled":
+      return "pending";
+  }
+}
+
 // src/lib/dispatch/runner/factory.ts
-var GITLAB_TRACKING_ISSUE = "https://github.com/big-emotion/ferry/issues/210";
 function resolveForgeFromEnv() {
   const raw = (process.env.FERRY_FORGE ?? "").trim().toLowerCase();
   if (raw === "" || raw === "github") return "github";
@@ -5220,9 +5461,10 @@ function createRunnerFromEnv(token, owner, repo) {
     case "github":
       return new GitHubActionsRunner(token, owner, repo);
     case "gitlab":
-      throw new FerryError("state-invariant", {
-        reason: "gitlab-runner-not-implemented",
-        tracking: GITLAB_TRACKING_ISSUE
+      return new GitLabRunner(token, owner, repo, {
+        apiBase: process.env.FERRY_GITLAB_API_BASE,
+        pipelineTriggerToken: process.env.FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN,
+        triggerRef: process.env.FERRY_GITLAB_TRIGGER_REF
       });
   }
 }

--- a/.github/actions/ferry-run-iterator/agent.js
+++ b/.github/actions/ferry-run-iterator/agent.js
@@ -5202,8 +5202,249 @@ var GitHubActionsRunner = class {
   }
 };
 
+// src/lib/dispatch/runner/gitlab/index.ts
+var MAX_CONTENT_CHARS_DEFAULT2 = 4e4;
+var DRAFT_PREFIX = "Draft: ";
+var GitLabRunner = class {
+  constructor(token, defaultOwner, defaultRepo, opts = {}) {
+    this.defaultOwner = defaultOwner;
+    this.defaultRepo = defaultRepo;
+    this.authHeader = `Bearer ${token}`;
+    this.apiBase = (opts.apiBase ?? "https://gitlab.com/api/v4").replace(/\/+$/, "");
+    this.pipelineTriggerToken = opts.pipelineTriggerToken;
+    this.triggerRef = opts.triggerRef ?? "main";
+  }
+  defaultOwner;
+  defaultRepo;
+  authHeader;
+  apiBase;
+  pipelineTriggerToken;
+  triggerRef;
+  // ── Internals ────────────────────────────────────────────────────────────
+  projectPath(owner, repo) {
+    return encodeURIComponent(`${owner}/${repo}`);
+  }
+  baseHeaders(extra) {
+    return { Authorization: this.authHeader, Accept: "application/json", ...extra };
+  }
+  async request(method, path7, init = {}) {
+    const headers = this.baseHeaders(init.headers);
+    let body;
+    if (init.rawBody !== void 0) {
+      body = init.rawBody;
+    } else if (init.body !== void 0) {
+      headers["Content-Type"] = "application/json";
+      body = JSON.stringify(init.body);
+    }
+    const url = `${this.apiBase}${path7}`;
+    const response = await fetch(url, { method, headers, body });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new FerryError("transient", {
+        reason: "gitlab-request-failed",
+        method,
+        path: path7,
+        status: response.status,
+        body: text.slice(0, 500)
+      });
+    }
+    if (response.status === 204) return void 0;
+    return await response.json();
+  }
+  async getProject(owner, repo) {
+    return this.request("GET", `/projects/${this.projectPath(owner, repo)}`);
+  }
+  // ── CIRunner methods ─────────────────────────────────────────────────────
+  async dispatch(phase, payload) {
+    const route = PHASE_TO_WORKFLOW[phase];
+    if (!route) throw new Error(`Unknown phase for dispatch: ${phase}`);
+    if (!this.pipelineTriggerToken) {
+      throw new FerryError("state-invariant", {
+        reason: "missing-pipeline-trigger-token",
+        env: "FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN"
+      });
+    }
+    const form = new URLSearchParams();
+    form.set("token", this.pipelineTriggerToken);
+    form.set("ref", this.triggerRef);
+    form.set("variables[FERRY_DISPATCH_TYPE]", route.dispatchType);
+    form.set("variables[FERRY_ENVELOPE_PAYLOAD]", JSON.stringify(payload));
+    const url = `${this.apiBase}/projects/${this.projectPath(this.defaultOwner, this.defaultRepo)}/trigger/pipeline`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: form.toString()
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new FerryError("transient", {
+        reason: "gitlab-pipeline-trigger-failed",
+        status: response.status,
+        body: text.slice(0, 500)
+      });
+    }
+  }
+  async getRepoDefaultBranch(owner, repo) {
+    const project = await this.getProject(owner, repo);
+    return project.default_branch;
+  }
+  async listPRsForBranch(owner, repo, branch) {
+    const path7 = `/projects/${this.projectPath(owner, repo)}/merge_requests?state=opened&source_branch=${encodeURIComponent(branch)}&per_page=1`;
+    const mrs = await this.request("GET", path7);
+    return mrs.map((mr) => this.toPR(mr));
+  }
+  async getPR(prRef) {
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}`;
+    const mr = await this.request("GET", path7);
+    return this.toPR(mr);
+  }
+  async listPRFiles(prRef) {
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/changes`;
+    const data = await this.request("GET", path7);
+    return data.changes.map((c) => ({
+      filename: c.new_path || c.old_path,
+      status: c.new_file ? "added" : c.deleted_file ? "removed" : c.renamed_file ? "renamed" : "modified",
+      additions: countDiffLines(c.diff, "+"),
+      deletions: countDiffLines(c.diff, "-"),
+      patch: c.diff || void 0
+    }));
+  }
+  async listPRCommits(prRef) {
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/commits?per_page=50`;
+    const commits = await this.request("GET", path7);
+    return commits.map((c) => ({ sha: c.id, message: c.message }));
+  }
+  async getCommitStatus(owner, repo, sha) {
+    const path7 = `/projects/${this.projectPath(owner, repo)}/pipelines?sha=${encodeURIComponent(sha)}&per_page=1&order_by=id&sort=desc`;
+    const pipelines = await this.request("GET", path7);
+    if (pipelines.length === 0) return "pending";
+    return collapsePipelineStatus(pipelines[0].status);
+  }
+  async getFileContent(owner, repo, path7, ref) {
+    try {
+      const url = `${this.apiBase}/projects/${this.projectPath(owner, repo)}/repository/files/${encodeURIComponent(path7)}/raw?ref=${encodeURIComponent(ref)}`;
+      const response = await fetch(url, { method: "GET", headers: this.baseHeaders() });
+      if (!response.ok) {
+        return `(error fetching content: HTTP ${response.status})`;
+      }
+      const text = await response.text();
+      const maxChars = parseInt(process.env.FERRY_FILE_DISPLAY_CHARS ?? "", 10) || MAX_CONTENT_CHARS_DEFAULT2;
+      return text.length > maxChars ? text.slice(0, maxChars) + "\n... (truncated)" : text;
+    } catch (e) {
+      return `(error fetching content: ${e.message})`;
+    }
+  }
+  async createPR(owner, repo, head, base, title, body) {
+    const draftTitle = title.startsWith(DRAFT_PREFIX) ? title : `${DRAFT_PREFIX}${title}`;
+    const path7 = `/projects/${this.projectPath(owner, repo)}/merge_requests`;
+    try {
+      const mr = await this.request("POST", path7, {
+        body: {
+          source_branch: head,
+          target_branch: base,
+          title: draftTitle,
+          description: body
+        }
+      });
+      return mr.web_url;
+    } catch {
+      const existing = await this.listPRsForBranch(owner, repo, head);
+      if (existing.length > 0) {
+        const mr = await this.request(
+          "GET",
+          `/projects/${this.projectPath(owner, repo)}/merge_requests/${existing[0].number}`
+        );
+        return mr.web_url;
+      }
+      throw new Error(`Failed to create or find MR for source branch ${head}`);
+    }
+  }
+  async markPRReadyForReview(owner, repo, prNumber) {
+    const mr = await this.request(
+      "GET",
+      `/projects/${this.projectPath(owner, repo)}/merge_requests/${prNumber}`
+    );
+    if (!mr.title.startsWith(DRAFT_PREFIX)) return;
+    const newTitle = mr.title.slice(DRAFT_PREFIX.length);
+    await this.request(
+      "PUT",
+      `/projects/${this.projectPath(owner, repo)}/merge_requests/${prNumber}`,
+      {
+        body: { title: newTitle }
+      }
+    );
+  }
+  async commentOnPR(prRef, body) {
+    await this.request(
+      "POST",
+      `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/notes`,
+      { body: { body } }
+    );
+  }
+  async addLabelsToPR(prRef, labels) {
+    if (labels.length === 0) return;
+    await this.request(
+      "PUT",
+      `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}`,
+      { body: { add_labels: labels.join(",") } }
+    );
+  }
+  async removeLabelFromPR(prRef, label) {
+    await this.request(
+      "PUT",
+      `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}`,
+      { body: { remove_labels: label } }
+    );
+  }
+  async listPRComments(prRef, count) {
+    const perPage = Math.min(Math.max(count, 1), 100);
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/notes?sort=desc&order_by=created_at&per_page=${perPage}`;
+    const notes = await this.request("GET", path7);
+    return notes.map((n) => ({ id: n.id, body: n.body ?? "" }));
+  }
+  // ── Helpers ──────────────────────────────────────────────────────────────
+  toPR(mr) {
+    const conflict = mr.has_conflicts === true || typeof mr.detailed_merge_status === "string" && mr.detailed_merge_status.includes("conflict");
+    const mergeable = conflict === true ? false : mr.has_conflicts === false ? true : null;
+    return {
+      number: mr.iid,
+      title: mr.title,
+      baseRef: mr.target_branch,
+      headRef: mr.source_branch,
+      headSha: mr.sha,
+      mergeable
+    };
+  }
+};
+function countDiffLines(diff, prefix) {
+  if (!diff) return 0;
+  let count = 0;
+  for (const line of diff.split("\n")) {
+    if (line.startsWith(prefix) && !line.startsWith(prefix.repeat(3))) count += 1;
+  }
+  return count;
+}
+function collapsePipelineStatus(status) {
+  switch (status) {
+    case "success":
+    case "skipped":
+    case "manual":
+      return "green";
+    case "failed":
+      return "red";
+    case "canceled":
+      return "red";
+    case "created":
+    case "waiting_for_resource":
+    case "preparing":
+    case "pending":
+    case "running":
+    case "scheduled":
+      return "pending";
+  }
+}
+
 // src/lib/dispatch/runner/factory.ts
-var GITLAB_TRACKING_ISSUE = "https://github.com/big-emotion/ferry/issues/210";
 function resolveForgeFromEnv() {
   const raw = (process.env.FERRY_FORGE ?? "").trim().toLowerCase();
   if (raw === "" || raw === "github") return "github";
@@ -5220,9 +5461,10 @@ function createRunnerFromEnv(token, owner, repo) {
     case "github":
       return new GitHubActionsRunner(token, owner, repo);
     case "gitlab":
-      throw new FerryError("state-invariant", {
-        reason: "gitlab-runner-not-implemented",
-        tracking: GITLAB_TRACKING_ISSUE
+      return new GitLabRunner(token, owner, repo, {
+        apiBase: process.env.FERRY_GITLAB_API_BASE,
+        pipelineTriggerToken: process.env.FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN,
+        triggerRef: process.env.FERRY_GITLAB_TRIGGER_REF
       });
   }
 }

--- a/.github/actions/ferry-run-refiner/agent.js
+++ b/.github/actions/ferry-run-refiner/agent.js
@@ -5202,8 +5202,249 @@ var GitHubActionsRunner = class {
   }
 };
 
+// src/lib/dispatch/runner/gitlab/index.ts
+var MAX_CONTENT_CHARS_DEFAULT2 = 4e4;
+var DRAFT_PREFIX = "Draft: ";
+var GitLabRunner = class {
+  constructor(token, defaultOwner, defaultRepo, opts = {}) {
+    this.defaultOwner = defaultOwner;
+    this.defaultRepo = defaultRepo;
+    this.authHeader = `Bearer ${token}`;
+    this.apiBase = (opts.apiBase ?? "https://gitlab.com/api/v4").replace(/\/+$/, "");
+    this.pipelineTriggerToken = opts.pipelineTriggerToken;
+    this.triggerRef = opts.triggerRef ?? "main";
+  }
+  defaultOwner;
+  defaultRepo;
+  authHeader;
+  apiBase;
+  pipelineTriggerToken;
+  triggerRef;
+  // ── Internals ────────────────────────────────────────────────────────────
+  projectPath(owner, repo) {
+    return encodeURIComponent(`${owner}/${repo}`);
+  }
+  baseHeaders(extra) {
+    return { Authorization: this.authHeader, Accept: "application/json", ...extra };
+  }
+  async request(method, path7, init = {}) {
+    const headers = this.baseHeaders(init.headers);
+    let body;
+    if (init.rawBody !== void 0) {
+      body = init.rawBody;
+    } else if (init.body !== void 0) {
+      headers["Content-Type"] = "application/json";
+      body = JSON.stringify(init.body);
+    }
+    const url = `${this.apiBase}${path7}`;
+    const response = await fetch(url, { method, headers, body });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new FerryError("transient", {
+        reason: "gitlab-request-failed",
+        method,
+        path: path7,
+        status: response.status,
+        body: text.slice(0, 500)
+      });
+    }
+    if (response.status === 204) return void 0;
+    return await response.json();
+  }
+  async getProject(owner, repo) {
+    return this.request("GET", `/projects/${this.projectPath(owner, repo)}`);
+  }
+  // ── CIRunner methods ─────────────────────────────────────────────────────
+  async dispatch(phase, payload) {
+    const route = PHASE_TO_WORKFLOW[phase];
+    if (!route) throw new Error(`Unknown phase for dispatch: ${phase}`);
+    if (!this.pipelineTriggerToken) {
+      throw new FerryError("state-invariant", {
+        reason: "missing-pipeline-trigger-token",
+        env: "FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN"
+      });
+    }
+    const form = new URLSearchParams();
+    form.set("token", this.pipelineTriggerToken);
+    form.set("ref", this.triggerRef);
+    form.set("variables[FERRY_DISPATCH_TYPE]", route.dispatchType);
+    form.set("variables[FERRY_ENVELOPE_PAYLOAD]", JSON.stringify(payload));
+    const url = `${this.apiBase}/projects/${this.projectPath(this.defaultOwner, this.defaultRepo)}/trigger/pipeline`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: form.toString()
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new FerryError("transient", {
+        reason: "gitlab-pipeline-trigger-failed",
+        status: response.status,
+        body: text.slice(0, 500)
+      });
+    }
+  }
+  async getRepoDefaultBranch(owner, repo) {
+    const project = await this.getProject(owner, repo);
+    return project.default_branch;
+  }
+  async listPRsForBranch(owner, repo, branch) {
+    const path7 = `/projects/${this.projectPath(owner, repo)}/merge_requests?state=opened&source_branch=${encodeURIComponent(branch)}&per_page=1`;
+    const mrs = await this.request("GET", path7);
+    return mrs.map((mr) => this.toPR(mr));
+  }
+  async getPR(prRef) {
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}`;
+    const mr = await this.request("GET", path7);
+    return this.toPR(mr);
+  }
+  async listPRFiles(prRef) {
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/changes`;
+    const data = await this.request("GET", path7);
+    return data.changes.map((c) => ({
+      filename: c.new_path || c.old_path,
+      status: c.new_file ? "added" : c.deleted_file ? "removed" : c.renamed_file ? "renamed" : "modified",
+      additions: countDiffLines(c.diff, "+"),
+      deletions: countDiffLines(c.diff, "-"),
+      patch: c.diff || void 0
+    }));
+  }
+  async listPRCommits(prRef) {
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/commits?per_page=50`;
+    const commits = await this.request("GET", path7);
+    return commits.map((c) => ({ sha: c.id, message: c.message }));
+  }
+  async getCommitStatus(owner, repo, sha) {
+    const path7 = `/projects/${this.projectPath(owner, repo)}/pipelines?sha=${encodeURIComponent(sha)}&per_page=1&order_by=id&sort=desc`;
+    const pipelines = await this.request("GET", path7);
+    if (pipelines.length === 0) return "pending";
+    return collapsePipelineStatus(pipelines[0].status);
+  }
+  async getFileContent(owner, repo, path7, ref) {
+    try {
+      const url = `${this.apiBase}/projects/${this.projectPath(owner, repo)}/repository/files/${encodeURIComponent(path7)}/raw?ref=${encodeURIComponent(ref)}`;
+      const response = await fetch(url, { method: "GET", headers: this.baseHeaders() });
+      if (!response.ok) {
+        return `(error fetching content: HTTP ${response.status})`;
+      }
+      const text = await response.text();
+      const maxChars = parseInt(process.env.FERRY_FILE_DISPLAY_CHARS ?? "", 10) || MAX_CONTENT_CHARS_DEFAULT2;
+      return text.length > maxChars ? text.slice(0, maxChars) + "\n... (truncated)" : text;
+    } catch (e) {
+      return `(error fetching content: ${e.message})`;
+    }
+  }
+  async createPR(owner, repo, head, base, title, body) {
+    const draftTitle = title.startsWith(DRAFT_PREFIX) ? title : `${DRAFT_PREFIX}${title}`;
+    const path7 = `/projects/${this.projectPath(owner, repo)}/merge_requests`;
+    try {
+      const mr = await this.request("POST", path7, {
+        body: {
+          source_branch: head,
+          target_branch: base,
+          title: draftTitle,
+          description: body
+        }
+      });
+      return mr.web_url;
+    } catch {
+      const existing = await this.listPRsForBranch(owner, repo, head);
+      if (existing.length > 0) {
+        const mr = await this.request(
+          "GET",
+          `/projects/${this.projectPath(owner, repo)}/merge_requests/${existing[0].number}`
+        );
+        return mr.web_url;
+      }
+      throw new Error(`Failed to create or find MR for source branch ${head}`);
+    }
+  }
+  async markPRReadyForReview(owner, repo, prNumber) {
+    const mr = await this.request(
+      "GET",
+      `/projects/${this.projectPath(owner, repo)}/merge_requests/${prNumber}`
+    );
+    if (!mr.title.startsWith(DRAFT_PREFIX)) return;
+    const newTitle = mr.title.slice(DRAFT_PREFIX.length);
+    await this.request(
+      "PUT",
+      `/projects/${this.projectPath(owner, repo)}/merge_requests/${prNumber}`,
+      {
+        body: { title: newTitle }
+      }
+    );
+  }
+  async commentOnPR(prRef, body) {
+    await this.request(
+      "POST",
+      `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/notes`,
+      { body: { body } }
+    );
+  }
+  async addLabelsToPR(prRef, labels) {
+    if (labels.length === 0) return;
+    await this.request(
+      "PUT",
+      `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}`,
+      { body: { add_labels: labels.join(",") } }
+    );
+  }
+  async removeLabelFromPR(prRef, label) {
+    await this.request(
+      "PUT",
+      `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}`,
+      { body: { remove_labels: label } }
+    );
+  }
+  async listPRComments(prRef, count) {
+    const perPage = Math.min(Math.max(count, 1), 100);
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/notes?sort=desc&order_by=created_at&per_page=${perPage}`;
+    const notes = await this.request("GET", path7);
+    return notes.map((n) => ({ id: n.id, body: n.body ?? "" }));
+  }
+  // ── Helpers ──────────────────────────────────────────────────────────────
+  toPR(mr) {
+    const conflict = mr.has_conflicts === true || typeof mr.detailed_merge_status === "string" && mr.detailed_merge_status.includes("conflict");
+    const mergeable = conflict === true ? false : mr.has_conflicts === false ? true : null;
+    return {
+      number: mr.iid,
+      title: mr.title,
+      baseRef: mr.target_branch,
+      headRef: mr.source_branch,
+      headSha: mr.sha,
+      mergeable
+    };
+  }
+};
+function countDiffLines(diff, prefix) {
+  if (!diff) return 0;
+  let count = 0;
+  for (const line of diff.split("\n")) {
+    if (line.startsWith(prefix) && !line.startsWith(prefix.repeat(3))) count += 1;
+  }
+  return count;
+}
+function collapsePipelineStatus(status) {
+  switch (status) {
+    case "success":
+    case "skipped":
+    case "manual":
+      return "green";
+    case "failed":
+      return "red";
+    case "canceled":
+      return "red";
+    case "created":
+    case "waiting_for_resource":
+    case "preparing":
+    case "pending":
+    case "running":
+    case "scheduled":
+      return "pending";
+  }
+}
+
 // src/lib/dispatch/runner/factory.ts
-var GITLAB_TRACKING_ISSUE = "https://github.com/big-emotion/ferry/issues/210";
 function resolveForgeFromEnv() {
   const raw = (process.env.FERRY_FORGE ?? "").trim().toLowerCase();
   if (raw === "" || raw === "github") return "github";
@@ -5220,9 +5461,10 @@ function createRunnerFromEnv(token, owner, repo) {
     case "github":
       return new GitHubActionsRunner(token, owner, repo);
     case "gitlab":
-      throw new FerryError("state-invariant", {
-        reason: "gitlab-runner-not-implemented",
-        tracking: GITLAB_TRACKING_ISSUE
+      return new GitLabRunner(token, owner, repo, {
+        apiBase: process.env.FERRY_GITLAB_API_BASE,
+        pipelineTriggerToken: process.env.FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN,
+        triggerRef: process.env.FERRY_GITLAB_TRIGGER_REF
       });
   }
 }

--- a/.github/actions/ferry-run-reviewer/agent.js
+++ b/.github/actions/ferry-run-reviewer/agent.js
@@ -5202,8 +5202,249 @@ var GitHubActionsRunner = class {
   }
 };
 
+// src/lib/dispatch/runner/gitlab/index.ts
+var MAX_CONTENT_CHARS_DEFAULT2 = 4e4;
+var DRAFT_PREFIX = "Draft: ";
+var GitLabRunner = class {
+  constructor(token, defaultOwner, defaultRepo, opts = {}) {
+    this.defaultOwner = defaultOwner;
+    this.defaultRepo = defaultRepo;
+    this.authHeader = `Bearer ${token}`;
+    this.apiBase = (opts.apiBase ?? "https://gitlab.com/api/v4").replace(/\/+$/, "");
+    this.pipelineTriggerToken = opts.pipelineTriggerToken;
+    this.triggerRef = opts.triggerRef ?? "main";
+  }
+  defaultOwner;
+  defaultRepo;
+  authHeader;
+  apiBase;
+  pipelineTriggerToken;
+  triggerRef;
+  // ── Internals ────────────────────────────────────────────────────────────
+  projectPath(owner, repo) {
+    return encodeURIComponent(`${owner}/${repo}`);
+  }
+  baseHeaders(extra) {
+    return { Authorization: this.authHeader, Accept: "application/json", ...extra };
+  }
+  async request(method, path7, init = {}) {
+    const headers = this.baseHeaders(init.headers);
+    let body;
+    if (init.rawBody !== void 0) {
+      body = init.rawBody;
+    } else if (init.body !== void 0) {
+      headers["Content-Type"] = "application/json";
+      body = JSON.stringify(init.body);
+    }
+    const url = `${this.apiBase}${path7}`;
+    const response = await fetch(url, { method, headers, body });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new FerryError("transient", {
+        reason: "gitlab-request-failed",
+        method,
+        path: path7,
+        status: response.status,
+        body: text.slice(0, 500)
+      });
+    }
+    if (response.status === 204) return void 0;
+    return await response.json();
+  }
+  async getProject(owner, repo) {
+    return this.request("GET", `/projects/${this.projectPath(owner, repo)}`);
+  }
+  // ── CIRunner methods ─────────────────────────────────────────────────────
+  async dispatch(phase, payload) {
+    const route = PHASE_TO_WORKFLOW[phase];
+    if (!route) throw new Error(`Unknown phase for dispatch: ${phase}`);
+    if (!this.pipelineTriggerToken) {
+      throw new FerryError("state-invariant", {
+        reason: "missing-pipeline-trigger-token",
+        env: "FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN"
+      });
+    }
+    const form = new URLSearchParams();
+    form.set("token", this.pipelineTriggerToken);
+    form.set("ref", this.triggerRef);
+    form.set("variables[FERRY_DISPATCH_TYPE]", route.dispatchType);
+    form.set("variables[FERRY_ENVELOPE_PAYLOAD]", JSON.stringify(payload));
+    const url = `${this.apiBase}/projects/${this.projectPath(this.defaultOwner, this.defaultRepo)}/trigger/pipeline`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: form.toString()
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new FerryError("transient", {
+        reason: "gitlab-pipeline-trigger-failed",
+        status: response.status,
+        body: text.slice(0, 500)
+      });
+    }
+  }
+  async getRepoDefaultBranch(owner, repo) {
+    const project = await this.getProject(owner, repo);
+    return project.default_branch;
+  }
+  async listPRsForBranch(owner, repo, branch) {
+    const path7 = `/projects/${this.projectPath(owner, repo)}/merge_requests?state=opened&source_branch=${encodeURIComponent(branch)}&per_page=1`;
+    const mrs = await this.request("GET", path7);
+    return mrs.map((mr) => this.toPR(mr));
+  }
+  async getPR(prRef) {
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}`;
+    const mr = await this.request("GET", path7);
+    return this.toPR(mr);
+  }
+  async listPRFiles(prRef) {
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/changes`;
+    const data = await this.request("GET", path7);
+    return data.changes.map((c) => ({
+      filename: c.new_path || c.old_path,
+      status: c.new_file ? "added" : c.deleted_file ? "removed" : c.renamed_file ? "renamed" : "modified",
+      additions: countDiffLines(c.diff, "+"),
+      deletions: countDiffLines(c.diff, "-"),
+      patch: c.diff || void 0
+    }));
+  }
+  async listPRCommits(prRef) {
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/commits?per_page=50`;
+    const commits = await this.request("GET", path7);
+    return commits.map((c) => ({ sha: c.id, message: c.message }));
+  }
+  async getCommitStatus(owner, repo, sha) {
+    const path7 = `/projects/${this.projectPath(owner, repo)}/pipelines?sha=${encodeURIComponent(sha)}&per_page=1&order_by=id&sort=desc`;
+    const pipelines = await this.request("GET", path7);
+    if (pipelines.length === 0) return "pending";
+    return collapsePipelineStatus(pipelines[0].status);
+  }
+  async getFileContent(owner, repo, path7, ref) {
+    try {
+      const url = `${this.apiBase}/projects/${this.projectPath(owner, repo)}/repository/files/${encodeURIComponent(path7)}/raw?ref=${encodeURIComponent(ref)}`;
+      const response = await fetch(url, { method: "GET", headers: this.baseHeaders() });
+      if (!response.ok) {
+        return `(error fetching content: HTTP ${response.status})`;
+      }
+      const text = await response.text();
+      const maxChars = parseInt(process.env.FERRY_FILE_DISPLAY_CHARS ?? "", 10) || MAX_CONTENT_CHARS_DEFAULT2;
+      return text.length > maxChars ? text.slice(0, maxChars) + "\n... (truncated)" : text;
+    } catch (e) {
+      return `(error fetching content: ${e.message})`;
+    }
+  }
+  async createPR(owner, repo, head, base, title, body) {
+    const draftTitle = title.startsWith(DRAFT_PREFIX) ? title : `${DRAFT_PREFIX}${title}`;
+    const path7 = `/projects/${this.projectPath(owner, repo)}/merge_requests`;
+    try {
+      const mr = await this.request("POST", path7, {
+        body: {
+          source_branch: head,
+          target_branch: base,
+          title: draftTitle,
+          description: body
+        }
+      });
+      return mr.web_url;
+    } catch {
+      const existing = await this.listPRsForBranch(owner, repo, head);
+      if (existing.length > 0) {
+        const mr = await this.request(
+          "GET",
+          `/projects/${this.projectPath(owner, repo)}/merge_requests/${existing[0].number}`
+        );
+        return mr.web_url;
+      }
+      throw new Error(`Failed to create or find MR for source branch ${head}`);
+    }
+  }
+  async markPRReadyForReview(owner, repo, prNumber) {
+    const mr = await this.request(
+      "GET",
+      `/projects/${this.projectPath(owner, repo)}/merge_requests/${prNumber}`
+    );
+    if (!mr.title.startsWith(DRAFT_PREFIX)) return;
+    const newTitle = mr.title.slice(DRAFT_PREFIX.length);
+    await this.request(
+      "PUT",
+      `/projects/${this.projectPath(owner, repo)}/merge_requests/${prNumber}`,
+      {
+        body: { title: newTitle }
+      }
+    );
+  }
+  async commentOnPR(prRef, body) {
+    await this.request(
+      "POST",
+      `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/notes`,
+      { body: { body } }
+    );
+  }
+  async addLabelsToPR(prRef, labels) {
+    if (labels.length === 0) return;
+    await this.request(
+      "PUT",
+      `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}`,
+      { body: { add_labels: labels.join(",") } }
+    );
+  }
+  async removeLabelFromPR(prRef, label) {
+    await this.request(
+      "PUT",
+      `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}`,
+      { body: { remove_labels: label } }
+    );
+  }
+  async listPRComments(prRef, count) {
+    const perPage = Math.min(Math.max(count, 1), 100);
+    const path7 = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/notes?sort=desc&order_by=created_at&per_page=${perPage}`;
+    const notes = await this.request("GET", path7);
+    return notes.map((n) => ({ id: n.id, body: n.body ?? "" }));
+  }
+  // ── Helpers ──────────────────────────────────────────────────────────────
+  toPR(mr) {
+    const conflict = mr.has_conflicts === true || typeof mr.detailed_merge_status === "string" && mr.detailed_merge_status.includes("conflict");
+    const mergeable = conflict === true ? false : mr.has_conflicts === false ? true : null;
+    return {
+      number: mr.iid,
+      title: mr.title,
+      baseRef: mr.target_branch,
+      headRef: mr.source_branch,
+      headSha: mr.sha,
+      mergeable
+    };
+  }
+};
+function countDiffLines(diff, prefix) {
+  if (!diff) return 0;
+  let count = 0;
+  for (const line of diff.split("\n")) {
+    if (line.startsWith(prefix) && !line.startsWith(prefix.repeat(3))) count += 1;
+  }
+  return count;
+}
+function collapsePipelineStatus(status) {
+  switch (status) {
+    case "success":
+    case "skipped":
+    case "manual":
+      return "green";
+    case "failed":
+      return "red";
+    case "canceled":
+      return "red";
+    case "created":
+    case "waiting_for_resource":
+    case "preparing":
+    case "pending":
+    case "running":
+    case "scheduled":
+      return "pending";
+  }
+}
+
 // src/lib/dispatch/runner/factory.ts
-var GITLAB_TRACKING_ISSUE = "https://github.com/big-emotion/ferry/issues/210";
 function resolveForgeFromEnv() {
   const raw = (process.env.FERRY_FORGE ?? "").trim().toLowerCase();
   if (raw === "" || raw === "github") return "github";
@@ -5220,9 +5461,10 @@ function createRunnerFromEnv(token, owner, repo) {
     case "github":
       return new GitHubActionsRunner(token, owner, repo);
     case "gitlab":
-      throw new FerryError("state-invariant", {
-        reason: "gitlab-runner-not-implemented",
-        tracking: GITLAB_TRACKING_ISSUE
+      return new GitLabRunner(token, owner, repo, {
+        apiBase: process.env.FERRY_GITLAB_API_BASE,
+        pipelineTriggerToken: process.env.FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN,
+        triggerRef: process.env.FERRY_GITLAB_TRIGGER_REF
       });
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Ferry uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **GitLab runner adapter (experimental)** (#212, part of #210) — `FERRY_FORGE=gitlab` now resolves to a working `GitLabRunner` that implements the full `CIRunner` surface against the GitLab REST API v4 (native fetch; no SDK dependency). Vocabulary mapping: GitLab merge request ↔ pull request; `Draft:` title prefix ↔ draft PR; latest pipeline status ↔ aggregated commit status (success/skipped/manual → green; failed/canceled → red; everything else → pending). `dispatch()` triggers a downstream pipeline via the pipeline-trigger token, passing the envelope as `FERRY_ENVELOPE_PAYLOAD`. Required env vars: `FERRY_GITLAB_API_BASE` (defaults to `https://gitlab.com/api/v4`), `FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN`, `FERRY_GITLAB_TRIGGER_REF`. Marked **experimental** until at least one consumer has exercised the full cycle in production — see #210 for the promotion checklist.
+
 ### Changed
 
 - **Runner factory + unified `ferry-agent` CLI** (#211, prerequisite for #210) — the runner layer is now resolved through `createRunnerFromEnv()` (`src/lib/dispatch/runner/factory.ts`), switching on a new `FERRY_FORGE` env var (default `github`; `gitlab` throws a clear "not yet implemented" error pointing at #210). The four agent composite actions (`ferry-run-{refiner,developer,reviewer,iterator}`) now invoke a single `ferry-agent run --role <role>` CLI; the per-role `.ferry/{refiner,dev,review,iterate}-action.js` bundles are replaced by a unified `.ferry/agent.js`. **No behaviour change for consumers** — the composite action interface is unchanged.

--- a/src/lib/dispatch/runner/factory.test.ts
+++ b/src/lib/dispatch/runner/factory.test.ts
@@ -1,12 +1,19 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { resolveForgeFromEnv, createRunnerFromEnv } from './factory.js';
 import { GitHubActionsRunner } from './github-actions/index.js';
+import { GitLabRunner } from './gitlab/index.js';
 import { FerryError } from '../../errors/index.js';
 
 const FORGE_VAR = 'FERRY_FORGE';
+const GITLAB_VARS = [
+  'FERRY_GITLAB_API_BASE',
+  'FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN',
+  'FERRY_GITLAB_TRIGGER_REF',
+];
 
 afterEach(() => {
   delete process.env[FORGE_VAR];
+  for (const v of GITLAB_VARS) delete process.env[v];
 });
 
 describe('resolveForgeFromEnv', () => {
@@ -54,18 +61,18 @@ describe('createRunnerFromEnv', () => {
     expect(runner).toBeInstanceOf(GitHubActionsRunner);
   });
 
-  it('throws a clear FerryError for FERRY_FORGE=gitlab pointing at the tracking issue', () => {
+  it('returns a GitLabRunner for FERRY_FORGE=gitlab', () => {
     process.env[FORGE_VAR] = 'gitlab';
-    expect(() => createRunnerFromEnv('token', 'owner', 'repo')).toThrowError(
-      /gitlab-runner-not-implemented/,
-    );
-    try {
-      createRunnerFromEnv('token', 'owner', 'repo');
-    } catch (err) {
-      expect(err).toBeInstanceOf(FerryError);
-      const ferryErr = err as FerryError;
-      expect(ferryErr.code).toBe('state-invariant');
-      expect(ferryErr.context?.tracking).toBe('https://github.com/big-emotion/ferry/issues/210');
-    }
+    const runner = createRunnerFromEnv('token', 'owner', 'repo');
+    expect(runner).toBeInstanceOf(GitLabRunner);
+  });
+
+  it('propagates GitLab options from env vars', () => {
+    process.env[FORGE_VAR] = 'gitlab';
+    process.env.FERRY_GITLAB_API_BASE = 'https://gitlab.example/api/v4';
+    process.env.FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN = 'trig';
+    process.env.FERRY_GITLAB_TRIGGER_REF = 'release';
+    const runner = createRunnerFromEnv('token', 'owner', 'repo');
+    expect(runner).toBeInstanceOf(GitLabRunner);
   });
 });

--- a/src/lib/dispatch/runner/factory.ts
+++ b/src/lib/dispatch/runner/factory.ts
@@ -1,10 +1,9 @@
 import { FerryError } from '../../errors/index.js';
 import { GitHubActionsRunner } from './github-actions/index.js';
+import { GitLabRunner } from './gitlab/index.js';
 import type { CIRunner } from './types.js';
 
 export type ForgeKind = 'github' | 'gitlab';
-
-const GITLAB_TRACKING_ISSUE = 'https://github.com/big-emotion/ferry/issues/210';
 
 export function resolveForgeFromEnv(): ForgeKind {
   const raw = (process.env.FERRY_FORGE ?? '').trim().toLowerCase();
@@ -23,9 +22,10 @@ export function createRunnerFromEnv(token: string, owner: string, repo: string):
     case 'github':
       return new GitHubActionsRunner(token, owner, repo);
     case 'gitlab':
-      throw new FerryError('state-invariant', {
-        reason: 'gitlab-runner-not-implemented',
-        tracking: GITLAB_TRACKING_ISSUE,
+      return new GitLabRunner(token, owner, repo, {
+        apiBase: process.env.FERRY_GITLAB_API_BASE,
+        pipelineTriggerToken: process.env.FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN,
+        triggerRef: process.env.FERRY_GITLAB_TRIGGER_REF,
       });
   }
 }

--- a/src/lib/dispatch/runner/gitlab/index.test.ts
+++ b/src/lib/dispatch/runner/gitlab/index.test.ts
@@ -1,0 +1,379 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GitLabRunner, collapsePipelineStatus } from './index.js';
+import { FerryError } from '../../../errors/index.js';
+
+const TOKEN = 'glpat-test-token';
+const OWNER = 'acme';
+const REPO = 'widgets';
+const PROJECT = encodeURIComponent(`${OWNER}/${REPO}`);
+const API = 'https://gitlab.example/api/v4';
+
+interface CapturedRequest {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: string;
+}
+
+interface MockResponse {
+  status?: number;
+  body?: unknown;
+  rawBody?: string;
+}
+
+function mockFetch(...responses: MockResponse[]): {
+  fn: ReturnType<typeof vi.fn>;
+  calls: CapturedRequest[];
+} {
+  const calls: CapturedRequest[] = [];
+  let i = 0;
+  const fn = vi.fn(async (url: string, init: RequestInit) => {
+    const headers: Record<string, string> = {};
+    if (init.headers) {
+      for (const [k, v] of Object.entries(init.headers as Record<string, string>)) {
+        headers[k] = v;
+      }
+    }
+    calls.push({
+      method: init.method ?? 'GET',
+      url,
+      headers,
+      body: typeof init.body === 'string' ? init.body : undefined,
+    });
+    const resp = responses[i] ?? { status: 200, body: {} };
+    i += 1;
+    const status = resp.status ?? 200;
+    return new Response(
+      resp.rawBody !== undefined ? resp.rawBody : JSON.stringify(resp.body ?? {}),
+      { status },
+    );
+  });
+  vi.stubGlobal('fetch', fn);
+  return { fn, calls };
+}
+
+beforeEach(() => {
+  delete process.env.FERRY_FILE_DISPLAY_CHARS;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('GitLabRunner', () => {
+  const runner = new GitLabRunner(TOKEN, OWNER, REPO, {
+    apiBase: API,
+    pipelineTriggerToken: 'trig-secret',
+    triggerRef: 'main',
+  });
+
+  it('sets Bearer auth header on every API call', async () => {
+    const { calls } = mockFetch({ body: { default_branch: 'main' } });
+    await runner.getRepoDefaultBranch(OWNER, REPO);
+    expect(calls[0].headers.Authorization).toBe(`Bearer ${TOKEN}`);
+    expect(calls[0].url).toBe(`${API}/projects/${PROJECT}`);
+  });
+
+  it('returns default branch from /projects/:id', async () => {
+    mockFetch({ body: { id: 1, default_branch: 'trunk' } });
+    expect(await runner.getRepoDefaultBranch(OWNER, REPO)).toBe('trunk');
+  });
+
+  it('lists open MRs for a source branch', async () => {
+    const { calls } = mockFetch({
+      body: [
+        {
+          iid: 42,
+          title: 'Draft: feat: foo',
+          source_branch: 'ferry/ACME-1',
+          target_branch: 'main',
+          sha: 'abc123',
+          web_url: `https://gitlab.example/${OWNER}/${REPO}/-/merge_requests/42`,
+          has_conflicts: false,
+        },
+      ],
+    });
+    const prs = await runner.listPRsForBranch(OWNER, REPO, 'ferry/ACME-1');
+    expect(prs).toHaveLength(1);
+    expect(prs[0]).toMatchObject({
+      number: 42,
+      title: 'Draft: feat: foo',
+      baseRef: 'main',
+      headRef: 'ferry/ACME-1',
+      headSha: 'abc123',
+      mergeable: true,
+    });
+    expect(calls[0].url).toContain('state=opened');
+    expect(calls[0].url).toContain('source_branch=ferry%2FACME-1');
+  });
+
+  it('getPR maps has_conflicts=true to mergeable=false', async () => {
+    mockFetch({
+      body: {
+        iid: 5,
+        title: 'WIP',
+        source_branch: 'topic',
+        target_branch: 'main',
+        sha: 'def456',
+        web_url: 'x',
+        has_conflicts: true,
+      },
+    });
+    const pr = await runner.getPR({ owner: OWNER, repo: REPO, prNumber: 5 });
+    expect(pr.mergeable).toBe(false);
+  });
+
+  it('createPR opens a draft MR by default and returns its URL', async () => {
+    const { calls } = mockFetch({
+      body: {
+        iid: 7,
+        title: 'Draft: feat: ACME-1',
+        source_branch: 'ferry/ACME-1',
+        target_branch: 'main',
+        sha: 'abc',
+        web_url: 'https://gitlab.example/acme/widgets/-/merge_requests/7',
+      },
+    });
+    const url = await runner.createPR(OWNER, REPO, 'ferry/ACME-1', 'main', 'feat: ACME-1', 'body');
+    expect(url).toBe('https://gitlab.example/acme/widgets/-/merge_requests/7');
+    expect(calls[0].method).toBe('POST');
+    const body = JSON.parse(calls[0].body ?? '{}');
+    expect(body.title).toBe('Draft: feat: ACME-1');
+    expect(body.source_branch).toBe('ferry/ACME-1');
+    expect(body.target_branch).toBe('main');
+  });
+
+  it('createPR returns the existing MR URL if creation fails', async () => {
+    mockFetch(
+      { status: 409, body: { message: 'MR already exists' } },
+      {
+        body: [
+          {
+            iid: 12,
+            title: 'Draft: feat: foo',
+            source_branch: 'ferry/ACME-1',
+            target_branch: 'main',
+            sha: 's',
+            web_url: 'https://gitlab.example/acme/widgets/-/merge_requests/12',
+            has_conflicts: false,
+          },
+        ],
+      },
+      {
+        body: {
+          iid: 12,
+          title: 'Draft: feat: foo',
+          source_branch: 'ferry/ACME-1',
+          target_branch: 'main',
+          sha: 's',
+          web_url: 'https://gitlab.example/acme/widgets/-/merge_requests/12',
+        },
+      },
+    );
+    const url = await runner.createPR(OWNER, REPO, 'ferry/ACME-1', 'main', 'feat: foo', 'body');
+    expect(url).toBe('https://gitlab.example/acme/widgets/-/merge_requests/12');
+  });
+
+  it('markPRReadyForReview strips the Draft: prefix from the title', async () => {
+    const { calls } = mockFetch(
+      {
+        body: {
+          iid: 7,
+          title: 'Draft: feat: ACME-1',
+          source_branch: 'b',
+          target_branch: 'm',
+          sha: 's',
+          web_url: 'u',
+        },
+      },
+      { body: {} },
+    );
+    await runner.markPRReadyForReview(OWNER, REPO, 7);
+    const put = calls[1];
+    expect(put.method).toBe('PUT');
+    expect(JSON.parse(put.body ?? '{}')).toEqual({ title: 'feat: ACME-1' });
+  });
+
+  it('markPRReadyForReview is a no-op when title has no Draft prefix', async () => {
+    const { calls } = mockFetch({
+      body: {
+        iid: 7,
+        title: 'feat: ACME-1',
+        source_branch: 'b',
+        target_branch: 'm',
+        sha: 's',
+        web_url: 'u',
+      },
+    });
+    await runner.markPRReadyForReview(OWNER, REPO, 7);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('commentOnPR posts a note', async () => {
+    const { calls } = mockFetch({ body: { id: 1, body: 'hi' } });
+    await runner.commentOnPR({ owner: OWNER, repo: REPO, prNumber: 9 }, 'hi');
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe(`${API}/projects/${PROJECT}/merge_requests/9/notes`);
+    expect(JSON.parse(calls[0].body ?? '{}')).toEqual({ body: 'hi' });
+  });
+
+  it('addLabelsToPR comma-joins labels and sends them via add_labels', async () => {
+    const { calls } = mockFetch({ body: {} });
+    await runner.addLabelsToPR({ owner: OWNER, repo: REPO, prNumber: 9 }, [
+      'ferry:approved',
+      'ferry:cost-estimate:1.00-2.00',
+    ]);
+    expect(calls[0].method).toBe('PUT');
+    expect(JSON.parse(calls[0].body ?? '{}')).toEqual({
+      add_labels: 'ferry:approved,ferry:cost-estimate:1.00-2.00',
+    });
+  });
+
+  it('addLabelsToPR is a no-op when labels is empty', async () => {
+    const { calls } = mockFetch();
+    await runner.addLabelsToPR({ owner: OWNER, repo: REPO, prNumber: 9 }, []);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('removeLabelFromPR sends remove_labels', async () => {
+    const { calls } = mockFetch({ body: {} });
+    await runner.removeLabelFromPR({ owner: OWNER, repo: REPO, prNumber: 9 }, 'ferry:reviewing');
+    expect(JSON.parse(calls[0].body ?? '{}')).toEqual({ remove_labels: 'ferry:reviewing' });
+  });
+
+  it('listPRComments returns notes sorted desc, capped at count', async () => {
+    const { calls } = mockFetch({
+      body: [
+        { id: 3, body: 'c' },
+        { id: 2, body: 'b' },
+        { id: 1, body: 'a' },
+      ],
+    });
+    const out = await runner.listPRComments({ owner: OWNER, repo: REPO, prNumber: 9 }, 3);
+    expect(out).toEqual([
+      { id: 3, body: 'c' },
+      { id: 2, body: 'b' },
+      { id: 1, body: 'a' },
+    ]);
+    expect(calls[0].url).toContain('sort=desc');
+    expect(calls[0].url).toContain('per_page=3');
+  });
+
+  it('listPRFiles derives status, additions, deletions from change records', async () => {
+    mockFetch({
+      body: {
+        changes: [
+          {
+            old_path: 'a.ts',
+            new_path: 'a.ts',
+            new_file: false,
+            renamed_file: false,
+            deleted_file: false,
+            diff: '@@ -1 +1,2 @@\n+new line\n-old line\n+another',
+          },
+          {
+            old_path: 'b.ts',
+            new_path: 'b.ts',
+            new_file: true,
+            renamed_file: false,
+            deleted_file: false,
+            diff: '+content',
+          },
+        ],
+      },
+    });
+    const files = await runner.listPRFiles({ owner: OWNER, repo: REPO, prNumber: 1 });
+    expect(files[0]).toMatchObject({
+      filename: 'a.ts',
+      status: 'modified',
+      additions: 2,
+      deletions: 1,
+    });
+    expect(files[1].status).toBe('added');
+  });
+
+  it('listPRCommits returns sha/message pairs', async () => {
+    mockFetch({
+      body: [
+        { id: 'sha1', message: 'first' },
+        { id: 'sha2', message: 'second' },
+      ],
+    });
+    const commits = await runner.listPRCommits({ owner: OWNER, repo: REPO, prNumber: 1 });
+    expect(commits).toEqual([
+      { sha: 'sha1', message: 'first' },
+      { sha: 'sha2', message: 'second' },
+    ]);
+  });
+
+  it('getCommitStatus returns pending when no pipeline exists', async () => {
+    mockFetch({ body: [] });
+    expect(await runner.getCommitStatus(OWNER, REPO, 'abc')).toBe('pending');
+  });
+
+  it('getCommitStatus collapses GitLab statuses correctly', async () => {
+    expect(collapsePipelineStatus('success')).toBe('green');
+    expect(collapsePipelineStatus('skipped')).toBe('green');
+    expect(collapsePipelineStatus('manual')).toBe('green');
+    expect(collapsePipelineStatus('failed')).toBe('red');
+    expect(collapsePipelineStatus('canceled')).toBe('red');
+    expect(collapsePipelineStatus('pending')).toBe('pending');
+    expect(collapsePipelineStatus('running')).toBe('pending');
+    expect(collapsePipelineStatus('preparing')).toBe('pending');
+    expect(collapsePipelineStatus('scheduled')).toBe('pending');
+  });
+
+  it('getFileContent returns raw text and truncates beyond the cap', async () => {
+    const big = 'x'.repeat(50_000);
+    mockFetch({ rawBody: big });
+    process.env.FERRY_FILE_DISPLAY_CHARS = '40000';
+    const content = await runner.getFileContent(OWNER, REPO, 'src/foo.ts', 'main');
+    expect(content.length).toBe(40_000 + '\n... (truncated)'.length);
+    expect(content.endsWith('... (truncated)')).toBe(true);
+  });
+
+  it('getFileContent returns a friendly error string on HTTP failure', async () => {
+    mockFetch({ status: 404, body: {} });
+    const content = await runner.getFileContent(OWNER, REPO, 'missing.ts', 'main');
+    expect(content).toMatch(/error fetching content/);
+    expect(content).toContain('404');
+  });
+
+  it('dispatch triggers a pipeline with the envelope as FERRY_ENVELOPE_PAYLOAD', async () => {
+    const { calls } = mockFetch({ body: { id: 100, status: 'pending' } });
+    await runner.dispatch('review', {
+      version: 'v1',
+      event_id: 'evt1234',
+      ticket_key: 'ACME-1',
+      phase: 'review',
+      source: 'jira-column',
+      ts: '2026-01-01T00:00:00Z',
+    });
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].url).toBe(`${API}/projects/${PROJECT}/trigger/pipeline`);
+    const body = calls[0].body ?? '';
+    expect(body).toContain('token=trig-secret');
+    expect(body).toContain('ref=main');
+    expect(body).toContain('variables%5BFERRY_DISPATCH_TYPE%5D=');
+    expect(body).toContain('variables%5BFERRY_ENVELOPE_PAYLOAD%5D=');
+  });
+
+  it('dispatch throws a clear error when the trigger token is absent', async () => {
+    const noToken = new GitLabRunner(TOKEN, OWNER, REPO, { apiBase: API });
+    await expect(
+      noToken.dispatch('review', {
+        version: 'v1',
+        event_id: 'e',
+        ticket_key: 'A-1',
+        phase: 'review',
+        source: 'jira-column',
+        ts: '2026-01-01T00:00:00Z',
+      }),
+    ).rejects.toThrow(FerryError);
+  });
+
+  it('throws a FerryError(transient) for any 5xx response on a regular request', async () => {
+    mockFetch({ status: 503, body: {} });
+    await expect(runner.getRepoDefaultBranch(OWNER, REPO)).rejects.toThrow(FerryError);
+  });
+});

--- a/src/lib/dispatch/runner/gitlab/index.ts
+++ b/src/lib/dispatch/runner/gitlab/index.ts
@@ -1,0 +1,384 @@
+/**
+ * GitLab CIRunner adapter — implements the forge-neutral CIRunner against the
+ * GitLab REST API (v4). Uses native fetch; no SDK dependency.
+ *
+ * Vocabulary mapping:
+ *   - GitHub "pull request" ↔ GitLab "merge request"
+ *   - "Draft PR"            ↔ "Draft: …" title prefix
+ *   - "GitHub Checks"       ↔ "latest pipeline for ref"
+ *   - repository_dispatch   ↔ pipeline trigger token
+ *
+ * Authentication: a GitLab project / personal access token with `api` scope.
+ * Required env vars (read in factory.ts):
+ *   FERRY_GITLAB_TOKEN              — API token (Bearer)
+ *   FERRY_GITLAB_API_BASE           — optional, defaults to https://gitlab.com/api/v4
+ *   FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN — only required if you use dispatch()
+ *   FERRY_GITLAB_TRIGGER_REF        — pipeline ref used by dispatch(); default 'main'
+ */
+import { FerryError } from '../../../errors/index.js';
+import { PHASE_TO_WORKFLOW } from '../../routing.js';
+import type {
+  CIRunner,
+  CommitStatus,
+  DispatchPayload,
+  PR,
+  PRComment,
+  PRFile,
+  PRRef,
+} from '../types.js';
+
+const MAX_CONTENT_CHARS_DEFAULT = 40_000;
+
+const DRAFT_PREFIX = 'Draft: ';
+
+export interface GitLabRunnerOptions {
+  /** Base URL of the GitLab API. Defaults to `https://gitlab.com/api/v4`. */
+  apiBase?: string;
+  /** Token used by `dispatch()` to trigger a pipeline. */
+  pipelineTriggerToken?: string;
+  /** Ref to trigger pipelines on. Defaults to `main`. */
+  triggerRef?: string;
+}
+
+interface GitLabProject {
+  id: number;
+  default_branch: string;
+}
+
+interface GitLabMergeRequest {
+  iid: number;
+  title: string;
+  source_branch: string;
+  target_branch: string;
+  sha: string;
+  web_url: string;
+  has_conflicts?: boolean;
+  detailed_merge_status?: string;
+  labels?: string[];
+}
+
+interface GitLabChangesResponse {
+  changes: Array<{
+    old_path: string;
+    new_path: string;
+    new_file: boolean;
+    renamed_file: boolean;
+    deleted_file: boolean;
+    diff: string;
+  }>;
+}
+
+interface GitLabCommit {
+  id: string;
+  message: string;
+}
+
+interface GitLabPipeline {
+  id: number;
+  status:
+    | 'created'
+    | 'waiting_for_resource'
+    | 'preparing'
+    | 'pending'
+    | 'running'
+    | 'success'
+    | 'failed'
+    | 'canceled'
+    | 'skipped'
+    | 'manual'
+    | 'scheduled';
+}
+
+interface GitLabNote {
+  id: number;
+  body: string;
+}
+
+export class GitLabRunner implements CIRunner {
+  private readonly authHeader: string;
+  private readonly apiBase: string;
+  private readonly pipelineTriggerToken?: string;
+  private readonly triggerRef: string;
+
+  constructor(
+    token: string,
+    private readonly defaultOwner: string,
+    private readonly defaultRepo: string,
+    opts: GitLabRunnerOptions = {},
+  ) {
+    this.authHeader = `Bearer ${token}`;
+    this.apiBase = (opts.apiBase ?? 'https://gitlab.com/api/v4').replace(/\/+$/, '');
+    this.pipelineTriggerToken = opts.pipelineTriggerToken;
+    this.triggerRef = opts.triggerRef ?? 'main';
+  }
+
+  // ── Internals ────────────────────────────────────────────────────────────
+
+  private projectPath(owner: string, repo: string): string {
+    return encodeURIComponent(`${owner}/${repo}`);
+  }
+
+  private baseHeaders(extra?: Record<string, string>): Record<string, string> {
+    return { Authorization: this.authHeader, Accept: 'application/json', ...extra };
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    init: { body?: unknown; rawBody?: BodyInit; headers?: Record<string, string> } = {},
+  ): Promise<T> {
+    const headers = this.baseHeaders(init.headers);
+    let body: BodyInit | undefined;
+    if (init.rawBody !== undefined) {
+      body = init.rawBody;
+    } else if (init.body !== undefined) {
+      headers['Content-Type'] = 'application/json';
+      body = JSON.stringify(init.body);
+    }
+    const url = `${this.apiBase}${path}`;
+    const response = await fetch(url, { method, headers, body });
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new FerryError('transient', {
+        reason: 'gitlab-request-failed',
+        method,
+        path,
+        status: response.status,
+        body: text.slice(0, 500),
+      });
+    }
+    if (response.status === 204) return undefined as T;
+    return (await response.json()) as T;
+  }
+
+  private async getProject(owner: string, repo: string): Promise<GitLabProject> {
+    return this.request<GitLabProject>('GET', `/projects/${this.projectPath(owner, repo)}`);
+  }
+
+  // ── CIRunner methods ─────────────────────────────────────────────────────
+
+  async dispatch(phase: string, payload: DispatchPayload): Promise<void> {
+    const route = (PHASE_TO_WORKFLOW as Record<string, { dispatchType: string } | undefined>)[
+      phase
+    ];
+    if (!route) throw new Error(`Unknown phase for dispatch: ${phase}`);
+    if (!this.pipelineTriggerToken) {
+      throw new FerryError('state-invariant', {
+        reason: 'missing-pipeline-trigger-token',
+        env: 'FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN',
+      });
+    }
+    const form = new URLSearchParams();
+    form.set('token', this.pipelineTriggerToken);
+    form.set('ref', this.triggerRef);
+    form.set('variables[FERRY_DISPATCH_TYPE]', route.dispatchType);
+    form.set('variables[FERRY_ENVELOPE_PAYLOAD]', JSON.stringify(payload));
+    const url = `${this.apiBase}/projects/${this.projectPath(this.defaultOwner, this.defaultRepo)}/trigger/pipeline`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: form.toString(),
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new FerryError('transient', {
+        reason: 'gitlab-pipeline-trigger-failed',
+        status: response.status,
+        body: text.slice(0, 500),
+      });
+    }
+  }
+
+  async getRepoDefaultBranch(owner: string, repo: string): Promise<string> {
+    const project = await this.getProject(owner, repo);
+    return project.default_branch;
+  }
+
+  async listPRsForBranch(owner: string, repo: string, branch: string): Promise<PR[]> {
+    const path = `/projects/${this.projectPath(owner, repo)}/merge_requests?state=opened&source_branch=${encodeURIComponent(branch)}&per_page=1`;
+    const mrs = await this.request<GitLabMergeRequest[]>('GET', path);
+    return mrs.map((mr) => this.toPR(mr));
+  }
+
+  async getPR(prRef: PRRef): Promise<PR> {
+    const path = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}`;
+    const mr = await this.request<GitLabMergeRequest>('GET', path);
+    return this.toPR(mr);
+  }
+
+  async listPRFiles(prRef: PRRef): Promise<PRFile[]> {
+    const path = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/changes`;
+    const data = await this.request<GitLabChangesResponse>('GET', path);
+    return data.changes.map((c) => ({
+      filename: c.new_path || c.old_path,
+      status: c.new_file
+        ? 'added'
+        : c.deleted_file
+          ? 'removed'
+          : c.renamed_file
+            ? 'renamed'
+            : 'modified',
+      additions: countDiffLines(c.diff, '+'),
+      deletions: countDiffLines(c.diff, '-'),
+      patch: c.diff || undefined,
+    }));
+  }
+
+  async listPRCommits(prRef: PRRef): Promise<Array<{ sha: string; message: string }>> {
+    const path = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/commits?per_page=50`;
+    const commits = await this.request<GitLabCommit[]>('GET', path);
+    return commits.map((c) => ({ sha: c.id, message: c.message }));
+  }
+
+  async getCommitStatus(owner: string, repo: string, sha: string): Promise<CommitStatus> {
+    const path = `/projects/${this.projectPath(owner, repo)}/pipelines?sha=${encodeURIComponent(sha)}&per_page=1&order_by=id&sort=desc`;
+    const pipelines = await this.request<GitLabPipeline[]>('GET', path);
+    if (pipelines.length === 0) return 'pending';
+    return collapsePipelineStatus(pipelines[0].status);
+  }
+
+  async getFileContent(owner: string, repo: string, path: string, ref: string): Promise<string> {
+    try {
+      const url = `${this.apiBase}/projects/${this.projectPath(owner, repo)}/repository/files/${encodeURIComponent(path)}/raw?ref=${encodeURIComponent(ref)}`;
+      const response = await fetch(url, { method: 'GET', headers: this.baseHeaders() });
+      if (!response.ok) {
+        return `(error fetching content: HTTP ${response.status})`;
+      }
+      const text = await response.text();
+      const maxChars =
+        parseInt(process.env.FERRY_FILE_DISPLAY_CHARS ?? '', 10) || MAX_CONTENT_CHARS_DEFAULT;
+      return text.length > maxChars ? text.slice(0, maxChars) + '\n... (truncated)' : text;
+    } catch (e) {
+      return `(error fetching content: ${(e as Error).message})`;
+    }
+  }
+
+  async createPR(
+    owner: string,
+    repo: string,
+    head: string,
+    base: string,
+    title: string,
+    body: string,
+  ): Promise<string> {
+    const draftTitle = title.startsWith(DRAFT_PREFIX) ? title : `${DRAFT_PREFIX}${title}`;
+    const path = `/projects/${this.projectPath(owner, repo)}/merge_requests`;
+    try {
+      const mr = await this.request<GitLabMergeRequest>('POST', path, {
+        body: {
+          source_branch: head,
+          target_branch: base,
+          title: draftTitle,
+          description: body,
+        },
+      });
+      return mr.web_url;
+    } catch {
+      // MR may already exist — find and return its URL.
+      const existing = await this.listPRsForBranch(owner, repo, head);
+      if (existing.length > 0) {
+        const mr = await this.request<GitLabMergeRequest>(
+          'GET',
+          `/projects/${this.projectPath(owner, repo)}/merge_requests/${existing[0].number}`,
+        );
+        return mr.web_url;
+      }
+      throw new Error(`Failed to create or find MR for source branch ${head}`);
+    }
+  }
+
+  async markPRReadyForReview(owner: string, repo: string, prNumber: number): Promise<void> {
+    const mr = await this.request<GitLabMergeRequest>(
+      'GET',
+      `/projects/${this.projectPath(owner, repo)}/merge_requests/${prNumber}`,
+    );
+    if (!mr.title.startsWith(DRAFT_PREFIX)) return;
+    const newTitle = mr.title.slice(DRAFT_PREFIX.length);
+    await this.request(
+      'PUT',
+      `/projects/${this.projectPath(owner, repo)}/merge_requests/${prNumber}`,
+      {
+        body: { title: newTitle },
+      },
+    );
+  }
+
+  async commentOnPR(prRef: PRRef, body: string): Promise<void> {
+    await this.request(
+      'POST',
+      `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/notes`,
+      { body: { body } },
+    );
+  }
+
+  async addLabelsToPR(prRef: PRRef, labels: string[]): Promise<void> {
+    if (labels.length === 0) return;
+    await this.request(
+      'PUT',
+      `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}`,
+      { body: { add_labels: labels.join(',') } },
+    );
+  }
+
+  async removeLabelFromPR(prRef: PRRef, label: string): Promise<void> {
+    await this.request(
+      'PUT',
+      `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}`,
+      { body: { remove_labels: label } },
+    );
+  }
+
+  async listPRComments(prRef: PRRef, count: number): Promise<PRComment[]> {
+    const perPage = Math.min(Math.max(count, 1), 100);
+    const path = `/projects/${this.projectPath(prRef.owner, prRef.repo)}/merge_requests/${prRef.prNumber}/notes?sort=desc&order_by=created_at&per_page=${perPage}`;
+    const notes = await this.request<GitLabNote[]>('GET', path);
+    return notes.map((n) => ({ id: n.id, body: n.body ?? '' }));
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  private toPR(mr: GitLabMergeRequest): PR {
+    const conflict =
+      mr.has_conflicts === true ||
+      (typeof mr.detailed_merge_status === 'string' &&
+        mr.detailed_merge_status.includes('conflict'));
+    const mergeable = conflict === true ? false : mr.has_conflicts === false ? true : null;
+    return {
+      number: mr.iid,
+      title: mr.title,
+      baseRef: mr.target_branch,
+      headRef: mr.source_branch,
+      headSha: mr.sha,
+      mergeable,
+    };
+  }
+}
+
+function countDiffLines(diff: string, prefix: '+' | '-'): number {
+  if (!diff) return 0;
+  let count = 0;
+  for (const line of diff.split('\n')) {
+    if (line.startsWith(prefix) && !line.startsWith(prefix.repeat(3))) count += 1;
+  }
+  return count;
+}
+
+export function collapsePipelineStatus(status: GitLabPipeline['status']): CommitStatus {
+  switch (status) {
+    case 'success':
+    case 'skipped':
+    case 'manual':
+      return 'green';
+    case 'failed':
+      return 'red';
+    case 'canceled':
+      return 'red';
+    case 'created':
+    case 'waiting_for_resource':
+    case 'preparing':
+    case 'pending':
+    case 'running':
+    case 'scheduled':
+      return 'pending';
+  }
+}


### PR DESCRIPTION
Closes #212. Part of #210. Successor to closed-on-rebase #280 (base branch was deleted when #279 squash-merged; same content, rebased onto main).

## Summary

Implements the second forge adapter behind the factory boundary from #211.

`src/lib/dispatch/runner/gitlab/index.ts` — full `CIRunner` against GitLab REST API v4 using native fetch (no SDK dep).

| GitHub concept | GitLab equivalent |
|---|---|
| Pull request | Merge request |
| Draft PR | `Draft:` title prefix |
| GitHub Checks | Latest pipeline for ref |
| `repository_dispatch` | Pipeline trigger token |

### Pipeline status mapping

- `success`, `skipped`, `manual` → **green**
- `failed`, `canceled` → **red**
- everything else → **pending**

### Dispatch

POSTs to `/projects/:id/trigger/pipeline` with the full envelope as `FERRY_ENVELOPE_PAYLOAD` — same wire shape as the GitHub path, no schema divergence.

### Factory

`createRunnerFromEnv` returns `GitLabRunner` for `FERRY_FORGE=gitlab`, threading `FERRY_GITLAB_{API_BASE,PIPELINE_TRIGGER_TOKEN,TRIGGER_REF}`.

## Verification

- `npm run typecheck` — green
- `npm run lint` — green
- `npm run format:check` — green
- `npm test` — 1528 / 1528 (+23 new GitLab tests)
- `npm run check:bundle` — exit 0