### PR TITLE
feat: label override for dry-run / read-only safety (#243)

### DIFF
--- a/.ferry/agent.js
+++ b/.ferry/agent.js
@@ -5929,6 +5929,8 @@ function resolveTicketOverrides(labels, logger, options) {
   let noPr = false;
   let paused = false;
   let noAutoTransition = false;
+  let dryRun = false;
+  let readOnly = false;
   const skipPhases = [];
   for (const label of labels) {
     if (!label.startsWith("ferry:")) continue;
@@ -6124,6 +6126,14 @@ function resolveTicketOverrides(labels, logger, options) {
       paused = true;
       continue;
     }
+    if (label === "ferry:dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (label === "ferry:read-only") {
+      readOnly = true;
+      continue;
+    }
     logger?.warn("unknown ferry override label ignored", { label });
   }
   if (blanketModel !== void 0) {
@@ -6158,7 +6168,9 @@ function resolveTicketOverrides(labels, logger, options) {
     ...noAutoTransition ? { noAutoTransition: true } : {},
     ...thinking !== void 0 ? { thinking } : {},
     ...noPr ? { git: { noPr: true } } : {},
-    ...paused ? { paused: true } : {}
+    ...paused ? { paused: true } : {},
+    ...dryRun ? { dryRun: true } : {},
+    ...readOnly ? { readOnly: true } : {}
   };
 }
 function applyTicketOverrides(cfg, overrides) {
@@ -6213,7 +6225,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6229,7 +6241,16 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
   if (overrides.git?.noPr) payload.git = overrides.git;
   if (overrides.paused) payload.paused = true;
-  return `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+  if (overrides.dryRun) payload.dryRun = true;
+  if (overrides.readOnly) payload.readOnly = true;
+  const body = `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+  return applyDryRunMarker(body, overrides.dryRun);
+}
+function applyDryRunMarker(body, dryRun) {
+  if (dryRun !== true) return body;
+  const match = body.match(/^(\[ferry:[^\]]+\])\s+(.*)$/s);
+  if (!match) return body;
+  return `${match[1]} [dry-run] ${match[2]}`;
 }
 function buildConflictComment(role, runId, err) {
   return [
@@ -9063,7 +9084,7 @@ async function runWipFinalizer(opts) {
 var REPO_ROOT2 = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main2(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
-  const dryRun = isDryRun();
+  let dryRun = isDryRun();
   if (dryRun) {
     logger.info("DRY_RUN mode \u2014 no branch push, no PR, no Jira writes");
   }
@@ -9084,6 +9105,10 @@ async function main2(envelope, logger) {
     typeOverride = overrides.typeOverride;
     forceLabel = overrides.forceLabel;
     noAutoTransition = overrides.noAutoTransition === true;
+    if (overrides.dryRun === true && !dryRun) {
+      dryRun = true;
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     logTicketOverrides(logger, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -9092,11 +9117,25 @@ async function main2(envelope, logger) {
         buildOverridesAuditComment("developer", eventId, overrides)
       );
     }
+    if (overrides.readOnly === true) {
+      logger.info("read-only mode \u2014 developer agent skipped");
+      await tracker.postComment(
+        ticketKey,
+        applyDryRunMarker(
+          `[ferry:developer:${eventId}] read-only: agent skipped`,
+          overrides.dryRun
+        )
+      );
+      process.exit(0);
+    }
     if (overrides.skipPhases?.includes("dev")) {
       logger.info("dev phase skipped via ferry:skip/dev \u2014 exiting");
       await tracker.postComment(
         ticketKey,
-        `[ferry:developer:${eventId}] Developer skipped via ferry:skip/dev \u2014 no implementation performed.`
+        applyDryRunMarker(
+          `[ferry:developer:${eventId}] Developer skipped via ferry:skip/dev \u2014 no implementation performed.`,
+          overrides.dryRun
+        )
       );
       process.exit(0);
     }
@@ -9107,8 +9146,8 @@ async function main2(envelope, logger) {
     }
     throw err;
   }
-  const shouldAutoTransition = configAutoTransition && !noAutoTransition;
-  const reviewTransitionId = dryRun || !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
+  const shouldAutoTransition = configAutoTransition && !noAutoTransition && !dryRun;
+  const reviewTransitionId = !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
   const jiraBaseUrl = requireEnv("FERRY_JIRA_BASE_URL");
   const { provider: devProvider } = effectiveCfg.models.dev;
   const labels = issue.labels.join(", ");

--- a/.ferry/agent.js
+++ b/.ferry/agent.js
@@ -6851,7 +6851,7 @@ var PRIOR_RUN_MARKER = /\[ferry:refiner:[^\]]+\]/;
 async function run(envelope, deps) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const logger = deps.logger ?? createLogger(eventId, "ferry:refiner-action");
-  const dryRun = isDryRun();
+  const dryRun = isDryRun() || deps.dryRun === true;
   const issue = await deps.tracker.getIssue(ticketKey);
   const runLink = `https://github.com/${process.env.GITHUB_REPO ?? "unknown"}/actions/runs/${process.env.GITHUB_RUN_ID ?? "0"}`;
   const existingSubtasks = await deps.tracker.getSubtaskDetails(ticketKey);
@@ -6977,10 +6977,15 @@ async function main(envelope, logger) {
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
   const issueForLabels = await tracker.getIssue(ticketKey);
   let effectiveCfg;
+  let labelDryRun = false;
   try {
     const overrides = resolveTicketOverrides(issueForLabels.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
     });
+    labelDryRun = overrides.dryRun === true;
+    if (labelDryRun) {
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     logTicketOverrides(logger, overrides);
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -6993,7 +6998,10 @@ async function main(envelope, logger) {
       logger.info("refiner phase skipped via ferry:skip/refiner \u2014 exiting");
       await tracker.postComment(
         ticketKey,
-        `[ferry:refiner:${eventId}] Refiner skipped via ferry:skip/refiner \u2014 no refinement performed.`
+        applyDryRunMarker(
+          `[ferry:refiner:${eventId}] Refiner skipped via ferry:skip/refiner \u2014 no refinement performed.`,
+          labelDryRun
+        )
       );
       return;
     }
@@ -7006,7 +7014,7 @@ async function main(envelope, logger) {
   }
   const route = effectiveCfg.models.refiner;
   const callLlm = createLlmCall(route);
-  await run(envelope, { tracker, callLlm, logger });
+  await run(envelope, { tracker, callLlm, logger, dryRun: labelDryRun });
 }
 
 // src/agents/developer/dev-action.ts
@@ -10104,6 +10112,7 @@ async function main3(envelope, logger) {
   let typeOverride;
   let autoApprove = false;
   let noAutoTransition = false;
+  let dryRun = false;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10111,6 +10120,10 @@ async function main3(envelope, logger) {
     typeOverride = overrides.typeOverride;
     autoApprove = overrides.skipPhases?.includes("review") === true;
     noAutoTransition = overrides.noAutoTransition === true;
+    dryRun = overrides.dryRun === true;
+    if (dryRun) {
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     logTicketOverrides(logger, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -10119,6 +10132,14 @@ async function main3(envelope, logger) {
         buildOverridesAuditComment("reviewer", eventId, overrides)
       );
     }
+    if (overrides.readOnly === true) {
+      logger.info("read-only mode \u2014 reviewer agent skipped");
+      await tracker.postComment(
+        ticketKey,
+        applyDryRunMarker(`[ferry:reviewer:${eventId}] read-only: agent skipped`, overrides.dryRun)
+      );
+      return;
+    }
   } catch (err) {
     if (err instanceof LabelConflictError) {
       await tracker.postComment(ticketKey, buildConflictComment("reviewer", eventId, err));
@@ -10126,8 +10147,8 @@ async function main3(envelope, logger) {
     }
     throw err;
   }
-  const shouldTransitionChanges = configTransitionChanges && !noAutoTransition;
-  const shouldTransitionApprove = configTransitionApprove && !noAutoTransition;
+  const shouldTransitionChanges = configTransitionChanges && !noAutoTransition && !dryRun;
+  const shouldTransitionApprove = configTransitionApprove && !noAutoTransition && !dryRun;
   const iterTransitionId = shouldTransitionChanges ? requireEnv("FERRY_ITER_TRANSITION_ID") : "";
   const approveTransitionId = shouldTransitionApprove ? requireEnv("FERRY_APPROVE_TRANSITION_ID") : "";
   const { provider, model } = effectiveCfg.models.review;
@@ -10166,18 +10187,23 @@ async function main3(envelope, logger) {
     const approveTransitionNote = shouldTransitionApprove ? " Moved to next column." : noAutoTransition ? " FR24 auto-transition skipped (ferry:no-auto-transition)." : "";
     await tracker.postComment(
       ticketKey,
-      `${idempotencyMarker} Auto-approved via ferry:skip/review \u2014 review loop bypassed. PR#${prNumber}.${approveTransitionNote}`
+      applyDryRunMarker(
+        `${idempotencyMarker} Auto-approved via ferry:skip/review \u2014 review loop bypassed. PR#${prNumber}.${approveTransitionNote}`,
+        dryRun
+      )
     );
-    await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
-    await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
-    });
-    await runner.markPRReadyForReview(owner, repo, prNumber);
-    await runner.commentOnPR(
-      { owner, repo, prNumber },
-      `${idempotencyMarker} Auto-approved via ferry:skip/review label \u2014 review skipped per ticket opt-in.`
-    );
-    if (shouldTransitionApprove) {
-      await tracker.postTransition(ticketKey, approveTransitionId);
+    if (!dryRun) {
+      await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
+      await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
+      });
+      await runner.markPRReadyForReview(owner, repo, prNumber);
+      await runner.commentOnPR(
+        { owner, repo, prNumber },
+        `${idempotencyMarker} Auto-approved via ferry:skip/review label \u2014 review skipped per ticket opt-in.`
+      );
+      if (shouldTransitionApprove) {
+        await tracker.postTransition(ticketKey, approveTransitionId);
+      }
     }
     appendOutput({ input_tokens: 0, output_tokens: 0, model, provider });
     return;
@@ -10291,26 +10317,33 @@ async function main3(envelope, logger) {
   if (review.approved) {
     await tracker.postComment(
       ticketKey,
-      `${idempotencyMarker} Approved. PR#${prNumber} is ready to merge.`
+      applyDryRunMarker(`${idempotencyMarker} Approved. PR#${prNumber} is ready to merge.`, dryRun)
     );
-    await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
-    await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
-    });
-    await runner.markPRReadyForReview(owner, repo, prNumber);
-    await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
-    if (shouldTransitionApprove) {
-      await tracker.postTransition(ticketKey, approveTransitionId);
+    if (!dryRun) {
+      await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
+      await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
+      });
+      await runner.markPRReadyForReview(owner, repo, prNumber);
+      await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
+      if (shouldTransitionApprove) {
+        await tracker.postTransition(ticketKey, approveTransitionId);
+      }
     }
   } else {
     const priorIterations = countPriorIterations(existingComments);
     const cap = effectiveCfg.limits.max_iterations;
     const capReached = priorIterations >= cap;
-    await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
+    if (!dryRun) {
+      await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
+    }
     if (!capReached) {
       const changesNote = shouldTransitionChanges ? " Moved to Dev Iteration." : "";
       await tracker.postComment(
         ticketKey,
-        `${idempotencyMarker} Changes requested (iteration ${priorIterations + 1}/${cap}).${changesNote} See PR#${prNumber} for details.`
+        applyDryRunMarker(
+          `${idempotencyMarker} Changes requested (iteration ${priorIterations + 1}/${cap}).${changesNote} See PR#${prNumber} for details.`,
+          dryRun
+        )
       );
       if (shouldTransitionChanges) {
         await tracker.postTransition(ticketKey, iterTransitionId);
@@ -10318,7 +10351,10 @@ async function main3(envelope, logger) {
     } else {
       await tracker.postComment(
         ticketKey,
-        `${idempotencyMarker} Changes requested (re-review). Iteration cap (${cap}) reached; see PR#${prNumber} and move ticket manually.`
+        applyDryRunMarker(
+          `${idempotencyMarker} Changes requested (re-review). Iteration cap (${cap}) reached; see PR#${prNumber} and move ticket manually.`,
+          dryRun
+        )
       );
     }
   }
@@ -10394,6 +10430,7 @@ async function main4(envelope, logger) {
   let typeOverride;
   let labelMaxIterations;
   let noAutoTransition = false;
+  let dryRun = false;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10401,6 +10438,10 @@ async function main4(envelope, logger) {
     typeOverride = overrides.typeOverride;
     labelMaxIterations = overrides.maxIterations;
     noAutoTransition = overrides.noAutoTransition === true;
+    dryRun = overrides.dryRun === true;
+    if (dryRun) {
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     logTicketOverrides(logger, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -10409,11 +10450,22 @@ async function main4(envelope, logger) {
         buildOverridesAuditComment("iterator", eventId, overrides)
       );
     }
+    if (overrides.readOnly === true) {
+      logger.info("read-only mode \u2014 iterator agent skipped");
+      await tracker.postComment(
+        ticketKey,
+        applyDryRunMarker(`[ferry:iterator:${eventId}] read-only: agent skipped`, overrides.dryRun)
+      );
+      return;
+    }
     if (overrides.skipPhases?.includes("iterate")) {
       logger.info("iterate phase skipped via ferry:skip/iter \u2014 exiting (no-op)");
       await tracker.postComment(
         ticketKey,
-        `[ferry:iterator:${eventId}] Iterator skipped via ferry:skip/iter \u2014 no iteration performed.`
+        applyDryRunMarker(
+          `[ferry:iterator:${eventId}] Iterator skipped via ferry:skip/iter \u2014 no iteration performed.`,
+          overrides.dryRun
+        )
       );
       return;
     }
@@ -10424,7 +10476,7 @@ async function main4(envelope, logger) {
     }
     throw err;
   }
-  const shouldAutoTransition = configAutoTransition && !noAutoTransition;
+  const shouldAutoTransition = configAutoTransition && !noAutoTransition && !dryRun;
   const reviewTransitionId = shouldAutoTransition ? requireEnv("FERRY_REVIEW_TRANSITION_ID") : "";
   const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
@@ -10626,8 +10678,12 @@ ${existingLog}` : "",
     await secretScan();
     execFileSync6("git", ["commit", "-m", commitMessage], { cwd: REPO_ROOT4 });
   }
-  execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
-  const branchPushed = true;
+  if (!dryRun) {
+    execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
+  } else {
+    logger.info("DRY_RUN \u2014 skipped: git push origin branch");
+  }
+  const branchPushed = !dryRun;
   let iterFilesTouched = [];
   try {
     const diff = execFileSync6("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
@@ -10637,14 +10693,17 @@ ${existingLog}` : "",
     iterFilesTouched = diff.trim().split("\n").filter(Boolean);
   } catch {
   }
-  assertIterOutputContract(resolvedOutcome, { branchPushed, prNumber });
+  if (!dryRun) {
+    assertIterOutputContract(resolvedOutcome, { branchPushed, prNumber });
+  }
   if (shouldAutoTransition) {
     await tracker.postTransition(ticketKey, reviewTransitionId);
   }
   const { next_iteration } = decideIteratorTransition({ current_iteration: priorIterations });
-  const transitionNote = shouldAutoTransition ? " Moved back to Review." : noAutoTransition ? " FR28 auto-transition skipped (ferry:no-auto-transition)." : "";
-  const terminalComment = resolvedOutcome === "already_satisfied" ? `${idempotencyMarker} Findings already addressed \u2014 no changes needed. Pushed to PR#${prNumber}.${transitionNote}` : `${idempotencyMarker} Iteration ${next_iteration} complete. Pushed fixes to PR#${prNumber}.${transitionNote}`;
-  await tracker.postComment(ticketKey, terminalComment);
+  const transitionNote = shouldAutoTransition ? " Moved back to Review." : noAutoTransition ? " FR28 auto-transition skipped (ferry:no-auto-transition)." : dryRun ? " FR28 auto-transition skipped (ferry:dry-run)." : "";
+  const pushNote = dryRun ? " (dry-run: branch push suppressed)" : "";
+  const terminalComment = resolvedOutcome === "already_satisfied" ? `${idempotencyMarker} Findings already addressed \u2014 no changes needed. Pushed to PR#${prNumber}.${transitionNote}` : `${idempotencyMarker} Iteration ${next_iteration} complete. Pushed fixes to PR#${prNumber}${pushNote}.${transitionNote}`;
+  await tracker.postComment(ticketKey, applyDryRunMarker(terminalComment, dryRun));
   writeStepSummary({
     role: "iterator",
     iterations,

--- a/.github/actions/ferry-run-developer/agent.js
+++ b/.github/actions/ferry-run-developer/agent.js
@@ -5929,6 +5929,8 @@ function resolveTicketOverrides(labels, logger, options) {
   let noPr = false;
   let paused = false;
   let noAutoTransition = false;
+  let dryRun = false;
+  let readOnly = false;
   const skipPhases = [];
   for (const label of labels) {
     if (!label.startsWith("ferry:")) continue;
@@ -6124,6 +6126,14 @@ function resolveTicketOverrides(labels, logger, options) {
       paused = true;
       continue;
     }
+    if (label === "ferry:dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (label === "ferry:read-only") {
+      readOnly = true;
+      continue;
+    }
     logger?.warn("unknown ferry override label ignored", { label });
   }
   if (blanketModel !== void 0) {
@@ -6158,7 +6168,9 @@ function resolveTicketOverrides(labels, logger, options) {
     ...noAutoTransition ? { noAutoTransition: true } : {},
     ...thinking !== void 0 ? { thinking } : {},
     ...noPr ? { git: { noPr: true } } : {},
-    ...paused ? { paused: true } : {}
+    ...paused ? { paused: true } : {},
+    ...dryRun ? { dryRun: true } : {},
+    ...readOnly ? { readOnly: true } : {}
   };
 }
 function applyTicketOverrides(cfg, overrides) {
@@ -6213,7 +6225,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6229,7 +6241,16 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
   if (overrides.git?.noPr) payload.git = overrides.git;
   if (overrides.paused) payload.paused = true;
-  return `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+  if (overrides.dryRun) payload.dryRun = true;
+  if (overrides.readOnly) payload.readOnly = true;
+  const body = `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+  return applyDryRunMarker(body, overrides.dryRun);
+}
+function applyDryRunMarker(body, dryRun) {
+  if (dryRun !== true) return body;
+  const match = body.match(/^(\[ferry:[^\]]+\])\s+(.*)$/s);
+  if (!match) return body;
+  return `${match[1]} [dry-run] ${match[2]}`;
 }
 function buildConflictComment(role, runId, err) {
   return [
@@ -9063,7 +9084,7 @@ async function runWipFinalizer(opts) {
 var REPO_ROOT2 = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main2(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
-  const dryRun = isDryRun();
+  let dryRun = isDryRun();
   if (dryRun) {
     logger.info("DRY_RUN mode \u2014 no branch push, no PR, no Jira writes");
   }
@@ -9084,6 +9105,10 @@ async function main2(envelope, logger) {
     typeOverride = overrides.typeOverride;
     forceLabel = overrides.forceLabel;
     noAutoTransition = overrides.noAutoTransition === true;
+    if (overrides.dryRun === true && !dryRun) {
+      dryRun = true;
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     logTicketOverrides(logger, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -9092,11 +9117,25 @@ async function main2(envelope, logger) {
         buildOverridesAuditComment("developer", eventId, overrides)
       );
     }
+    if (overrides.readOnly === true) {
+      logger.info("read-only mode \u2014 developer agent skipped");
+      await tracker.postComment(
+        ticketKey,
+        applyDryRunMarker(
+          `[ferry:developer:${eventId}] read-only: agent skipped`,
+          overrides.dryRun
+        )
+      );
+      process.exit(0);
+    }
     if (overrides.skipPhases?.includes("dev")) {
       logger.info("dev phase skipped via ferry:skip/dev \u2014 exiting");
       await tracker.postComment(
         ticketKey,
-        `[ferry:developer:${eventId}] Developer skipped via ferry:skip/dev \u2014 no implementation performed.`
+        applyDryRunMarker(
+          `[ferry:developer:${eventId}] Developer skipped via ferry:skip/dev \u2014 no implementation performed.`,
+          overrides.dryRun
+        )
       );
       process.exit(0);
     }
@@ -9107,8 +9146,8 @@ async function main2(envelope, logger) {
     }
     throw err;
   }
-  const shouldAutoTransition = configAutoTransition && !noAutoTransition;
-  const reviewTransitionId = dryRun || !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
+  const shouldAutoTransition = configAutoTransition && !noAutoTransition && !dryRun;
+  const reviewTransitionId = !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
   const jiraBaseUrl = requireEnv("FERRY_JIRA_BASE_URL");
   const { provider: devProvider } = effectiveCfg.models.dev;
   const labels = issue.labels.join(", ");

--- a/.github/actions/ferry-run-developer/agent.js
+++ b/.github/actions/ferry-run-developer/agent.js
@@ -6851,7 +6851,7 @@ var PRIOR_RUN_MARKER = /\[ferry:refiner:[^\]]+\]/;
 async function run(envelope, deps) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const logger = deps.logger ?? createLogger(eventId, "ferry:refiner-action");
-  const dryRun = isDryRun();
+  const dryRun = isDryRun() || deps.dryRun === true;
   const issue = await deps.tracker.getIssue(ticketKey);
   const runLink = `https://github.com/${process.env.GITHUB_REPO ?? "unknown"}/actions/runs/${process.env.GITHUB_RUN_ID ?? "0"}`;
   const existingSubtasks = await deps.tracker.getSubtaskDetails(ticketKey);
@@ -6977,10 +6977,15 @@ async function main(envelope, logger) {
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
   const issueForLabels = await tracker.getIssue(ticketKey);
   let effectiveCfg;
+  let labelDryRun = false;
   try {
     const overrides = resolveTicketOverrides(issueForLabels.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
     });
+    labelDryRun = overrides.dryRun === true;
+    if (labelDryRun) {
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     logTicketOverrides(logger, overrides);
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -6993,7 +6998,10 @@ async function main(envelope, logger) {
       logger.info("refiner phase skipped via ferry:skip/refiner \u2014 exiting");
       await tracker.postComment(
         ticketKey,
-        `[ferry:refiner:${eventId}] Refiner skipped via ferry:skip/refiner \u2014 no refinement performed.`
+        applyDryRunMarker(
+          `[ferry:refiner:${eventId}] Refiner skipped via ferry:skip/refiner \u2014 no refinement performed.`,
+          labelDryRun
+        )
       );
       return;
     }
@@ -7006,7 +7014,7 @@ async function main(envelope, logger) {
   }
   const route = effectiveCfg.models.refiner;
   const callLlm = createLlmCall(route);
-  await run(envelope, { tracker, callLlm, logger });
+  await run(envelope, { tracker, callLlm, logger, dryRun: labelDryRun });
 }
 
 // src/agents/developer/dev-action.ts
@@ -10104,6 +10112,7 @@ async function main3(envelope, logger) {
   let typeOverride;
   let autoApprove = false;
   let noAutoTransition = false;
+  let dryRun = false;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10111,6 +10120,10 @@ async function main3(envelope, logger) {
     typeOverride = overrides.typeOverride;
     autoApprove = overrides.skipPhases?.includes("review") === true;
     noAutoTransition = overrides.noAutoTransition === true;
+    dryRun = overrides.dryRun === true;
+    if (dryRun) {
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     logTicketOverrides(logger, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -10119,6 +10132,14 @@ async function main3(envelope, logger) {
         buildOverridesAuditComment("reviewer", eventId, overrides)
       );
     }
+    if (overrides.readOnly === true) {
+      logger.info("read-only mode \u2014 reviewer agent skipped");
+      await tracker.postComment(
+        ticketKey,
+        applyDryRunMarker(`[ferry:reviewer:${eventId}] read-only: agent skipped`, overrides.dryRun)
+      );
+      return;
+    }
   } catch (err) {
     if (err instanceof LabelConflictError) {
       await tracker.postComment(ticketKey, buildConflictComment("reviewer", eventId, err));
@@ -10126,8 +10147,8 @@ async function main3(envelope, logger) {
     }
     throw err;
   }
-  const shouldTransitionChanges = configTransitionChanges && !noAutoTransition;
-  const shouldTransitionApprove = configTransitionApprove && !noAutoTransition;
+  const shouldTransitionChanges = configTransitionChanges && !noAutoTransition && !dryRun;
+  const shouldTransitionApprove = configTransitionApprove && !noAutoTransition && !dryRun;
   const iterTransitionId = shouldTransitionChanges ? requireEnv("FERRY_ITER_TRANSITION_ID") : "";
   const approveTransitionId = shouldTransitionApprove ? requireEnv("FERRY_APPROVE_TRANSITION_ID") : "";
   const { provider, model } = effectiveCfg.models.review;
@@ -10166,18 +10187,23 @@ async function main3(envelope, logger) {
     const approveTransitionNote = shouldTransitionApprove ? " Moved to next column." : noAutoTransition ? " FR24 auto-transition skipped (ferry:no-auto-transition)." : "";
     await tracker.postComment(
       ticketKey,
-      `${idempotencyMarker} Auto-approved via ferry:skip/review \u2014 review loop bypassed. PR#${prNumber}.${approveTransitionNote}`
+      applyDryRunMarker(
+        `${idempotencyMarker} Auto-approved via ferry:skip/review \u2014 review loop bypassed. PR#${prNumber}.${approveTransitionNote}`,
+        dryRun
+      )
     );
-    await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
-    await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
-    });
-    await runner.markPRReadyForReview(owner, repo, prNumber);
-    await runner.commentOnPR(
-      { owner, repo, prNumber },
-      `${idempotencyMarker} Auto-approved via ferry:skip/review label \u2014 review skipped per ticket opt-in.`
-    );
-    if (shouldTransitionApprove) {
-      await tracker.postTransition(ticketKey, approveTransitionId);
+    if (!dryRun) {
+      await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
+      await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
+      });
+      await runner.markPRReadyForReview(owner, repo, prNumber);
+      await runner.commentOnPR(
+        { owner, repo, prNumber },
+        `${idempotencyMarker} Auto-approved via ferry:skip/review label \u2014 review skipped per ticket opt-in.`
+      );
+      if (shouldTransitionApprove) {
+        await tracker.postTransition(ticketKey, approveTransitionId);
+      }
     }
     appendOutput({ input_tokens: 0, output_tokens: 0, model, provider });
     return;
@@ -10291,26 +10317,33 @@ async function main3(envelope, logger) {
   if (review.approved) {
     await tracker.postComment(
       ticketKey,
-      `${idempotencyMarker} Approved. PR#${prNumber} is ready to merge.`
+      applyDryRunMarker(`${idempotencyMarker} Approved. PR#${prNumber} is ready to merge.`, dryRun)
     );
-    await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
-    await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
-    });
-    await runner.markPRReadyForReview(owner, repo, prNumber);
-    await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
-    if (shouldTransitionApprove) {
-      await tracker.postTransition(ticketKey, approveTransitionId);
+    if (!dryRun) {
+      await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
+      await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
+      });
+      await runner.markPRReadyForReview(owner, repo, prNumber);
+      await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
+      if (shouldTransitionApprove) {
+        await tracker.postTransition(ticketKey, approveTransitionId);
+      }
     }
   } else {
     const priorIterations = countPriorIterations(existingComments);
     const cap = effectiveCfg.limits.max_iterations;
     const capReached = priorIterations >= cap;
-    await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
+    if (!dryRun) {
+      await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
+    }
     if (!capReached) {
       const changesNote = shouldTransitionChanges ? " Moved to Dev Iteration." : "";
       await tracker.postComment(
         ticketKey,
-        `${idempotencyMarker} Changes requested (iteration ${priorIterations + 1}/${cap}).${changesNote} See PR#${prNumber} for details.`
+        applyDryRunMarker(
+          `${idempotencyMarker} Changes requested (iteration ${priorIterations + 1}/${cap}).${changesNote} See PR#${prNumber} for details.`,
+          dryRun
+        )
       );
       if (shouldTransitionChanges) {
         await tracker.postTransition(ticketKey, iterTransitionId);
@@ -10318,7 +10351,10 @@ async function main3(envelope, logger) {
     } else {
       await tracker.postComment(
         ticketKey,
-        `${idempotencyMarker} Changes requested (re-review). Iteration cap (${cap}) reached; see PR#${prNumber} and move ticket manually.`
+        applyDryRunMarker(
+          `${idempotencyMarker} Changes requested (re-review). Iteration cap (${cap}) reached; see PR#${prNumber} and move ticket manually.`,
+          dryRun
+        )
       );
     }
   }
@@ -10394,6 +10430,7 @@ async function main4(envelope, logger) {
   let typeOverride;
   let labelMaxIterations;
   let noAutoTransition = false;
+  let dryRun = false;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10401,6 +10438,10 @@ async function main4(envelope, logger) {
     typeOverride = overrides.typeOverride;
     labelMaxIterations = overrides.maxIterations;
     noAutoTransition = overrides.noAutoTransition === true;
+    dryRun = overrides.dryRun === true;
+    if (dryRun) {
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     logTicketOverrides(logger, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -10409,11 +10450,22 @@ async function main4(envelope, logger) {
         buildOverridesAuditComment("iterator", eventId, overrides)
       );
     }
+    if (overrides.readOnly === true) {
+      logger.info("read-only mode \u2014 iterator agent skipped");
+      await tracker.postComment(
+        ticketKey,
+        applyDryRunMarker(`[ferry:iterator:${eventId}] read-only: agent skipped`, overrides.dryRun)
+      );
+      return;
+    }
     if (overrides.skipPhases?.includes("iterate")) {
       logger.info("iterate phase skipped via ferry:skip/iter \u2014 exiting (no-op)");
       await tracker.postComment(
         ticketKey,
-        `[ferry:iterator:${eventId}] Iterator skipped via ferry:skip/iter \u2014 no iteration performed.`
+        applyDryRunMarker(
+          `[ferry:iterator:${eventId}] Iterator skipped via ferry:skip/iter \u2014 no iteration performed.`,
+          overrides.dryRun
+        )
       );
       return;
     }
@@ -10424,7 +10476,7 @@ async function main4(envelope, logger) {
     }
     throw err;
   }
-  const shouldAutoTransition = configAutoTransition && !noAutoTransition;
+  const shouldAutoTransition = configAutoTransition && !noAutoTransition && !dryRun;
   const reviewTransitionId = shouldAutoTransition ? requireEnv("FERRY_REVIEW_TRANSITION_ID") : "";
   const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
@@ -10626,8 +10678,12 @@ ${existingLog}` : "",
     await secretScan();
     execFileSync6("git", ["commit", "-m", commitMessage], { cwd: REPO_ROOT4 });
   }
-  execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
-  const branchPushed = true;
+  if (!dryRun) {
+    execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
+  } else {
+    logger.info("DRY_RUN \u2014 skipped: git push origin branch");
+  }
+  const branchPushed = !dryRun;
   let iterFilesTouched = [];
   try {
     const diff = execFileSync6("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
@@ -10637,14 +10693,17 @@ ${existingLog}` : "",
     iterFilesTouched = diff.trim().split("\n").filter(Boolean);
   } catch {
   }
-  assertIterOutputContract(resolvedOutcome, { branchPushed, prNumber });
+  if (!dryRun) {
+    assertIterOutputContract(resolvedOutcome, { branchPushed, prNumber });
+  }
   if (shouldAutoTransition) {
     await tracker.postTransition(ticketKey, reviewTransitionId);
   }
   const { next_iteration } = decideIteratorTransition({ current_iteration: priorIterations });
-  const transitionNote = shouldAutoTransition ? " Moved back to Review." : noAutoTransition ? " FR28 auto-transition skipped (ferry:no-auto-transition)." : "";
-  const terminalComment = resolvedOutcome === "already_satisfied" ? `${idempotencyMarker} Findings already addressed \u2014 no changes needed. Pushed to PR#${prNumber}.${transitionNote}` : `${idempotencyMarker} Iteration ${next_iteration} complete. Pushed fixes to PR#${prNumber}.${transitionNote}`;
-  await tracker.postComment(ticketKey, terminalComment);
+  const transitionNote = shouldAutoTransition ? " Moved back to Review." : noAutoTransition ? " FR28 auto-transition skipped (ferry:no-auto-transition)." : dryRun ? " FR28 auto-transition skipped (ferry:dry-run)." : "";
+  const pushNote = dryRun ? " (dry-run: branch push suppressed)" : "";
+  const terminalComment = resolvedOutcome === "already_satisfied" ? `${idempotencyMarker} Findings already addressed \u2014 no changes needed. Pushed to PR#${prNumber}.${transitionNote}` : `${idempotencyMarker} Iteration ${next_iteration} complete. Pushed fixes to PR#${prNumber}${pushNote}.${transitionNote}`;
+  await tracker.postComment(ticketKey, applyDryRunMarker(terminalComment, dryRun));
   writeStepSummary({
     role: "iterator",
     iterations,

--- a/.github/actions/ferry-run-iterator/agent.js
+++ b/.github/actions/ferry-run-iterator/agent.js
@@ -5929,6 +5929,8 @@ function resolveTicketOverrides(labels, logger, options) {
   let noPr = false;
   let paused = false;
   let noAutoTransition = false;
+  let dryRun = false;
+  let readOnly = false;
   const skipPhases = [];
   for (const label of labels) {
     if (!label.startsWith("ferry:")) continue;
@@ -6124,6 +6126,14 @@ function resolveTicketOverrides(labels, logger, options) {
       paused = true;
       continue;
     }
+    if (label === "ferry:dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (label === "ferry:read-only") {
+      readOnly = true;
+      continue;
+    }
     logger?.warn("unknown ferry override label ignored", { label });
   }
   if (blanketModel !== void 0) {
@@ -6158,7 +6168,9 @@ function resolveTicketOverrides(labels, logger, options) {
     ...noAutoTransition ? { noAutoTransition: true } : {},
     ...thinking !== void 0 ? { thinking } : {},
     ...noPr ? { git: { noPr: true } } : {},
-    ...paused ? { paused: true } : {}
+    ...paused ? { paused: true } : {},
+    ...dryRun ? { dryRun: true } : {},
+    ...readOnly ? { readOnly: true } : {}
   };
 }
 function applyTicketOverrides(cfg, overrides) {
@@ -6213,7 +6225,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6229,7 +6241,16 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
   if (overrides.git?.noPr) payload.git = overrides.git;
   if (overrides.paused) payload.paused = true;
-  return `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+  if (overrides.dryRun) payload.dryRun = true;
+  if (overrides.readOnly) payload.readOnly = true;
+  const body = `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+  return applyDryRunMarker(body, overrides.dryRun);
+}
+function applyDryRunMarker(body, dryRun) {
+  if (dryRun !== true) return body;
+  const match = body.match(/^(\[ferry:[^\]]+\])\s+(.*)$/s);
+  if (!match) return body;
+  return `${match[1]} [dry-run] ${match[2]}`;
 }
 function buildConflictComment(role, runId, err) {
   return [
@@ -6830,7 +6851,7 @@ var PRIOR_RUN_MARKER = /\[ferry:refiner:[^\]]+\]/;
 async function run(envelope, deps) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const logger = deps.logger ?? createLogger(eventId, "ferry:refiner-action");
-  const dryRun = isDryRun();
+  const dryRun = isDryRun() || deps.dryRun === true;
   const issue = await deps.tracker.getIssue(ticketKey);
   const runLink = `https://github.com/${process.env.GITHUB_REPO ?? "unknown"}/actions/runs/${process.env.GITHUB_RUN_ID ?? "0"}`;
   const existingSubtasks = await deps.tracker.getSubtaskDetails(ticketKey);
@@ -6956,10 +6977,15 @@ async function main(envelope, logger) {
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
   const issueForLabels = await tracker.getIssue(ticketKey);
   let effectiveCfg;
+  let labelDryRun = false;
   try {
     const overrides = resolveTicketOverrides(issueForLabels.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
     });
+    labelDryRun = overrides.dryRun === true;
+    if (labelDryRun) {
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     logTicketOverrides(logger, overrides);
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -6972,7 +6998,10 @@ async function main(envelope, logger) {
       logger.info("refiner phase skipped via ferry:skip/refiner \u2014 exiting");
       await tracker.postComment(
         ticketKey,
-        `[ferry:refiner:${eventId}] Refiner skipped via ferry:skip/refiner \u2014 no refinement performed.`
+        applyDryRunMarker(
+          `[ferry:refiner:${eventId}] Refiner skipped via ferry:skip/refiner \u2014 no refinement performed.`,
+          labelDryRun
+        )
       );
       return;
     }
@@ -6985,7 +7014,7 @@ async function main(envelope, logger) {
   }
   const route = effectiveCfg.models.refiner;
   const callLlm = createLlmCall(route);
-  await run(envelope, { tracker, callLlm, logger });
+  await run(envelope, { tracker, callLlm, logger, dryRun: labelDryRun });
 }
 
 // src/agents/developer/dev-action.ts
@@ -9063,7 +9092,7 @@ async function runWipFinalizer(opts) {
 var REPO_ROOT2 = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main2(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
-  const dryRun = isDryRun();
+  let dryRun = isDryRun();
   if (dryRun) {
     logger.info("DRY_RUN mode \u2014 no branch push, no PR, no Jira writes");
   }
@@ -9084,6 +9113,10 @@ async function main2(envelope, logger) {
     typeOverride = overrides.typeOverride;
     forceLabel = overrides.forceLabel;
     noAutoTransition = overrides.noAutoTransition === true;
+    if (overrides.dryRun === true && !dryRun) {
+      dryRun = true;
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     logTicketOverrides(logger, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -9092,11 +9125,25 @@ async function main2(envelope, logger) {
         buildOverridesAuditComment("developer", eventId, overrides)
       );
     }
+    if (overrides.readOnly === true) {
+      logger.info("read-only mode \u2014 developer agent skipped");
+      await tracker.postComment(
+        ticketKey,
+        applyDryRunMarker(
+          `[ferry:developer:${eventId}] read-only: agent skipped`,
+          overrides.dryRun
+        )
+      );
+      process.exit(0);
+    }
     if (overrides.skipPhases?.includes("dev")) {
       logger.info("dev phase skipped via ferry:skip/dev \u2014 exiting");
       await tracker.postComment(
         ticketKey,
-        `[ferry:developer:${eventId}] Developer skipped via ferry:skip/dev \u2014 no implementation performed.`
+        applyDryRunMarker(
+          `[ferry:developer:${eventId}] Developer skipped via ferry:skip/dev \u2014 no implementation performed.`,
+          overrides.dryRun
+        )
       );
       process.exit(0);
     }
@@ -9107,8 +9154,8 @@ async function main2(envelope, logger) {
     }
     throw err;
   }
-  const shouldAutoTransition = configAutoTransition && !noAutoTransition;
-  const reviewTransitionId = dryRun || !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
+  const shouldAutoTransition = configAutoTransition && !noAutoTransition && !dryRun;
+  const reviewTransitionId = !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
   const jiraBaseUrl = requireEnv("FERRY_JIRA_BASE_URL");
   const { provider: devProvider } = effectiveCfg.models.dev;
   const labels = issue.labels.join(", ");
@@ -10065,6 +10112,7 @@ async function main3(envelope, logger) {
   let typeOverride;
   let autoApprove = false;
   let noAutoTransition = false;
+  let dryRun = false;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10072,6 +10120,10 @@ async function main3(envelope, logger) {
     typeOverride = overrides.typeOverride;
     autoApprove = overrides.skipPhases?.includes("review") === true;
     noAutoTransition = overrides.noAutoTransition === true;
+    dryRun = overrides.dryRun === true;
+    if (dryRun) {
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     logTicketOverrides(logger, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -10080,6 +10132,14 @@ async function main3(envelope, logger) {
         buildOverridesAuditComment("reviewer", eventId, overrides)
       );
     }
+    if (overrides.readOnly === true) {
+      logger.info("read-only mode \u2014 reviewer agent skipped");
+      await tracker.postComment(
+        ticketKey,
+        applyDryRunMarker(`[ferry:reviewer:${eventId}] read-only: agent skipped`, overrides.dryRun)
+      );
+      return;
+    }
   } catch (err) {
     if (err instanceof LabelConflictError) {
       await tracker.postComment(ticketKey, buildConflictComment("reviewer", eventId, err));
@@ -10087,8 +10147,8 @@ async function main3(envelope, logger) {
     }
     throw err;
   }
-  const shouldTransitionChanges = configTransitionChanges && !noAutoTransition;
-  const shouldTransitionApprove = configTransitionApprove && !noAutoTransition;
+  const shouldTransitionChanges = configTransitionChanges && !noAutoTransition && !dryRun;
+  const shouldTransitionApprove = configTransitionApprove && !noAutoTransition && !dryRun;
   const iterTransitionId = shouldTransitionChanges ? requireEnv("FERRY_ITER_TRANSITION_ID") : "";
   const approveTransitionId = shouldTransitionApprove ? requireEnv("FERRY_APPROVE_TRANSITION_ID") : "";
   const { provider, model } = effectiveCfg.models.review;
@@ -10127,18 +10187,23 @@ async function main3(envelope, logger) {
     const approveTransitionNote = shouldTransitionApprove ? " Moved to next column." : noAutoTransition ? " FR24 auto-transition skipped (ferry:no-auto-transition)." : "";
     await tracker.postComment(
       ticketKey,
-      `${idempotencyMarker} Auto-approved via ferry:skip/review \u2014 review loop bypassed. PR#${prNumber}.${approveTransitionNote}`
+      applyDryRunMarker(
+        `${idempotencyMarker} Auto-approved via ferry:skip/review \u2014 review loop bypassed. PR#${prNumber}.${approveTransitionNote}`,
+        dryRun
+      )
     );
-    await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
-    await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
-    });
-    await runner.markPRReadyForReview(owner, repo, prNumber);
-    await runner.commentOnPR(
-      { owner, repo, prNumber },
-      `${idempotencyMarker} Auto-approved via ferry:skip/review label \u2014 review skipped per ticket opt-in.`
-    );
-    if (shouldTransitionApprove) {
-      await tracker.postTransition(ticketKey, approveTransitionId);
+    if (!dryRun) {
+      await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
+      await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
+      });
+      await runner.markPRReadyForReview(owner, repo, prNumber);
+      await runner.commentOnPR(
+        { owner, repo, prNumber },
+        `${idempotencyMarker} Auto-approved via ferry:skip/review label \u2014 review skipped per ticket opt-in.`
+      );
+      if (shouldTransitionApprove) {
+        await tracker.postTransition(ticketKey, approveTransitionId);
+      }
     }
     appendOutput({ input_tokens: 0, output_tokens: 0, model, provider });
     return;
@@ -10252,26 +10317,33 @@ async function main3(envelope, logger) {
   if (review.approved) {
     await tracker.postComment(
       ticketKey,
-      `${idempotencyMarker} Approved. PR#${prNumber} is ready to merge.`
+      applyDryRunMarker(`${idempotencyMarker} Approved. PR#${prNumber} is ready to merge.`, dryRun)
     );
-    await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
-    await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
-    });
-    await runner.markPRReadyForReview(owner, repo, prNumber);
-    await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
-    if (shouldTransitionApprove) {
-      await tracker.postTransition(ticketKey, approveTransitionId);
+    if (!dryRun) {
+      await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
+      await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
+      });
+      await runner.markPRReadyForReview(owner, repo, prNumber);
+      await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
+      if (shouldTransitionApprove) {
+        await tracker.postTransition(ticketKey, approveTransitionId);
+      }
     }
   } else {
     const priorIterations = countPriorIterations(existingComments);
     const cap = effectiveCfg.limits.max_iterations;
     const capReached = priorIterations >= cap;
-    await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
+    if (!dryRun) {
+      await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
+    }
     if (!capReached) {
       const changesNote = shouldTransitionChanges ? " Moved to Dev Iteration." : "";
       await tracker.postComment(
         ticketKey,
-        `${idempotencyMarker} Changes requested (iteration ${priorIterations + 1}/${cap}).${changesNote} See PR#${prNumber} for details.`
+        applyDryRunMarker(
+          `${idempotencyMarker} Changes requested (iteration ${priorIterations + 1}/${cap}).${changesNote} See PR#${prNumber} for details.`,
+          dryRun
+        )
       );
       if (shouldTransitionChanges) {
         await tracker.postTransition(ticketKey, iterTransitionId);
@@ -10279,7 +10351,10 @@ async function main3(envelope, logger) {
     } else {
       await tracker.postComment(
         ticketKey,
-        `${idempotencyMarker} Changes requested (re-review). Iteration cap (${cap}) reached; see PR#${prNumber} and move ticket manually.`
+        applyDryRunMarker(
+          `${idempotencyMarker} Changes requested (re-review). Iteration cap (${cap}) reached; see PR#${prNumber} and move ticket manually.`,
+          dryRun
+        )
       );
     }
   }
@@ -10355,6 +10430,7 @@ async function main4(envelope, logger) {
   let typeOverride;
   let labelMaxIterations;
   let noAutoTransition = false;
+  let dryRun = false;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10362,6 +10438,10 @@ async function main4(envelope, logger) {
     typeOverride = overrides.typeOverride;
     labelMaxIterations = overrides.maxIterations;
     noAutoTransition = overrides.noAutoTransition === true;
+    dryRun = overrides.dryRun === true;
+    if (dryRun) {
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     logTicketOverrides(logger, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -10370,11 +10450,22 @@ async function main4(envelope, logger) {
         buildOverridesAuditComment("iterator", eventId, overrides)
       );
     }
+    if (overrides.readOnly === true) {
+      logger.info("read-only mode \u2014 iterator agent skipped");
+      await tracker.postComment(
+        ticketKey,
+        applyDryRunMarker(`[ferry:iterator:${eventId}] read-only: agent skipped`, overrides.dryRun)
+      );
+      return;
+    }
     if (overrides.skipPhases?.includes("iterate")) {
       logger.info("iterate phase skipped via ferry:skip/iter \u2014 exiting (no-op)");
       await tracker.postComment(
         ticketKey,
-        `[ferry:iterator:${eventId}] Iterator skipped via ferry:skip/iter \u2014 no iteration performed.`
+        applyDryRunMarker(
+          `[ferry:iterator:${eventId}] Iterator skipped via ferry:skip/iter \u2014 no iteration performed.`,
+          overrides.dryRun
+        )
       );
       return;
     }
@@ -10385,7 +10476,7 @@ async function main4(envelope, logger) {
     }
     throw err;
   }
-  const shouldAutoTransition = configAutoTransition && !noAutoTransition;
+  const shouldAutoTransition = configAutoTransition && !noAutoTransition && !dryRun;
   const reviewTransitionId = shouldAutoTransition ? requireEnv("FERRY_REVIEW_TRANSITION_ID") : "";
   const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
@@ -10587,8 +10678,12 @@ ${existingLog}` : "",
     await secretScan();
     execFileSync6("git", ["commit", "-m", commitMessage], { cwd: REPO_ROOT4 });
   }
-  execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
-  const branchPushed = true;
+  if (!dryRun) {
+    execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
+  } else {
+    logger.info("DRY_RUN \u2014 skipped: git push origin branch");
+  }
+  const branchPushed = !dryRun;
   let iterFilesTouched = [];
   try {
     const diff = execFileSync6("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
@@ -10598,14 +10693,17 @@ ${existingLog}` : "",
     iterFilesTouched = diff.trim().split("\n").filter(Boolean);
   } catch {
   }
-  assertIterOutputContract(resolvedOutcome, { branchPushed, prNumber });
+  if (!dryRun) {
+    assertIterOutputContract(resolvedOutcome, { branchPushed, prNumber });
+  }
   if (shouldAutoTransition) {
     await tracker.postTransition(ticketKey, reviewTransitionId);
   }
   const { next_iteration } = decideIteratorTransition({ current_iteration: priorIterations });
-  const transitionNote = shouldAutoTransition ? " Moved back to Review." : noAutoTransition ? " FR28 auto-transition skipped (ferry:no-auto-transition)." : "";
-  const terminalComment = resolvedOutcome === "already_satisfied" ? `${idempotencyMarker} Findings already addressed \u2014 no changes needed. Pushed to PR#${prNumber}.${transitionNote}` : `${idempotencyMarker} Iteration ${next_iteration} complete. Pushed fixes to PR#${prNumber}.${transitionNote}`;
-  await tracker.postComment(ticketKey, terminalComment);
+  const transitionNote = shouldAutoTransition ? " Moved back to Review." : noAutoTransition ? " FR28 auto-transition skipped (ferry:no-auto-transition)." : dryRun ? " FR28 auto-transition skipped (ferry:dry-run)." : "";
+  const pushNote = dryRun ? " (dry-run: branch push suppressed)" : "";
+  const terminalComment = resolvedOutcome === "already_satisfied" ? `${idempotencyMarker} Findings already addressed \u2014 no changes needed. Pushed to PR#${prNumber}.${transitionNote}` : `${idempotencyMarker} Iteration ${next_iteration} complete. Pushed fixes to PR#${prNumber}${pushNote}.${transitionNote}`;
+  await tracker.postComment(ticketKey, applyDryRunMarker(terminalComment, dryRun));
   writeStepSummary({
     role: "iterator",
     iterations,

--- a/.github/actions/ferry-run-refiner/agent.js
+++ b/.github/actions/ferry-run-refiner/agent.js
@@ -5929,6 +5929,8 @@ function resolveTicketOverrides(labels, logger, options) {
   let noPr = false;
   let paused = false;
   let noAutoTransition = false;
+  let dryRun = false;
+  let readOnly = false;
   const skipPhases = [];
   for (const label of labels) {
     if (!label.startsWith("ferry:")) continue;
@@ -6124,6 +6126,14 @@ function resolveTicketOverrides(labels, logger, options) {
       paused = true;
       continue;
     }
+    if (label === "ferry:dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (label === "ferry:read-only") {
+      readOnly = true;
+      continue;
+    }
     logger?.warn("unknown ferry override label ignored", { label });
   }
   if (blanketModel !== void 0) {
@@ -6158,7 +6168,9 @@ function resolveTicketOverrides(labels, logger, options) {
     ...noAutoTransition ? { noAutoTransition: true } : {},
     ...thinking !== void 0 ? { thinking } : {},
     ...noPr ? { git: { noPr: true } } : {},
-    ...paused ? { paused: true } : {}
+    ...paused ? { paused: true } : {},
+    ...dryRun ? { dryRun: true } : {},
+    ...readOnly ? { readOnly: true } : {}
   };
 }
 function applyTicketOverrides(cfg, overrides) {
@@ -6213,7 +6225,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6229,7 +6241,16 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
   if (overrides.git?.noPr) payload.git = overrides.git;
   if (overrides.paused) payload.paused = true;
-  return `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+  if (overrides.dryRun) payload.dryRun = true;
+  if (overrides.readOnly) payload.readOnly = true;
+  const body = `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+  return applyDryRunMarker(body, overrides.dryRun);
+}
+function applyDryRunMarker(body, dryRun) {
+  if (dryRun !== true) return body;
+  const match = body.match(/^(\[ferry:[^\]]+\])\s+(.*)$/s);
+  if (!match) return body;
+  return `${match[1]} [dry-run] ${match[2]}`;
 }
 function buildConflictComment(role, runId, err) {
   return [
@@ -6830,7 +6851,7 @@ var PRIOR_RUN_MARKER = /\[ferry:refiner:[^\]]+\]/;
 async function run(envelope, deps) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const logger = deps.logger ?? createLogger(eventId, "ferry:refiner-action");
-  const dryRun = isDryRun();
+  const dryRun = isDryRun() || deps.dryRun === true;
   const issue = await deps.tracker.getIssue(ticketKey);
   const runLink = `https://github.com/${process.env.GITHUB_REPO ?? "unknown"}/actions/runs/${process.env.GITHUB_RUN_ID ?? "0"}`;
   const existingSubtasks = await deps.tracker.getSubtaskDetails(ticketKey);
@@ -6956,10 +6977,15 @@ async function main(envelope, logger) {
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
   const issueForLabels = await tracker.getIssue(ticketKey);
   let effectiveCfg;
+  let labelDryRun = false;
   try {
     const overrides = resolveTicketOverrides(issueForLabels.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
     });
+    labelDryRun = overrides.dryRun === true;
+    if (labelDryRun) {
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     logTicketOverrides(logger, overrides);
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -6972,7 +6998,10 @@ async function main(envelope, logger) {
       logger.info("refiner phase skipped via ferry:skip/refiner \u2014 exiting");
       await tracker.postComment(
         ticketKey,
-        `[ferry:refiner:${eventId}] Refiner skipped via ferry:skip/refiner \u2014 no refinement performed.`
+        applyDryRunMarker(
+          `[ferry:refiner:${eventId}] Refiner skipped via ferry:skip/refiner \u2014 no refinement performed.`,
+          labelDryRun
+        )
       );
       return;
     }
@@ -6985,7 +7014,7 @@ async function main(envelope, logger) {
   }
   const route = effectiveCfg.models.refiner;
   const callLlm = createLlmCall(route);
-  await run(envelope, { tracker, callLlm, logger });
+  await run(envelope, { tracker, callLlm, logger, dryRun: labelDryRun });
 }
 
 // src/agents/developer/dev-action.ts
@@ -9063,7 +9092,7 @@ async function runWipFinalizer(opts) {
 var REPO_ROOT2 = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main2(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
-  const dryRun = isDryRun();
+  let dryRun = isDryRun();
   if (dryRun) {
     logger.info("DRY_RUN mode \u2014 no branch push, no PR, no Jira writes");
   }
@@ -9084,6 +9113,10 @@ async function main2(envelope, logger) {
     typeOverride = overrides.typeOverride;
     forceLabel = overrides.forceLabel;
     noAutoTransition = overrides.noAutoTransition === true;
+    if (overrides.dryRun === true && !dryRun) {
+      dryRun = true;
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     logTicketOverrides(logger, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -9092,11 +9125,25 @@ async function main2(envelope, logger) {
         buildOverridesAuditComment("developer", eventId, overrides)
       );
     }
+    if (overrides.readOnly === true) {
+      logger.info("read-only mode \u2014 developer agent skipped");
+      await tracker.postComment(
+        ticketKey,
+        applyDryRunMarker(
+          `[ferry:developer:${eventId}] read-only: agent skipped`,
+          overrides.dryRun
+        )
+      );
+      process.exit(0);
+    }
     if (overrides.skipPhases?.includes("dev")) {
       logger.info("dev phase skipped via ferry:skip/dev \u2014 exiting");
       await tracker.postComment(
         ticketKey,
-        `[ferry:developer:${eventId}] Developer skipped via ferry:skip/dev \u2014 no implementation performed.`
+        applyDryRunMarker(
+          `[ferry:developer:${eventId}] Developer skipped via ferry:skip/dev \u2014 no implementation performed.`,
+          overrides.dryRun
+        )
       );
       process.exit(0);
     }
@@ -9107,8 +9154,8 @@ async function main2(envelope, logger) {
     }
     throw err;
   }
-  const shouldAutoTransition = configAutoTransition && !noAutoTransition;
-  const reviewTransitionId = dryRun || !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
+  const shouldAutoTransition = configAutoTransition && !noAutoTransition && !dryRun;
+  const reviewTransitionId = !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
   const jiraBaseUrl = requireEnv("FERRY_JIRA_BASE_URL");
   const { provider: devProvider } = effectiveCfg.models.dev;
   const labels = issue.labels.join(", ");
@@ -10065,6 +10112,7 @@ async function main3(envelope, logger) {
   let typeOverride;
   let autoApprove = false;
   let noAutoTransition = false;
+  let dryRun = false;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10072,6 +10120,10 @@ async function main3(envelope, logger) {
     typeOverride = overrides.typeOverride;
     autoApprove = overrides.skipPhases?.includes("review") === true;
     noAutoTransition = overrides.noAutoTransition === true;
+    dryRun = overrides.dryRun === true;
+    if (dryRun) {
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     logTicketOverrides(logger, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -10080,6 +10132,14 @@ async function main3(envelope, logger) {
         buildOverridesAuditComment("reviewer", eventId, overrides)
       );
     }
+    if (overrides.readOnly === true) {
+      logger.info("read-only mode \u2014 reviewer agent skipped");
+      await tracker.postComment(
+        ticketKey,
+        applyDryRunMarker(`[ferry:reviewer:${eventId}] read-only: agent skipped`, overrides.dryRun)
+      );
+      return;
+    }
   } catch (err) {
     if (err instanceof LabelConflictError) {
       await tracker.postComment(ticketKey, buildConflictComment("reviewer", eventId, err));
@@ -10087,8 +10147,8 @@ async function main3(envelope, logger) {
     }
     throw err;
   }
-  const shouldTransitionChanges = configTransitionChanges && !noAutoTransition;
-  const shouldTransitionApprove = configTransitionApprove && !noAutoTransition;
+  const shouldTransitionChanges = configTransitionChanges && !noAutoTransition && !dryRun;
+  const shouldTransitionApprove = configTransitionApprove && !noAutoTransition && !dryRun;
   const iterTransitionId = shouldTransitionChanges ? requireEnv("FERRY_ITER_TRANSITION_ID") : "";
   const approveTransitionId = shouldTransitionApprove ? requireEnv("FERRY_APPROVE_TRANSITION_ID") : "";
   const { provider, model } = effectiveCfg.models.review;
@@ -10127,18 +10187,23 @@ async function main3(envelope, logger) {
     const approveTransitionNote = shouldTransitionApprove ? " Moved to next column." : noAutoTransition ? " FR24 auto-transition skipped (ferry:no-auto-transition)." : "";
     await tracker.postComment(
       ticketKey,
-      `${idempotencyMarker} Auto-approved via ferry:skip/review \u2014 review loop bypassed. PR#${prNumber}.${approveTransitionNote}`
+      applyDryRunMarker(
+        `${idempotencyMarker} Auto-approved via ferry:skip/review \u2014 review loop bypassed. PR#${prNumber}.${approveTransitionNote}`,
+        dryRun
+      )
     );
-    await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
-    await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
-    });
-    await runner.markPRReadyForReview(owner, repo, prNumber);
-    await runner.commentOnPR(
-      { owner, repo, prNumber },
-      `${idempotencyMarker} Auto-approved via ferry:skip/review label \u2014 review skipped per ticket opt-in.`
-    );
-    if (shouldTransitionApprove) {
-      await tracker.postTransition(ticketKey, approveTransitionId);
+    if (!dryRun) {
+      await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
+      await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
+      });
+      await runner.markPRReadyForReview(owner, repo, prNumber);
+      await runner.commentOnPR(
+        { owner, repo, prNumber },
+        `${idempotencyMarker} Auto-approved via ferry:skip/review label \u2014 review skipped per ticket opt-in.`
+      );
+      if (shouldTransitionApprove) {
+        await tracker.postTransition(ticketKey, approveTransitionId);
+      }
     }
     appendOutput({ input_tokens: 0, output_tokens: 0, model, provider });
     return;
@@ -10252,26 +10317,33 @@ async function main3(envelope, logger) {
   if (review.approved) {
     await tracker.postComment(
       ticketKey,
-      `${idempotencyMarker} Approved. PR#${prNumber} is ready to merge.`
+      applyDryRunMarker(`${idempotencyMarker} Approved. PR#${prNumber} is ready to merge.`, dryRun)
     );
-    await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
-    await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
-    });
-    await runner.markPRReadyForReview(owner, repo, prNumber);
-    await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
-    if (shouldTransitionApprove) {
-      await tracker.postTransition(ticketKey, approveTransitionId);
+    if (!dryRun) {
+      await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
+      await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
+      });
+      await runner.markPRReadyForReview(owner, repo, prNumber);
+      await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
+      if (shouldTransitionApprove) {
+        await tracker.postTransition(ticketKey, approveTransitionId);
+      }
     }
   } else {
     const priorIterations = countPriorIterations(existingComments);
     const cap = effectiveCfg.limits.max_iterations;
     const capReached = priorIterations >= cap;
-    await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
+    if (!dryRun) {
+      await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
+    }
     if (!capReached) {
       const changesNote = shouldTransitionChanges ? " Moved to Dev Iteration." : "";
       await tracker.postComment(
         ticketKey,
-        `${idempotencyMarker} Changes requested (iteration ${priorIterations + 1}/${cap}).${changesNote} See PR#${prNumber} for details.`
+        applyDryRunMarker(
+          `${idempotencyMarker} Changes requested (iteration ${priorIterations + 1}/${cap}).${changesNote} See PR#${prNumber} for details.`,
+          dryRun
+        )
       );
       if (shouldTransitionChanges) {
         await tracker.postTransition(ticketKey, iterTransitionId);
@@ -10279,7 +10351,10 @@ async function main3(envelope, logger) {
     } else {
       await tracker.postComment(
         ticketKey,
-        `${idempotencyMarker} Changes requested (re-review). Iteration cap (${cap}) reached; see PR#${prNumber} and move ticket manually.`
+        applyDryRunMarker(
+          `${idempotencyMarker} Changes requested (re-review). Iteration cap (${cap}) reached; see PR#${prNumber} and move ticket manually.`,
+          dryRun
+        )
       );
     }
   }
@@ -10355,6 +10430,7 @@ async function main4(envelope, logger) {
   let typeOverride;
   let labelMaxIterations;
   let noAutoTransition = false;
+  let dryRun = false;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10362,6 +10438,10 @@ async function main4(envelope, logger) {
     typeOverride = overrides.typeOverride;
     labelMaxIterations = overrides.maxIterations;
     noAutoTransition = overrides.noAutoTransition === true;
+    dryRun = overrides.dryRun === true;
+    if (dryRun) {
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     logTicketOverrides(logger, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -10370,11 +10450,22 @@ async function main4(envelope, logger) {
         buildOverridesAuditComment("iterator", eventId, overrides)
       );
     }
+    if (overrides.readOnly === true) {
+      logger.info("read-only mode \u2014 iterator agent skipped");
+      await tracker.postComment(
+        ticketKey,
+        applyDryRunMarker(`[ferry:iterator:${eventId}] read-only: agent skipped`, overrides.dryRun)
+      );
+      return;
+    }
     if (overrides.skipPhases?.includes("iterate")) {
       logger.info("iterate phase skipped via ferry:skip/iter \u2014 exiting (no-op)");
       await tracker.postComment(
         ticketKey,
-        `[ferry:iterator:${eventId}] Iterator skipped via ferry:skip/iter \u2014 no iteration performed.`
+        applyDryRunMarker(
+          `[ferry:iterator:${eventId}] Iterator skipped via ferry:skip/iter \u2014 no iteration performed.`,
+          overrides.dryRun
+        )
       );
       return;
     }
@@ -10385,7 +10476,7 @@ async function main4(envelope, logger) {
     }
     throw err;
   }
-  const shouldAutoTransition = configAutoTransition && !noAutoTransition;
+  const shouldAutoTransition = configAutoTransition && !noAutoTransition && !dryRun;
   const reviewTransitionId = shouldAutoTransition ? requireEnv("FERRY_REVIEW_TRANSITION_ID") : "";
   const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
@@ -10587,8 +10678,12 @@ ${existingLog}` : "",
     await secretScan();
     execFileSync6("git", ["commit", "-m", commitMessage], { cwd: REPO_ROOT4 });
   }
-  execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
-  const branchPushed = true;
+  if (!dryRun) {
+    execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
+  } else {
+    logger.info("DRY_RUN \u2014 skipped: git push origin branch");
+  }
+  const branchPushed = !dryRun;
   let iterFilesTouched = [];
   try {
     const diff = execFileSync6("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
@@ -10598,14 +10693,17 @@ ${existingLog}` : "",
     iterFilesTouched = diff.trim().split("\n").filter(Boolean);
   } catch {
   }
-  assertIterOutputContract(resolvedOutcome, { branchPushed, prNumber });
+  if (!dryRun) {
+    assertIterOutputContract(resolvedOutcome, { branchPushed, prNumber });
+  }
   if (shouldAutoTransition) {
     await tracker.postTransition(ticketKey, reviewTransitionId);
   }
   const { next_iteration } = decideIteratorTransition({ current_iteration: priorIterations });
-  const transitionNote = shouldAutoTransition ? " Moved back to Review." : noAutoTransition ? " FR28 auto-transition skipped (ferry:no-auto-transition)." : "";
-  const terminalComment = resolvedOutcome === "already_satisfied" ? `${idempotencyMarker} Findings already addressed \u2014 no changes needed. Pushed to PR#${prNumber}.${transitionNote}` : `${idempotencyMarker} Iteration ${next_iteration} complete. Pushed fixes to PR#${prNumber}.${transitionNote}`;
-  await tracker.postComment(ticketKey, terminalComment);
+  const transitionNote = shouldAutoTransition ? " Moved back to Review." : noAutoTransition ? " FR28 auto-transition skipped (ferry:no-auto-transition)." : dryRun ? " FR28 auto-transition skipped (ferry:dry-run)." : "";
+  const pushNote = dryRun ? " (dry-run: branch push suppressed)" : "";
+  const terminalComment = resolvedOutcome === "already_satisfied" ? `${idempotencyMarker} Findings already addressed \u2014 no changes needed. Pushed to PR#${prNumber}.${transitionNote}` : `${idempotencyMarker} Iteration ${next_iteration} complete. Pushed fixes to PR#${prNumber}${pushNote}.${transitionNote}`;
+  await tracker.postComment(ticketKey, applyDryRunMarker(terminalComment, dryRun));
   writeStepSummary({
     role: "iterator",
     iterations,

--- a/.github/actions/ferry-run-reviewer/agent.js
+++ b/.github/actions/ferry-run-reviewer/agent.js
@@ -5929,6 +5929,8 @@ function resolveTicketOverrides(labels, logger, options) {
   let noPr = false;
   let paused = false;
   let noAutoTransition = false;
+  let dryRun = false;
+  let readOnly = false;
   const skipPhases = [];
   for (const label of labels) {
     if (!label.startsWith("ferry:")) continue;
@@ -6124,6 +6126,14 @@ function resolveTicketOverrides(labels, logger, options) {
       paused = true;
       continue;
     }
+    if (label === "ferry:dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (label === "ferry:read-only") {
+      readOnly = true;
+      continue;
+    }
     logger?.warn("unknown ferry override label ignored", { label });
   }
   if (blanketModel !== void 0) {
@@ -6158,7 +6168,9 @@ function resolveTicketOverrides(labels, logger, options) {
     ...noAutoTransition ? { noAutoTransition: true } : {},
     ...thinking !== void 0 ? { thinking } : {},
     ...noPr ? { git: { noPr: true } } : {},
-    ...paused ? { paused: true } : {}
+    ...paused ? { paused: true } : {},
+    ...dryRun ? { dryRun: true } : {},
+    ...readOnly ? { readOnly: true } : {}
   };
 }
 function applyTicketOverrides(cfg, overrides) {
@@ -6213,7 +6225,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.git?.noPr === true || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6229,7 +6241,16 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if (overrides.thinking !== void 0) payload.thinking = overrides.thinking;
   if (overrides.git?.noPr) payload.git = overrides.git;
   if (overrides.paused) payload.paused = true;
-  return `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+  if (overrides.dryRun) payload.dryRun = true;
+  if (overrides.readOnly) payload.readOnly = true;
+  const body = `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+  return applyDryRunMarker(body, overrides.dryRun);
+}
+function applyDryRunMarker(body, dryRun) {
+  if (dryRun !== true) return body;
+  const match = body.match(/^(\[ferry:[^\]]+\])\s+(.*)$/s);
+  if (!match) return body;
+  return `${match[1]} [dry-run] ${match[2]}`;
 }
 function buildConflictComment(role, runId, err) {
   return [
@@ -6830,7 +6851,7 @@ var PRIOR_RUN_MARKER = /\[ferry:refiner:[^\]]+\]/;
 async function run(envelope, deps) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const logger = deps.logger ?? createLogger(eventId, "ferry:refiner-action");
-  const dryRun = isDryRun();
+  const dryRun = isDryRun() || deps.dryRun === true;
   const issue = await deps.tracker.getIssue(ticketKey);
   const runLink = `https://github.com/${process.env.GITHUB_REPO ?? "unknown"}/actions/runs/${process.env.GITHUB_RUN_ID ?? "0"}`;
   const existingSubtasks = await deps.tracker.getSubtaskDetails(ticketKey);
@@ -6956,10 +6977,15 @@ async function main(envelope, logger) {
   const ferryCfg = loadFerryConfigFromBaseBranch(baseBranch, REPO_ROOT, initialCfg);
   const issueForLabels = await tracker.getIssue(ticketKey);
   let effectiveCfg;
+  let labelDryRun = false;
   try {
     const overrides = resolveTicketOverrides(issueForLabels.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
     });
+    labelDryRun = overrides.dryRun === true;
+    if (labelDryRun) {
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     logTicketOverrides(logger, overrides);
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -6972,7 +6998,10 @@ async function main(envelope, logger) {
       logger.info("refiner phase skipped via ferry:skip/refiner \u2014 exiting");
       await tracker.postComment(
         ticketKey,
-        `[ferry:refiner:${eventId}] Refiner skipped via ferry:skip/refiner \u2014 no refinement performed.`
+        applyDryRunMarker(
+          `[ferry:refiner:${eventId}] Refiner skipped via ferry:skip/refiner \u2014 no refinement performed.`,
+          labelDryRun
+        )
       );
       return;
     }
@@ -6985,7 +7014,7 @@ async function main(envelope, logger) {
   }
   const route = effectiveCfg.models.refiner;
   const callLlm = createLlmCall(route);
-  await run(envelope, { tracker, callLlm, logger });
+  await run(envelope, { tracker, callLlm, logger, dryRun: labelDryRun });
 }
 
 // src/agents/developer/dev-action.ts
@@ -9063,7 +9092,7 @@ async function runWipFinalizer(opts) {
 var REPO_ROOT2 = process.env.GITHUB_WORKSPACE ?? process.cwd();
 async function main2(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
-  const dryRun = isDryRun();
+  let dryRun = isDryRun();
   if (dryRun) {
     logger.info("DRY_RUN mode \u2014 no branch push, no PR, no Jira writes");
   }
@@ -9084,6 +9113,10 @@ async function main2(envelope, logger) {
     typeOverride = overrides.typeOverride;
     forceLabel = overrides.forceLabel;
     noAutoTransition = overrides.noAutoTransition === true;
+    if (overrides.dryRun === true && !dryRun) {
+      dryRun = true;
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     logTicketOverrides(logger, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -9092,11 +9125,25 @@ async function main2(envelope, logger) {
         buildOverridesAuditComment("developer", eventId, overrides)
       );
     }
+    if (overrides.readOnly === true) {
+      logger.info("read-only mode \u2014 developer agent skipped");
+      await tracker.postComment(
+        ticketKey,
+        applyDryRunMarker(
+          `[ferry:developer:${eventId}] read-only: agent skipped`,
+          overrides.dryRun
+        )
+      );
+      process.exit(0);
+    }
     if (overrides.skipPhases?.includes("dev")) {
       logger.info("dev phase skipped via ferry:skip/dev \u2014 exiting");
       await tracker.postComment(
         ticketKey,
-        `[ferry:developer:${eventId}] Developer skipped via ferry:skip/dev \u2014 no implementation performed.`
+        applyDryRunMarker(
+          `[ferry:developer:${eventId}] Developer skipped via ferry:skip/dev \u2014 no implementation performed.`,
+          overrides.dryRun
+        )
       );
       process.exit(0);
     }
@@ -9107,8 +9154,8 @@ async function main2(envelope, logger) {
     }
     throw err;
   }
-  const shouldAutoTransition = configAutoTransition && !noAutoTransition;
-  const reviewTransitionId = dryRun || !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
+  const shouldAutoTransition = configAutoTransition && !noAutoTransition && !dryRun;
+  const reviewTransitionId = !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
   const jiraBaseUrl = requireEnv("FERRY_JIRA_BASE_URL");
   const { provider: devProvider } = effectiveCfg.models.dev;
   const labels = issue.labels.join(", ");
@@ -10065,6 +10112,7 @@ async function main3(envelope, logger) {
   let typeOverride;
   let autoApprove = false;
   let noAutoTransition = false;
+  let dryRun = false;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10072,6 +10120,10 @@ async function main3(envelope, logger) {
     typeOverride = overrides.typeOverride;
     autoApprove = overrides.skipPhases?.includes("review") === true;
     noAutoTransition = overrides.noAutoTransition === true;
+    dryRun = overrides.dryRun === true;
+    if (dryRun) {
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     logTicketOverrides(logger, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -10080,6 +10132,14 @@ async function main3(envelope, logger) {
         buildOverridesAuditComment("reviewer", eventId, overrides)
       );
     }
+    if (overrides.readOnly === true) {
+      logger.info("read-only mode \u2014 reviewer agent skipped");
+      await tracker.postComment(
+        ticketKey,
+        applyDryRunMarker(`[ferry:reviewer:${eventId}] read-only: agent skipped`, overrides.dryRun)
+      );
+      return;
+    }
   } catch (err) {
     if (err instanceof LabelConflictError) {
       await tracker.postComment(ticketKey, buildConflictComment("reviewer", eventId, err));
@@ -10087,8 +10147,8 @@ async function main3(envelope, logger) {
     }
     throw err;
   }
-  const shouldTransitionChanges = configTransitionChanges && !noAutoTransition;
-  const shouldTransitionApprove = configTransitionApprove && !noAutoTransition;
+  const shouldTransitionChanges = configTransitionChanges && !noAutoTransition && !dryRun;
+  const shouldTransitionApprove = configTransitionApprove && !noAutoTransition && !dryRun;
   const iterTransitionId = shouldTransitionChanges ? requireEnv("FERRY_ITER_TRANSITION_ID") : "";
   const approveTransitionId = shouldTransitionApprove ? requireEnv("FERRY_APPROVE_TRANSITION_ID") : "";
   const { provider, model } = effectiveCfg.models.review;
@@ -10127,18 +10187,23 @@ async function main3(envelope, logger) {
     const approveTransitionNote = shouldTransitionApprove ? " Moved to next column." : noAutoTransition ? " FR24 auto-transition skipped (ferry:no-auto-transition)." : "";
     await tracker.postComment(
       ticketKey,
-      `${idempotencyMarker} Auto-approved via ferry:skip/review \u2014 review loop bypassed. PR#${prNumber}.${approveTransitionNote}`
+      applyDryRunMarker(
+        `${idempotencyMarker} Auto-approved via ferry:skip/review \u2014 review loop bypassed. PR#${prNumber}.${approveTransitionNote}`,
+        dryRun
+      )
     );
-    await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
-    await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
-    });
-    await runner.markPRReadyForReview(owner, repo, prNumber);
-    await runner.commentOnPR(
-      { owner, repo, prNumber },
-      `${idempotencyMarker} Auto-approved via ferry:skip/review label \u2014 review skipped per ticket opt-in.`
-    );
-    if (shouldTransitionApprove) {
-      await tracker.postTransition(ticketKey, approveTransitionId);
+    if (!dryRun) {
+      await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
+      await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
+      });
+      await runner.markPRReadyForReview(owner, repo, prNumber);
+      await runner.commentOnPR(
+        { owner, repo, prNumber },
+        `${idempotencyMarker} Auto-approved via ferry:skip/review label \u2014 review skipped per ticket opt-in.`
+      );
+      if (shouldTransitionApprove) {
+        await tracker.postTransition(ticketKey, approveTransitionId);
+      }
     }
     appendOutput({ input_tokens: 0, output_tokens: 0, model, provider });
     return;
@@ -10252,26 +10317,33 @@ async function main3(envelope, logger) {
   if (review.approved) {
     await tracker.postComment(
       ticketKey,
-      `${idempotencyMarker} Approved. PR#${prNumber} is ready to merge.`
+      applyDryRunMarker(`${idempotencyMarker} Approved. PR#${prNumber} is ready to merge.`, dryRun)
     );
-    await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
-    await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
-    });
-    await runner.markPRReadyForReview(owner, repo, prNumber);
-    await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
-    if (shouldTransitionApprove) {
-      await tracker.postTransition(ticketKey, approveTransitionId);
+    if (!dryRun) {
+      await runner.addLabelsToPR({ owner, repo, prNumber }, ["ferry:approved"]);
+      await runner.removeLabelFromPR({ owner, repo, prNumber }, "ferry:reviewing").catch(() => {
+      });
+      await runner.markPRReadyForReview(owner, repo, prNumber);
+      await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
+      if (shouldTransitionApprove) {
+        await tracker.postTransition(ticketKey, approveTransitionId);
+      }
     }
   } else {
     const priorIterations = countPriorIterations(existingComments);
     const cap = effectiveCfg.limits.max_iterations;
     const capReached = priorIterations >= cap;
-    await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
+    if (!dryRun) {
+      await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
+    }
     if (!capReached) {
       const changesNote = shouldTransitionChanges ? " Moved to Dev Iteration." : "";
       await tracker.postComment(
         ticketKey,
-        `${idempotencyMarker} Changes requested (iteration ${priorIterations + 1}/${cap}).${changesNote} See PR#${prNumber} for details.`
+        applyDryRunMarker(
+          `${idempotencyMarker} Changes requested (iteration ${priorIterations + 1}/${cap}).${changesNote} See PR#${prNumber} for details.`,
+          dryRun
+        )
       );
       if (shouldTransitionChanges) {
         await tracker.postTransition(ticketKey, iterTransitionId);
@@ -10279,7 +10351,10 @@ async function main3(envelope, logger) {
     } else {
       await tracker.postComment(
         ticketKey,
-        `${idempotencyMarker} Changes requested (re-review). Iteration cap (${cap}) reached; see PR#${prNumber} and move ticket manually.`
+        applyDryRunMarker(
+          `${idempotencyMarker} Changes requested (re-review). Iteration cap (${cap}) reached; see PR#${prNumber} and move ticket manually.`,
+          dryRun
+        )
       );
     }
   }
@@ -10355,6 +10430,7 @@ async function main4(envelope, logger) {
   let typeOverride;
   let labelMaxIterations;
   let noAutoTransition = false;
+  let dryRun = false;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true
@@ -10362,6 +10438,10 @@ async function main4(envelope, logger) {
     typeOverride = overrides.typeOverride;
     labelMaxIterations = overrides.maxIterations;
     noAutoTransition = overrides.noAutoTransition === true;
+    dryRun = overrides.dryRun === true;
+    if (dryRun) {
+      logger.warn("DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.");
+    }
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     logTicketOverrides(logger, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -10370,11 +10450,22 @@ async function main4(envelope, logger) {
         buildOverridesAuditComment("iterator", eventId, overrides)
       );
     }
+    if (overrides.readOnly === true) {
+      logger.info("read-only mode \u2014 iterator agent skipped");
+      await tracker.postComment(
+        ticketKey,
+        applyDryRunMarker(`[ferry:iterator:${eventId}] read-only: agent skipped`, overrides.dryRun)
+      );
+      return;
+    }
     if (overrides.skipPhases?.includes("iterate")) {
       logger.info("iterate phase skipped via ferry:skip/iter \u2014 exiting (no-op)");
       await tracker.postComment(
         ticketKey,
-        `[ferry:iterator:${eventId}] Iterator skipped via ferry:skip/iter \u2014 no iteration performed.`
+        applyDryRunMarker(
+          `[ferry:iterator:${eventId}] Iterator skipped via ferry:skip/iter \u2014 no iteration performed.`,
+          overrides.dryRun
+        )
       );
       return;
     }
@@ -10385,7 +10476,7 @@ async function main4(envelope, logger) {
     }
     throw err;
   }
-  const shouldAutoTransition = configAutoTransition && !noAutoTransition;
+  const shouldAutoTransition = configAutoTransition && !noAutoTransition && !dryRun;
   const reviewTransitionId = shouldAutoTransition ? requireEnv("FERRY_REVIEW_TRANSITION_ID") : "";
   const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
@@ -10587,8 +10678,12 @@ ${existingLog}` : "",
     await secretScan();
     execFileSync6("git", ["commit", "-m", commitMessage], { cwd: REPO_ROOT4 });
   }
-  execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
-  const branchPushed = true;
+  if (!dryRun) {
+    execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
+  } else {
+    logger.info("DRY_RUN \u2014 skipped: git push origin branch");
+  }
+  const branchPushed = !dryRun;
   let iterFilesTouched = [];
   try {
     const diff = execFileSync6("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
@@ -10598,14 +10693,17 @@ ${existingLog}` : "",
     iterFilesTouched = diff.trim().split("\n").filter(Boolean);
   } catch {
   }
-  assertIterOutputContract(resolvedOutcome, { branchPushed, prNumber });
+  if (!dryRun) {
+    assertIterOutputContract(resolvedOutcome, { branchPushed, prNumber });
+  }
   if (shouldAutoTransition) {
     await tracker.postTransition(ticketKey, reviewTransitionId);
   }
   const { next_iteration } = decideIteratorTransition({ current_iteration: priorIterations });
-  const transitionNote = shouldAutoTransition ? " Moved back to Review." : noAutoTransition ? " FR28 auto-transition skipped (ferry:no-auto-transition)." : "";
-  const terminalComment = resolvedOutcome === "already_satisfied" ? `${idempotencyMarker} Findings already addressed \u2014 no changes needed. Pushed to PR#${prNumber}.${transitionNote}` : `${idempotencyMarker} Iteration ${next_iteration} complete. Pushed fixes to PR#${prNumber}.${transitionNote}`;
-  await tracker.postComment(ticketKey, terminalComment);
+  const transitionNote = shouldAutoTransition ? " Moved back to Review." : noAutoTransition ? " FR28 auto-transition skipped (ferry:no-auto-transition)." : dryRun ? " FR28 auto-transition skipped (ferry:dry-run)." : "";
+  const pushNote = dryRun ? " (dry-run: branch push suppressed)" : "";
+  const terminalComment = resolvedOutcome === "already_satisfied" ? `${idempotencyMarker} Findings already addressed \u2014 no changes needed. Pushed to PR#${prNumber}.${transitionNote}` : `${idempotencyMarker} Iteration ${next_iteration} complete. Pushed fixes to PR#${prNumber}${pushNote}.${transitionNote}`;
+  await tracker.postComment(ticketKey, applyDryRunMarker(terminalComment, dryRun));
   writeStepSummary({
     role: "iterator",
     iterations,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -517,6 +517,23 @@ Disable Ferry's automatic Jira column moves (FR18, FR24, FR28) for this ticket o
 
 **Use case:** a research spike where the engineer wants to read the agent's output before deciding the next column.
 
+##### Dry-run / read-only (`ferry:dry-run`, `ferry:read-only`)
+
+Let a Jira ticket run Ferry without producing side effects — to validate prompts, MCP wiring, or rough token spend before committing real work.
+
+| Label             | Effect                                                                                                                                                                                                                                       |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ferry:dry-run`   | Run every phase but suppress all external writes: no branch push, no PR creation, no Jira label / transition / sub-task writes. The audit comment still posts, prefixed with `[dry-run]` so consumers can spot it in the Jira comment stream. |
+| `ferry:read-only` | Refiner runs normally; Developer / Reviewer / Iterator short-circuit at entry with a single `[ferry:<role>:<run-id>] read-only: agent skipped` audit comment and exit cleanly. Useful for "what would Ferry plan for this ticket?".            |
+
+**LLM cost warning:** `ferry:dry-run` only suppresses **external** side effects. LLM calls still happen and **token cost is still incurred**. Each agent logs a `DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.` warning at start. Use `ferry:read-only` to also skip Developer / Reviewer / Iterator LLM calls — only the Refiner pays tokens.
+
+**Combination:** `ferry:dry-run` + `ferry:read-only` is **not a conflict** — the two labels compose. Read-only is stricter (only Refiner runs); combining with dry-run additionally suppresses the Refiner's Jira sub-task creation, so the entire pipeline produces no Jira mutations beyond the audit comment.
+
+**Auto-transitions:** under `ferry:dry-run`, FR18 / FR24 / FR28 are skipped just like with `ferry:no-auto-transition`. The terminal Jira comment notes that the transition was suppressed.
+
+**Use case:** validate a new MCP server configuration or refined prompt by running the full agent loop on a real ticket without touching the repo or the Jira board.
+
 ##### Extended thinking (`ferry:thinking/*`)
 
 | Label                | Effect                                                         |

--- a/src/agents/developer/dev-action.ts
+++ b/src/agents/developer/dev-action.ts
@@ -41,6 +41,7 @@ import {
   hasNonDefaultOverrides,
   buildOverridesAuditComment,
   buildConflictComment,
+  applyDryRunMarker,
   LabelConflictError,
 } from '../../lib/agent-runtime/index.js';
 import { detectTestRunner, repoTree, packageJsonPath, detectPackageManager } from './workspace.js';
@@ -52,7 +53,7 @@ const REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
 export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
 
-  const dryRun = isDryRun();
+  let dryRun = isDryRun();
   if (dryRun) {
     logger.info('DRY_RUN mode — no branch push, no PR, no Jira writes');
   }
@@ -84,6 +85,11 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     typeOverride = overrides.typeOverride;
     forceLabel = overrides.forceLabel;
     noAutoTransition = overrides.noAutoTransition === true;
+    // ferry:dry-run label → enable dry-run mode (same gating as FERRY_DRY_RUN env var).
+    if (overrides.dryRun === true && !dryRun) {
+      dryRun = true;
+      logger.warn('DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.');
+    }
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     logTicketOverrides(logger, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -92,12 +98,27 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
         buildOverridesAuditComment('developer', eventId, overrides),
       );
     }
+    // ferry:read-only — Developer short-circuits at entry; Refiner runs normally.
+    if (overrides.readOnly === true) {
+      logger.info('read-only mode — developer agent skipped');
+      await tracker.postComment(
+        ticketKey,
+        applyDryRunMarker(
+          `[ferry:developer:${eventId}] read-only: agent skipped`,
+          overrides.dryRun,
+        ),
+      );
+      process.exit(0);
+    }
     // ferry:skip/dev — Developer exits immediately.
     if (overrides.skipPhases?.includes('dev')) {
       logger.info('dev phase skipped via ferry:skip/dev — exiting');
       await tracker.postComment(
         ticketKey,
-        `[ferry:developer:${eventId}] Developer skipped via ferry:skip/dev — no implementation performed.`,
+        applyDryRunMarker(
+          `[ferry:developer:${eventId}] Developer skipped via ferry:skip/dev — no implementation performed.`,
+          overrides.dryRun,
+        ),
       );
       process.exit(0);
     }
@@ -109,10 +130,10 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     throw err;
   }
 
-  // FR18 auto-transition is gated by both config and the ferry:no-auto-transition label.
-  const shouldAutoTransition = configAutoTransition && !noAutoTransition;
-  const reviewTransitionId =
-    dryRun || !shouldAutoTransition ? '' : requireEnv('FERRY_REVIEW_TRANSITION_ID');
+  // FR18 auto-transition is gated by config, the ferry:no-auto-transition label,
+  // and dry-run mode (dry-run suppresses all external writes).
+  const shouldAutoTransition = configAutoTransition && !noAutoTransition && !dryRun;
+  const reviewTransitionId = !shouldAutoTransition ? '' : requireEnv('FERRY_REVIEW_TRANSITION_ID');
   const jiraBaseUrl = requireEnv('FERRY_JIRA_BASE_URL');
 
   const { provider: devProvider } = effectiveCfg.models.dev;

--- a/src/agents/iterator/iterate-action.ts
+++ b/src/agents/iterator/iterate-action.ts
@@ -15,6 +15,7 @@ import {
   hasNonDefaultOverrides,
   buildOverridesAuditComment,
   buildConflictComment,
+  applyDryRunMarker,
   LabelConflictError,
 } from '../../lib/agent-runtime/index.js';
 import {
@@ -68,6 +69,7 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
   let typeOverride: string | undefined;
   let labelMaxIterations: number | undefined;
   let noAutoTransition = false;
+  let dryRun = false;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true,
@@ -75,6 +77,10 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     typeOverride = overrides.typeOverride;
     labelMaxIterations = overrides.maxIterations;
     noAutoTransition = overrides.noAutoTransition === true;
+    dryRun = overrides.dryRun === true;
+    if (dryRun) {
+      logger.warn('DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.');
+    }
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     logTicketOverrides(logger, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -83,12 +89,24 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
         buildOverridesAuditComment('iterator', eventId, overrides),
       );
     }
+    // ferry:read-only — Iterator short-circuits at entry; Refiner runs normally.
+    if (overrides.readOnly === true) {
+      logger.info('read-only mode — iterator agent skipped');
+      await tracker.postComment(
+        ticketKey,
+        applyDryRunMarker(`[ferry:iterator:${eventId}] read-only: agent skipped`, overrides.dryRun),
+      );
+      return;
+    }
     // ferry:skip/iter (alias: iterate) — Iterator becomes a no-op.
     if (overrides.skipPhases?.includes('iterate')) {
       logger.info('iterate phase skipped via ferry:skip/iter — exiting (no-op)');
       await tracker.postComment(
         ticketKey,
-        `[ferry:iterator:${eventId}] Iterator skipped via ferry:skip/iter — no iteration performed.`,
+        applyDryRunMarker(
+          `[ferry:iterator:${eventId}] Iterator skipped via ferry:skip/iter — no iteration performed.`,
+          overrides.dryRun,
+        ),
       );
       return;
     }
@@ -100,8 +118,9 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     throw err;
   }
 
-  // FR28 auto-transition is gated by both config and the ferry:no-auto-transition label.
-  const shouldAutoTransition = configAutoTransition && !noAutoTransition;
+  // FR28 auto-transition is gated by config, the ferry:no-auto-transition label,
+  // and the ferry:dry-run label (dry-run suppresses all external writes).
+  const shouldAutoTransition = configAutoTransition && !noAutoTransition && !dryRun;
   const reviewTransitionId = shouldAutoTransition ? requireEnv('FERRY_REVIEW_TRANSITION_ID') : '';
 
   const { provider: iterProvider, model } = effectiveCfg.models.iterate;
@@ -351,8 +370,13 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     await secretScan();
     execFileSync('git', ['commit', '-m', commitMessage], { cwd: REPO_ROOT });
   }
-  execFileSync('git', ['push', 'origin', branchName, '--force-with-lease'], { cwd: REPO_ROOT });
-  const branchPushed = true;
+  // ferry:dry-run suppresses the branch push (no external write side effects).
+  if (!dryRun) {
+    execFileSync('git', ['push', 'origin', branchName, '--force-with-lease'], { cwd: REPO_ROOT });
+  } else {
+    logger.info('DRY_RUN — skipped: git push origin branch');
+  }
+  const branchPushed = !dryRun;
 
   let iterFilesTouched: string[] = [];
   try {
@@ -366,7 +390,10 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
   }
 
   // Output-contract guard: verify required outputs exist before terminal comment.
-  assertIterOutputContract(resolvedOutcome, { branchPushed, prNumber });
+  // Skip the assertion under dry-run since branchPushed is intentionally false.
+  if (!dryRun) {
+    assertIterOutputContract(resolvedOutcome, { branchPushed, prNumber });
+  }
 
   if (shouldAutoTransition) {
     await tracker.postTransition(ticketKey, reviewTransitionId);
@@ -377,14 +404,17 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     ? ' Moved back to Review.'
     : noAutoTransition
       ? ' FR28 auto-transition skipped (ferry:no-auto-transition).'
-      : '';
+      : dryRun
+        ? ' FR28 auto-transition skipped (ferry:dry-run).'
+        : '';
 
+  const pushNote = dryRun ? ' (dry-run: branch push suppressed)' : '';
   const terminalComment =
     resolvedOutcome === 'already_satisfied'
       ? `${idempotencyMarker} Findings already addressed — no changes needed. Pushed to PR#${prNumber}.${transitionNote}`
-      : `${idempotencyMarker} Iteration ${next_iteration} complete. Pushed fixes to PR#${prNumber}.${transitionNote}`;
+      : `${idempotencyMarker} Iteration ${next_iteration} complete. Pushed fixes to PR#${prNumber}${pushNote}.${transitionNote}`;
 
-  await tracker.postComment(ticketKey, terminalComment);
+  await tracker.postComment(ticketKey, applyDryRunMarker(terminalComment, dryRun));
 
   writeStepSummary({
     role: 'iterator',

--- a/src/agents/refiner/refiner-action.dry-run.test.ts
+++ b/src/agents/refiner/refiner-action.dry-run.test.ts
@@ -101,6 +101,42 @@ describe('refiner-action normal mode — first run (no FERRY_DRY_RUN)', () => {
   });
 });
 
+describe('refiner-action dry-run (label-driven via deps.dryRun)', () => {
+  beforeEach(() => {
+    delete process.env.FERRY_DRY_RUN;
+  });
+
+  it('calls the LLM but posts no Jira comment when deps.dryRun=true', async () => {
+    const tracker = makeTracker();
+    const mockLlm = makeMockLlm();
+    await run(envelope, { tracker, callLlm: mockLlm, dryRun: true });
+
+    expect(mockLlm).toHaveBeenCalledOnce();
+    expect(tracker.postedComments).toHaveLength(0);
+  });
+
+  it('creates no subtasks when deps.dryRun=true (Refiner sub-task write suppressed)', async () => {
+    const tracker = makeTracker();
+    await run(envelope, { tracker, callLlm: makeMockLlm(), dryRun: true });
+
+    expect(tracker.createdSubtasks).toHaveLength(0);
+  });
+
+  it('posts no transitions when deps.dryRun=true', async () => {
+    const tracker = makeTracker();
+    await run(envelope, { tracker, callLlm: makeMockLlm(), dryRun: true });
+
+    expect(tracker.postedTransitions).toHaveLength(0);
+  });
+
+  it('adds no labels when deps.dryRun=true (cost-estimate label suppressed)', async () => {
+    const tracker = makeTracker();
+    await run(envelope, { tracker, callLlm: makeMockLlm(), dryRun: true });
+
+    expect(tracker.addedLabels).toHaveLength(0);
+  });
+});
+
 describe('refiner-action re-trigger scenario', () => {
   beforeEach(() => {
     delete process.env.FERRY_DRY_RUN;

--- a/src/agents/refiner/refiner-action.ts
+++ b/src/agents/refiner/refiner-action.ts
@@ -11,6 +11,7 @@ import {
   hasNonDefaultOverrides,
   buildOverridesAuditComment,
   buildConflictComment,
+  applyDryRunMarker,
   LabelConflictError,
   logTicketOverrides,
 } from '../../lib/agent-runtime/index.js';
@@ -30,12 +31,18 @@ export interface RefinerActionDeps {
   tracker: IssueTracker;
   callLlm: LlmCall;
   logger?: Logger;
+  /**
+   * When true (set via ferry:dry-run label or FERRY_DRY_RUN=1), the Refiner skips
+   * all Jira mutations (sub-task create, label add, transition, comment except
+   * the audit comment marker). LLM cost is still incurred.
+   */
+  dryRun?: boolean;
 }
 
 export async function run(envelope: EventEnvelopeV1, deps: RefinerActionDeps): Promise<void> {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const logger = deps.logger ?? createLogger(eventId, 'ferry:refiner-action');
-  const dryRun = isDryRun();
+  const dryRun = isDryRun() || deps.dryRun === true;
 
   const issue = await deps.tracker.getIssue(ticketKey);
   const runLink = `https://github.com/${process.env.GITHUB_REPO ?? 'unknown'}/actions/runs/${process.env.GITHUB_RUN_ID ?? '0'}`;
@@ -183,10 +190,15 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
   // Resolve label overrides (model/provider/budget/…) before creating the LLM call.
   const issueForLabels = await tracker.getIssue(ticketKey);
   let effectiveCfg;
+  let labelDryRun = false;
   try {
     const overrides = resolveTicketOverrides(issueForLabels.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true,
     });
+    labelDryRun = overrides.dryRun === true;
+    if (labelDryRun) {
+      logger.warn('DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.');
+    }
     logTicketOverrides(logger, overrides);
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -200,10 +212,15 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
       logger.info('refiner phase skipped via ferry:skip/refiner — exiting');
       await tracker.postComment(
         ticketKey,
-        `[ferry:refiner:${eventId}] Refiner skipped via ferry:skip/refiner — no refinement performed.`,
+        applyDryRunMarker(
+          `[ferry:refiner:${eventId}] Refiner skipped via ferry:skip/refiner — no refinement performed.`,
+          labelDryRun,
+        ),
       );
       return;
     }
+    // ferry:read-only does NOT short-circuit the Refiner — per spec, Refiner runs normally.
+    // When combined with ferry:dry-run, the dryRun gating below suppresses sub-task writes.
   } catch (err) {
     if (err instanceof LabelConflictError) {
       await tracker.postComment(ticketKey, buildConflictComment('refiner', eventId, err));
@@ -214,5 +231,5 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
 
   const route = effectiveCfg.models.refiner;
   const callLlm: LlmCall = createLlmCall(route);
-  await run(envelope, { tracker, callLlm, logger });
+  await run(envelope, { tracker, callLlm, logger, dryRun: labelDryRun });
 }

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -10,6 +10,7 @@ import {
   hasNonDefaultOverrides,
   buildOverridesAuditComment,
   buildConflictComment,
+  applyDryRunMarker,
   LabelConflictError,
 } from '../../lib/agent-runtime/index.js';
 import {
@@ -53,6 +54,7 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
   let typeOverride: string | undefined;
   let autoApprove = false;
   let noAutoTransition = false;
+  let dryRun = false;
   try {
     const overrides = resolveTicketOverrides(issue.labels, logger, {
       allowSkipReview: ferryCfg.safety?.allow_skip_review === true,
@@ -60,6 +62,10 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     typeOverride = overrides.typeOverride;
     autoApprove = overrides.skipPhases?.includes('review') === true;
     noAutoTransition = overrides.noAutoTransition === true;
+    dryRun = overrides.dryRun === true;
+    if (dryRun) {
+      logger.warn('DRY-RUN: LLM calls will still incur cost; no commits or PRs will be pushed.');
+    }
     effectiveCfg = applyTicketOverrides(ferryCfg, overrides);
     logTicketOverrides(logger, overrides);
     if (hasNonDefaultOverrides(overrides)) {
@@ -67,6 +73,15 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
         ticketKey,
         buildOverridesAuditComment('reviewer', eventId, overrides),
       );
+    }
+    // ferry:read-only — Reviewer short-circuits at entry; Refiner runs normally.
+    if (overrides.readOnly === true) {
+      logger.info('read-only mode — reviewer agent skipped');
+      await tracker.postComment(
+        ticketKey,
+        applyDryRunMarker(`[ferry:reviewer:${eventId}] read-only: agent skipped`, overrides.dryRun),
+      );
+      return;
     }
   } catch (err) {
     if (err instanceof LabelConflictError) {
@@ -76,9 +91,10 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     throw err;
   }
 
-  // FR24 auto-transitions are gated by both config and the ferry:no-auto-transition label.
-  const shouldTransitionChanges = configTransitionChanges && !noAutoTransition;
-  const shouldTransitionApprove = configTransitionApprove && !noAutoTransition;
+  // FR24 auto-transitions are gated by config, the ferry:no-auto-transition label,
+  // and the ferry:dry-run label (dry-run suppresses all external writes).
+  const shouldTransitionChanges = configTransitionChanges && !noAutoTransition && !dryRun;
+  const shouldTransitionApprove = configTransitionApprove && !noAutoTransition && !dryRun;
   const iterTransitionId = shouldTransitionChanges ? requireEnv('FERRY_ITER_TRANSITION_ID') : '';
   const approveTransitionId = shouldTransitionApprove
     ? requireEnv('FERRY_APPROVE_TRANSITION_ID')
@@ -136,17 +152,22 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
         : '';
     await tracker.postComment(
       ticketKey,
-      `${idempotencyMarker} Auto-approved via ferry:skip/review — review loop bypassed. PR#${prNumber}.${approveTransitionNote}`,
+      applyDryRunMarker(
+        `${idempotencyMarker} Auto-approved via ferry:skip/review — review loop bypassed. PR#${prNumber}.${approveTransitionNote}`,
+        dryRun,
+      ),
     );
-    await runner.addLabelsToPR({ owner, repo, prNumber }, ['ferry:approved']);
-    await runner.removeLabelFromPR({ owner, repo, prNumber }, 'ferry:reviewing').catch(() => {});
-    await runner.markPRReadyForReview(owner, repo, prNumber);
-    await runner.commentOnPR(
-      { owner, repo, prNumber },
-      `${idempotencyMarker} Auto-approved via ferry:skip/review label — review skipped per ticket opt-in.`,
-    );
-    if (shouldTransitionApprove) {
-      await tracker.postTransition(ticketKey, approveTransitionId);
+    if (!dryRun) {
+      await runner.addLabelsToPR({ owner, repo, prNumber }, ['ferry:approved']);
+      await runner.removeLabelFromPR({ owner, repo, prNumber }, 'ferry:reviewing').catch(() => {});
+      await runner.markPRReadyForReview(owner, repo, prNumber);
+      await runner.commentOnPR(
+        { owner, repo, prNumber },
+        `${idempotencyMarker} Auto-approved via ferry:skip/review label — review skipped per ticket opt-in.`,
+      );
+      if (shouldTransitionApprove) {
+        await tracker.postTransition(ticketKey, approveTransitionId);
+      }
     }
     appendOutput({ input_tokens: 0, output_tokens: 0, model, provider });
     return;
@@ -282,27 +303,34 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
   if (review.approved) {
     await tracker.postComment(
       ticketKey,
-      `${idempotencyMarker} Approved. PR#${prNumber} is ready to merge.`,
+      applyDryRunMarker(`${idempotencyMarker} Approved. PR#${prNumber} is ready to merge.`, dryRun),
     );
-    await runner.addLabelsToPR({ owner, repo, prNumber }, ['ferry:approved']);
-    await runner.removeLabelFromPR({ owner, repo, prNumber }, 'ferry:reviewing').catch(() => {});
-    await runner.markPRReadyForReview(owner, repo, prNumber);
-    await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
-    if (shouldTransitionApprove) {
-      await tracker.postTransition(ticketKey, approveTransitionId);
+    if (!dryRun) {
+      await runner.addLabelsToPR({ owner, repo, prNumber }, ['ferry:approved']);
+      await runner.removeLabelFromPR({ owner, repo, prNumber }, 'ferry:reviewing').catch(() => {});
+      await runner.markPRReadyForReview(owner, repo, prNumber);
+      await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
+      if (shouldTransitionApprove) {
+        await tracker.postTransition(ticketKey, approveTransitionId);
+      }
     }
   } else {
     const priorIterations = countPriorIterations(existingComments);
     const cap = effectiveCfg.limits.max_iterations;
     const capReached = priorIterations >= cap;
 
-    await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
+    if (!dryRun) {
+      await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
+    }
 
     if (!capReached) {
       const changesNote = shouldTransitionChanges ? ' Moved to Dev Iteration.' : '';
       await tracker.postComment(
         ticketKey,
-        `${idempotencyMarker} Changes requested (iteration ${priorIterations + 1}/${cap}).${changesNote} See PR#${prNumber} for details.`,
+        applyDryRunMarker(
+          `${idempotencyMarker} Changes requested (iteration ${priorIterations + 1}/${cap}).${changesNote} See PR#${prNumber} for details.`,
+          dryRun,
+        ),
       );
       if (shouldTransitionChanges) {
         await tracker.postTransition(ticketKey, iterTransitionId);
@@ -310,7 +338,10 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     } else {
       await tracker.postComment(
         ticketKey,
-        `${idempotencyMarker} Changes requested (re-review). Iteration cap (${cap}) reached; see PR#${prNumber} and move ticket manually.`,
+        applyDryRunMarker(
+          `${idempotencyMarker} Changes requested (re-review). Iteration cap (${cap}) reached; see PR#${prNumber} and move ticket manually.`,
+          dryRun,
+        ),
       );
     }
   }

--- a/src/labels/allowlist.ts
+++ b/src/labels/allowlist.ts
@@ -41,6 +41,8 @@ export const LABELS_ALLOWLIST = [
   'ferry:skip/iter',
   'ferry:skip/iterate',
   'ferry:no-auto-transition',
+  'ferry:dry-run',
+  'ferry:read-only',
   'ferry:thinking/',
   'ferry:thinking/on',
   'ferry:thinking/off',

--- a/src/lib/agent-runtime/index.ts
+++ b/src/lib/agent-runtime/index.ts
@@ -43,4 +43,5 @@ export {
   hasNonDefaultOverrides,
   buildOverridesAuditComment,
   buildConflictComment,
+  applyDryRunMarker,
 } from '../labels/overrides.js';

--- a/src/lib/labels/capabilities.ts
+++ b/src/lib/labels/capabilities.ts
@@ -133,6 +133,27 @@ export interface TicketOverrides {
    * Agents should exit immediately without processing when this is true.
    */
   paused?: boolean;
+
+  // --- ferry:dry-run (validation / no side effects) ---
+
+  /**
+   * True when the ticket carries the ferry:dry-run label.
+   * Suppresses all external write side effects (branch push, PR creation, Jira
+   * label / transition / sub-task writes) so prompts and MCP wiring can be
+   * validated without committing real work. LLM calls still happen and incur
+   * token cost. Audit comments still post, prefixed with `[dry-run]`.
+   */
+  dryRun?: boolean;
+
+  // --- ferry:read-only (Refiner-only run) ---
+
+  /**
+   * True when the ticket carries the ferry:read-only label.
+   * Only the Refiner runs; Developer / Reviewer / Iterator short-circuit at
+   * action entry with a single audit comment. When combined with ferry:dry-run,
+   * even the Refiner's Jira sub-task writes are suppressed (per dryRun gating).
+   */
+  readOnly?: boolean;
 }
 
 /** Built-in label → normalised issue type mapping. Order matters: last match wins. */

--- a/src/lib/labels/overrides.test.ts
+++ b/src/lib/labels/overrides.test.ts
@@ -5,6 +5,7 @@ import {
   hasNonDefaultOverrides,
   buildOverridesAuditComment,
   buildConflictComment,
+  applyDryRunMarker,
   LabelConflictError,
 } from './overrides.js';
 import { createTestLogger } from '../logger/index.js';
@@ -914,5 +915,136 @@ describe('buildConflictComment', () => {
     expect(comment).toContain('ferry:model/dev/opus');
     expect(comment).toContain('ferry:model/dev/sonnet');
     expect(comment).toContain('model.dev');
+  });
+});
+
+// ------------------------------------------------------------------
+// ferry:dry-run
+// ------------------------------------------------------------------
+
+describe('resolveTicketOverrides — ferry:dry-run', () => {
+  it('sets dryRun to true when ferry:dry-run label is present', () => {
+    expect(resolveTicketOverrides(['ferry:dry-run']).dryRun).toBe(true);
+  });
+
+  it('does not set dryRun when label is absent', () => {
+    expect(resolveTicketOverrides([]).dryRun).toBeUndefined();
+  });
+
+  it('does not set dryRun for other ferry labels', () => {
+    expect(resolveTicketOverrides(['ferry:paused']).dryRun).toBeUndefined();
+  });
+
+  it('logs a warning for unknown suffix ferry:dry-run/foo', () => {
+    const { logger, records } = createTestLogger('t', 'test');
+    const r = resolveTicketOverrides(['ferry:dry-run/foo'], logger);
+    expect(r.dryRun).toBeUndefined();
+    expect(records.some((rec) => rec.level === 'warn')).toBe(true);
+  });
+
+  it('hasNonDefaultOverrides returns true when dryRun is set', () => {
+    expect(hasNonDefaultOverrides(resolveTicketOverrides(['ferry:dry-run']))).toBe(true);
+  });
+});
+
+// ------------------------------------------------------------------
+// ferry:read-only
+// ------------------------------------------------------------------
+
+describe('resolveTicketOverrides — ferry:read-only', () => {
+  it('sets readOnly to true when ferry:read-only label is present', () => {
+    expect(resolveTicketOverrides(['ferry:read-only']).readOnly).toBe(true);
+  });
+
+  it('does not set readOnly when label is absent', () => {
+    expect(resolveTicketOverrides([]).readOnly).toBeUndefined();
+  });
+
+  it('logs a warning for unknown suffix ferry:read-only/foo', () => {
+    const { logger, records } = createTestLogger('t', 'test');
+    const r = resolveTicketOverrides(['ferry:read-only/foo'], logger);
+    expect(r.readOnly).toBeUndefined();
+    expect(records.some((rec) => rec.level === 'warn')).toBe(true);
+  });
+
+  it('hasNonDefaultOverrides returns true when readOnly is set', () => {
+    expect(hasNonDefaultOverrides(resolveTicketOverrides(['ferry:read-only']))).toBe(true);
+  });
+});
+
+// ------------------------------------------------------------------
+// ferry:dry-run + ferry:read-only — combination (NOT mutually exclusive)
+// ------------------------------------------------------------------
+
+describe('resolveTicketOverrides — ferry:dry-run + ferry:read-only', () => {
+  it('sets both dryRun and readOnly when both labels are present (no conflict)', () => {
+    const r = resolveTicketOverrides(['ferry:dry-run', 'ferry:read-only']);
+    expect(r.dryRun).toBe(true);
+    expect(r.readOnly).toBe(true);
+  });
+
+  it('does not throw LabelConflictError for the combination', () => {
+    expect(() => resolveTicketOverrides(['ferry:dry-run', 'ferry:read-only'])).not.toThrow();
+  });
+});
+
+// ------------------------------------------------------------------
+// buildOverridesAuditComment — dryRun / readOnly payload + marker
+// ------------------------------------------------------------------
+
+describe('buildOverridesAuditComment — dry-run / read-only', () => {
+  it('includes dryRun in the JSON payload', () => {
+    const overrides = resolveTicketOverrides(['ferry:dry-run']);
+    const comment = buildOverridesAuditComment('developer', 'run1', overrides);
+    expect(comment).toContain('"dryRun":true');
+  });
+
+  it('includes readOnly in the JSON payload', () => {
+    const overrides = resolveTicketOverrides(['ferry:read-only']);
+    const comment = buildOverridesAuditComment('developer', 'run1', overrides);
+    expect(comment).toContain('"readOnly":true');
+  });
+
+  it('prepends [dry-run] marker after fingerprint when overrides.dryRun is set', () => {
+    const overrides = resolveTicketOverrides(['ferry:dry-run']);
+    const comment = buildOverridesAuditComment('developer', 'run1', overrides);
+    expect(comment).toMatch(/^\[ferry:developer:run1\] \[dry-run\]/);
+  });
+
+  it('does not prepend [dry-run] marker when overrides.dryRun is not set', () => {
+    const overrides = resolveTicketOverrides(['ferry:read-only']);
+    const comment = buildOverridesAuditComment('developer', 'run1', overrides);
+    expect(comment).not.toContain('[dry-run]');
+  });
+});
+
+// ------------------------------------------------------------------
+// applyDryRunMarker
+// ------------------------------------------------------------------
+
+describe('applyDryRunMarker', () => {
+  it('prepends [dry-run] after [ferry:role:run-id] prefix when dryRun=true', () => {
+    const out = applyDryRunMarker('[ferry:developer:run1] some message', true);
+    expect(out).toBe('[ferry:developer:run1] [dry-run] some message');
+  });
+
+  it('returns body unchanged when dryRun=false', () => {
+    const out = applyDryRunMarker('[ferry:developer:run1] some message', false);
+    expect(out).toBe('[ferry:developer:run1] some message');
+  });
+
+  it('returns body unchanged when dryRun is undefined', () => {
+    const out = applyDryRunMarker('[ferry:developer:run1] some message', undefined);
+    expect(out).toBe('[ferry:developer:run1] some message');
+  });
+
+  it('returns body unchanged when there is no [ferry:...] prefix', () => {
+    const out = applyDryRunMarker('plain body', true);
+    expect(out).toBe('plain body');
+  });
+
+  it('handles multiline body correctly (marker only on first line)', () => {
+    const out = applyDryRunMarker('[ferry:developer:run1] line1\nline2', true);
+    expect(out).toBe('[ferry:developer:run1] [dry-run] line1\nline2');
   });
 });

--- a/src/lib/labels/overrides.ts
+++ b/src/lib/labels/overrides.ts
@@ -138,6 +138,8 @@ export function resolveTicketOverrides(
   let noPr = false;
   let paused = false;
   let noAutoTransition = false;
+  let dryRun = false;
+  let readOnly = false;
   const skipPhases: AgentPhase[] = [];
 
   for (const label of labels) {
@@ -367,6 +369,18 @@ export function resolveTicketOverrides(
       continue;
     }
 
+    // ferry:dry-run — suppress external writes (commits, PRs, Jira mutations).
+    if (label === 'ferry:dry-run') {
+      dryRun = true;
+      continue;
+    }
+
+    // ferry:read-only — Refiner runs only; Developer/Reviewer/Iterator short-circuit.
+    if (label === 'ferry:read-only') {
+      readOnly = true;
+      continue;
+    }
+
     // Unrecognised ferry:* label in override namespace — log and ignore
     logger?.warn('unknown ferry override label ignored', { label });
   }
@@ -410,6 +424,8 @@ export function resolveTicketOverrides(
     ...(thinking !== undefined ? { thinking } : {}),
     ...(noPr ? { git: { noPr: true } } : {}),
     ...(paused ? { paused: true } : {}),
+    ...(dryRun ? { dryRun: true } : {}),
+    ...(readOnly ? { readOnly: true } : {}),
   };
 }
 
@@ -501,7 +517,9 @@ export function hasNonDefaultOverrides(overrides: TicketOverrides): boolean {
     overrides.noAutoTransition === true ||
     overrides.thinking !== undefined ||
     overrides.git?.noPr === true ||
-    overrides.paused === true
+    overrides.paused === true ||
+    overrides.dryRun === true ||
+    overrides.readOnly === true
   );
 }
 
@@ -510,6 +528,9 @@ export function hasNonDefaultOverrides(overrides: TicketOverrides): boolean {
  *
  * The comment format follows the standard fingerprint convention:
  * `[ferry:<role>:<run-id>] overrides applied: <json>`
+ *
+ * When `overrides.dryRun` is true, the comment is prefixed with `[dry-run]`
+ * immediately after the fingerprint (see `applyDryRunMarker`).
  */
 export function buildOverridesAuditComment(
   role: string,
@@ -530,8 +551,29 @@ export function buildOverridesAuditComment(
   if (overrides.thinking !== undefined) payload.thinking = overrides.thinking;
   if (overrides.git?.noPr) payload.git = overrides.git;
   if (overrides.paused) payload.paused = true;
+  if (overrides.dryRun) payload.dryRun = true;
+  if (overrides.readOnly) payload.readOnly = true;
 
-  return `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+  const body = `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
+  return applyDryRunMarker(body, overrides.dryRun);
+}
+
+/**
+ * Prepends a `[dry-run]` marker to a comment body so consumers can visually
+ * distinguish audit comments emitted under a `ferry:dry-run` execution.
+ *
+ * The marker is inserted immediately after the `[ferry:<role>:<run-id>]`
+ * fingerprint prefix. If the body has no such prefix (or `dryRun` is falsy),
+ * the body is returned unchanged.
+ *
+ * Multiline bodies receive the marker on the first line only — subsequent
+ * lines are preserved verbatim.
+ */
+export function applyDryRunMarker(body: string, dryRun: boolean | undefined): string {
+  if (dryRun !== true) return body;
+  const match = body.match(/^(\[ferry:[^\]]+\])\s+(.*)$/s);
+  if (!match) return body;
+  return `${match[1]} [dry-run] ${match[2]}`;
 }
 
 /**


### PR DESCRIPTION
Closes #243

> Replaces closed PR #278 (auto-closed when its stacked base branch `claude/issue-239-…` was deleted on merge of #277). Rebased onto `main` after #277 squash-merged.

## Summary

- Adds `ferry:dry-run` — suppresses all external writes (branch push, PR creation, Jira label / transition / sub-task writes). LLM calls still incur cost. Audit comments still post, prefixed with `[dry-run]` after the fingerprint.
- Adds `ferry:read-only` — Refiner runs normally; Developer / Reviewer / Iterator short-circuit at entry with a single `[ferry:<role>:<run-id>] read-only: agent skipped` audit note.
- Combination `ferry:dry-run` + `ferry:read-only` is not a conflict — additively suppresses Refiner sub-task writes too.
- FR18 / FR24 / FR28 auto-transitions AND-combined with `!dryRun`.

## Test plan

- [x] All 1582 tests pass (`npm test`)
- [x] TypeScript typecheck passes
- [x] +24 new tests across `overrides.test.ts` (+20) and new `refiner-action.dry-run.test.ts` (+4)
- [x] Bundles rebuilt (`npm run build:ferry`)

Generated with [Claude Code](https://claude.ai/code)