### PR TITLE
feat(cli): ferry-init install-time execution-path choice + CLAUDE_CODE_OAUTH_TOKEN (closes #304)

### DIFF
--- a/docs/adr/0006-claude-code-action-execution-path.md
+++ b/docs/adr/0006-claude-code-action-execution-path.md
@@ -1,0 +1,101 @@
+# 0006 — claude-code-action as the conditional default execution path
+
+**Status:** Accepted (target architecture — not yet implemented)  
+**Date:** 2026-05-19  
+**See also:** [0003](./0003-anthropic-messages-vs-agent-sdk.md) (this is a third execution option beyond raw Messages API and Agent SDK), [0004](./0004-idempotency-via-comment-markers.md) (the audit-marker invariant this ADR must preserve), [0005](./0005-no-auto-merge-invariant.md) (the no-auto-merge invariant whose runtime enforcement does **not** automatically extend to this path)
+
+## Context
+
+Ferry's four agents (Refiner, Developer, Reviewer, Iterator) run today via a single execution path: the bundled script `node agent.js run --role <role>`, invoked by the per-agent composite actions, calling the raw provider SDKs through `src/lib/llm/`. This path is multi-provider (Anthropic / OpenAI / Google), has a deterministic agent loop, enforces structured output schemas, validates the `EventEnvelopeV1` payload, emits idempotent fingerprinted audit comments, and is bounded by per-run cost governance.
+
+`anthropics/claude-code-action@v1` already exists in the repository (`.github/workflows/claude.yml`) but only as an unrelated repo-development assistant triggered by `@claude` mentions — it is not part of the pipeline.
+
+Two forces motivate adding it to the pipeline:
+
+1. **A different budget/autonomy profile.** Some tickets — especially those that have already gone through several Refiner/Developer/Reviewer/Iterator round-trips — benefit from letting the LLM act more freely (full Claude Code agent loop with broad tooling) rather than the tightly-scoped deterministic script. This is a deliberately different cost profile.
+2. **Lower maintenance for the reasoning core.** The bundled script's value is its _contract_ (envelope, schema, audit, cost), not its agent loop; offloading the loop to a maintained action is attractive when the contract can still be guaranteed.
+
+Hard constraints, established by analysis:
+
+- `claude-code-action` is **Anthropic-only** and an **opaque agent loop**. It cannot itself guarantee `EventEnvelopeV1` validation, structured output schema, fingerprinted audit emission (the Reconciler depends on these — ADR-0004), per-run EUR cost ceiling, or multi-provider routing.
+- The Developer sandbox deny-list that enforces the no-auto-merge invariant (ADR-0005) lives in `src/agents/developer/sandbox.ts` and runs **inside the bundled loop**. It does **not** wrap `claude-code-action`'s separate agent loop.
+- `claude-code-action@v1` supports an automation mode (explicit `prompt:` input) on arbitrary events, including `repository_dispatch`.
+
+## Decision
+
+Adopt a **two-tier execution model behind one dispatch boundary**:
+
+1. **`claude-code-action` is the conditional default; the bundled script is the conditional fallback.** The default is resolved deterministically from the consumer's configured providers:
+   - **Anthropic-only consumer** → `claude-code-action` is the default path for all four agents.
+   - **OpenAI or Google configured for any agent** → the bundled script remains the default (the only multi-provider, per-run-EUR-capped path). No silent regression for non-Anthropic consumers.
+
+   The explicit Jira-label override (point 3) takes precedence over this default in **both** cases.
+
+2. **`claude-code-action` replaces only the agent _reasoning core_; the Ferry contract stays in deterministic workflow steps that bracket it.** The four agents' existing prompts are reused verbatim — no prompt rewrite:
+   - System prompt = the resolved output of `buildSystem(<role>)` (bundled `prompts/<agent>.md` composed with the consumer's `prompts/<agent>.extra.md` via `src/lib/prompts/resolve.ts`), passed through `claude_args: --append-system-prompt`.
+   - Initial prompt = the same `initialPrompt` the script builds today (the `<<<UNTRUSTED>>>` ticket block + `SUBTASKS` / review findings / repo tree), passed via the action's `prompt:` input.
+
+   Per-agent input/output parity (what each agent reads, the exact Jira/GitHub side effects, transitions FR18/FR24/FR28, idempotency markers, and the native-tool ↔ Ferry-tool mapping) is the **parity contract** the wrapping steps must satisfy; it is specified in the implementation epic, not duplicated here. The contract stays in deterministic workflow steps that bracket the action:
+
+   ```
+   repository_dispatch
+     → step: AJV validate EventEnvelopeV1 (fail-closed)
+     → step: compute routing decision (deterministic, from envelope + audit history)
+     → claude-code-action  (prompt = injected envelope; Jira via MCP)
+     → step: AJV validate structured agent output (fail-closed)
+     → step: emit fingerprinted audit comment  [ferry:<role>:<run-id>]
+   ```
+
+   Envelope validation, output-schema validation, audit emission, and cost governance are **never delegated to the LLM** — they are non-LLM steps.
+
+3. **Routing policy is deterministic, with an explicit Jira-label override taking precedence over the automatic heuristic.** A workflow step computes the route from the validated envelope (which carries the ticket's Jira labels) plus the audit-comment history (round-trip count). Resolution order, evaluated deterministically:
+   1. **Explicit Jira label** — `ferry:claude-code` forces the `claude-code-action` path; `ferry:no-claude-code` forces the bundled script. Names follow Ferry's existing `ferry:`-prefixed label convention and are resolved through the same `resolveTicketOverrides` mechanism as other ticket overrides. Conflicting labels resolve to the safe path (bundled script).
+   2. **Automatic heuristic** (only if no explicit label) — escalate to `claude-code-action` when _role ∈ {developer, iterator}_ **AND** _prior Ferry round-trips ≥ N_.
+   3. **Conditional default** — per point 1: `claude-code-action` for Anthropic-only consumers, bundled script otherwise.
+
+   The `ferry:claude-code` label still requires the consumer to have the path enabled (Anthropic creds + tool allowlist configured); it _selects_ the path, it does not provision credentials. The explicit label changes routing only — it never overrides the hard invariants: the cost-governance auto-pause (`ferry:paused`) and the no-auto-merge allowlist apply regardless of how the path was chosen. The resolved route **and the reason** (`label` / `heuristic` / `default`) are recorded in the audit comment so the Reconciler observes it.
+
+4. **Cost governance stays at the dispatch/label layer, not inside the action.** `claude-code-action` is bounded crudely by `--max-turns` plus the job `timeout-minutes`; eligibility is gated behind the existing daily cost-governance auto-pause (`ferry:paused` label). The action never receives a per-run EUR cap because it cannot enforce one.
+
+5. **The no-auto-merge invariant (ADR-0005) must be re-established for this path.** Because the bundled sandbox deny-list does not apply, the `claude-code-action` step uses a restricted `--allowedTools` allowlist (no `gh pr merge`, no `git push` to protected refs) and a least-privilege `GITHUB_TOKEN`. This is a precondition of adopting the path, not a follow-up.
+
+6. **The execution path is chosen at install time, and the claude-code path requires `CLAUDE_CODE_OAUTH_TOKEN`.** This supersedes the earlier "reuse `ANTHROPIC_API_KEY` / zero new step" provision.
+   - **`ferry-init` offers an explicit path choice.** The wizard asks which execution path to install: **(a) bundled script** (default for non-Anthropic, multi-provider, per-run EUR cap) or **(b) `claude-code-action`** (Anthropic subscription, free agent loop). A consumer can pick either at install time; the choice is recorded in `ferry.config.json` and materialized in the generated workflows. The Jira-label override (point 3) still lets individual tickets switch path afterward.
+   - **The claude-code path authenticates _exclusively_ with `CLAUDE_CODE_OAUTH_TOKEN`.** It must **never** use `ANTHROPIC_API_KEY` (`claude_code_oauth_token:` only, never `anthropic_api_key:`). The token is obtained via `claude setup-token` (requires a Claude Pro/Max subscription) and stored as a new repo secret. This is a **required** install element when path (b) is chosen — onboarding is therefore **not** zero-friction for that path.
+   - GitHub write access still reuses the existing GitHub App installation token (`github_token:`); Jira still uses the existing `FERRY_JIRA_*` secrets via wrapper steps / MCP. The only new credential is `CLAUDE_CODE_OAUTH_TOKEN`.
+
+7. **The conditional default applies on upgrades too, gated by a version-delta manifest — never a silent flip.** It is not limited to fresh `ferry-init`. `ferry-update` stays **credential-silent for code-only updates** (pre-update credentials keep working); it prompts **only when the crossed `MIGRATIONS.md` `## <from> → <to>` section declares a newly-required secret** (a new declarative `requires-secrets:` line, parallel to the existing `forge:` line), and **only for the ones missing** (diffed against `gh secret list`). For the claude-code transition the entry declares `CLAUDE_CODE_OAUTH_TOKEN`: already set → auto-adopts; missing + interactive → prompts only for that secret then adopts; missing + non-interactive → does not flip, stays on script (zero breakage), prints a mandatory follow-up. An explicit `execution_path: script` is always respected. The path-select branch ships **inert** until the manifest-declared secrets are satisfied. The "never re-prompts for credentials" property is thus **preserved for ordinary updates and merely narrowed**, via a general mechanism reusable by any future release that adds a required secret — not a one-off. Rollback (set `execution_path: script`, re-run `ferry-update`) is symmetric and cannot break a consumer. See [decisions/0002 §G](../decisions/0002-claude-code-path-parity-analysis.md).
+
+See [decisions/0002](../decisions/0002-claude-code-path-parity-analysis.md) for the full install→operate→uninstall reuse/set-aside analysis.
+
+## Consequences
+
+**Positive:**
+
+- Operators gain an explicit, bounded "let the LLM act freely" mode for high-iteration tickets without abandoning Ferry's guarantees on the default path.
+- The Ferry contract (envelope, schema, audit, cost) is preserved by deterministic steps regardless of which reasoning core runs — the Reconciler and downstream agents are unaffected.
+- The reasoning-core maintenance burden for the opt-in path shifts to a maintained action.
+- The execution path is an explicit, recorded install-time choice (script vs claude-code), not an implicit behavior — consumers opt in deliberately and can still switch per-ticket via label.
+
+**Negative:**
+
+- Two execution paths to test and document; the wrapping steps (AJV in/out, audit emission, routing) are new deterministic code that must be unit-tested (TDD) before the path is enabled.
+- The `claude-code-action` path is Anthropic-only — which is why the default is _conditional_: it is the default only for Anthropic-only consumers, and the script stays default when OpenAI/Google is configured so multi-provider consumers see no regression.
+- ADR-0005 enforcement on this path relies on tool allowlisting + token scoping, which is weaker defense-in-depth than the runtime regex deny-list; a misconfigured allowlist re-opens the auto-merge risk.
+- Per-run EUR cost is not enforceable on this path — only coarse turn/time bounds plus the daily auto-pause backstop.
+- The claude-code path is not zero-friction: it requires a Claude subscription + `claude setup-token` + a new `CLAUDE_CODE_OAUTH_TOKEN` secret. A fresh consumer must explicitly choose and provision it at install time.
+- `ferry-update` gains a manifest-driven credential gate (new `requires-secrets:` line in `MIGRATIONS.md`). This narrows — does not break — the "never re-prompts for credentials" property: silent for code-only updates, prompts only for manifest-declared missing secrets. Non-interactive upgrades still cannot self-adopt the path and require a follow-up interactive run.
+
+## Alternatives Considered
+
+**`claude-code-action` as the unconditional global default** — rejected. It would silently drop multi-provider consumers (Anthropic-only) and remove the per-run EUR ceiling for everyone. **A _conditional_ default was adopted instead**: `claude-code-action` defaults only for Anthropic-only consumers; the script stays default whenever OpenAI/Google is configured, so non-Anthropic consumers keep multi-provider support and the per-run EUR cap with no silent regression.
+
+**Keep the script as the unconditional default (claude-code-action opt-in only)** — superseded by this revision. The original ADR-0006 decision; reversed because for Anthropic-only consumers the maintained-loop + free-action profile is the preferred default, and the conditional rule removes the regression that motivated the original rejection.
+
+**Replace the bundled script entirely** — rejected. This discards the multi-provider loop, the runtime no-auto-merge deny-list (ADR-0005), and per-run cost governance in exchange for one maintained loop — a net loss of guarantees Ferry exists to provide.
+
+**Delegate envelope validation / audit emission to the LLM inside the action's prompt** — rejected. ADR-0004 makes audit markers a load-bearing idempotency mechanism for the Reconciler; an LLM that "usually" emits them produces non-deterministic re-trigger loops. These must be deterministic steps.
+
+**Manual per-ticket selection only (Jira label, no automatic heuristic)** — evaluated, kept as one tier rather than the whole policy. The explicit Jira label is the right primitive for an operator deciding "this specific ticket should run free", and it takes precedence. But a label alone gives no principled answer to _when_ to escalate by default; the automatic heuristic (round-trip count + role) is what makes "let the LLM act freely on already-iterated tickets" a reproducible rule rather than requiring a human to label every ticket. Both tiers are kept, label first.
+
+**Automatic heuristic only (no manual label)** — rejected. Operators need a per-ticket escape hatch in both directions (force claude-code-action, or force the script) without changing global config; the Jira label provides it deterministically and is observable in the ticket itself.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,13 +4,14 @@ This directory contains Architecture Decision Records (ADRs) for the Ferry proje
 
 ## Index
 
-| #                                                 | Title                                        | Status   |
-| ------------------------------------------------- | -------------------------------------------- | -------- |
-| [0001](./0001-three-fr-auto-transitions.md)       | Three FR auto-transitions (FR18, FR24, FR28) | Accepted |
-| [0002](./0002-ferry-bundles-committed.md)         | Ferry bundles committed to the repository    | Accepted |
-| [0003](./0003-anthropic-messages-vs-agent-sdk.md) | Anthropic Messages API over Agent SDK        | Accepted |
-| [0004](./0004-idempotency-via-comment-markers.md) | Idempotency via comment markers              | Accepted |
-| [0005](./0005-no-auto-merge-invariant.md)         | No auto-merge invariant                      | Accepted |
+| #                                                   | Title                                                        | Status   |
+| --------------------------------------------------- | ------------------------------------------------------------ | -------- |
+| [0001](./0001-three-fr-auto-transitions.md)         | Three FR auto-transitions (FR18, FR24, FR28)                 | Accepted |
+| [0002](./0002-ferry-bundles-committed.md)           | Ferry bundles committed to the repository                    | Accepted |
+| [0003](./0003-anthropic-messages-vs-agent-sdk.md)   | Anthropic Messages API over Agent SDK                        | Accepted |
+| [0004](./0004-idempotency-via-comment-markers.md)   | Idempotency via comment markers                              | Accepted |
+| [0005](./0005-no-auto-merge-invariant.md)           | No auto-merge invariant                                      | Accepted |
+| [0006](./0006-claude-code-action-execution-path.md) | claude-code-action as the conditional default execution path | Accepted |
 
 ## ADR Template
 

--- a/docs/decisions/0002-claude-code-path-parity-analysis.md
+++ b/docs/decisions/0002-claude-code-path-parity-analysis.md
@@ -1,0 +1,181 @@
+# 0002 — claude-code-action Path: Full-Lifecycle Parity Analysis
+
+**Status:** Accepted (analysis backing [ADR-0006](../adr/0006-claude-code-action-execution-path.md))
+**Date:** 2026-05-19
+**Relates to:** [ADR-0006](../adr/0006-claude-code-action-execution-path.md) (the decision), [ADR-0004](../adr/0004-idempotency-via-comment-markers.md), [ADR-0005](../adr/0005-no-auto-merge-invariant.md)
+
+## Goal
+
+Establish whether a consumer's experience of Ferry-on-Anthropic is **near-identical** whether agents
+run via the bundled script or via `claude-code-action`, across the **whole lifecycle**: install →
+operate (use cases + edge cases) → maintain → uninstall. Classify every Ferry element as reused,
+wrapped, adapted, set aside, or new.
+
+**Hard constraint (caller directive):** the `claude-code-action` path authenticates **exclusively
+with `CLAUDE_CODE_OAUTH_TOKEN`** (Claude subscription, obtained via `claude setup-token`). It must
+**never** use `ANTHROPIC_API_KEY`. This supersedes ADR-0006 point 6's "reuse ANTHROPIC_API_KEY /
+zero new step" provision: the OAuth token is now a **required** install element for the path.
+
+Legend: ✅ reused as-is · 🔁 reused but moved to a deterministic wrapper step · 🟡 adapted (different
+mechanism, identical observable outcome) · ⛔ set aside (does not apply) · ➕ new (claude-code path only)
+
+## A. Installation (`ferry-init` → consumer repo)
+
+| Element                                                         | Class | Notes                                                                                                                                                                                                                                                                                     |
+| --------------------------------------------------------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GitHub App auth (`FERRY_APP_ID`, `FERRY_PRIVATE_KEY`)           | ✅    | Installation token passed to `claude-code-action` `github_token:`.                                                                                                                                                                                                                        |
+| Jira secrets (`FERRY_JIRA_BASE_URL/EMAIL/API_TOKEN`)            | ✅    | Used by wrapper steps / Jira MCP.                                                                                                                                                                                                                                                         |
+| Transition IDs (`FERRY_REVIEW/ITER/APPROVE_TRANSITION_ID`)      | ✅    | Read by the post-step that performs FR18/24/28.                                                                                                                                                                                                                                           |
+| `FERRY_AUDIT_ISSUE` variable, `ferry.config.json`               | ✅    | Path-agnostic; read by wrapper steps.                                                                                                                                                                                                                                                     |
+| 4 Jira automation rules → `repository_dispatch`                 | ✅    | Same trigger; unchanged.                                                                                                                                                                                                                                                                  |
+| `gate-envelope` job (`ferry-envelope-validate` composite)       | ✅    | Runs unchanged before either path.                                                                                                                                                                                                                                                        |
+| `ANTHROPIC_API_KEY`                                             | ⛔    | **Forbidden** on the claude-code path (caller directive). Still used by the script path / non-Anthropic consumers.                                                                                                                                                                        |
+| `CLAUDE_CODE_OAUTH_TOKEN` secret                                | ➕    | **Required** new secret. Obtained via `claude setup-token` (needs a Claude Pro/Max subscription). New mandatory `ferry-init` step for the claude-code path.                                                                                                                               |
+| Install-time path choice (wizard)                               | ➕    | `ferry-init` asks which path to install — **(a) bundled script** or **(b) claude-code-action**. The choice is recorded in `ferry.config.json` and materialized in the generated workflows. Either path is selectable at install; the Jira label still switches path per-ticket afterward. |
+| Consumer workflow stubs (`ferry-refine/dev/review/iterate.yml`) | 🟡    | A path-select branch (or a sibling `run-agent-cc` job) invokes `claude-code-action` instead of `ferry-run-<role>`; `gate-envelope` job reused verbatim.                                                                                                                                   |
+| gitleaks install / secret scan                                  | 🔁    | The in-loop `makeSecretScan` callback has no equivalent inside the action; becomes a **deterministic gate before push** (see §D).                                                                                                                                                         |
+
+**Net install delta:** +1 wizard question (choose path: script vs claude-code), and **when the
+claude-code path is chosen**: +1 required secret (`CLAUDE_CODE_OAUTH_TOKEN`, subscription via
+`claude setup-token`) and +1 workflow path-select branch. The script path is unchanged. Everything
+else is reused.
+
+## B. Operation — the contract layer
+
+| Element                                                                                                   | Class | Notes                                                                                                                                                                                                                       |
+| --------------------------------------------------------------------------------------------------------- | ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `repository_dispatch` + `EventEnvelopeV1` + envelope-validate                                             | ✅    | Identical entry.                                                                                                                                                                                                            |
+| `resolveTicketOverrides` (dry-run/skip/read-only/no-auto-transition/base/target/thinking/rubric/max-iter) | 🔁    | Runs as a deterministic pre-step around the action instead of in-process.                                                                                                                                                   |
+| `model` / `provider` overrides (label/config)                                                             | 🟡    | `provider` is meaningless (Anthropic-only); `model` maps to `claude_args --model` if supported, else fixed by the subscription.                                                                                             |
+| Idempotency markers (`byEventId` / `byPrHeadSha`, `checkIdempotencyMarker`)                               | 🔁    | Pre-step skip check + post-step marker emission.                                                                                                                                                                            |
+| Audit comment `[ferry:<role>:…]` (ADR-0004)                                                               | 🔁    | Deterministic post-step — **never** the LLM. Reconciler depends on it.                                                                                                                                                      |
+| Transitions FR18 / FR24 / FR28                                                                            | 🔁    | Post-step using the transition-ID secrets.                                                                                                                                                                                  |
+| Per-run EUR cap (`maxCostEur` in agent-loop)                                                              | ⛔    | No mid-loop EUR enforcement in the action. Replaced by `--max-turns` + job `timeout-minutes`. Under subscription billing, per-run EUR is conceptually moot — but the **`ferry:spend-cap` edge case loses parity** (see §D). |
+| `writeStepSummary` / `appendOutput` (cost telemetry)                                                      | 🟡    | Action emits its own usage; wrapper maps it to the step summary. EUR cost is unknown under subscription billing.                                                                                                            |
+| Reconciler (`src/reconciler`)                                                                             | ✅    | Operates on audit comments + Jira columns — path-agnostic, provided the wrapper emits markers (it does).                                                                                                                    |
+| Daily cost-governance auto-pause (`ferry:paused` at 50% monthly)                                          | 🟡    | Monthly **EUR** spend is not measurable under a subscription token → this backstop is **weakened** on the claude-code path.                                                                                                 |
+| Prompts: `buildSystem(<role>)` + `prompts/<agent>.extra.md` resolver                                      | ✅    | Reused **verbatim** via `claude_args --append-system-prompt`. No rewrite.                                                                                                                                                   |
+| `initialPrompt` builders (ticket block, SUBTASKS, findings, repo tree)                                    | ✅    | Reused verbatim via the action `prompt:` input.                                                                                                                                                                             |
+| `delimitUntrusted` injection fences                                                                       | ✅    | Part of `initialPrompt`; same prompt-injection posture.                                                                                                                                                                     |
+
+## C. Per-agent reasoning core
+
+| Element                                                                                                               | Class | Notes                                                                                                                                                             |
+| --------------------------------------------------------------------------------------------------------------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Refiner / Reviewer (read + structured verdict)                                                                        | 🔁    | LLM emits the same JSON contract; all Jira/PR writes, labels, FR24, audit = deterministic post-step.                                                              |
+| Developer / Iterator code tools (`bash/read_file/write_file/str_replace/list_dir/search_files/move_file/delete_file`) | 🟡    | Mapped to native `Bash/Read/Write/Edit/Glob/Grep`.                                                                                                                |
+| `spawn_subagent`                                                                                                      | 🟡    | Mapped to the action's sub-agent/Task facility, or set aside (single loop).                                                                                       |
+| `done` / `commit_progress` / `finish_review`                                                                          | 🔁    | Replaced by a final structured-JSON artifact the LLM writes; post-step parses it and applies outcomes — same result as the script.                                |
+| `outcome-guard` (`assertDev/IterOutputContract`)                                                                      | 🔁    | Post-step assertion before the terminal comment.                                                                                                                  |
+| Reviewer CI gate (`gateCi`)                                                                                           | 🔁    | Pre-step; blocks a red/pending CI exactly as today.                                                                                                               |
+| Reviewer rubric (`applyRubricToPrompt`)                                                                               | ✅    | Folded into the built system prompt.                                                                                                                              |
+| Sandbox no-merge deny-list (ADR-0005, `developer/sandbox.ts`)                                                         | ⛔    | Does not wrap the action's loop.                                                                                                                                  |
+| No-merge enforcement for the action                                                                                   | ➕    | `--allowedTools` allowlist (no `gh pr merge`, no push to protected refs) + least-privilege token (ADR-0006 §5). Weaker defense-in-depth than the regex deny-list. |
+| MCP pool (`loadMcpServers` + `filterMcpServers` by capabilities)                                                      | 🟡    | Capability filtering becomes a pre-step that emits `--mcp-config`; consumer MCP servers passed through for parity.                                                |
+
+## D. Edge-case parity matrix
+
+| Edge case                                                | Parity?             | Mechanism                                                                                                                                                                      |
+| -------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ferry:dry-run` / `FERRY_DRY_RUN`                        | ✅ 🔁               | Pre-step detects; post-step suppresses all external writes. (LLM turn still consumed.)                                                                                         |
+| `ferry:read-only`                                        | ✅ 🔁               | Pre-step short-circuits — the action is never invoked.                                                                                                                         |
+| `ferry:skip/<phase>`                                     | ✅ 🔁               | Pre-step no-op + standard comment.                                                                                                                                             |
+| Outcome `blocked`                                        | ✅ 🔁               | Post-step reads structured outcome → `ferry:blocked` + comment + exit 1 (output-schema validation is fail-closed).                                                             |
+| Outcome `already_satisfied`                              | ✅ 🔁               | Post-step writes verification note + verify PR — same as script.                                                                                                               |
+| Iteration cap (`max_iterations`, `countPriorIterations`) | ✅ 🔁               | Pre-step counts prior iterations from audit comments.                                                                                                                          |
+| Agent-loop iteration cap (`max_agent_iterations`)        | 🟡                  | `--max-turns` ≈ equivalent; `ferry:max-iterations/<n>` "success-of-intent" nuance differs slightly.                                                                            |
+| Merge conflicts (iterator/reviewer)                      | ✅                  | Detected in a pre-step; resolved by the LLM via git, same as the script.                                                                                                       |
+| No PR / no review comment / reviewer-not-visible race    | ✅ 🔁               | Pre-step guards + defer logic, path-agnostic.                                                                                                                                  |
+| `LabelConflictError`                                     | ✅ 🔁               | Pre-step `resolveTicketOverrides`; same conflict comment.                                                                                                                      |
+| CI red / pending (reviewer)                              | ✅ 🔁               | Pre-step `gateCi`; same comments + FR24.                                                                                                                                       |
+| Resume branch / existing-PR context                      | ✅                  | Pre-step builds resume context into the prompt — same as script.                                                                                                               |
+| Prompt injection (untrusted ticket content)              | ✅                  | `delimitUntrusted` fences + system instruction; same posture.                                                                                                                  |
+| **`ferry:spend-cap` (mid-run EUR budget exceeded)**      | ⛔ **no parity**    | The action cannot raise a mid-loop EUR `FerryError`; the `ferry:spend-cap` label + comment will not appear. Bounded only by `--max-turns`/timeout. Accepted divergence.        |
+| **Secret scan before push**                              | ➕ must re-engineer | No in-loop `secretScan` hook. Either: gate the push through a wrapper that scans first, or accept the action's own pre-push controls. Must be solved before enabling the path. |
+
+## E. Maintenance
+
+| Element             | Class | Notes                                                                                                                |
+| ------------------- | ----- | -------------------------------------------------------------------------------------------------------------------- |
+| `ferry-doctor`      | 🟡 ➕ | Existing probes reused; **add** a `CLAUDE_CODE_OAUTH_TOKEN` presence/validity probe and a path-selection diagnostic. |
+| `ferry-update`      | ✅    | Version/ref bump and `MIGRATIONS.md` handling cover the new wrapper workflow unchanged.                              |
+| `ferry.config.json` | 🟡    | Existing keys reused; **add** path-enable + routing-threshold (`N`) + label-name keys.                               |
+
+## F. Destruction (`ferry-uninstall`)
+
+| Element                                            | Class | Notes                                                                                               |
+| -------------------------------------------------- | ----- | --------------------------------------------------------------------------------------------------- |
+| Remove `workflows/ferry-*.yml`, secrets, variables | ✅    | Mechanism reused.                                                                                   |
+| Remove `CLAUDE_CODE_OAUTH_TOKEN`                   | ➕    | Add the new secret to the uninstall removal list, otherwise a stale subscription token is orphaned. |
+
+## G. Existing consumers (migration via `ferry-update`)
+
+`ferry-update` re-renders `.github/workflows/ferry-*.yml` from templates, adds missing workflow
+files, bumps pinned `@vX` refs, and prints the relevant `MIGRATIONS.md` section as
+"Manual follow-ups required". Crucially, it **never re-prompts for credentials**.
+
+**Design rule: a version-delta manifest decides whether `ferry-update` prompts for credentials.**
+`ferry-update` stays **credential-silent for code-only updates** — the pre-update credentials keep
+working, so it must not re-prompt. It becomes credential-aware **only when the version transition
+being crossed declares a newly-required secret**, and then prompts **only for the ones missing**.
+
+The manifest is the existing `MIGRATIONS.md`: each `## <from> → <to>` section gains an optional
+declarative line — parallel to the existing `forge:` line — e.g.:
+
+```
+## v0.X.x → v0.Y.0
+requires-secrets: CLAUDE_CODE_OAUTH_TOKEN
+```
+
+`ferry-update` already parses these sections and already has `listExistingSecrets()` (from
+`ferry-init`'s secret step). The added logic is small:
+
+1. For the crossed range, collect `requires-secrets:` (empty for code-only releases → **silent**, property preserved).
+2. Diff declared-required against `gh secret list` → compute the **missing** set.
+3. If non-empty: interactive → run the targeted secret step **only for the missing secrets** (e.g. guide `claude setup-token` → `gh secret set CLAUDE_CODE_OAUTH_TOKEN`); non-interactive/CI → do not flip, keep the script path (zero breakage), print a mandatory "re-run `ferry-init`" / re-run interactively follow-up.
+4. Apply `execution_path: claude-code` (conditional default) only once the required secrets are present.
+
+Resulting migration matrix for an Anthropic-only existing consumer:
+
+| Situation on `ferry-update`                          | Outcome                                                            |
+| ---------------------------------------------------- | ------------------------------------------------------------------ |
+| Crossed range has no `requires-secrets:` (code-only) | **Silent** — no prompt, credentials untouched (property preserved) |
+| Declares `CLAUDE_CODE_OAUTH_TOKEN`, already set      | Auto-adopts claude-code path (conditional default applied)         |
+| Declares it, missing, interactive                    | Prompts **only for the missing** secret → then adopts              |
+| Declares it, missing, non-interactive                | Stays on script + mandatory follow-up                              |
+| `execution_path: script` explicitly set              | Respected — never overridden                                       |
+
+The path-select branch ships **inert** in re-rendered workflows until `execution_path` resolves to
+claude-code, so the upgrade is a no-op until the manifest-declared secrets are satisfied.
+
+**No trade-off:** the "never re-prompts for credentials" property is **preserved for ordinary code
+updates** and merely **narrowed** — `ferry-update` prompts only when the version-delta manifest
+declares a new required secret, and only for the missing ones. This is a general mechanism, not a
+one-off for the claude-code path; any future release that introduces a required secret uses the same
+`requires-secrets:` line.
+
+**Rollback** is symmetric and safe: set `execution_path` back to `script` (or remove the key),
+re-run `ferry-update`. The script path needs no new secret, so reverting cannot break a consumer.
+
+## Accepted divergences (the "set aside" list)
+
+Near-parity holds for the **entire observable contract** (Jira/PR/audit/transitions/idempotency and
+every operational edge case) **except** these, which are accepted as non-parity and documented:
+
+1. **Per-run EUR cap + `ferry:spend-cap` edge case** — no mid-loop EUR enforcement; the label/comment
+   path does not fire. Conceptually moot under subscription billing, but observably different.
+2. **Daily cost-governance auto-pause** — monthly EUR spend is not measurable on a subscription
+   token; this safety backstop is weakened on the claude-code path.
+3. **No-auto-merge runtime enforcement (ADR-0005)** — the regex deny-list is set aside; replaced by
+   an `--allowedTools` allowlist + token scoping (weaker defense-in-depth).
+4. **Secret-scan-before-push** — must be re-engineered as a deterministic gate; not free.
+
+## Recommendation
+
+Adopt the path with the classification above. The reuse ratio is high: prompts, envelope, trigger,
+reconciler, transitions, idempotency, and **every edge case except `spend-cap`** are reused as-is or
+wrapped without behavioral change. The four accepted divergences are all **cost/safety-budget**
+concerns — coherent with the deliberate decision (ADR-0006) that the claude-code path trades the
+per-run EUR ceiling for the subscription-billing + free-agent-loop profile. The `CLAUDE_CODE_OAUTH_TOKEN`
+requirement makes this a non-zero-friction install (one extra required secret + wizard step), which
+ADR-0006 must reflect (point 6 superseded).

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -22,7 +22,8 @@ import { installWorkflows, scaffoldCodeowners } from './steps/workflows.js';
 import { stepJiraBundle, DEFAULT_STATUS_NAMES } from './steps/jira-bundle.js';
 import { resolveJiraWorkspaceId, resolveJiraProjectId } from './steps/jira-resolve.js';
 import { stepVerify } from './steps/verify.js';
-import type { FerryConfig, LlmProvider } from './types.js';
+import { EXECUTION_PATH_QUESTION, parseExecutionPathChoice } from './steps/execution-path.js';
+import type { ExecutionPath, FerryConfig, LlmProvider } from './types.js';
 
 const FERRY_VERSION_DEFAULT = 'v1';
 
@@ -165,8 +166,11 @@ async function main(): Promise<void> {
   const iteratorAutoTransition = await ask('Iterator → after iteration (moves to)', 'In Review');
 
   print('');
-  print('LLM provider per phase (anthropic / openai / google, default: anthropic):');
-  print('  Note: MCP server support (labels, context7, etc.) requires Anthropic.');
+  print('Execution path (ADR-0006):');
+  print(`  ${EXECUTION_PATH_QUESTION}`);
+  const executionPath: ExecutionPath = parseExecutionPathChoice(
+    await ask('Execution path (a=script / b=claude-code)', 'a'),
+  );
 
   function validateProvider(input: string): LlmProvider {
     const lower = input.toLowerCase().trim();
@@ -174,35 +178,57 @@ async function main(): Promise<void> {
     return 'anthropic';
   }
 
-  const refinerProviderRaw = await ask('Refiner provider', 'anthropic');
-  const devProviderRaw = await ask('Developer provider', 'anthropic');
-  const reviewProviderRaw = await ask('Reviewer provider', 'anthropic');
-  const iterateProviderRaw = await ask('Iterator provider', 'anthropic');
-
-  const refinerProvider = validateProvider(refinerProviderRaw);
-  const devProvider = validateProvider(devProviderRaw);
-  const reviewProvider = validateProvider(reviewProviderRaw);
-  const iterateProvider = validateProvider(iterateProviderRaw);
-
-  const needsOpenAI = [refinerProvider, devProvider, reviewProvider, iterateProvider].includes(
-    'openai',
-  );
-  const needsGoogle = [refinerProvider, devProvider, reviewProvider, iterateProvider].includes(
-    'google',
-  );
-
-  print('');
-  print('API keys:');
-  const anthropicApiKey = await askSecret('Anthropic API key (sk-ant-...)');
-
+  let refinerProvider: LlmProvider = 'anthropic';
+  let devProvider: LlmProvider = 'anthropic';
+  let reviewProvider: LlmProvider = 'anthropic';
+  let iterateProvider: LlmProvider = 'anthropic';
+  let needsOpenAI = false;
+  let needsGoogle = false;
+  let anthropicApiKey = '';
   let openaiApiKey = '';
-  if (needsOpenAI) {
-    openaiApiKey = await askSecret('OpenAI API key (sk-...)');
-  }
-
   let googleApiKey = '';
-  if (needsGoogle) {
-    googleApiKey = await askSecret('Google AI API key');
+  let claudeCodeOauthToken = '';
+
+  if (executionPath === 'claude-code') {
+    // ADR-0006 §6: claude-code is Anthropic-only and authenticates EXCLUSIVELY
+    // with CLAUDE_CODE_OAUTH_TOKEN — no provider choice, no ANTHROPIC_API_KEY.
+    print('');
+    print('claude-code-action path selected — agents run on your Claude subscription.');
+    print('  Obtain a token by running:  claude setup-token   (needs Claude Pro/Max)');
+    claudeCodeOauthToken = await askSecret('Claude Code OAuth token');
+  } else {
+    print('');
+    print('LLM provider per phase (anthropic / openai / google, default: anthropic):');
+    print('  Note: MCP server support (labels, context7, etc.) requires Anthropic.');
+
+    const refinerProviderRaw = await ask('Refiner provider', 'anthropic');
+    const devProviderRaw = await ask('Developer provider', 'anthropic');
+    const reviewProviderRaw = await ask('Reviewer provider', 'anthropic');
+    const iterateProviderRaw = await ask('Iterator provider', 'anthropic');
+
+    refinerProvider = validateProvider(refinerProviderRaw);
+    devProvider = validateProvider(devProviderRaw);
+    reviewProvider = validateProvider(reviewProviderRaw);
+    iterateProvider = validateProvider(iterateProviderRaw);
+
+    needsOpenAI = [refinerProvider, devProvider, reviewProvider, iterateProvider].includes(
+      'openai',
+    );
+    needsGoogle = [refinerProvider, devProvider, reviewProvider, iterateProvider].includes(
+      'google',
+    );
+
+    print('');
+    print('API keys:');
+    anthropicApiKey = await askSecret('Anthropic API key (sk-ant-...)');
+
+    if (needsOpenAI) {
+      openaiApiKey = await askSecret('OpenAI API key (sk-...)');
+    }
+
+    if (needsGoogle) {
+      googleApiKey = await askSecret('Google AI API key');
+    }
   }
 
   closePrompt();
@@ -222,6 +248,8 @@ async function main(): Promise<void> {
     anthropicApiKey,
     openaiApiKey: openaiApiKey || undefined,
     googleApiKey: googleApiKey || undefined,
+    executionPath,
+    claudeCodeOauthToken: claudeCodeOauthToken || undefined,
     refinerProvider,
     devProvider,
     reviewProvider,
@@ -239,7 +267,7 @@ async function main(): Promise<void> {
 
   // ── Step 3: Workflows + ferry.config.yaml ────────────────────────────────
   printStep(3, TOTAL_STEPS, 'Installing workflow files');
-  const templates = workflowTemplates(config.ferryVersion);
+  const templates = workflowTemplates(config.ferryVersion, config.executionPath);
   const workflowDir = join(repoRoot, '.github', 'workflows');
   installWorkflows(workflowDir, templates, overwrite);
   scaffoldCodeowners(repoRoot, owner);
@@ -276,6 +304,8 @@ async function main(): Promise<void> {
         : [];
 
     const workflowYaml = [
+      `execution_path: ${config.executionPath}`,
+      '',
       ...modelsBlock,
       'workflow:',
       '  agents:',
@@ -316,7 +346,15 @@ async function main(): Promise<void> {
 
   // ── Step 5: Verify ────────────────────────────────────────────────────────
   printStep(5, TOTAL_STEPS, 'Verifying provider API key');
-  const verifyResult = await stepVerify(config.anthropicApiKey);
+  const verifyResult =
+    config.executionPath === 'claude-code'
+      ? ((): { ok: true } => {
+          printSkip(
+            'claude-code path: CLAUDE_CODE_OAUTH_TOKEN validity is probed by `ferry-doctor`',
+          );
+          return { ok: true };
+        })()
+      : await stepVerify(config.anthropicApiKey);
 
   // ── Summary ───────────────────────────────────────────────────────────────
   print('');
@@ -343,6 +381,12 @@ async function main(): Promise<void> {
   if (needsGoogle) {
     print(`  ${nextStep++}. Google AI key was set as GOOGLE_API_KEY secret.`);
     print('     Enable budget alerts: https://console.cloud.google.com/billing');
+  }
+  if (config.executionPath === 'claude-code') {
+    print(
+      `  ${nextStep++}. Execution path: claude-code (recorded in ferry.config.yaml). Agents run`,
+    );
+    print('     on your Claude subscription via CLAUDE_CODE_OAUTH_TOKEN — no ANTHROPIC_API_KEY.');
   }
   print(`  ${nextStep}. Move a Jira ticket to "Refinement" — watch the Actions tab!`);
   print('');

--- a/src/cli/init/init.test.ts
+++ b/src/cli/init/init.test.ts
@@ -41,6 +41,28 @@ describe('buildSecrets', () => {
       expect(s.description.length).toBeGreaterThan(0);
     }
   });
+
+  it('defaults to the script path (ANTHROPIC_API_KEY, no OAuth token)', () => {
+    const names = buildSecrets(cfg).map((s) => s.name);
+    expect(names).toContain('ANTHROPIC_API_KEY');
+    expect(names).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
+  });
+
+  it('claude-code path uses CLAUDE_CODE_OAUTH_TOKEN exclusively, never ANTHROPIC_API_KEY', () => {
+    const secrets = buildSecrets({
+      ...cfg,
+      executionPath: 'claude-code',
+      claudeCodeOauthToken: 'sk-ant-oat-xyz',
+    });
+    const names = secrets.map((s) => s.name);
+    expect(names).toContain('CLAUDE_CODE_OAUTH_TOKEN');
+    expect(names).not.toContain('ANTHROPIC_API_KEY');
+    expect(secrets.find((s) => s.name === 'CLAUDE_CODE_OAUTH_TOKEN')?.value).toBe('sk-ant-oat-xyz');
+    // GitHub App + Jira secrets are still reused unchanged.
+    expect(names).toContain('FERRY_APP_ID');
+    expect(names).toContain('FERRY_JIRA_API_TOKEN');
+    expect(secrets).toHaveLength(6);
+  });
 });
 
 // ── buildJiraBundle ───────────────────────────────────────────────────────────
@@ -176,5 +198,39 @@ describe('workflowTemplates', () => {
   it('ferry-refine.yml triggers on ferry-refine event', () => {
     const refine = workflowTemplates('v1').find((t) => t.filename === 'ferry-refine.yml');
     expect(refine?.content).toContain('ferry-refine');
+  });
+
+  it('script path is byte-identical whether the path is implicit or explicit', () => {
+    expect(workflowTemplates('v1', 'script')).toEqual(workflowTemplates('v1'));
+  });
+
+  it('script path contains no claude-code guard or header', () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      expect(tmpl.content).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
+      expect(tmpl.content).not.toContain('Execution path: claude-code');
+    }
+  });
+
+  it('claude-code path materializes a fail-fast CLAUDE_CODE_OAUTH_TOKEN guard in every agent workflow', () => {
+    for (const tmpl of workflowTemplates('v1', 'claude-code')) {
+      expect(tmpl.content).toContain('# Execution path: claude-code');
+      expect(tmpl.content).toContain('Require CLAUDE_CODE_OAUTH_TOKEN');
+      expect(tmpl.content).toContain(
+        'CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}',
+      );
+      expect(tmpl.content).toContain('exit 1');
+      // The guard goes in the agent job only — exactly one occurrence per file.
+      const occurrences = tmpl.content.split('Require CLAUDE_CODE_OAUTH_TOKEN').length - 1;
+      expect(occurrences).toBe(1);
+    }
+  });
+
+  it('claude-code guard runs before the agent action', () => {
+    const dev = workflowTemplates('v1', 'claude-code').find((t) => t.filename === 'ferry-dev.yml');
+    const guardIdx = dev?.content.indexOf('Require CLAUDE_CODE_OAUTH_TOKEN') ?? -1;
+    const agentIdx = dev?.content.indexOf('ferry-run-developer') ?? -1;
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(agentIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(agentIdx);
   });
 });

--- a/src/cli/init/steps/execution-path.test.ts
+++ b/src/cli/init/steps/execution-path.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { EXECUTION_PATH_QUESTION, parseExecutionPathChoice } from './execution-path.js';
+
+describe('parseExecutionPathChoice', () => {
+  it('defaults to "script" for the (a) answer', () => {
+    expect(parseExecutionPathChoice('a')).toBe('script');
+    expect(parseExecutionPathChoice('A')).toBe('script');
+  });
+
+  it('selects "claude-code" for the (b) answer', () => {
+    expect(parseExecutionPathChoice('b')).toBe('claude-code');
+    expect(parseExecutionPathChoice('B')).toBe('claude-code');
+  });
+
+  it('accepts explicit path names (case/space-insensitive)', () => {
+    expect(parseExecutionPathChoice('  Claude-Code ')).toBe('claude-code');
+    expect(parseExecutionPathChoice('claude-code-action')).toBe('claude-code');
+    expect(parseExecutionPathChoice('script')).toBe('script');
+  });
+
+  it('falls back to the safe "script" path for empty or unknown input', () => {
+    expect(parseExecutionPathChoice('')).toBe('script');
+    expect(parseExecutionPathChoice('   ')).toBe('script');
+    expect(parseExecutionPathChoice('yolo')).toBe('script');
+  });
+
+  it('exposes a prompt that names both options', () => {
+    expect(EXECUTION_PATH_QUESTION).toMatch(/script/i);
+    expect(EXECUTION_PATH_QUESTION).toMatch(/claude-code/i);
+  });
+});

--- a/src/cli/init/steps/execution-path.ts
+++ b/src/cli/init/steps/execution-path.ts
@@ -1,0 +1,23 @@
+import type { ExecutionPath } from '../../../lib/config.js';
+
+/**
+ * Wizard question for the install-time execution-path choice (ADR-0006 §6).
+ * Default is the bundled script — the safe, multi-provider, per-run-EUR-capped
+ * path. The claude-code-action path is Anthropic-subscription only and adds the
+ * required `CLAUDE_CODE_OAUTH_TOKEN` secret.
+ */
+export const EXECUTION_PATH_QUESTION =
+  'Execution path: (a) bundled script [multi-provider, per-run EUR cap — default] ' +
+  'or (b) claude-code-action [Anthropic subscription, free agent loop, requires CLAUDE_CODE_OAUTH_TOKEN]';
+
+/**
+ * Parse the wizard answer into an {@link ExecutionPath}. Anything that is not an
+ * explicit claude-code choice resolves to the safe `script` path.
+ */
+export function parseExecutionPathChoice(answer: string): ExecutionPath {
+  const v = answer.trim().toLowerCase();
+  if (v === 'b' || v === 'claude-code' || v === 'claude-code-action') {
+    return 'claude-code';
+  }
+  return 'script';
+}

--- a/src/cli/init/steps/secrets.test.ts
+++ b/src/cli/init/steps/secrets.test.ts
@@ -14,8 +14,18 @@ vi.mock('../prompt.js', () => ({
   print: vi.fn(),
 }));
 
-import { listExistingSecrets, setSecret, stepSecrets } from './secrets.js';
+import { buildSecrets, listExistingSecrets, setSecret, stepSecrets } from './secrets.js';
 import type { SecretEntry } from '../types.js';
+
+const CLAUDE_CODE_CFG = {
+  appId: '12345',
+  privateKey: 'pem-data',
+  jiraBaseUrl: 'https://acme.atlassian.net',
+  jiraEmail: 'bot@acme.com',
+  jiraApiToken: 'token-abc',
+  executionPath: 'claude-code' as const,
+  claudeCodeOauthToken: 'sk-ant-oat-xyz',
+};
 
 const SECRET_ENTRIES: SecretEntry[] = [
   { name: 'FERRY_APP_ID', value: '12345', description: 'App ID' },
@@ -129,5 +139,20 @@ describe('stepSecrets', () => {
       expect(result.reason).toContain('FERRY_APP_ID');
       expect(result.reason).toContain('FERRY_PRIVATE_KEY');
     }
+  });
+
+  it('sets CLAUDE_CODE_OAUTH_TOKEN (and never ANTHROPIC_API_KEY) for the claude-code path', async () => {
+    mockExecSync
+      .mockReturnValueOnce('[]') // listExistingSecrets
+      .mockReturnValue(''); // setSecret calls
+
+    const result = await stepSecrets('org/repo', buildSecrets(CLAUDE_CODE_CFG), false);
+    expect(result.ok).toBe(true);
+
+    const setCalls = mockExecSync.mock.calls.map((c) => String(c[0]));
+    expect(setCalls.some((cmd) => cmd.includes('gh secret set CLAUDE_CODE_OAUTH_TOKEN'))).toBe(
+      true,
+    );
+    expect(setCalls.some((cmd) => cmd.includes('gh secret set ANTHROPIC_API_KEY'))).toBe(false);
   });
 });

--- a/src/cli/init/steps/secrets.ts
+++ b/src/cli/init/steps/secrets.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'node:child_process';
 import { printSuccess, printSkip, printError } from '../prompt.js';
+import type { ExecutionPath } from '../../../lib/config.js';
 import type { SecretEntry, StepResult } from '../types.js';
 
 export function buildSecrets(config: {
@@ -8,9 +9,11 @@ export function buildSecrets(config: {
   jiraBaseUrl: string;
   jiraEmail: string;
   jiraApiToken: string;
-  anthropicApiKey: string;
+  anthropicApiKey?: string;
   openaiApiKey?: string;
   googleApiKey?: string;
+  executionPath?: ExecutionPath;
+  claudeCodeOauthToken?: string;
 }): SecretEntry[] {
   const secrets: SecretEntry[] = [
     { name: 'FERRY_APP_ID', value: config.appId, description: 'GitHub App numeric ID' },
@@ -26,12 +29,23 @@ export function buildSecrets(config: {
       value: config.jiraApiToken,
       description: 'Atlassian API token',
     },
-    {
-      name: 'ANTHROPIC_API_KEY',
-      value: config.anthropicApiKey,
-      description: 'Anthropic API key',
-    },
   ];
+
+  if (config.executionPath === 'claude-code') {
+    // ADR-0006 §6 / decisions-0002 §A: the claude-code path authenticates
+    // EXCLUSIVELY with CLAUDE_CODE_OAUTH_TOKEN — ANTHROPIC_API_KEY is forbidden.
+    secrets.push({
+      name: 'CLAUDE_CODE_OAUTH_TOKEN',
+      value: config.claudeCodeOauthToken ?? '',
+      description: 'Claude Code OAuth token (claude setup-token; Claude Pro/Max subscription)',
+    });
+  } else {
+    secrets.push({
+      name: 'ANTHROPIC_API_KEY',
+      value: config.anthropicApiKey ?? '',
+      description: 'Anthropic API key',
+    });
+  }
 
   if (config.openaiApiKey) {
     secrets.push({

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -1,7 +1,48 @@
+import type { ExecutionPath } from '../../lib/config.js';
 import type { WorkflowEntry } from './types.js';
 
-export function workflowTemplates(version: string): WorkflowEntry[] {
-  return [
+const MANAGED_BY_LINE =
+  '# Managed by ferry-init. Re-run `npx -p @big-emotion/ferry ferry-init` to update.\n';
+
+const CLAUDE_CODE_HEADER =
+  '# Execution path: claude-code — agents run via claude-code-action.\n' +
+  '# Required secret: CLAUDE_CODE_OAUTH_TOKEN (run `claude setup-token`; Claude Pro/Max subscription).\n' +
+  '# Set execution_path: script in ferry.config.yaml to revert to the bundled multi-provider path.\n';
+
+// Deterministic fail-fast guard (ADR-0006 §6): the claude-code path must abort
+// before the agent runs if the OAuth token secret is absent. Anchored before the
+// gitleaks install, which exists only in the agent job (not gate-envelope /
+// emit-audit), so the guard is injected exactly once per workflow.
+const INSTALL_GITLEAKS_ANCHOR = '      - name: Install gitleaks\n';
+const CLAUDE_CODE_GUARD_STEP = `      - name: Require CLAUDE_CODE_OAUTH_TOKEN (claude-code execution path)
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        shell: bash
+        run: |
+          if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
+            echo "::error::CLAUDE_CODE_OAUTH_TOKEN is required for the claude-code execution path. Run 'claude setup-token' (needs a Claude Pro/Max subscription) and add it as a repo secret, or set execution_path: script in ferry.config.yaml."
+            exit 1
+          fi
+${INSTALL_GITLEAKS_ANCHOR}`;
+
+function applyExecutionPath(
+  templates: WorkflowEntry[],
+  executionPath: ExecutionPath,
+): WorkflowEntry[] {
+  if (executionPath !== 'claude-code') return templates;
+  return templates.map((t) => ({
+    filename: t.filename,
+    content: t.content
+      .replace(MANAGED_BY_LINE, MANAGED_BY_LINE + CLAUDE_CODE_HEADER)
+      .replace(INSTALL_GITLEAKS_ANCHOR, CLAUDE_CODE_GUARD_STEP),
+  }));
+}
+
+export function workflowTemplates(
+  version: string,
+  executionPath: ExecutionPath = 'script',
+): WorkflowEntry[] {
+  const templates: WorkflowEntry[] = [
     {
       filename: 'ferry-refine.yml',
       content: `# Managed by ferry-init. Re-run \`npx -p @big-emotion/ferry ferry-init\` to update.
@@ -410,4 +451,5 @@ jobs:
 `,
     },
   ];
+  return applyExecutionPath(templates, executionPath);
 }

--- a/src/cli/init/types.ts
+++ b/src/cli/init/types.ts
@@ -1,3 +1,7 @@
+import type { ExecutionPath } from '../../lib/config.js';
+
+export type { ExecutionPath };
+
 export type LlmProvider = 'anthropic' | 'openai' | 'google';
 
 export interface FerryConfig {
@@ -15,6 +19,10 @@ export interface FerryConfig {
   anthropicApiKey: string;
   openaiApiKey?: string;
   googleApiKey?: string;
+  /** Execution path chosen at install time (ADR-0006 §6). */
+  executionPath: ExecutionPath;
+  /** Claude Code OAuth token — set only on the claude-code path. */
+  claudeCodeOauthToken?: string;
   refinerProvider: LlmProvider;
   devProvider: LlmProvider;
   reviewProvider: LlmProvider;


### PR DESCRIPTION
Closes #304. Part of epic #299 (ADR-0006 §6, decisions/0002 §A).

## Scope

Install-time **execution-path choice** in `ferry-init`. The deterministic resolver (#300), contract wrapper steps (#301), and the actual `claude-code-action` job swap (#302) are sibling issues and intentionally **not** in this PR.

## What changed

- **Wizard question** — `ferry-init` now asks the execution path: **(a) bundled script** (default — multi-provider, per-run EUR cap) or **(b) claude-code-action** (Anthropic subscription, free agent loop). New `parseExecutionPathChoice` helper, unit-tested.
- **`CLAUDE_CODE_OAUTH_TOKEN` secret step** — on path (b), the wizard guides `claude setup-token` and stores `CLAUDE_CODE_OAUTH_TOKEN`. The claude-code path authenticates **exclusively** with this token: `buildSecrets` never emits `ANTHROPIC_API_KEY` on that path (and skips the provider/API-key/verify prompts, which are script-path only). Reuses `stepSecrets` unchanged.
- **`execution_path` config key** — first-class, validated key in `src/lib/config.ts` (`'script' | 'claude-code'`, default `'script'`), merged + schema-validated. Persisted to the generated `ferry.config.yaml`.
- **Path-select branch materialized in workflows** — `workflowTemplates(version, executionPath)`: on the claude-code path every agent workflow gains a deterministic **fail-fast guard** that `exit 1`s before the agent runs when `CLAUDE_CODE_OAUTH_TOKEN` is absent, plus a header note. The script path output is **byte-identical** to before (verified by test).

## Acceptance criteria

- ✅ Choice persisted (`execution_path` in `ferry.config.yaml`) and reflected in rendered workflows.
- ✅ Script path unchanged / no new secret; claude-code path fails fast if the token is absent.
- ✅ Wizard + secret step unit-tested (reuses `stepSecrets`).

## TDD

Tests written first: config schema validation/merge, `parseExecutionPathChoice`, `buildSecrets` branch + `stepSecrets` reuse, workflow-template materialization incl. byte-identical script path. Full suite green (130 files / 1865 tests); `typecheck`, `eslint`, `prettier` clean on changed files.

## Notes

- The issue says `ferry.config.json`; `ferry-init` actually generates **`ferry.config.yaml`** (the loader reads both). `execution_path` is written there — flagged here for visibility.
- This branch also carries the epic design docs it references (ADR-0006, decisions/0002, ADR index row) so the PR is self-contained; if the epic PR lands them too the content is identical.
