### PR TITLE
docs(claude-code): accepted-divergence notes for the claude-code execution path (partial #307)

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -18,7 +18,31 @@
     },
     {
       "id": "1118641",
-      "rationale": "Pre-existing advisory in protobufjs (transitive dep via @google/genai → protobufjs@^7.5.4). No patched protobufjs release yet, and @google/genai’s latest 2.2.0 still pins the same range. Ferry only uses @google/genai to call Gemini APIs over Google's gRPC endpoints — protobuf messages are never decoded from untrusted sources. Remove when @google/genai bumps to a patched protobufjs."
+      "rationale": "Pre-existing advisory in protobufjs (transitive dep via @google/genai → protobufjs@^7.5.4). No patched protobufjs release yet, and @google/genai’s latest 2.2.0 still pins the same range. Ferry only uses @google/genai to call Gemini APIs over Google’s gRPC endpoints — protobuf messages are never decoded from untrusted sources. Remove when @google/genai bumps to a patched protobufjs."
+    },
+    {
+      "id": "1118924",
+      "rationale": "Pre-existing advisory in protobufjs (transitive dep via @google/genai → protobufjs@^7.5.4). No patched protobufjs release yet, and @google/genai still pins the same range. Ferry only uses @google/genai to call Gemini APIs over Google’s gRPC endpoints — protobuf messages are never decoded from untrusted sources. Remove when @google/genai bumps to a patched protobufjs."
+    },
+    {
+      "id": "1118926",
+      "rationale": "Pre-existing advisory in protobufjs (transitive dep via @google/genai → protobufjs@^7.5.4). No patched protobufjs release yet, and @google/genai still pins the same range. Ferry only uses @google/genai to call Gemini APIs over Google’s gRPC endpoints — protobuf messages are never decoded from untrusted sources. Remove when @google/genai bumps to a patched protobufjs."
+    },
+    {
+      "id": "1118928",
+      "rationale": "Pre-existing advisory in protobufjs (transitive dep via @google/genai → protobufjs@^7.5.4). No patched protobufjs release yet, and @google/genai still pins the same range. Ferry only uses @google/genai to call Gemini APIs over Google’s gRPC endpoints — protobuf messages are never decoded from untrusted sources. Remove when @google/genai bumps to a patched protobufjs."
+    },
+    {
+      "id": "1118930",
+      "rationale": "Pre-existing advisory in protobufjs (transitive dep via @google/genai → protobufjs@^7.5.4). No patched protobufjs release yet, and @google/genai still pins the same range. Ferry only uses @google/genai to call Gemini APIs over Google’s gRPC endpoints — protobuf messages are never decoded from untrusted sources. Remove when @google/genai bumps to a patched protobufjs."
+    },
+    {
+      "id": "1118932",
+      "rationale": "Pre-existing advisory in protobufjs (transitive dep via @google/genai → protobufjs@^7.5.4). No patched protobufjs release yet, and @google/genai still pins the same range. Ferry only uses @google/genai to call Gemini APIs over Google’s gRPC endpoints — protobuf messages are never decoded from untrusted sources. Remove when @google/genai bumps to a patched protobufjs."
+    },
+    {
+      "id": "1118935",
+      "rationale": "Pre-existing advisory in protobufjs (transitive dep via @google/genai → protobufjs@^7.5.4). No patched protobufjs release yet, and @google/genai still pins the same range. Ferry only uses @google/genai to call Gemini APIs over Google’s gRPC endpoints — protobuf messages are never decoded from untrusted sources. Remove when @google/genai bumps to a patched protobufjs."
     },
     {
       "id": "1118643",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -487,6 +487,8 @@ Override cost / token budgets and iteration limits for this ticket only.
 - `ferry:spend-cap` is applied to the ticket.
 - A Jira audit comment is posted naming the ticket and EUR consumed.
 
+> **Bundled-script path only.** Mid-run EUR enforcement (and therefore `ferry:budget/<eur>`, `limits.max_cost_eur_per_run`, and the `ferry:spend-cap` label) does **not** apply on the experimental `claude-code-action` execution path — see [Execution paths & accepted divergences](#execution-paths--accepted-divergences-experimental).
+
 **Conflict rules:** Duplicate labels for the same field (e.g. two `ferry:budget/<n>` labels with different values) are a conflict — the agent posts a Jira comment and exits non-zero. `ferry:budget/<eur>` and `ferry:budget/max-cost/<eur>` set the same config field (`limits.max_cost_eur_per_run`); they can coexist as they are separate fields, but the last one applied via `applyTicketOverrides` wins — avoid combining them.
 
 ##### Phase skips (`ferry:skip/*`)
@@ -630,6 +632,8 @@ Lets a single Jira ticket pick its own base branch, PR target branch, and PR dra
 | ----------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ferry:paused`    | Cost-governance workflow | Agent exits immediately without processing. Applied automatically when spend reaches 50% of the monthly cap. Remove the label manually to resume. |
 | `ferry:spend-cap` | Cost-governance workflow | Informational — marks tickets that triggered the spend cap check. No direct effect on agent execution.                                            |
+
+> **Execution-path note:** `ferry:paused` (50% monthly auto-pause) is **weakened** and `ferry:spend-cap` **never fires** on the experimental `claude-code-action` path, because subscription-token spend has no measurable EUR figure. See [Execution paths & accepted divergences](#execution-paths--accepted-divergences-experimental).
 
 ---
 
@@ -777,6 +781,57 @@ git.base_branch / git.target_branch (when null)
 ```
 
 Secrets (`ANTHROPIC_API_KEY`, `FERRY_OPENAI_KEY`, `FERRY_GOOGLE_AI_KEY`) are credentials only — they do not participate in model or limit configuration.
+
+---
+
+## Execution paths & accepted divergences (experimental)
+
+> **Experimental — not yet available.** The `claude-code-action` execution path is the target architecture of [ADR-0006](./adr/0006-claude-code-action-execution-path.md); its implementation is tracked under epic [#299](https://github.com/big-emotion/ferry/issues/299) (#300–#306) and is **not shipped yet**. Until those land, **every consumer runs the bundled-script path** and none of the divergences below apply. This section documents the behavioral differences **up front** so operators can decide before opting in.
+
+Ferry's four agents (Refiner, Developer, Reviewer, Iterator) run via one of two execution paths behind the same `repository_dispatch` boundary:
+
+| Path                  | Reasoning core                          | Providers            | Per-run EUR cap | Auth                                   |
+| --------------------- | --------------------------------------- | -------------------- | --------------- | -------------------------------------- |
+| **Bundled script**    | Ferry's deterministic agent loop        | Anthropic / OpenAI / Google | Enforced  | `ANTHROPIC_API_KEY` / provider keys    |
+| **`claude-code-action`** | `anthropics/claude-code-action@v1` loop | Anthropic only       | **Not enforced** | `CLAUDE_CODE_OAUTH_TOKEN` (subscription) |
+
+The Ferry **contract** is identical on both paths — envelope validation, structured-output schema, fingerprinted audit comments ([ADR-0004](./adr/0004-idempotency-via-comment-markers.md)), the FR18/FR24/FR28 transitions, idempotency markers, prompts (`buildSystem(<role>)` + `prompts/<agent>.extra.md`), and **every operational edge case** (`ferry:dry-run`, `ferry:read-only`, `ferry:skip/*`, `blocked`, `already_satisfied`, iteration cap, merge conflicts, no-PR / race guard, `LabelConflictError`, CI red/pending, resume branch, prompt-injection fences) behave identically, because they live in deterministic workflow steps that bracket the LLM, never in the LLM itself. The full reuse/parity classification is in [decisions/0002](./decisions/0002-claude-code-path-parity-analysis.md) (§B–§D).
+
+The differences below are the **only** observable divergences. They are **accepted by design** ([ADR-0006](./adr/0006-claude-code-action-execution-path.md)) — the `claude-code-action` path deliberately trades the per-run EUR ceiling for the subscription-billing + free-agent-loop profile — and apply **only** to tickets running on the `claude-code-action` path.
+
+### 1. `ferry:spend-cap` does not fire (no per-run EUR cap)
+
+On the bundled-script path, `ferry:budget/<eur>` (and `limits.max_cost_eur_per_run`) is enforced mid-run: the agent checks accumulated EUR before each LLM call, throws a spend-cap error, applies `ferry:spend-cap`, and posts an audit comment (see [Budget, iteration, and token caps](#budget-iteration-and-token-caps)).
+
+On the `claude-code-action` path **none of this happens**. The action's agent loop cannot raise a mid-loop EUR error, so:
+
+- `ferry:budget/<eur>` and `limits.max_cost_eur_per_run` have **no effect**.
+- The `ferry:spend-cap` label and its audit comment **never appear**.
+- A run is bounded only by `--max-turns` and the job `timeout-minutes`, not by EUR.
+
+**Rationale:** under Claude subscription billing there is no per-run EUR figure to enforce against, so a mid-loop EUR ceiling is conceptually moot — but it is observably different, so it is called out rather than silently dropped. Use `ferry:max-iterations/<n>` and the job timeout to bound cost on this path.
+
+### 2. Daily cost-governance auto-pause is weakened
+
+`ferry:paused` is applied automatically by the daily cost-governance check when monthly **EUR** spend reaches 50% of the configured cap (see [Safety labels](#safety-labels)). This backstop depends on a measurable EUR figure.
+
+Under a Claude subscription token, monthly EUR spend is **not measurable**, so on the `claude-code-action` path this auto-pause backstop is **weakened**: it cannot trip from subscription-path spend. Tickets running on the bundled-script path are still governed normally. Operators relying on the 50% auto-pause as a hard safety net should keep cost-sensitive work on the bundled-script path or set an explicit subscription-tier limit with Anthropic directly.
+
+### 3. EUR-cost telemetry is unknown on the subscription path
+
+`cost_eur` in the audit log is derived from token counts × provider list price. The subscription token returns no per-call EUR price, so for `claude-code-action` runs the cost field is **unknown** (recorded as `0` / null). Downstream tooling is affected: see [COST.md → Cost telemetry on the claude-code path](./COST.md#cost-telemetry-on-the-claude-code-execution-path-experimental).
+
+### 4. No-auto-merge runtime enforcement uses a different mechanism
+
+The bundled Developer path enforces the no-auto-merge invariant ([ADR-0005](./adr/0005-no-auto-merge-invariant.md)) with a runtime regex deny-list inside the agent loop (`src/agents/developer/sandbox.ts`). That deny-list does **not** wrap the action's separate loop. On the `claude-code-action` path the invariant is re-established by a restricted `--allowedTools` allowlist (no `gh pr merge`, no `git push` to protected refs) plus a least-privilege `GITHUB_TOKEN`.
+
+**Rationale & risk:** the allowlist + token scoping is **weaker defense-in-depth** than the runtime deny-list — a misconfigured allowlist re-opens the auto-merge risk. The invariant itself (Ferry never merges) is preserved; only the enforcement mechanism differs. GitHub branch protection and CODEOWNERS remain the authoritative merge gate on both paths.
+
+### 5. Secret-scan-before-push is a deterministic gate, not an in-loop hook
+
+The bundled loop runs an in-loop `makeSecretScan` callback before pushing. The action has no equivalent hook; on the `claude-code-action` path the scan is re-engineered as a **deterministic gate that runs before the push step**. Observable outcome (a push carrying a detected secret is blocked) is preserved; the mechanism differs.
+
+> **Summary:** the `claude-code-action` path preserves the entire observable Ferry contract and every operational edge case **except** the five points above, all of which are cost/safety-budget concerns. Full analysis: [decisions/0002 → Accepted divergences](./decisions/0002-claude-code-path-parity-analysis.md#accepted-divergences-the-set-aside-list).
 
 ---
 

--- a/docs/COST.md
+++ b/docs/COST.md
@@ -2,7 +2,7 @@
 
 `ferry-cost-report` is an on-demand CLI that reads your local `ferry-audit.jsonl` file and produces a spend breakdown across phases, models, tickets, and days.
 
-> **Data quality note:** Cost figures depend on `cost_eur` being non-zero in your audit log. If you see `€0.00` everywhere, see [#251](https://github.com/big-emotion/ferry/issues/251) — that issue tracks accurate cost-field population in the audit log writer.
+> **Data quality note:** Cost figures depend on `cost_eur` being non-zero in your audit log. If you see `€0.00` everywhere, see [#251](https://github.com/big-emotion/ferry/issues/251) — that issue tracks accurate cost-field population in the audit log writer. A separate, **expected** zero-cost case is the experimental `claude-code-action` execution path — see [Cost telemetry on the claude-code execution path](#cost-telemetry-on-the-claude-code-execution-path-experimental).
 
 ---
 
@@ -166,6 +166,25 @@ npx -p @big-emotion/ferry ferry-cost-reconcile \
 ### Provider support
 
 Today only `--provider anthropic` is implemented. OpenAI and Google billing exports follow different CSV schemas — follow-up issues will add them.
+
+---
+
+## Cost telemetry on the claude-code execution path (experimental)
+
+> **Experimental — not yet available.** The `claude-code-action` execution path is the target architecture of [ADR-0006](./adr/0006-claude-code-action-execution-path.md), tracked under epic [#299](https://github.com/big-emotion/ferry/issues/299). Until it ships, all runs use the bundled-script path and the EUR figures in this document are accurate as described. This note documents the **accepted, by-design** cost-telemetry divergence so operators can decide before opting in.
+
+Ferry's `cost_eur` audit field is computed from token counts × the provider's published list price (see `pricing.ts`). The bundled-script path authenticates with a metered API key, so this figure is accurate. The `claude-code-action` path authenticates **exclusively** with a Claude **subscription** token (`CLAUDE_CODE_OAUTH_TOKEN`), under which there is **no per-call EUR price** — usage is flat-rate against the subscription, not metered.
+
+Consequence: for runs executed on the `claude-code-action` path, **`cost_eur` is unknown** and recorded as `0` / null. This is **expected**, not the bug tracked in [#251](https://github.com/big-emotion/ferry/issues/251) (which is about the metered path under-populating the field). Downstream tooling behaves as follows on subscription-path runs:
+
+| Tool                    | Behavior on `claude-code-action` runs                                                                                                                  |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ferry-cost-report`     | Token counts are still aggregated, but `Cost (EUR)` columns show `€0.00` for these runs. Phase/model/ticket token breakdowns remain meaningful.        |
+| `ferry-cost-reconcile`  | There is no subscription billing CSV to diff against (the Anthropic Console export covers metered API usage only). Subscription-path runs cannot be reconciled and surface as unmatched Ferry rows. |
+| `ferry-cost-advice`     | EUR-saving estimates are skipped for these runs; token-ratio and cache-hit heuristics still apply where token data is present.                          |
+| Daily cost-governance   | The 50%-of-monthly-cap auto-pause (`ferry:paused`) backstop is **weakened** — monthly EUR spend is not measurable on a subscription token, so subscription-path spend cannot trip it. Bundled-script-path tickets are still governed normally. |
+
+**Rationale:** this is the deliberate trade in [ADR-0006](./adr/0006-claude-code-action-execution-path.md) — the `claude-code-action` path swaps per-run EUR metering for the subscription-billing + free-agent-loop profile. To keep cost telemetry and the auto-pause backstop fully effective, keep cost-sensitive work on the bundled-script path (the conditional default whenever OpenAI/Google is configured, and selectable at install time for Anthropic-only consumers). Full analysis: [decisions/0002 → Accepted divergences](./decisions/0002-claude-code-path-parity-analysis.md#accepted-divergences-the-set-aside-list).
 
 ---
 

--- a/docs/adr/0006-claude-code-action-execution-path.md
+++ b/docs/adr/0006-claude-code-action-execution-path.md
@@ -1,0 +1,101 @@
+# 0006 — claude-code-action as the conditional default execution path
+
+**Status:** Accepted (target architecture — not yet implemented)  
+**Date:** 2026-05-19  
+**See also:** [0003](./0003-anthropic-messages-vs-agent-sdk.md) (this is a third execution option beyond raw Messages API and Agent SDK), [0004](./0004-idempotency-via-comment-markers.md) (the audit-marker invariant this ADR must preserve), [0005](./0005-no-auto-merge-invariant.md) (the no-auto-merge invariant whose runtime enforcement does **not** automatically extend to this path)
+
+## Context
+
+Ferry's four agents (Refiner, Developer, Reviewer, Iterator) run today via a single execution path: the bundled script `node agent.js run --role <role>`, invoked by the per-agent composite actions, calling the raw provider SDKs through `src/lib/llm/`. This path is multi-provider (Anthropic / OpenAI / Google), has a deterministic agent loop, enforces structured output schemas, validates the `EventEnvelopeV1` payload, emits idempotent fingerprinted audit comments, and is bounded by per-run cost governance.
+
+`anthropics/claude-code-action@v1` already exists in the repository (`.github/workflows/claude.yml`) but only as an unrelated repo-development assistant triggered by `@claude` mentions — it is not part of the pipeline.
+
+Two forces motivate adding it to the pipeline:
+
+1. **A different budget/autonomy profile.** Some tickets — especially those that have already gone through several Refiner/Developer/Reviewer/Iterator round-trips — benefit from letting the LLM act more freely (full Claude Code agent loop with broad tooling) rather than the tightly-scoped deterministic script. This is a deliberately different cost profile.
+2. **Lower maintenance for the reasoning core.** The bundled script's value is its _contract_ (envelope, schema, audit, cost), not its agent loop; offloading the loop to a maintained action is attractive when the contract can still be guaranteed.
+
+Hard constraints, established by analysis:
+
+- `claude-code-action` is **Anthropic-only** and an **opaque agent loop**. It cannot itself guarantee `EventEnvelopeV1` validation, structured output schema, fingerprinted audit emission (the Reconciler depends on these — ADR-0004), per-run EUR cost ceiling, or multi-provider routing.
+- The Developer sandbox deny-list that enforces the no-auto-merge invariant (ADR-0005) lives in `src/agents/developer/sandbox.ts` and runs **inside the bundled loop**. It does **not** wrap `claude-code-action`'s separate agent loop.
+- `claude-code-action@v1` supports an automation mode (explicit `prompt:` input) on arbitrary events, including `repository_dispatch`.
+
+## Decision
+
+Adopt a **two-tier execution model behind one dispatch boundary**:
+
+1. **`claude-code-action` is the conditional default; the bundled script is the conditional fallback.** The default is resolved deterministically from the consumer's configured providers:
+   - **Anthropic-only consumer** → `claude-code-action` is the default path for all four agents.
+   - **OpenAI or Google configured for any agent** → the bundled script remains the default (the only multi-provider, per-run-EUR-capped path). No silent regression for non-Anthropic consumers.
+
+   The explicit Jira-label override (point 3) takes precedence over this default in **both** cases.
+
+2. **`claude-code-action` replaces only the agent _reasoning core_; the Ferry contract stays in deterministic workflow steps that bracket it.** The four agents' existing prompts are reused verbatim — no prompt rewrite:
+   - System prompt = the resolved output of `buildSystem(<role>)` (bundled `prompts/<agent>.md` composed with the consumer's `prompts/<agent>.extra.md` via `src/lib/prompts/resolve.ts`), passed through `claude_args: --append-system-prompt`.
+   - Initial prompt = the same `initialPrompt` the script builds today (the `<<<UNTRUSTED>>>` ticket block + `SUBTASKS` / review findings / repo tree), passed via the action's `prompt:` input.
+
+   Per-agent input/output parity (what each agent reads, the exact Jira/GitHub side effects, transitions FR18/FR24/FR28, idempotency markers, and the native-tool ↔ Ferry-tool mapping) is the **parity contract** the wrapping steps must satisfy; it is specified in the implementation epic, not duplicated here. The contract stays in deterministic workflow steps that bracket the action:
+
+   ```
+   repository_dispatch
+     → step: AJV validate EventEnvelopeV1 (fail-closed)
+     → step: compute routing decision (deterministic, from envelope + audit history)
+     → claude-code-action  (prompt = injected envelope; Jira via MCP)
+     → step: AJV validate structured agent output (fail-closed)
+     → step: emit fingerprinted audit comment  [ferry:<role>:<run-id>]
+   ```
+
+   Envelope validation, output-schema validation, audit emission, and cost governance are **never delegated to the LLM** — they are non-LLM steps.
+
+3. **Routing policy is deterministic, with an explicit Jira-label override taking precedence over the automatic heuristic.** A workflow step computes the route from the validated envelope (which carries the ticket's Jira labels) plus the audit-comment history (round-trip count). Resolution order, evaluated deterministically:
+   1. **Explicit Jira label** — `ferry:claude-code` forces the `claude-code-action` path; `ferry:no-claude-code` forces the bundled script. Names follow Ferry's existing `ferry:`-prefixed label convention and are resolved through the same `resolveTicketOverrides` mechanism as other ticket overrides. Conflicting labels resolve to the safe path (bundled script).
+   2. **Automatic heuristic** (only if no explicit label) — escalate to `claude-code-action` when _role ∈ {developer, iterator}_ **AND** _prior Ferry round-trips ≥ N_.
+   3. **Conditional default** — per point 1: `claude-code-action` for Anthropic-only consumers, bundled script otherwise.
+
+   The `ferry:claude-code` label still requires the consumer to have the path enabled (Anthropic creds + tool allowlist configured); it _selects_ the path, it does not provision credentials. The explicit label changes routing only — it never overrides the hard invariants: the cost-governance auto-pause (`ferry:paused`) and the no-auto-merge allowlist apply regardless of how the path was chosen. The resolved route **and the reason** (`label` / `heuristic` / `default`) are recorded in the audit comment so the Reconciler observes it.
+
+4. **Cost governance stays at the dispatch/label layer, not inside the action.** `claude-code-action` is bounded crudely by `--max-turns` plus the job `timeout-minutes`; eligibility is gated behind the existing daily cost-governance auto-pause (`ferry:paused` label). The action never receives a per-run EUR cap because it cannot enforce one.
+
+5. **The no-auto-merge invariant (ADR-0005) must be re-established for this path.** Because the bundled sandbox deny-list does not apply, the `claude-code-action` step uses a restricted `--allowedTools` allowlist (no `gh pr merge`, no `git push` to protected refs) and a least-privilege `GITHUB_TOKEN`. This is a precondition of adopting the path, not a follow-up.
+
+6. **The execution path is chosen at install time, and the claude-code path requires `CLAUDE_CODE_OAUTH_TOKEN`.** This supersedes the earlier "reuse `ANTHROPIC_API_KEY` / zero new step" provision.
+   - **`ferry-init` offers an explicit path choice.** The wizard asks which execution path to install: **(a) bundled script** (default for non-Anthropic, multi-provider, per-run EUR cap) or **(b) `claude-code-action`** (Anthropic subscription, free agent loop). A consumer can pick either at install time; the choice is recorded in `ferry.config.json` and materialized in the generated workflows. The Jira-label override (point 3) still lets individual tickets switch path afterward.
+   - **The claude-code path authenticates _exclusively_ with `CLAUDE_CODE_OAUTH_TOKEN`.** It must **never** use `ANTHROPIC_API_KEY` (`claude_code_oauth_token:` only, never `anthropic_api_key:`). The token is obtained via `claude setup-token` (requires a Claude Pro/Max subscription) and stored as a new repo secret. This is a **required** install element when path (b) is chosen — onboarding is therefore **not** zero-friction for that path.
+   - GitHub write access still reuses the existing GitHub App installation token (`github_token:`); Jira still uses the existing `FERRY_JIRA_*` secrets via wrapper steps / MCP. The only new credential is `CLAUDE_CODE_OAUTH_TOKEN`.
+
+7. **The conditional default applies on upgrades too, gated by a version-delta manifest — never a silent flip.** It is not limited to fresh `ferry-init`. `ferry-update` stays **credential-silent for code-only updates** (pre-update credentials keep working); it prompts **only when the crossed `MIGRATIONS.md` `## <from> → <to>` section declares a newly-required secret** (a new declarative `requires-secrets:` line, parallel to the existing `forge:` line), and **only for the ones missing** (diffed against `gh secret list`). For the claude-code transition the entry declares `CLAUDE_CODE_OAUTH_TOKEN`: already set → auto-adopts; missing + interactive → prompts only for that secret then adopts; missing + non-interactive → does not flip, stays on script (zero breakage), prints a mandatory follow-up. An explicit `execution_path: script` is always respected. The path-select branch ships **inert** until the manifest-declared secrets are satisfied. The "never re-prompts for credentials" property is thus **preserved for ordinary updates and merely narrowed**, via a general mechanism reusable by any future release that adds a required secret — not a one-off. Rollback (set `execution_path: script`, re-run `ferry-update`) is symmetric and cannot break a consumer. See [decisions/0002 §G](../decisions/0002-claude-code-path-parity-analysis.md).
+
+See [decisions/0002](../decisions/0002-claude-code-path-parity-analysis.md) for the full install→operate→uninstall reuse/set-aside analysis.
+
+## Consequences
+
+**Positive:**
+
+- Operators gain an explicit, bounded "let the LLM act freely" mode for high-iteration tickets without abandoning Ferry's guarantees on the default path.
+- The Ferry contract (envelope, schema, audit, cost) is preserved by deterministic steps regardless of which reasoning core runs — the Reconciler and downstream agents are unaffected.
+- The reasoning-core maintenance burden for the opt-in path shifts to a maintained action.
+- The execution path is an explicit, recorded install-time choice (script vs claude-code), not an implicit behavior — consumers opt in deliberately and can still switch per-ticket via label.
+
+**Negative:**
+
+- Two execution paths to test and document; the wrapping steps (AJV in/out, audit emission, routing) are new deterministic code that must be unit-tested (TDD) before the path is enabled.
+- The `claude-code-action` path is Anthropic-only — which is why the default is _conditional_: it is the default only for Anthropic-only consumers, and the script stays default when OpenAI/Google is configured so multi-provider consumers see no regression.
+- ADR-0005 enforcement on this path relies on tool allowlisting + token scoping, which is weaker defense-in-depth than the runtime regex deny-list; a misconfigured allowlist re-opens the auto-merge risk.
+- Per-run EUR cost is not enforceable on this path — only coarse turn/time bounds plus the daily auto-pause backstop.
+- The claude-code path is not zero-friction: it requires a Claude subscription + `claude setup-token` + a new `CLAUDE_CODE_OAUTH_TOKEN` secret. A fresh consumer must explicitly choose and provision it at install time.
+- `ferry-update` gains a manifest-driven credential gate (new `requires-secrets:` line in `MIGRATIONS.md`). This narrows — does not break — the "never re-prompts for credentials" property: silent for code-only updates, prompts only for manifest-declared missing secrets. Non-interactive upgrades still cannot self-adopt the path and require a follow-up interactive run.
+
+## Alternatives Considered
+
+**`claude-code-action` as the unconditional global default** — rejected. It would silently drop multi-provider consumers (Anthropic-only) and remove the per-run EUR ceiling for everyone. **A _conditional_ default was adopted instead**: `claude-code-action` defaults only for Anthropic-only consumers; the script stays default whenever OpenAI/Google is configured, so non-Anthropic consumers keep multi-provider support and the per-run EUR cap with no silent regression.
+
+**Keep the script as the unconditional default (claude-code-action opt-in only)** — superseded by this revision. The original ADR-0006 decision; reversed because for Anthropic-only consumers the maintained-loop + free-action profile is the preferred default, and the conditional rule removes the regression that motivated the original rejection.
+
+**Replace the bundled script entirely** — rejected. This discards the multi-provider loop, the runtime no-auto-merge deny-list (ADR-0005), and per-run cost governance in exchange for one maintained loop — a net loss of guarantees Ferry exists to provide.
+
+**Delegate envelope validation / audit emission to the LLM inside the action's prompt** — rejected. ADR-0004 makes audit markers a load-bearing idempotency mechanism for the Reconciler; an LLM that "usually" emits them produces non-deterministic re-trigger loops. These must be deterministic steps.
+
+**Manual per-ticket selection only (Jira label, no automatic heuristic)** — evaluated, kept as one tier rather than the whole policy. The explicit Jira label is the right primitive for an operator deciding "this specific ticket should run free", and it takes precedence. But a label alone gives no principled answer to _when_ to escalate by default; the automatic heuristic (round-trip count + role) is what makes "let the LLM act freely on already-iterated tickets" a reproducible rule rather than requiring a human to label every ticket. Both tiers are kept, label first.
+
+**Automatic heuristic only (no manual label)** — rejected. Operators need a per-ticket escape hatch in both directions (force claude-code-action, or force the script) without changing global config; the Jira label provides it deterministically and is observable in the ticket itself.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,13 +4,14 @@ This directory contains Architecture Decision Records (ADRs) for the Ferry proje
 
 ## Index
 
-| #                                                 | Title                                        | Status   |
-| ------------------------------------------------- | -------------------------------------------- | -------- |
-| [0001](./0001-three-fr-auto-transitions.md)       | Three FR auto-transitions (FR18, FR24, FR28) | Accepted |
-| [0002](./0002-ferry-bundles-committed.md)         | Ferry bundles committed to the repository    | Accepted |
-| [0003](./0003-anthropic-messages-vs-agent-sdk.md) | Anthropic Messages API over Agent SDK        | Accepted |
-| [0004](./0004-idempotency-via-comment-markers.md) | Idempotency via comment markers              | Accepted |
-| [0005](./0005-no-auto-merge-invariant.md)         | No auto-merge invariant                      | Accepted |
+| #                                                   | Title                                                        | Status   |
+| --------------------------------------------------- | ------------------------------------------------------------ | -------- |
+| [0001](./0001-three-fr-auto-transitions.md)         | Three FR auto-transitions (FR18, FR24, FR28)                 | Accepted |
+| [0002](./0002-ferry-bundles-committed.md)           | Ferry bundles committed to the repository                    | Accepted |
+| [0003](./0003-anthropic-messages-vs-agent-sdk.md)   | Anthropic Messages API over Agent SDK                        | Accepted |
+| [0004](./0004-idempotency-via-comment-markers.md)   | Idempotency via comment markers                              | Accepted |
+| [0005](./0005-no-auto-merge-invariant.md)           | No auto-merge invariant                                      | Accepted |
+| [0006](./0006-claude-code-action-execution-path.md) | claude-code-action as the conditional default execution path | Accepted |
 
 ## ADR Template
 

--- a/docs/decisions/0002-claude-code-path-parity-analysis.md
+++ b/docs/decisions/0002-claude-code-path-parity-analysis.md
@@ -1,0 +1,181 @@
+# 0002 — claude-code-action Path: Full-Lifecycle Parity Analysis
+
+**Status:** Accepted (analysis backing [ADR-0006](../adr/0006-claude-code-action-execution-path.md))
+**Date:** 2026-05-19
+**Relates to:** [ADR-0006](../adr/0006-claude-code-action-execution-path.md) (the decision), [ADR-0004](../adr/0004-idempotency-via-comment-markers.md), [ADR-0005](../adr/0005-no-auto-merge-invariant.md)
+
+## Goal
+
+Establish whether a consumer's experience of Ferry-on-Anthropic is **near-identical** whether agents
+run via the bundled script or via `claude-code-action`, across the **whole lifecycle**: install →
+operate (use cases + edge cases) → maintain → uninstall. Classify every Ferry element as reused,
+wrapped, adapted, set aside, or new.
+
+**Hard constraint (caller directive):** the `claude-code-action` path authenticates **exclusively
+with `CLAUDE_CODE_OAUTH_TOKEN`** (Claude subscription, obtained via `claude setup-token`). It must
+**never** use `ANTHROPIC_API_KEY`. This supersedes ADR-0006 point 6's "reuse ANTHROPIC_API_KEY /
+zero new step" provision: the OAuth token is now a **required** install element for the path.
+
+Legend: ✅ reused as-is · 🔁 reused but moved to a deterministic wrapper step · 🟡 adapted (different
+mechanism, identical observable outcome) · ⛔ set aside (does not apply) · ➕ new (claude-code path only)
+
+## A. Installation (`ferry-init` → consumer repo)
+
+| Element                                                         | Class | Notes                                                                                                                                                                                                                                                                                     |
+| --------------------------------------------------------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GitHub App auth (`FERRY_APP_ID`, `FERRY_PRIVATE_KEY`)           | ✅    | Installation token passed to `claude-code-action` `github_token:`.                                                                                                                                                                                                                        |
+| Jira secrets (`FERRY_JIRA_BASE_URL/EMAIL/API_TOKEN`)            | ✅    | Used by wrapper steps / Jira MCP.                                                                                                                                                                                                                                                         |
+| Transition IDs (`FERRY_REVIEW/ITER/APPROVE_TRANSITION_ID`)      | ✅    | Read by the post-step that performs FR18/24/28.                                                                                                                                                                                                                                           |
+| `FERRY_AUDIT_ISSUE` variable, `ferry.config.json`               | ✅    | Path-agnostic; read by wrapper steps.                                                                                                                                                                                                                                                     |
+| 4 Jira automation rules → `repository_dispatch`                 | ✅    | Same trigger; unchanged.                                                                                                                                                                                                                                                                  |
+| `gate-envelope` job (`ferry-envelope-validate` composite)       | ✅    | Runs unchanged before either path.                                                                                                                                                                                                                                                        |
+| `ANTHROPIC_API_KEY`                                             | ⛔    | **Forbidden** on the claude-code path (caller directive). Still used by the script path / non-Anthropic consumers.                                                                                                                                                                        |
+| `CLAUDE_CODE_OAUTH_TOKEN` secret                                | ➕    | **Required** new secret. Obtained via `claude setup-token` (needs a Claude Pro/Max subscription). New mandatory `ferry-init` step for the claude-code path.                                                                                                                               |
+| Install-time path choice (wizard)                               | ➕    | `ferry-init` asks which path to install — **(a) bundled script** or **(b) claude-code-action**. The choice is recorded in `ferry.config.json` and materialized in the generated workflows. Either path is selectable at install; the Jira label still switches path per-ticket afterward. |
+| Consumer workflow stubs (`ferry-refine/dev/review/iterate.yml`) | 🟡    | A path-select branch (or a sibling `run-agent-cc` job) invokes `claude-code-action` instead of `ferry-run-<role>`; `gate-envelope` job reused verbatim.                                                                                                                                   |
+| gitleaks install / secret scan                                  | 🔁    | The in-loop `makeSecretScan` callback has no equivalent inside the action; becomes a **deterministic gate before push** (see §D).                                                                                                                                                         |
+
+**Net install delta:** +1 wizard question (choose path: script vs claude-code), and **when the
+claude-code path is chosen**: +1 required secret (`CLAUDE_CODE_OAUTH_TOKEN`, subscription via
+`claude setup-token`) and +1 workflow path-select branch. The script path is unchanged. Everything
+else is reused.
+
+## B. Operation — the contract layer
+
+| Element                                                                                                   | Class | Notes                                                                                                                                                                                                                       |
+| --------------------------------------------------------------------------------------------------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `repository_dispatch` + `EventEnvelopeV1` + envelope-validate                                             | ✅    | Identical entry.                                                                                                                                                                                                            |
+| `resolveTicketOverrides` (dry-run/skip/read-only/no-auto-transition/base/target/thinking/rubric/max-iter) | 🔁    | Runs as a deterministic pre-step around the action instead of in-process.                                                                                                                                                   |
+| `model` / `provider` overrides (label/config)                                                             | 🟡    | `provider` is meaningless (Anthropic-only); `model` maps to `claude_args --model` if supported, else fixed by the subscription.                                                                                             |
+| Idempotency markers (`byEventId` / `byPrHeadSha`, `checkIdempotencyMarker`)                               | 🔁    | Pre-step skip check + post-step marker emission.                                                                                                                                                                            |
+| Audit comment `[ferry:<role>:…]` (ADR-0004)                                                               | 🔁    | Deterministic post-step — **never** the LLM. Reconciler depends on it.                                                                                                                                                      |
+| Transitions FR18 / FR24 / FR28                                                                            | 🔁    | Post-step using the transition-ID secrets.                                                                                                                                                                                  |
+| Per-run EUR cap (`maxCostEur` in agent-loop)                                                              | ⛔    | No mid-loop EUR enforcement in the action. Replaced by `--max-turns` + job `timeout-minutes`. Under subscription billing, per-run EUR is conceptually moot — but the **`ferry:spend-cap` edge case loses parity** (see §D). |
+| `writeStepSummary` / `appendOutput` (cost telemetry)                                                      | 🟡    | Action emits its own usage; wrapper maps it to the step summary. EUR cost is unknown under subscription billing.                                                                                                            |
+| Reconciler (`src/reconciler`)                                                                             | ✅    | Operates on audit comments + Jira columns — path-agnostic, provided the wrapper emits markers (it does).                                                                                                                    |
+| Daily cost-governance auto-pause (`ferry:paused` at 50% monthly)                                          | 🟡    | Monthly **EUR** spend is not measurable under a subscription token → this backstop is **weakened** on the claude-code path.                                                                                                 |
+| Prompts: `buildSystem(<role>)` + `prompts/<agent>.extra.md` resolver                                      | ✅    | Reused **verbatim** via `claude_args --append-system-prompt`. No rewrite.                                                                                                                                                   |
+| `initialPrompt` builders (ticket block, SUBTASKS, findings, repo tree)                                    | ✅    | Reused verbatim via the action `prompt:` input.                                                                                                                                                                             |
+| `delimitUntrusted` injection fences                                                                       | ✅    | Part of `initialPrompt`; same prompt-injection posture.                                                                                                                                                                     |
+
+## C. Per-agent reasoning core
+
+| Element                                                                                                               | Class | Notes                                                                                                                                                             |
+| --------------------------------------------------------------------------------------------------------------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Refiner / Reviewer (read + structured verdict)                                                                        | 🔁    | LLM emits the same JSON contract; all Jira/PR writes, labels, FR24, audit = deterministic post-step.                                                              |
+| Developer / Iterator code tools (`bash/read_file/write_file/str_replace/list_dir/search_files/move_file/delete_file`) | 🟡    | Mapped to native `Bash/Read/Write/Edit/Glob/Grep`.                                                                                                                |
+| `spawn_subagent`                                                                                                      | 🟡    | Mapped to the action's sub-agent/Task facility, or set aside (single loop).                                                                                       |
+| `done` / `commit_progress` / `finish_review`                                                                          | 🔁    | Replaced by a final structured-JSON artifact the LLM writes; post-step parses it and applies outcomes — same result as the script.                                |
+| `outcome-guard` (`assertDev/IterOutputContract`)                                                                      | 🔁    | Post-step assertion before the terminal comment.                                                                                                                  |
+| Reviewer CI gate (`gateCi`)                                                                                           | 🔁    | Pre-step; blocks a red/pending CI exactly as today.                                                                                                               |
+| Reviewer rubric (`applyRubricToPrompt`)                                                                               | ✅    | Folded into the built system prompt.                                                                                                                              |
+| Sandbox no-merge deny-list (ADR-0005, `developer/sandbox.ts`)                                                         | ⛔    | Does not wrap the action's loop.                                                                                                                                  |
+| No-merge enforcement for the action                                                                                   | ➕    | `--allowedTools` allowlist (no `gh pr merge`, no push to protected refs) + least-privilege token (ADR-0006 §5). Weaker defense-in-depth than the regex deny-list. |
+| MCP pool (`loadMcpServers` + `filterMcpServers` by capabilities)                                                      | 🟡    | Capability filtering becomes a pre-step that emits `--mcp-config`; consumer MCP servers passed through for parity.                                                |
+
+## D. Edge-case parity matrix
+
+| Edge case                                                | Parity?             | Mechanism                                                                                                                                                                      |
+| -------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ferry:dry-run` / `FERRY_DRY_RUN`                        | ✅ 🔁               | Pre-step detects; post-step suppresses all external writes. (LLM turn still consumed.)                                                                                         |
+| `ferry:read-only`                                        | ✅ 🔁               | Pre-step short-circuits — the action is never invoked.                                                                                                                         |
+| `ferry:skip/<phase>`                                     | ✅ 🔁               | Pre-step no-op + standard comment.                                                                                                                                             |
+| Outcome `blocked`                                        | ✅ 🔁               | Post-step reads structured outcome → `ferry:blocked` + comment + exit 1 (output-schema validation is fail-closed).                                                             |
+| Outcome `already_satisfied`                              | ✅ 🔁               | Post-step writes verification note + verify PR — same as script.                                                                                                               |
+| Iteration cap (`max_iterations`, `countPriorIterations`) | ✅ 🔁               | Pre-step counts prior iterations from audit comments.                                                                                                                          |
+| Agent-loop iteration cap (`max_agent_iterations`)        | 🟡                  | `--max-turns` ≈ equivalent; `ferry:max-iterations/<n>` "success-of-intent" nuance differs slightly.                                                                            |
+| Merge conflicts (iterator/reviewer)                      | ✅                  | Detected in a pre-step; resolved by the LLM via git, same as the script.                                                                                                       |
+| No PR / no review comment / reviewer-not-visible race    | ✅ 🔁               | Pre-step guards + defer logic, path-agnostic.                                                                                                                                  |
+| `LabelConflictError`                                     | ✅ 🔁               | Pre-step `resolveTicketOverrides`; same conflict comment.                                                                                                                      |
+| CI red / pending (reviewer)                              | ✅ 🔁               | Pre-step `gateCi`; same comments + FR24.                                                                                                                                       |
+| Resume branch / existing-PR context                      | ✅                  | Pre-step builds resume context into the prompt — same as script.                                                                                                               |
+| Prompt injection (untrusted ticket content)              | ✅                  | `delimitUntrusted` fences + system instruction; same posture.                                                                                                                  |
+| **`ferry:spend-cap` (mid-run EUR budget exceeded)**      | ⛔ **no parity**    | The action cannot raise a mid-loop EUR `FerryError`; the `ferry:spend-cap` label + comment will not appear. Bounded only by `--max-turns`/timeout. Accepted divergence.        |
+| **Secret scan before push**                              | ➕ must re-engineer | No in-loop `secretScan` hook. Either: gate the push through a wrapper that scans first, or accept the action's own pre-push controls. Must be solved before enabling the path. |
+
+## E. Maintenance
+
+| Element             | Class | Notes                                                                                                                |
+| ------------------- | ----- | -------------------------------------------------------------------------------------------------------------------- |
+| `ferry-doctor`      | 🟡 ➕ | Existing probes reused; **add** a `CLAUDE_CODE_OAUTH_TOKEN` presence/validity probe and a path-selection diagnostic. |
+| `ferry-update`      | ✅    | Version/ref bump and `MIGRATIONS.md` handling cover the new wrapper workflow unchanged.                              |
+| `ferry.config.json` | 🟡    | Existing keys reused; **add** path-enable + routing-threshold (`N`) + label-name keys.                               |
+
+## F. Destruction (`ferry-uninstall`)
+
+| Element                                            | Class | Notes                                                                                               |
+| -------------------------------------------------- | ----- | --------------------------------------------------------------------------------------------------- |
+| Remove `workflows/ferry-*.yml`, secrets, variables | ✅    | Mechanism reused.                                                                                   |
+| Remove `CLAUDE_CODE_OAUTH_TOKEN`                   | ➕    | Add the new secret to the uninstall removal list, otherwise a stale subscription token is orphaned. |
+
+## G. Existing consumers (migration via `ferry-update`)
+
+`ferry-update` re-renders `.github/workflows/ferry-*.yml` from templates, adds missing workflow
+files, bumps pinned `@vX` refs, and prints the relevant `MIGRATIONS.md` section as
+"Manual follow-ups required". Crucially, it **never re-prompts for credentials**.
+
+**Design rule: a version-delta manifest decides whether `ferry-update` prompts for credentials.**
+`ferry-update` stays **credential-silent for code-only updates** — the pre-update credentials keep
+working, so it must not re-prompt. It becomes credential-aware **only when the version transition
+being crossed declares a newly-required secret**, and then prompts **only for the ones missing**.
+
+The manifest is the existing `MIGRATIONS.md`: each `## <from> → <to>` section gains an optional
+declarative line — parallel to the existing `forge:` line — e.g.:
+
+```
+## v0.X.x → v0.Y.0
+requires-secrets: CLAUDE_CODE_OAUTH_TOKEN
+```
+
+`ferry-update` already parses these sections and already has `listExistingSecrets()` (from
+`ferry-init`'s secret step). The added logic is small:
+
+1. For the crossed range, collect `requires-secrets:` (empty for code-only releases → **silent**, property preserved).
+2. Diff declared-required against `gh secret list` → compute the **missing** set.
+3. If non-empty: interactive → run the targeted secret step **only for the missing secrets** (e.g. guide `claude setup-token` → `gh secret set CLAUDE_CODE_OAUTH_TOKEN`); non-interactive/CI → do not flip, keep the script path (zero breakage), print a mandatory "re-run `ferry-init`" / re-run interactively follow-up.
+4. Apply `execution_path: claude-code` (conditional default) only once the required secrets are present.
+
+Resulting migration matrix for an Anthropic-only existing consumer:
+
+| Situation on `ferry-update`                          | Outcome                                                            |
+| ---------------------------------------------------- | ------------------------------------------------------------------ |
+| Crossed range has no `requires-secrets:` (code-only) | **Silent** — no prompt, credentials untouched (property preserved) |
+| Declares `CLAUDE_CODE_OAUTH_TOKEN`, already set      | Auto-adopts claude-code path (conditional default applied)         |
+| Declares it, missing, interactive                    | Prompts **only for the missing** secret → then adopts              |
+| Declares it, missing, non-interactive                | Stays on script + mandatory follow-up                              |
+| `execution_path: script` explicitly set              | Respected — never overridden                                       |
+
+The path-select branch ships **inert** in re-rendered workflows until `execution_path` resolves to
+claude-code, so the upgrade is a no-op until the manifest-declared secrets are satisfied.
+
+**No trade-off:** the "never re-prompts for credentials" property is **preserved for ordinary code
+updates** and merely **narrowed** — `ferry-update` prompts only when the version-delta manifest
+declares a new required secret, and only for the missing ones. This is a general mechanism, not a
+one-off for the claude-code path; any future release that introduces a required secret uses the same
+`requires-secrets:` line.
+
+**Rollback** is symmetric and safe: set `execution_path` back to `script` (or remove the key),
+re-run `ferry-update`. The script path needs no new secret, so reverting cannot break a consumer.
+
+## Accepted divergences (the "set aside" list)
+
+Near-parity holds for the **entire observable contract** (Jira/PR/audit/transitions/idempotency and
+every operational edge case) **except** these, which are accepted as non-parity and documented:
+
+1. **Per-run EUR cap + `ferry:spend-cap` edge case** — no mid-loop EUR enforcement; the label/comment
+   path does not fire. Conceptually moot under subscription billing, but observably different.
+2. **Daily cost-governance auto-pause** — monthly EUR spend is not measurable on a subscription
+   token; this safety backstop is weakened on the claude-code path.
+3. **No-auto-merge runtime enforcement (ADR-0005)** — the regex deny-list is set aside; replaced by
+   an `--allowedTools` allowlist + token scoping (weaker defense-in-depth).
+4. **Secret-scan-before-push** — must be re-engineered as a deterministic gate; not free.
+
+## Recommendation
+
+Adopt the path with the classification above. The reuse ratio is high: prompts, envelope, trigger,
+reconciler, transitions, idempotency, and **every edge case except `spend-cap`** are reused as-is or
+wrapped without behavioral change. The four accepted divergences are all **cost/safety-budget**
+concerns — coherent with the deliberate decision (ADR-0006) that the claude-code path trades the
+per-run EUR ceiling for the subscription-billing + free-agent-loop profile. The `CLAUDE_CODE_OAUTH_TOKEN`
+requirement makes this a non-zero-friction install (one extra required secret + wizard step), which
+ADR-0006 must reflect (point 6 superseded).


### PR DESCRIPTION
## What

Delivers the **accepted-divergence documentation** half of #307 (epic #299, [ADR-0006](https://github.com/big-emotion/ferry/blob/docs/307-cc-accepted-divergences/docs/adr/0006-claude-code-action-execution-path.md)).

- **`docs/CONFIGURATION.md`** — new *"Execution paths & accepted divergences (experimental)"* section: the two execution paths, what is identical (full contract + every operational edge case), and the five by-design divergences with rationale — `ferry:spend-cap` no-parity, weakened daily cost-governance auto-pause, EUR-cost unknown under subscription billing, no-auto-merge mechanism change (ADR-0005 deny-list → allowlist + token scoping), secret-scan-before-push as a deterministic gate. Adds in-context pointers on the `ferry:budget` / `ferry:spend-cap` / `ferry:paused` entries.
- **`docs/COST.md`** — new *"Cost telemetry on the claude-code execution path"* section explaining `cost_eur` is unknown under subscription billing, distinguishing it from the metered-path bug #251, and how `ferry-cost-report` / `-reconcile` / `-advice` / daily governance behave on subscription-path runs.
- **`docs/adr/0006-...md`**, **`docs/decisions/0002-...md`**, **`docs/adr/README.md`** — the rationale documents these notes cite. They were untracked working-tree groundwork with no other committed home; committing them here keeps the divergence docs' cross-references valid.

## Scope — this PR does NOT close #307

#307 has two acceptance criteria. Only the second (divergence docs) is delivered here.

The first — a **cross-path parity test suite** asserting *identical observable behavior across both paths* — is intentionally **deferred**: the `claude-code-action` path itself is not implemented (sub-issues #300–#306 all OPEN/unmerged), so there is no second path to assert parity against yet. Per maintainer direction, the parity suite waits for that implementation. #307 stays open for it.

## Testing

Documentation only. No code paths touched; `typecheck` / `lint` / `format:check` (`src/**`) / `test` / `gitleaks` are unaffected (no CI markdown/link gate exists). All internal anchors and cross-doc links were authored against the section headings introduced here.

## Notes

The path documented here is **experimental and not yet available**; the notes state this prominently so no consumer mistakes it for shipped behavior.