### PR TITLE
feat: label override ferry:as/<type> for ticket typing (#242)

### DIFF
--- a/.ferry/agent.js
+++ b/.ferry/agent.js
@@ -5788,9 +5788,16 @@ var FORCE_TYPE_LABELS = Object.freeze({
   "ferry:type:force-story": "Story"
 });
 var ENABLE_TASK_LABEL = "ferry:type:enable-task";
+var AS_LABEL_PREFIX = "ferry:as/";
+var AS_TYPE_LABELS = Object.freeze({
+  bug: "Bug",
+  spike: "Spike",
+  story: "Story"
+});
 var BUILTIN_TYPE_LABELS = /* @__PURE__ */ new Set([
   ENABLE_TASK_LABEL,
-  ...Object.keys(FORCE_TYPE_LABELS)
+  ...Object.keys(FORCE_TYPE_LABELS),
+  ...Object.keys(AS_TYPE_LABELS).map((s) => `${AS_LABEL_PREFIX}${s}`)
 ]);
 function resolveTypeOverrides(labels) {
   let bypassTaskSkip = false;
@@ -5922,6 +5929,31 @@ function isKnownNonOverrideLabel(label) {
 }
 function resolveTicketOverrides(labels, logger, options) {
   const typeOverrides = resolveTypeOverrides(labels);
+  let asLabel;
+  let asTypeValue;
+  for (const label of labels) {
+    if (!label.startsWith(AS_LABEL_PREFIX)) continue;
+    const suffix = label.slice(AS_LABEL_PREFIX.length);
+    const mapped = AS_TYPE_LABELS[suffix];
+    if (mapped === void 0) {
+      logger?.warn("unknown suffix in ferry:as label", { label, suffix });
+      continue;
+    }
+    if (asTypeValue !== void 0 && asTypeValue !== mapped) {
+      throw new LabelConflictError(asLabel, label, "typeOverride");
+    }
+    if (asTypeValue === void 0) {
+      asTypeValue = mapped;
+      asLabel = label;
+    }
+  }
+  if (asTypeValue !== void 0) {
+    if (typeOverrides.typeOverride !== void 0 && typeOverrides.typeOverride !== asTypeValue) {
+      throw new LabelConflictError(typeOverrides.forceLabel, asLabel, "typeOverride");
+    }
+    typeOverrides.typeOverride = asTypeValue;
+    typeOverrides.forceLabel = asLabel;
+  }
   const modelOverrides = {};
   const modelSources = {};
   const providerSources = {};

--- a/.github/actions/ferry-run-developer/agent.js
+++ b/.github/actions/ferry-run-developer/agent.js
@@ -5788,9 +5788,16 @@ var FORCE_TYPE_LABELS = Object.freeze({
   "ferry:type:force-story": "Story"
 });
 var ENABLE_TASK_LABEL = "ferry:type:enable-task";
+var AS_LABEL_PREFIX = "ferry:as/";
+var AS_TYPE_LABELS = Object.freeze({
+  bug: "Bug",
+  spike: "Spike",
+  story: "Story"
+});
 var BUILTIN_TYPE_LABELS = /* @__PURE__ */ new Set([
   ENABLE_TASK_LABEL,
-  ...Object.keys(FORCE_TYPE_LABELS)
+  ...Object.keys(FORCE_TYPE_LABELS),
+  ...Object.keys(AS_TYPE_LABELS).map((s) => `${AS_LABEL_PREFIX}${s}`)
 ]);
 function resolveTypeOverrides(labels) {
   let bypassTaskSkip = false;
@@ -5922,6 +5929,31 @@ function isKnownNonOverrideLabel(label) {
 }
 function resolveTicketOverrides(labels, logger, options) {
   const typeOverrides = resolveTypeOverrides(labels);
+  let asLabel;
+  let asTypeValue;
+  for (const label of labels) {
+    if (!label.startsWith(AS_LABEL_PREFIX)) continue;
+    const suffix = label.slice(AS_LABEL_PREFIX.length);
+    const mapped = AS_TYPE_LABELS[suffix];
+    if (mapped === void 0) {
+      logger?.warn("unknown suffix in ferry:as label", { label, suffix });
+      continue;
+    }
+    if (asTypeValue !== void 0 && asTypeValue !== mapped) {
+      throw new LabelConflictError(asLabel, label, "typeOverride");
+    }
+    if (asTypeValue === void 0) {
+      asTypeValue = mapped;
+      asLabel = label;
+    }
+  }
+  if (asTypeValue !== void 0) {
+    if (typeOverrides.typeOverride !== void 0 && typeOverrides.typeOverride !== asTypeValue) {
+      throw new LabelConflictError(typeOverrides.forceLabel, asLabel, "typeOverride");
+    }
+    typeOverrides.typeOverride = asTypeValue;
+    typeOverrides.forceLabel = asLabel;
+  }
   const modelOverrides = {};
   const modelSources = {};
   const providerSources = {};

--- a/.github/actions/ferry-run-iterator/agent.js
+++ b/.github/actions/ferry-run-iterator/agent.js
@@ -5788,9 +5788,16 @@ var FORCE_TYPE_LABELS = Object.freeze({
   "ferry:type:force-story": "Story"
 });
 var ENABLE_TASK_LABEL = "ferry:type:enable-task";
+var AS_LABEL_PREFIX = "ferry:as/";
+var AS_TYPE_LABELS = Object.freeze({
+  bug: "Bug",
+  spike: "Spike",
+  story: "Story"
+});
 var BUILTIN_TYPE_LABELS = /* @__PURE__ */ new Set([
   ENABLE_TASK_LABEL,
-  ...Object.keys(FORCE_TYPE_LABELS)
+  ...Object.keys(FORCE_TYPE_LABELS),
+  ...Object.keys(AS_TYPE_LABELS).map((s) => `${AS_LABEL_PREFIX}${s}`)
 ]);
 function resolveTypeOverrides(labels) {
   let bypassTaskSkip = false;
@@ -5922,6 +5929,31 @@ function isKnownNonOverrideLabel(label) {
 }
 function resolveTicketOverrides(labels, logger, options) {
   const typeOverrides = resolveTypeOverrides(labels);
+  let asLabel;
+  let asTypeValue;
+  for (const label of labels) {
+    if (!label.startsWith(AS_LABEL_PREFIX)) continue;
+    const suffix = label.slice(AS_LABEL_PREFIX.length);
+    const mapped = AS_TYPE_LABELS[suffix];
+    if (mapped === void 0) {
+      logger?.warn("unknown suffix in ferry:as label", { label, suffix });
+      continue;
+    }
+    if (asTypeValue !== void 0 && asTypeValue !== mapped) {
+      throw new LabelConflictError(asLabel, label, "typeOverride");
+    }
+    if (asTypeValue === void 0) {
+      asTypeValue = mapped;
+      asLabel = label;
+    }
+  }
+  if (asTypeValue !== void 0) {
+    if (typeOverrides.typeOverride !== void 0 && typeOverrides.typeOverride !== asTypeValue) {
+      throw new LabelConflictError(typeOverrides.forceLabel, asLabel, "typeOverride");
+    }
+    typeOverrides.typeOverride = asTypeValue;
+    typeOverrides.forceLabel = asLabel;
+  }
   const modelOverrides = {};
   const modelSources = {};
   const providerSources = {};

--- a/.github/actions/ferry-run-refiner/agent.js
+++ b/.github/actions/ferry-run-refiner/agent.js
@@ -5788,9 +5788,16 @@ var FORCE_TYPE_LABELS = Object.freeze({
   "ferry:type:force-story": "Story"
 });
 var ENABLE_TASK_LABEL = "ferry:type:enable-task";
+var AS_LABEL_PREFIX = "ferry:as/";
+var AS_TYPE_LABELS = Object.freeze({
+  bug: "Bug",
+  spike: "Spike",
+  story: "Story"
+});
 var BUILTIN_TYPE_LABELS = /* @__PURE__ */ new Set([
   ENABLE_TASK_LABEL,
-  ...Object.keys(FORCE_TYPE_LABELS)
+  ...Object.keys(FORCE_TYPE_LABELS),
+  ...Object.keys(AS_TYPE_LABELS).map((s) => `${AS_LABEL_PREFIX}${s}`)
 ]);
 function resolveTypeOverrides(labels) {
   let bypassTaskSkip = false;
@@ -5922,6 +5929,31 @@ function isKnownNonOverrideLabel(label) {
 }
 function resolveTicketOverrides(labels, logger, options) {
   const typeOverrides = resolveTypeOverrides(labels);
+  let asLabel;
+  let asTypeValue;
+  for (const label of labels) {
+    if (!label.startsWith(AS_LABEL_PREFIX)) continue;
+    const suffix = label.slice(AS_LABEL_PREFIX.length);
+    const mapped = AS_TYPE_LABELS[suffix];
+    if (mapped === void 0) {
+      logger?.warn("unknown suffix in ferry:as label", { label, suffix });
+      continue;
+    }
+    if (asTypeValue !== void 0 && asTypeValue !== mapped) {
+      throw new LabelConflictError(asLabel, label, "typeOverride");
+    }
+    if (asTypeValue === void 0) {
+      asTypeValue = mapped;
+      asLabel = label;
+    }
+  }
+  if (asTypeValue !== void 0) {
+    if (typeOverrides.typeOverride !== void 0 && typeOverrides.typeOverride !== asTypeValue) {
+      throw new LabelConflictError(typeOverrides.forceLabel, asLabel, "typeOverride");
+    }
+    typeOverrides.typeOverride = asTypeValue;
+    typeOverrides.forceLabel = asLabel;
+  }
   const modelOverrides = {};
   const modelSources = {};
   const providerSources = {};

--- a/.github/actions/ferry-run-reviewer/agent.js
+++ b/.github/actions/ferry-run-reviewer/agent.js
@@ -5788,9 +5788,16 @@ var FORCE_TYPE_LABELS = Object.freeze({
   "ferry:type:force-story": "Story"
 });
 var ENABLE_TASK_LABEL = "ferry:type:enable-task";
+var AS_LABEL_PREFIX = "ferry:as/";
+var AS_TYPE_LABELS = Object.freeze({
+  bug: "Bug",
+  spike: "Spike",
+  story: "Story"
+});
 var BUILTIN_TYPE_LABELS = /* @__PURE__ */ new Set([
   ENABLE_TASK_LABEL,
-  ...Object.keys(FORCE_TYPE_LABELS)
+  ...Object.keys(FORCE_TYPE_LABELS),
+  ...Object.keys(AS_TYPE_LABELS).map((s) => `${AS_LABEL_PREFIX}${s}`)
 ]);
 function resolveTypeOverrides(labels) {
   let bypassTaskSkip = false;
@@ -5922,6 +5929,31 @@ function isKnownNonOverrideLabel(label) {
 }
 function resolveTicketOverrides(labels, logger, options) {
   const typeOverrides = resolveTypeOverrides(labels);
+  let asLabel;
+  let asTypeValue;
+  for (const label of labels) {
+    if (!label.startsWith(AS_LABEL_PREFIX)) continue;
+    const suffix = label.slice(AS_LABEL_PREFIX.length);
+    const mapped = AS_TYPE_LABELS[suffix];
+    if (mapped === void 0) {
+      logger?.warn("unknown suffix in ferry:as label", { label, suffix });
+      continue;
+    }
+    if (asTypeValue !== void 0 && asTypeValue !== mapped) {
+      throw new LabelConflictError(asLabel, label, "typeOverride");
+    }
+    if (asTypeValue === void 0) {
+      asTypeValue = mapped;
+      asLabel = label;
+    }
+  }
+  if (asTypeValue !== void 0) {
+    if (typeOverrides.typeOverride !== void 0 && typeOverrides.typeOverride !== asTypeValue) {
+      throw new LabelConflictError(typeOverrides.forceLabel, asLabel, "typeOverride");
+    }
+    typeOverrides.typeOverride = asTypeValue;
+    typeOverrides.forceLabel = asLabel;
+  }
   const modelOverrides = {};
   const modelSources = {};
   const providerSources = {};

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -402,9 +402,9 @@ Maps Jira ticket labels to MCP server capabilities. If this section is omitted, 
 
 ---
 
-#### Built-in ticket-type label overrides (`ferry:type:*`)
+#### Built-in ticket-type label overrides (`ferry:type:*` and `ferry:as/<type>`)
 
-These four labels are **hardcoded built-ins** — they require no `ferry.config.json` entry and are always recognised by the Developer, Reviewer, and Iterator agents. Apply them directly to your Jira ticket.
+These labels are **hardcoded built-ins** — they require no `ferry.config.json` entry and are always recognised by the Developer, Reviewer, and Iterator agents. Apply them directly to your Jira ticket.
 
 | Label                    | Effect                                                                                                                                                                                |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -412,12 +412,23 @@ These four labels are **hardcoded built-ins** — they require no `ferry.config.
 | `ferry:type:force-bug`   | Treat the ticket as a **Bug** regardless of its Jira issue type. The agent sees `TYPE: Bug` in the prompt.                                                                            |
 | `ferry:type:force-spike` | Treat the ticket as a **Spike** regardless of its Jira issue type.                                                                                                                    |
 | `ferry:type:force-story` | Treat the ticket as a **Story** regardless of its Jira issue type.                                                                                                                    |
+| `ferry:as/bug`           | Alias of `ferry:type:force-bug` (issue #242) with strict conflict semantics — see below.                                                                                              |
+| `ferry:as/spike`         | Alias of `ferry:type:force-spike` (issue #242) with strict conflict semantics.                                                                                                        |
+| `ferry:as/story`         | Alias of `ferry:type:force-story` (issue #242) with strict conflict semantics.                                                                                                        |
 
 **How it works:**
 
 - `ferry:type:enable-task` bypasses the FR6 Task filter inside agent actions (Developer, Reviewer, Iterator). The pre-flight `skip-task-type-action` step runs before the Jira issue is fetched and therefore cannot honour this label — if the envelope issue type is `Task`, the pre-flight step still skips and posts a comment. Add the label to a ticket that starts in a non-Task Jira column to avoid the pre-flight trigger entirely, or trigger the agent directly via `repository_dispatch` with a non-Task `issue_type`.
 - `ferry:type:force-*` labels replace `issue.issueType` in the prompt without mutating the original Jira record. When active, the terminal Jira comment includes an audit note in the format: `[type override: {"issuetype":"Bug","issuetype_raw":"Story","override":"force-bug"}]`.
 - If multiple `force-*` labels are present, the last one in the label list wins.
+
+**`ferry:as/<type>` — alias with strict conflict semantics (issue #242):**
+
+- Maps to the same `typeOverride` field as `ferry:type:force-<type>`. Both namespaces are honoured everywhere `typeOverride` is consumed (prompt block, allowlist evaluation, audit comment payload).
+- **Two different `ferry:as/<x>` labels** on the same ticket throw `LabelConflictError` (rather than the legacy last-wins behaviour of `ferry:type:force-*`).
+- **Mixing `ferry:as/<a>` with `ferry:type:force-<b>`** that resolve to different values also throws `LabelConflictError`. Same values are vacuous.
+- Unknown suffix (e.g. `ferry:as/improvement`) is logged to stderr and ignored.
+- **Security invariant — Task-skip is preserved.** `ferry:as/*` does NOT set `bypassTaskSkip`. A Task ticket with `ferry:as/story` is still skipped by FR6, because the Task-skip is a structural defense against Refiner-created sub-task loops, not a type filter. Use `ferry:type:enable-task` if you need to bypass the Task-skip; combine it with `ferry:as/story` to also set the effective type.
 
 ---
 

--- a/src/labels/allowlist.ts
+++ b/src/labels/allowlist.ts
@@ -25,6 +25,11 @@ export const LABELS_ALLOWLIST = [
   'ferry:type:force-bug',
   'ferry:type:force-spike',
   'ferry:type:force-story',
+  // Alias namespace for ticket-type override (#242) — strict conflict semantics
+  'ferry:as/',
+  'ferry:as/bug',
+  'ferry:as/spike',
+  'ferry:as/story',
   // Configuration override labels (user-applied; parsed by resolveTicketOverrides)
   // Prefix-only entries: the actual label appends additional segments
   'ferry:model/',

--- a/src/lib/dispatch/routing.test.ts
+++ b/src/lib/dispatch/routing.test.ts
@@ -84,6 +84,28 @@ describe('shouldSkipForTaskType (FR6 task-type filter)', () => {
     });
     expect(shouldSkipForTaskType('Story')).toEqual({ skip: false });
   });
+
+  // --- issue #242 invariants: typeOverride MUST NOT bypass Task-skip ---
+
+  it('still skips a Task ticket when typeOverride is set but bypassTaskSkip is false (ferry:as/* path)', () => {
+    expect(shouldSkipForTaskType('Task', { bypassTaskSkip: false, typeOverride: 'Story' })).toEqual(
+      {
+        skip: true,
+        reason: 'ticket type Task is not processed by Ferry',
+      },
+    );
+  });
+
+  it('still skips a Task ticket when typeOverride is set without bypassTaskSkip (defaulted)', () => {
+    expect(shouldSkipForTaskType('Task', { typeOverride: 'Bug' } as never)).toEqual({
+      skip: true,
+      reason: 'ticket type Task is not processed by Ferry',
+    });
+  });
+
+  it('does not skip a Task ticket when bypassTaskSkip is true, even without typeOverride', () => {
+    expect(shouldSkipForTaskType('Task', { bypassTaskSkip: true })).toEqual({ skip: false });
+  });
 });
 
 describe('buildTaskSkipComment', () => {

--- a/src/lib/labels/capabilities.ts
+++ b/src/lib/labels/capabilities.ts
@@ -187,10 +187,30 @@ const FORCE_TYPE_LABELS: Readonly<Record<string, string>> = Object.freeze({
 
 const ENABLE_TASK_LABEL = 'ferry:type:enable-task';
 
-/** All recognised built-in ferry:type:* labels (used to suppress unknown-label warnings). */
+/**
+ * Alias namespace ferry:as/<type> (issue #242). Maps directly to the same
+ * typeOverride field as ferry:type:force-<type> but with stricter conflict
+ * semantics — multiple ferry:as/<x> with different suffixes throw
+ * LabelConflictError, and mixing ferry:as/<a> with ferry:type:force-<b>
+ * also throws when <a> and <b> resolve to different values.
+ *
+ * Unlike ferry:type:enable-task, the alias namespace does NOT bypass the
+ * FR6 Task-skip — a Task ticket with ferry:as/story is still skipped.
+ */
+export const AS_LABEL_PREFIX = 'ferry:as/';
+
+/** Suffix → normalised issue type mapping for the ferry:as/<type> namespace. */
+export const AS_TYPE_LABELS: Readonly<Record<string, string>> = Object.freeze({
+  bug: 'Bug',
+  spike: 'Spike',
+  story: 'Story',
+});
+
+/** All recognised built-in ferry:type:* and ferry:as/<type> labels (suppress warnings). */
 const BUILTIN_TYPE_LABELS: ReadonlySet<string> = new Set([
   ENABLE_TASK_LABEL,
   ...Object.keys(FORCE_TYPE_LABELS),
+  ...Object.keys(AS_TYPE_LABELS).map((s) => `${AS_LABEL_PREFIX}${s}`),
 ]);
 
 /**

--- a/src/lib/labels/overrides.test.ts
+++ b/src/lib/labels/overrides.test.ts
@@ -65,6 +65,94 @@ describe('resolveTicketOverrides — ticket-type (ferry:type:*)', () => {
 });
 
 // ------------------------------------------------------------------
+// ferry:as/<type> (alias namespace from issue #242)
+// ------------------------------------------------------------------
+
+describe('resolveTicketOverrides — ferry:as/<type> alias namespace (#242)', () => {
+  it('sets typeOverride to Spike for ferry:as/spike', () => {
+    const r = resolveTicketOverrides(['ferry:as/spike']);
+    expect(r.typeOverride).toBe('Spike');
+    expect(r.forceLabel).toBe('ferry:as/spike');
+  });
+
+  it('sets typeOverride to Bug for ferry:as/bug', () => {
+    const r = resolveTicketOverrides(['ferry:as/bug']);
+    expect(r.typeOverride).toBe('Bug');
+    expect(r.forceLabel).toBe('ferry:as/bug');
+  });
+
+  it('sets typeOverride to Story for ferry:as/story', () => {
+    const r = resolveTicketOverrides(['ferry:as/story']);
+    expect(r.typeOverride).toBe('Story');
+    expect(r.forceLabel).toBe('ferry:as/story');
+  });
+
+  it('does NOT set bypassTaskSkip — Task-skip is preserved (FR6 structural rule)', () => {
+    const r = resolveTicketOverrides(['ferry:as/story']);
+    expect(r.bypassTaskSkip).toBe(false);
+  });
+
+  it('throws LabelConflictError when two different ferry:as/<x> labels are present', () => {
+    expect(() => resolveTicketOverrides(['ferry:as/bug', 'ferry:as/story'])).toThrow(
+      LabelConflictError,
+    );
+  });
+
+  it('is vacuous (no conflict) when the same ferry:as/<x> label is repeated', () => {
+    const r = resolveTicketOverrides(['ferry:as/bug', 'ferry:as/bug']);
+    expect(r.typeOverride).toBe('Bug');
+  });
+
+  it('throws LabelConflictError when ferry:as/<a> and ferry:type:force-<b> map to different values', () => {
+    expect(() => resolveTicketOverrides(['ferry:as/bug', 'ferry:type:force-story'])).toThrow(
+      LabelConflictError,
+    );
+  });
+
+  it('emits typeOverride field name on cross-namespace conflict', () => {
+    try {
+      resolveTicketOverrides(['ferry:as/bug', 'ferry:type:force-story']);
+      throw new Error('expected LabelConflictError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(LabelConflictError);
+      expect((err as LabelConflictError).field).toBe('typeOverride');
+    }
+  });
+
+  it('does NOT conflict when ferry:as/<x> and ferry:type:force-<x> map to the same value', () => {
+    const r = resolveTicketOverrides(['ferry:as/bug', 'ferry:type:force-bug']);
+    expect(r.typeOverride).toBe('Bug');
+  });
+
+  it('logs a warning and ignores ferry:as/<unknown> suffix', () => {
+    const { logger, records } = createTestLogger('t', 'test');
+    const r = resolveTicketOverrides(['ferry:as/improvement'], logger);
+    expect(r.typeOverride).toBeUndefined();
+    expect(records.some((rec) => rec.level === 'warn' && rec.message.includes('ferry:as'))).toBe(
+      true,
+    );
+  });
+
+  it('still allows ferry:type:enable-task to coexist with ferry:as/<x> (different fields)', () => {
+    const r = resolveTicketOverrides(['ferry:type:enable-task', 'ferry:as/story']);
+    expect(r.bypassTaskSkip).toBe(true);
+    expect(r.typeOverride).toBe('Story');
+  });
+
+  it('surfaces ferry:as/<x> typeOverride in the audit comment payload', () => {
+    const overrides = resolveTicketOverrides(['ferry:as/spike']);
+    const body = buildOverridesAuditComment('developer', 'r1', overrides);
+    expect(body).toContain('"typeOverride":"Spike"');
+  });
+
+  it('does NOT emit ferry:as/<x> as an unknown label warning', () => {
+    const { logger, records } = createTestLogger('t', 'test');
+    resolveTicketOverrides(['ferry:as/bug'], logger);
+    expect(records.filter((r) => r.level === 'warn')).toHaveLength(0);
+  });
+});
+
+// ------------------------------------------------------------------
 // ferry:model/<phase>/<model-id>
 // ------------------------------------------------------------------
 

--- a/src/lib/labels/overrides.ts
+++ b/src/lib/labels/overrides.ts
@@ -1,6 +1,11 @@
 import type { Logger } from '../logger/index.js';
 import type { FerryConfig } from '../config.js';
-import { resolveTypeOverrides, isBuiltinTypeLabel } from './capabilities.js';
+import {
+  resolveTypeOverrides,
+  isBuiltinTypeLabel,
+  AS_LABEL_PREFIX,
+  AS_TYPE_LABELS,
+} from './capabilities.js';
 import type { TicketOverrides, AgentPhase, PhaseModelOverride } from './capabilities.js';
 
 const AGENT_PHASES: ReadonlySet<string> = new Set(['refiner', 'dev', 'review', 'iterate']);
@@ -118,6 +123,40 @@ export function resolveTicketOverrides(
   options?: ResolveOverridesOptions,
 ): TicketOverrides {
   const typeOverrides = resolveTypeOverrides(labels);
+
+  // ferry:as/<type> (alias namespace from issue #242).
+  // Distinct from ferry:type:force-<type> in two ways:
+  //   - multiple ferry:as/<x> with different suffixes throw LabelConflictError;
+  //   - mixing ferry:as/<a> with ferry:type:force-<b> throws when they
+  //     resolve to different typeOverride values.
+  // The alias does NOT set bypassTaskSkip — a Task ticket with ferry:as/story
+  // is still skipped by FR6.
+  let asLabel: string | undefined;
+  let asTypeValue: string | undefined;
+  for (const label of labels) {
+    if (!label.startsWith(AS_LABEL_PREFIX)) continue;
+    const suffix = label.slice(AS_LABEL_PREFIX.length);
+    const mapped = AS_TYPE_LABELS[suffix];
+    if (mapped === undefined) {
+      logger?.warn('unknown suffix in ferry:as label', { label, suffix });
+      continue;
+    }
+    if (asTypeValue !== undefined && asTypeValue !== mapped) {
+      throw new LabelConflictError(asLabel!, label, 'typeOverride');
+    }
+    if (asTypeValue === undefined) {
+      asTypeValue = mapped;
+      asLabel = label;
+    }
+  }
+  if (asTypeValue !== undefined) {
+    // Cross-namespace conflict: ferry:as/<a> vs ferry:type:force-<b> with different values.
+    if (typeOverrides.typeOverride !== undefined && typeOverrides.typeOverride !== asTypeValue) {
+      throw new LabelConflictError(typeOverrides.forceLabel!, asLabel!, 'typeOverride');
+    }
+    typeOverrides.typeOverride = asTypeValue;
+    typeOverrides.forceLabel = asLabel;
+  }
 
   const modelOverrides: Partial<Record<AgentPhase, PhaseModelOverride>> = {};
   const modelSources: Partial<Record<AgentPhase, string>> = {};


### PR DESCRIPTION
Closes #242

> Stacked on #285 → #281 → #278 → #277 → main. After upstream PRs merge, this should be re-targeted to `main`.

## Summary

- Adds `ferry:as/bug` | `ferry:as/spike` | `ferry:as/story` as an **alias** of the existing `ferry:type:force-*` namespace. Both write to the same `TicketOverrides.typeOverride` field consumed by the Developer / Reviewer / Iterator prompt blocks and the audit comment payload.
- Stricter conflict semantics than the legacy `force-*` namespace:
  - Two different `ferry:as/<x>` → `LabelConflictError` (legacy `force-*` keeps last-wins).
  - `ferry:as/<a>` + `ferry:type:force-<b>` with different mapped values → `LabelConflictError` on the shared `typeOverride` field. Same-value combinations are vacuous.
  - Unknown suffix (e.g. `ferry:as/improvement`) is logged to stderr and ignored.
- **Task-skip preserved (FR6 invariant).** `ferry:as/*` does NOT set `bypassTaskSkip`. A Task ticket carrying `ferry:as/story` is still skipped by `shouldSkipForTaskType`. The Task-skip is a structural defense against Refiner-created sub-task loops; only `ferry:type:enable-task` overrides it.

### What was already wired vs. newly added

- **Already wired** (no churn needed): `routing.ts` `shouldSkipForTaskType` already honours `overrides.bypassTaskSkip` only; `buildTicketBlock` already consumes `typeOverride` in dev / review / iterate actions; `buildOverridesAuditComment` already emits `typeOverride` in its payload. The alias namespace plugs directly into all of these.
- **Newly added**: alias-namespace parser + cross-namespace conflict detection in `overrides.ts`; `AS_LABEL_PREFIX` / `AS_TYPE_LABELS` constants and warning-suppression entries in `capabilities.ts`; allowlist entries; docs section; tests.

## Test plan

- [x] All 1610 tests pass (`npm test`).
- [x] TypeScript typecheck passes (`npm run typecheck`).
- [x] ESLint passes (`npm run lint`).
- [x] Prettier check passes (`npm run format:check`).
- [x] 11 new tests in `src/lib/labels/overrides.test.ts` covering: each suffix → typeOverride, no bypassTaskSkip, conflict on two `ferry:as/<x>`, identical labels vacuous, cross-namespace conflict `ferry:as/<a>` vs `ferry:type:force-<b>`, unknown suffix warning, coexistence with `ferry:type:enable-task`, audit payload, and no spurious unknown-label warning.
- [x] 3 new tests in `src/lib/dispatch/routing.test.ts` covering: `typeOverride` without `bypassTaskSkip` still skips Task, defaulted `bypassTaskSkip` still skips Task, `bypassTaskSkip=true` without `typeOverride` does not skip Task.
- [x] Bundle rebuilt (`npm run build:ferry`) — committed separately as `build: rebuild ferry bundles`.

Generated with [Claude Code](https://claude.ai/code)