### PR TITLE
feat(claude-code): action job + prompt reuse + per-agent tool/MCP mapping (closes #302)

### DIFF
--- a/src/lib/claude-code/claude-args.test.ts
+++ b/src/lib/claude-code/claude-args.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import type { McpServerConfig } from '../llm/agent-loop/types.js';
+import { buildClaudeArgs } from './claude-args.js';
+
+function flagValue(args: string[], flag: string): string | undefined {
+  const i = args.indexOf(flag);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+describe('buildClaudeArgs', () => {
+  it('passes the system prompt verbatim via --append-system-prompt', () => {
+    const sys = 'You are the Ferry Developer.\n\nLine two.';
+    const args = buildClaudeArgs({ role: 'developer', system: sys });
+    expect(flagValue(args, '--append-system-prompt')).toBe(sys);
+  });
+
+  it('builds --allowedTools from the role native set (read-write for developer)', () => {
+    const args = buildClaudeArgs({ role: 'developer', system: 's' });
+    expect(flagValue(args, '--allowedTools')).toBe('Bash,Read,Write,Edit,Glob,Grep');
+  });
+
+  it('builds the read-only native set for reviewer and refiner', () => {
+    for (const role of ['reviewer', 'refiner'] as const) {
+      expect(flagValue(buildClaudeArgs({ role, system: 's' }), '--allowedTools')).toBe(
+        'Read,Glob,Grep',
+      );
+    }
+  });
+
+  it('appends MCP allowlist entries after the native tools', () => {
+    const servers: McpServerConfig[] = [
+      { type: 'stdio', name: 'jira', command: 'x', allowed_tools: ['get_issue'] },
+      { name: 'context7', url: 'https://mcp.context7.com/mcp' },
+    ];
+    const args = buildClaudeArgs({ role: 'reviewer', system: 's', mcpServers: servers });
+    expect(flagValue(args, '--allowedTools')).toBe(
+      'Read,Glob,Grep,mcp__jira__get_issue,mcp__context7',
+    );
+  });
+
+  it('emits --mcp-config as compact JSON only when servers are present', () => {
+    const none = buildClaudeArgs({ role: 'developer', system: 's' });
+    expect(none).not.toContain('--mcp-config');
+
+    const servers: McpServerConfig[] = [{ type: 'stdio', name: 'jira', command: 'run' }];
+    const args = buildClaudeArgs({ role: 'developer', system: 's', mcpServers: servers });
+    expect(JSON.parse(flagValue(args, '--mcp-config') as string)).toEqual({
+      mcpServers: { jira: { type: 'stdio', command: 'run' } },
+    });
+  });
+
+  it('adds --max-turns and --model only when provided', () => {
+    const bare = buildClaudeArgs({ role: 'developer', system: 's' });
+    expect(bare).not.toContain('--max-turns');
+    expect(bare).not.toContain('--model');
+
+    const full = buildClaudeArgs({
+      role: 'developer',
+      system: 's',
+      maxTurns: 40,
+      model: 'claude-opus-4-7',
+    });
+    expect(flagValue(full, '--max-turns')).toBe('40');
+    expect(flagValue(full, '--model')).toBe('claude-opus-4-7');
+  });
+
+  it('rejects a non-positive max-turns (fail-closed)', () => {
+    expect(() => buildClaudeArgs({ role: 'developer', system: 's', maxTurns: 0 })).toThrow(
+      /max-turns/i,
+    );
+  });
+});

--- a/src/lib/claude-code/claude-args.ts
+++ b/src/lib/claude-code/claude-args.ts
@@ -1,0 +1,58 @@
+/**
+ * Assembles the `claude_args` token list for the `claude-code-action` step.
+ *
+ * Returned as an ordered `string[]` of `[flag, value, …]` pairs — NOT a
+ * pre-quoted shell string. Shell-safe serialization into the action's
+ * `claude_args:` input is the deterministic wrapper's job (#301); keeping this
+ * a pure token list makes it trivially unit-testable and quoting-agnostic.
+ *
+ * The system prompt is forwarded **verbatim** via `--append-system-prompt`
+ * (ADR-0006 §2): no rewrite of `buildSystem()` output. No-auto-merge tool
+ * hardening (`--disallowedTools`, protected-ref scoping) is intentionally NOT
+ * here — that is #303's scope.
+ */
+
+import type { McpServerConfig } from '../llm/agent-loop/types.js';
+import type { FerryRole } from './tool-profiles.js';
+import { nativeToolsForRole } from './tool-profiles.js';
+import { toClaudeCodeMcpConfig, mcpToolAllowlist } from './mcp-config.js';
+
+export interface BuildClaudeArgsInput {
+  role: FerryRole;
+  /** Resolved `buildSystem(<role>)` output — passed through unchanged. */
+  system: string;
+  /** Already capability-filtered MCP pool (caller runs `filterMcpServers`). */
+  mcpServers?: McpServerConfig[];
+  /** Coarse loop bound (ADR-0006 §4) — there is no per-run EUR cap on this path. */
+  maxTurns?: number;
+  model?: string;
+}
+
+export function buildClaudeArgs(input: BuildClaudeArgsInput): string[] {
+  const servers = input.mcpServers ?? [];
+  const allowedTools = [...nativeToolsForRole(input.role), ...mcpToolAllowlist(servers)];
+
+  const args: string[] = [
+    '--append-system-prompt',
+    input.system,
+    '--allowedTools',
+    allowedTools.join(','),
+  ];
+
+  if (servers.length > 0) {
+    args.push('--mcp-config', JSON.stringify(toClaudeCodeMcpConfig(servers)));
+  }
+
+  if (input.maxTurns !== undefined) {
+    if (!Number.isInteger(input.maxTurns) || input.maxTurns <= 0) {
+      throw new Error(`max-turns must be a positive integer, got ${input.maxTurns}`);
+    }
+    args.push('--max-turns', String(input.maxTurns));
+  }
+
+  if (input.model !== undefined && input.model.trim().length > 0) {
+    args.push('--model', input.model);
+  }
+
+  return args;
+}

--- a/src/lib/claude-code/index.ts
+++ b/src/lib/claude-code/index.ts
@@ -1,8 +1,27 @@
-// No-auto-merge hardening for the claude-code-action execution path (ADR-0006
-// §5, ADR-0005, decisions/0002 §C/§D). These are the deterministic primitives
-// #302 brackets the action with — they are intentionally pure and side-effect
-// free so the no-auto-merge invariant is unit-testable before the path is
-// enabled.
+/**
+ * Public surface of the claude-code-action execution path.
+ *
+ * Two complementary layers ship side-by-side and are both re-exported here:
+ *
+ * 1. **No-auto-merge hardening primitives** (#303, ADR-0006 §5, ADR-0005,
+ *    decisions/0002 §C/§D) — `tool-policy.ts`, `job-permissions.ts`,
+ *    `secret-scan-gate.ts`. Deterministic invariants that re-establish the
+ *    ADR-0005 no-auto-merge constraint when an external reasoning core has
+ *    write access; pure and side-effect free so they are unit-testable
+ *    before the path is enabled.
+ *
+ * 2. **Job + prompt-reuse + tool/MCP mapping** (#302, ADR-0006 §2) —
+ *    `tool-profiles.ts`, `mcp-config.ts`, `output-artifact.ts`,
+ *    `claude-args.ts`, `job.ts`. Maps Ferry's existing role → prompt and
+ *    role → tool model onto the inputs `claude-code-action` consumes,
+ *    and parses the terminal artifact back into the script-path outcome
+ *    objects.
+ *
+ * The whole module is inert: it is consumed by the contract wrapper steps
+ * (#301) and routing (#300), but no workflow imports it yet.
+ */
+
+// --- #303: no-auto-merge hardening primitives ---
 
 export {
   NO_AUTO_MERGE_DENY,
@@ -21,3 +40,44 @@ export type { JobPermissions, PermissionScope } from './job-permissions.js';
 
 export { secretScanGate, gatedPush } from './secret-scan-gate.js';
 export type { ScanFn, SecretScanGateOptions, GatedPushOptions } from './secret-scan-gate.js';
+
+// --- #302: job + prompt-reuse + tool/MCP mapping ---
+
+export {
+  type FerryRole,
+  type ToolAccess,
+  ROLE_PROMPT_NAME,
+  ROLE_ACCESS,
+  READ_ONLY_NATIVE_TOOLS,
+  READ_WRITE_NATIVE_TOOLS,
+  nativeToolsForRole,
+} from './tool-profiles.js';
+
+export {
+  type ClaudeCodeMcpServer,
+  type ClaudeCodeMcpConfig,
+  toClaudeCodeMcpConfig,
+  mcpToolAllowlist,
+} from './mcp-config.js';
+
+export {
+  type ReviewerVerdict,
+  type RefinerArtifact,
+  type ClaudeCodeArtifact,
+  CC_OUTPUT_ARTIFACT_PATH,
+  parseDevIterArtifact,
+  parseReviewerArtifact,
+  parseRefinerArtifact,
+  parseClaudeCodeArtifact,
+  outcomePromptSuffix,
+} from './output-artifact.js';
+
+export { type BuildClaudeArgsInput, buildClaudeArgs } from './claude-args.js';
+
+export {
+  type BuildClaudeCodeJobInput,
+  type ClaudeCodeJob,
+  CLAUDE_CODE_AUTH_INPUT,
+  FORBIDDEN_AUTH_INPUT,
+  buildClaudeCodeJob,
+} from './job.js';

--- a/src/lib/claude-code/job.test.ts
+++ b/src/lib/claude-code/job.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import type { McpServerConfig } from '../llm/agent-loop/types.js';
+import { buildClaudeCodeJob, CLAUDE_CODE_AUTH_INPUT, FORBIDDEN_AUTH_INPUT } from './job.js';
+import { CC_OUTPUT_ARTIFACT_PATH } from './output-artifact.js';
+
+describe('auth invariant (ADR-0006 §6 / decisions/0002 hard constraint)', () => {
+  it('authenticates exclusively via claude_code_oauth_token, never anthropic_api_key', () => {
+    expect(CLAUDE_CODE_AUTH_INPUT).toBe('claude_code_oauth_token');
+    expect(FORBIDDEN_AUTH_INPUT).toBe('anthropic_api_key');
+    const job = buildClaudeCodeJob({ role: 'developer', system: 's', initialPrompt: 'p' });
+    expect(job.authInput).toBe('claude_code_oauth_token');
+    expect(job.authInput).not.toBe(FORBIDDEN_AUTH_INPUT);
+  });
+});
+
+describe('buildClaudeCodeJob', () => {
+  it('uses the initial prompt verbatim and appends only the transport suffix', () => {
+    const initialPrompt = '<<<UNTRUSTED>>>\nTICKET: ABC-1\n<<<END>>>\nSUBTASKS: (none)';
+    const job = buildClaudeCodeJob({ role: 'developer', system: 's', initialPrompt });
+    expect(job.prompt.startsWith(initialPrompt)).toBe(true);
+    expect(job.prompt).toContain(CC_OUTPUT_ARTIFACT_PATH);
+    // verbatim: removing the suffix recovers the original initial prompt exactly
+    expect(job.prompt.slice(0, initialPrompt.length)).toBe(initialPrompt);
+  });
+
+  it('exposes the artifact path and a role-bound fail-closed parser', () => {
+    const job = buildClaudeCodeJob({ role: 'reviewer', system: 's', initialPrompt: 'p' });
+    expect(job.outputArtifactPath).toBe(CC_OUTPUT_ARTIFACT_PATH);
+    expect(job.parseOutput({ approved: true, comment: 'ok' })).toEqual({
+      approved: true,
+      comment: 'ok',
+    });
+    expect(() => job.parseOutput({ approved: 'nope' })).toThrow(/cc-output/i);
+  });
+
+  it('binds the parser to the role (developer → DonePayload)', () => {
+    const job = buildClaudeCodeJob({ role: 'developer', system: 's', initialPrompt: 'p' });
+    expect(job.parseOutput({ outcome: 'implemented', summary: 'done' })).toMatchObject({
+      actionable: true,
+      outcome: 'implemented',
+    });
+  });
+
+  it('threads role/system/mcp/maxTurns/model into claude_args', () => {
+    const servers: McpServerConfig[] = [{ type: 'stdio', name: 'jira', command: 'run' }];
+    const job = buildClaudeCodeJob({
+      role: 'developer',
+      system: 'SYS',
+      initialPrompt: 'p',
+      mcpServers: servers,
+      maxTurns: 25,
+      model: 'claude-opus-4-7',
+    });
+    expect(job.claudeArgs).toContain('--append-system-prompt');
+    expect(job.claudeArgs[job.claudeArgs.indexOf('--append-system-prompt') + 1]).toBe('SYS');
+    expect(job.claudeArgs).toContain('--mcp-config');
+    expect(job.claudeArgs[job.claudeArgs.indexOf('--max-turns') + 1]).toBe('25');
+    expect(job.claudeArgs[job.claudeArgs.indexOf('--model') + 1]).toBe('claude-opus-4-7');
+  });
+
+  it('reports the role read/write access for the parity table', () => {
+    expect(buildClaudeCodeJob({ role: 'refiner', system: 's', initialPrompt: 'p' }).access).toBe(
+      'read-only',
+    );
+    expect(buildClaudeCodeJob({ role: 'iterator', system: 's', initialPrompt: 'p' }).access).toBe(
+      'read-write',
+    );
+  });
+
+  it('fail-closed on an unknown role', () => {
+    // @ts-expect-error intentional bad role
+    expect(() => buildClaudeCodeJob({ role: 'x', system: 's', initialPrompt: 'p' })).toThrow(
+      /unknown ferry role/i,
+    );
+  });
+});

--- a/src/lib/claude-code/job.ts
+++ b/src/lib/claude-code/job.ts
@@ -1,0 +1,90 @@
+/**
+ * Top-level assembler for the `claude-code-action` execution path (issue #302).
+ *
+ * Given a role plus the **already-resolved, verbatim** Ferry prompts
+ * (`buildSystem(<role>)` and the existing `initialPrompt` builder output) and
+ * the **already capability-filtered** MCP pool, produces the deterministic
+ * inputs the wrapping workflow steps (#301) feed into `claude-code-action`:
+ *
+ *   - `prompt`            → action `prompt:` input (initial prompt + transport suffix)
+ *   - `claudeArgs`        → `claude_args:` token list (system via --append-system-prompt)
+ *   - `authInput`         → the ONLY allowed auth input name (OAuth token; never API key)
+ *   - `outputArtifactPath`→ where the LLM writes its final structured result
+ *   - `parseOutput`       → role-bound, fail-closed parser → identical script outcomes
+ *
+ * This module does NOT resolve prompts, filter MCP by capability, run the
+ * action, validate the envelope, emit audit comments, or perform transitions —
+ * those are the deterministic wrapper steps (#301) and routing (#300). Nothing
+ * here is wired into a workflow; the path stays inert until those land.
+ */
+
+import type { McpServerConfig } from '../llm/agent-loop/types.js';
+import type { FerryRole, ToolAccess } from './tool-profiles.js';
+import { ROLE_ACCESS, nativeToolsForRole } from './tool-profiles.js';
+import { buildClaudeArgs } from './claude-args.js';
+import {
+  CC_OUTPUT_ARTIFACT_PATH,
+  outcomePromptSuffix,
+  parseClaudeCodeArtifact,
+  type ClaudeCodeArtifact,
+} from './output-artifact.js';
+
+/**
+ * The claude-code path authenticates EXCLUSIVELY with this action input
+ * (ADR-0006 §6 / decisions/0002 hard constraint). `anthropic_api_key` is
+ * forbidden on this path — exported so wrapper/init code and tests can assert
+ * the invariant rather than re-encode the string.
+ */
+export const CLAUDE_CODE_AUTH_INPUT = 'claude_code_oauth_token' as const;
+export const FORBIDDEN_AUTH_INPUT = 'anthropic_api_key' as const;
+
+export interface BuildClaudeCodeJobInput {
+  role: FerryRole;
+  /** Resolved `buildSystem(<role>)` output — forwarded unchanged. */
+  system: string;
+  /** Resolved existing `initialPrompt` — forwarded unchanged (verbatim). */
+  initialPrompt: string;
+  /** Already capability-filtered MCP pool (caller runs `filterMcpServers`). */
+  mcpServers?: McpServerConfig[];
+  maxTurns?: number;
+  model?: string;
+}
+
+export interface ClaudeCodeJob {
+  role: FerryRole;
+  access: ToolAccess;
+  /** action `prompt:` — the verbatim initial prompt + the terminal-output suffix. */
+  prompt: string;
+  /** action `claude_args:` token list. */
+  claudeArgs: string[];
+  /** The only permitted auth input name (OAuth token). */
+  authInput: typeof CLAUDE_CODE_AUTH_INPUT;
+  /** Native tools granted to this role (parity-table observable). */
+  allowedNativeTools: string[];
+  outputArtifactPath: string;
+  /** Role-bound, fail-closed parser of the LLM's final artifact. */
+  parseOutput: (raw: unknown) => ClaudeCodeArtifact;
+}
+
+export function buildClaudeCodeJob(input: BuildClaudeCodeJobInput): ClaudeCodeJob {
+  // nativeToolsForRole is fail-closed on an unknown role — call it first so an
+  // invalid role throws before we build anything partial.
+  const allowedNativeTools = nativeToolsForRole(input.role);
+
+  return {
+    role: input.role,
+    access: ROLE_ACCESS[input.role],
+    prompt: input.initialPrompt + outcomePromptSuffix(input.role),
+    claudeArgs: buildClaudeArgs({
+      role: input.role,
+      system: input.system,
+      mcpServers: input.mcpServers,
+      maxTurns: input.maxTurns,
+      model: input.model,
+    }),
+    authInput: CLAUDE_CODE_AUTH_INPUT,
+    allowedNativeTools,
+    outputArtifactPath: CC_OUTPUT_ARTIFACT_PATH,
+    parseOutput: (raw: unknown) => parseClaudeCodeArtifact(input.role, raw),
+  };
+}

--- a/src/lib/claude-code/mcp-config.test.ts
+++ b/src/lib/claude-code/mcp-config.test.ts
@@ -91,4 +91,39 @@ describe('mcpToolAllowlist', () => {
   it('returns an empty list for no servers', () => {
     expect(mcpToolAllowlist([])).toEqual([]);
   });
+
+  it('excludes denied tools from a per-tool allowed_tools list (parity with pool.ts)', () => {
+    const scoped: McpServerConfig = {
+      ...stdio,
+      allowed_tools: ['get_issue', 'search', 'delete_issue'],
+      denied_tools: ['delete_issue'],
+    };
+    expect(mcpToolAllowlist([scoped])).toEqual(['mcp__jira__get_issue', 'mcp__jira__search']);
+  });
+
+  it('drops a server entirely when denied_tools removes every allowed tool', () => {
+    const scoped: McpServerConfig = {
+      ...stdio,
+      allowed_tools: ['delete_issue'],
+      denied_tools: ['delete_issue'],
+    };
+    expect(mcpToolAllowlist([scoped])).toEqual([]);
+  });
+
+  it('fails closed when denied_tools is set without allowed_tools (stdio)', () => {
+    const scoped: McpServerConfig = { ...stdio, denied_tools: ['delete_issue'] };
+    expect(() => mcpToolAllowlist([scoped])).toThrow(
+      /denied_tools without allowed_tools.*failing closed/is,
+    );
+  });
+
+  it('fails closed when denied_tools is set without allowed_tools (http)', () => {
+    const scoped: McpServerConfig = { ...http, denied_tools: ['danger'] };
+    expect(() => mcpToolAllowlist([scoped])).toThrow(/denied_tools without allowed_tools/i);
+  });
+
+  it('treats an empty denied_tools as no deny and keeps the wildcard', () => {
+    const scoped: McpServerConfig = { ...stdio, denied_tools: [] };
+    expect(mcpToolAllowlist([scoped])).toEqual(['mcp__jira']);
+  });
 });

--- a/src/lib/claude-code/mcp-config.test.ts
+++ b/src/lib/claude-code/mcp-config.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import type {
+  McpServerConfig,
+  StdioMcpServerConfig,
+  HttpMcpServerConfig,
+} from '../llm/agent-loop/types.js';
+import { toClaudeCodeMcpConfig, mcpToolAllowlist } from './mcp-config.js';
+
+const stdio: StdioMcpServerConfig = {
+  type: 'stdio',
+  name: 'jira',
+  command: 'npx',
+  args: ['-y', '@ferry/jira-mcp'],
+  env: { FERRY_JIRA_BASE_URL: 'https://x.atlassian.net' },
+};
+
+const http: HttpMcpServerConfig = {
+  name: 'context7',
+  url: 'https://mcp.context7.com/mcp',
+};
+
+const httpAuth: HttpMcpServerConfig = {
+  name: 'secure',
+  url: 'https://mcp.example.com/mcp',
+  authorization_token: 'tok-123',
+};
+
+describe('toClaudeCodeMcpConfig', () => {
+  it('wraps servers under an mcpServers object keyed by server name', () => {
+    const cfg = toClaudeCodeMcpConfig([stdio, http]);
+    expect(Object.keys(cfg.mcpServers)).toEqual(['jira', 'context7']);
+  });
+
+  it('maps a stdio server to command/args/env (type stdio)', () => {
+    const cfg = toClaudeCodeMcpConfig([stdio]);
+    expect(cfg.mcpServers.jira).toEqual({
+      type: 'stdio',
+      command: 'npx',
+      args: ['-y', '@ferry/jira-mcp'],
+      env: { FERRY_JIRA_BASE_URL: 'https://x.atlassian.net' },
+    });
+  });
+
+  it('omits empty args/env for a minimal stdio server', () => {
+    const minimal: StdioMcpServerConfig = { type: 'stdio', name: 's', command: 'run' };
+    const cfg = toClaudeCodeMcpConfig([minimal]);
+    expect(cfg.mcpServers.s).toEqual({ type: 'stdio', command: 'run' });
+  });
+
+  it('maps an http server to a remote http url', () => {
+    const cfg = toClaudeCodeMcpConfig([http]);
+    expect(cfg.mcpServers.context7).toEqual({
+      type: 'http',
+      url: 'https://mcp.context7.com/mcp',
+    });
+  });
+
+  it('maps an http authorization_token to an Authorization Bearer header', () => {
+    const cfg = toClaudeCodeMcpConfig([httpAuth]);
+    expect(cfg.mcpServers.secure).toEqual({
+      type: 'http',
+      url: 'https://mcp.example.com/mcp',
+      headers: { Authorization: 'Bearer tok-123' },
+    });
+  });
+
+  it('returns an empty mcpServers object for no servers', () => {
+    expect(toClaudeCodeMcpConfig([])).toEqual({ mcpServers: {} });
+  });
+
+  it('throws on a duplicate server name (fail-closed)', () => {
+    expect(() => toClaudeCodeMcpConfig([stdio, { ...stdio }])).toThrow(/duplicate mcp server/i);
+  });
+});
+
+describe('mcpToolAllowlist', () => {
+  it('emits a server-wide wildcard when no per-server allowlist is set', () => {
+    expect(mcpToolAllowlist([stdio, http])).toEqual(['mcp__jira', 'mcp__context7']);
+  });
+
+  it('emits per-tool entries when allowed_tools is set on a server', () => {
+    const scoped: McpServerConfig = { ...stdio, allowed_tools: ['get_issue', 'search'] };
+    expect(mcpToolAllowlist([scoped])).toEqual(['mcp__jira__get_issue', 'mcp__jira__search']);
+  });
+
+  it('falls back to the wildcard when allowed_tools is present but empty', () => {
+    const scoped: McpServerConfig = { ...stdio, allowed_tools: [] };
+    expect(mcpToolAllowlist([scoped])).toEqual(['mcp__jira']);
+  });
+
+  it('returns an empty list for no servers', () => {
+    expect(mcpToolAllowlist([])).toEqual([]);
+  });
+});

--- a/src/lib/claude-code/mcp-config.ts
+++ b/src/lib/claude-code/mcp-config.ts
@@ -1,0 +1,85 @@
+/**
+ * Translates Ferry's internal MCP server configs into the shape
+ * `claude-code-action` expects via `claude_args --mcp-config`, and derives the
+ * matching `mcp__<server>[__<tool>]` allowlist entries.
+ *
+ * Capability filtering (ticket-label → enabled servers / per-server tool
+ * allowlists) is NOT done here — callers run the existing
+ * `filterMcpServers()` (src/lib/labels/capabilities.ts) first and pass the
+ * already-filtered pool in. This module is a pure shape translator so it stays
+ * trivially unit-testable and the parity logic has a single home.
+ */
+
+import type {
+  McpServerConfig,
+  StdioMcpServerConfig,
+  HttpMcpServerConfig,
+} from '../llm/agent-loop/types.js';
+import { isStdioMcpServer } from '../llm/agent-loop/types.js';
+
+interface ClaudeCodeStdioServer {
+  type: 'stdio';
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+interface ClaudeCodeHttpServer {
+  type: 'http';
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export type ClaudeCodeMcpServer = ClaudeCodeStdioServer | ClaudeCodeHttpServer;
+
+export interface ClaudeCodeMcpConfig {
+  mcpServers: Record<string, ClaudeCodeMcpServer>;
+}
+
+function mapStdio(s: StdioMcpServerConfig): ClaudeCodeStdioServer {
+  const out: ClaudeCodeStdioServer = { type: 'stdio', command: s.command };
+  if (s.args && s.args.length > 0) out.args = [...s.args];
+  if (s.env && Object.keys(s.env).length > 0) out.env = { ...s.env };
+  return out;
+}
+
+function mapHttp(s: HttpMcpServerConfig): ClaudeCodeHttpServer {
+  const out: ClaudeCodeHttpServer = { type: 'http', url: s.url };
+  if (s.authorization_token) {
+    out.headers = { Authorization: `Bearer ${s.authorization_token}` };
+  }
+  return out;
+}
+
+/**
+ * Builds the `{ mcpServers: { <name>: <server> } }` object for
+ * `--mcp-config`. Throws on a duplicate server name (fail-closed: a silent
+ * last-wins merge could drop a security-relevant server).
+ */
+export function toClaudeCodeMcpConfig(servers: McpServerConfig[]): ClaudeCodeMcpConfig {
+  const mcpServers: Record<string, ClaudeCodeMcpServer> = {};
+  for (const s of servers) {
+    if (Object.prototype.hasOwnProperty.call(mcpServers, s.name)) {
+      throw new Error(`duplicate mcp server name: ${s.name}`);
+    }
+    mcpServers[s.name] = isStdioMcpServer(s) ? mapStdio(s) : mapHttp(s);
+  }
+  return { mcpServers };
+}
+
+/**
+ * Derives the MCP entries for `--allowedTools`. A server with a non-empty
+ * `allowed_tools` yields one `mcp__<server>__<tool>` entry per tool; otherwise
+ * a single `mcp__<server>` wildcard allowing all of that server's tools.
+ */
+export function mcpToolAllowlist(servers: McpServerConfig[]): string[] {
+  const allow: string[] = [];
+  for (const s of servers) {
+    if (s.allowed_tools && s.allowed_tools.length > 0) {
+      for (const tool of s.allowed_tools) allow.push(`mcp__${s.name}__${tool}`);
+    } else {
+      allow.push(`mcp__${s.name}`);
+    }
+  }
+  return allow;
+}

--- a/src/lib/claude-code/mcp-config.ts
+++ b/src/lib/claude-code/mcp-config.ts
@@ -68,15 +68,44 @@ export function toClaudeCodeMcpConfig(servers: McpServerConfig[]): ClaudeCodeMcp
 }
 
 /**
- * Derives the MCP entries for `--allowedTools`. A server with a non-empty
- * `allowed_tools` yields one `mcp__<server>__<tool>` entry per tool; otherwise
- * a single `mcp__<server>` wildcard allowing all of that server's tools.
+ * Derives the MCP entries for `--allowedTools`.
+ *
+ * `claude-code-action`'s `--allowedTools` is allow-only and matches by prefix
+ * (`mcp__<server>` allows every tool of that server; `mcp__<server>__<tool>`
+ * allows exactly one). It has no "deny" form and no enumeration of a server's
+ * live tool list at this layer, so "all tools except the denied set" is not
+ * directly expressible from a bare wildcard.
+ *
+ * To keep parity with the bundled path — which enforces `denied_tools`
+ * (`src/lib/llm/agent-loop/anthropic.ts` emits it into `mcp_toolset`;
+ * `src/lib/mcp/pool.ts` filters it out of the local stdio tool list) — this
+ * function honors `denied_tools`:
+ *
+ * - non-empty `allowed_tools`: emit one `mcp__<server>__<tool>` per tool, but
+ *   exclude any tool also present in `denied_tools` (mirrors pool.ts ordering:
+ *   allow-list intersect, then deny-list subtract);
+ * - no `allowed_tools` but a non-empty `denied_tools`: a `mcp__<server>`
+ *   wildcard would silently re-allow the denied tools and there is no tool
+ *   list to enumerate the complement from — fail closed by throwing rather
+ *   than silently widening the agent's MCP allowlist;
+ * - otherwise: a single `mcp__<server>` wildcard allowing all of that
+ *   server's tools.
  */
 export function mcpToolAllowlist(servers: McpServerConfig[]): string[] {
   const allow: string[] = [];
   for (const s of servers) {
+    const denied = new Set(s.denied_tools ?? []);
     if (s.allowed_tools && s.allowed_tools.length > 0) {
-      for (const tool of s.allowed_tools) allow.push(`mcp__${s.name}__${tool}`);
+      for (const tool of s.allowed_tools) {
+        if (denied.has(tool)) continue;
+        allow.push(`mcp__${s.name}__${tool}`);
+      }
+    } else if (denied.size > 0) {
+      throw new Error(
+        `mcp server "${s.name}" sets denied_tools without allowed_tools: ` +
+          `claude-code-action --allowedTools cannot express a deny-only allowlist ` +
+          `(failing closed to avoid silently re-allowing denied tools)`,
+      );
     } else {
       allow.push(`mcp__${s.name}`);
     }

--- a/src/lib/claude-code/output-artifact.test.ts
+++ b/src/lib/claude-code/output-artifact.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CC_OUTPUT_ARTIFACT_PATH,
+  parseDevIterArtifact,
+  parseReviewerArtifact,
+  parseRefinerArtifact,
+  parseClaudeCodeArtifact,
+  outcomePromptSuffix,
+} from './output-artifact.js';
+
+describe('CC_OUTPUT_ARTIFACT_PATH', () => {
+  it('is the fixed repo-relative artifact path', () => {
+    expect(CC_OUTPUT_ARTIFACT_PATH).toBe('.ferry/cc-output.json');
+  });
+});
+
+describe('parseDevIterArtifact (≈ script `done` outcome)', () => {
+  it('parses an implemented outcome and derives actionable=true', () => {
+    const out = parseDevIterArtifact({
+      outcome: 'implemented',
+      summary: 'Added the feature',
+      commit_message: 'feat: add feature',
+      validation: [{ command: 'npm test', outcome: '10 passed' }],
+      notes: ['follow-up: docs'],
+    });
+    expect(out).toEqual({
+      actionable: true,
+      outcome: 'implemented',
+      summary: 'Added the feature',
+      commit_message: 'feat: add feature',
+      validation: [{ command: 'npm test', outcome: '10 passed' }],
+      notes: ['follow-up: docs'],
+    });
+  });
+
+  it('derives actionable=true for already_satisfied', () => {
+    expect(
+      parseDevIterArtifact({ outcome: 'already_satisfied', summary: 'nothing to do' }),
+    ).toMatchObject({ actionable: true, outcome: 'already_satisfied' });
+  });
+
+  it('derives actionable=false for blocked and keeps reason', () => {
+    expect(
+      parseDevIterArtifact({
+        outcome: 'blocked',
+        summary: 'cannot proceed',
+        reason: 'missing API',
+      }),
+    ).toMatchObject({ actionable: false, outcome: 'blocked', reason: 'missing API' });
+  });
+
+  it.each([
+    ['not an object', 'nope'],
+    ['null', null],
+    ['missing summary', { outcome: 'implemented' }],
+    ['empty summary', { outcome: 'implemented', summary: '   ' }],
+    ['missing outcome', { summary: 'x' }],
+    ['invalid outcome', { outcome: 'done', summary: 'x' }],
+    ['validation wrong type', { outcome: 'implemented', summary: 'x', validation: 'bad' }],
+    ['notes wrong type', { outcome: 'implemented', summary: 'x', notes: [1, 2] }],
+  ])('fail-closed: throws on %s', (_label, bad) => {
+    expect(() => parseDevIterArtifact(bad)).toThrow(/cc-output/i);
+  });
+});
+
+describe('parseReviewerArtifact (≈ script `finish_review` outcome)', () => {
+  it('parses an approved verdict', () => {
+    expect(parseReviewerArtifact({ approved: true, comment: 'LGTM' })).toEqual({
+      approved: true,
+      comment: 'LGTM',
+    });
+  });
+
+  it('parses a changes-requested verdict', () => {
+    expect(parseReviewerArtifact({ approved: false, comment: 'fix X' })).toEqual({
+      approved: false,
+      comment: 'fix X',
+    });
+  });
+
+  it.each([
+    ['not an object', 42],
+    ['missing approved', { comment: 'x' }],
+    ['approved not boolean', { approved: 'yes', comment: 'x' }],
+    ['missing comment', { approved: true }],
+    ['empty comment', { approved: true, comment: '' }],
+  ])('fail-closed: throws on %s', (_label, bad) => {
+    expect(() => parseReviewerArtifact(bad)).toThrow(/cc-output/i);
+  });
+});
+
+describe('parseRefinerArtifact (≈ REFINER_OUTPUT_SCHEMA shape)', () => {
+  const valid = {
+    actions: [
+      { type: 'create', title: 'T', description: 'D' },
+      { type: 'noop', reason: 'unchanged' },
+    ],
+    touch_paths: ['src/a.ts'],
+    output_locale: 'en',
+    audit_summary: 'refined 1 subtask',
+  };
+
+  it('parses a valid refiner output verbatim', () => {
+    expect(parseRefinerArtifact(valid)).toEqual(valid);
+  });
+
+  it('accepts the optional attachments/cost_estimate fields', () => {
+    const withOpt = { ...valid, attachments: ['x.png'] };
+    expect(parseRefinerArtifact(withOpt)).toEqual(withOpt);
+  });
+
+  it.each([
+    ['not an object', null],
+    ['missing actions', { touch_paths: [], output_locale: 'en', audit_summary: 'a' }],
+    ['empty actions', { ...valid, actions: [] }],
+    ['unknown action type', { ...valid, actions: [{ type: 'delete', existing_key: 'K' }] }],
+    ['bad output_locale', { ...valid, output_locale: 'de' }],
+    ['empty audit_summary', { ...valid, audit_summary: '' }],
+    ['touch_paths not string[]', { ...valid, touch_paths: [1] }],
+  ])('fail-closed: throws on %s', (_label, bad) => {
+    expect(() => parseRefinerArtifact(bad)).toThrow(/cc-output/i);
+  });
+});
+
+describe('parseClaudeCodeArtifact (role dispatch)', () => {
+  it('routes developer/iterator to the done parser', () => {
+    expect(
+      parseClaudeCodeArtifact('developer', { outcome: 'blocked', summary: 's' }),
+    ).toMatchObject({ actionable: false });
+    expect(
+      parseClaudeCodeArtifact('iterator', { outcome: 'implemented', summary: 's' }),
+    ).toMatchObject({ outcome: 'implemented' });
+  });
+
+  it('routes reviewer to the verdict parser', () => {
+    expect(parseClaudeCodeArtifact('reviewer', { approved: true, comment: 'ok' })).toEqual({
+      approved: true,
+      comment: 'ok',
+    });
+  });
+
+  it('routes refiner to the refiner parser', () => {
+    const r = {
+      actions: [{ type: 'noop', reason: 'x' }],
+      touch_paths: [],
+      output_locale: 'fr',
+      audit_summary: 'rien',
+    };
+    expect(parseClaudeCodeArtifact('refiner', r)).toEqual(r);
+  });
+
+  it('throws on an unknown role (fail-closed)', () => {
+    // @ts-expect-error intentional bad role
+    expect(() => parseClaudeCodeArtifact('ghost', {})).toThrow(/unknown ferry role/i);
+  });
+});
+
+describe('outcomePromptSuffix', () => {
+  it('instructs every role to write the artifact at the fixed path and not call removed tools', () => {
+    for (const role of ['refiner', 'developer', 'reviewer', 'iterator'] as const) {
+      const s = outcomePromptSuffix(role);
+      expect(s).toContain(CC_OUTPUT_ARTIFACT_PATH);
+      expect(s.toLowerCase()).toContain('json');
+    }
+  });
+
+  it('tells dev/iter to commit via git (commit_progress has no terminal artifact)', () => {
+    expect(outcomePromptSuffix('developer').toLowerCase()).toContain('git');
+    expect(outcomePromptSuffix('iterator').toLowerCase()).toContain('git');
+  });
+
+  it('tells reviewer/refiner the expected verdict keys', () => {
+    expect(outcomePromptSuffix('reviewer')).toContain('approved');
+    expect(outcomePromptSuffix('refiner')).toContain('actions');
+  });
+});

--- a/src/lib/claude-code/output-artifact.test.ts
+++ b/src/lib/claude-code/output-artifact.test.ts
@@ -105,7 +105,11 @@ describe('parseRefinerArtifact (≈ REFINER_OUTPUT_SCHEMA shape)', () => {
   });
 
   it('accepts the optional attachments/cost_estimate fields', () => {
-    const withOpt = { ...valid, attachments: ['x.png'] };
+    const withOpt = {
+      ...valid,
+      attachments: ['x.png'],
+      cost_estimate: { loUsd: 0.12, hiUsd: 0.34, confidence: 'medium', baselineRuns: 3 },
+    };
     expect(parseRefinerArtifact(withOpt)).toEqual(withOpt);
   });
 
@@ -119,6 +123,28 @@ describe('parseRefinerArtifact (≈ REFINER_OUTPUT_SCHEMA shape)', () => {
     ['touch_paths not string[]', { ...valid, touch_paths: [1] }],
   ])('fail-closed: throws on %s', (_label, bad) => {
     expect(() => parseRefinerArtifact(bad)).toThrow(/cc-output/i);
+  });
+
+  it('fail-closed: rejects a malformed cost_estimate', () => {
+    // loUsd as a non-number string must be rejected — the claude-code parser
+    // must not accept payloads the strict RefinerCostEstimate shape rejects.
+    expect(() =>
+      parseRefinerArtifact({
+        ...valid,
+        cost_estimate: { loUsd: 'not-a-number', hiUsd: 1, confidence: 'low', baselineRuns: 0 },
+      }),
+    ).toThrow(/cost_estimate\.loUsd/i);
+    // Missing required fields are also rejected.
+    expect(() => parseRefinerArtifact({ ...valid, cost_estimate: { loUsd: 0.1 } })).toThrow(
+      /cost_estimate/i,
+    );
+    // Confidence outside the enum is rejected.
+    expect(() =>
+      parseRefinerArtifact({
+        ...valid,
+        cost_estimate: { loUsd: 0, hiUsd: 0, confidence: 'maybe', baselineRuns: 1 },
+      }),
+    ).toThrow(/cost_estimate\.confidence/i);
   });
 });
 

--- a/src/lib/claude-code/output-artifact.ts
+++ b/src/lib/claude-code/output-artifact.ts
@@ -1,0 +1,228 @@
+/**
+ * The claude-code-action final structured-output artifact contract.
+ *
+ * `claude-code-action` runs an opaque agent loop — Ferry's own terminal tools
+ * (`done`, `finish_review`) and the in-loop checkpoint tool (`commit_progress`)
+ * do not exist inside it. Per ADR-0006 §2 / decisions/0002 §C, the LLM instead
+ * writes its final result as JSON to a fixed repo-relative path; the
+ * deterministic wrapper (#301) reads and parses it back into the *exact same
+ * outcome objects the bundled script produces*, so the observable contract is
+ * identical.
+ *
+ *   - developer / iterator  → `DonePayload` (the script's `done` outcome)
+ *   - reviewer              → `ReviewerVerdict` (the script's `finish_review`)
+ *   - refiner               → `RefinerArtifact` (the REFINER_OUTPUT_SCHEMA shape)
+ *
+ * `commit_progress` is an *in-loop* checkpoint (stage + scan + commit + push),
+ * not a terminal result — on this path the LLM commits via native `git`
+ * (bounded by the no-auto-merge allowlist, #303). It therefore has no terminal
+ * artifact representation; the suffix instructs dev/iter accordingly.
+ *
+ * Parsing is fail-closed: any structural deviation throws (the wrapper treats
+ * a throw as a hard `blocked`, mirroring the script's fail-closed schema
+ * validation). Errors are tagged with the artifact path for operator triage.
+ */
+
+import type { DonePayload, DoneOutcome } from '../llm/agent-loop/types.js';
+import type { FerryRole } from './tool-profiles.js';
+import { ROLE_ACCESS } from './tool-profiles.js';
+
+/** Repo-relative path the LLM must write its final structured result to. */
+export const CC_OUTPUT_ARTIFACT_PATH = '.ferry/cc-output.json';
+
+/** Reviewer terminal verdict — mirrors the `finish_review` tool input. */
+export interface ReviewerVerdict {
+  approved: boolean;
+  comment: string;
+}
+
+/** Refiner terminal output — mirrors `REFINER_OUTPUT_SCHEMA` (src/agents/refiner/schema.ts). */
+export interface RefinerArtifact {
+  actions: RefinerArtifactAction[];
+  touch_paths: string[];
+  output_locale: 'en' | 'fr';
+  audit_summary: string;
+  attachments?: string[];
+  cost_estimate?: Record<string, unknown>;
+}
+
+type RefinerArtifactAction =
+  | { type: 'create'; title: string; description: string }
+  | { type: 'keep'; existing_key: string; reason: string }
+  | { type: 'mark_stale'; existing_key: string; reason: string }
+  | { type: 'noop'; reason: string };
+
+const DONE_OUTCOMES: readonly DoneOutcome[] = ['implemented', 'already_satisfied', 'blocked'];
+
+function fail(detail: string): never {
+  throw new Error(`Invalid ${CC_OUTPUT_ARTIFACT_PATH}: ${detail}`);
+}
+
+function asObject(raw: unknown): Record<string, unknown> {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    fail('expected a JSON object');
+  }
+  return raw as Record<string, unknown>;
+}
+
+function nonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((e) => typeof e === 'string');
+}
+
+/** developer / iterator — produces the same `DonePayload` the script's `done` tool yields. */
+export function parseDevIterArtifact(raw: unknown): DonePayload {
+  const o = asObject(raw);
+  const outcome = o.outcome;
+  if (typeof outcome !== 'string' || !DONE_OUTCOMES.includes(outcome as DoneOutcome)) {
+    fail(`outcome must be one of ${DONE_OUTCOMES.join(', ')}`);
+  }
+  if (!nonEmptyString(o.summary)) fail('summary is required');
+  if (o.validation !== undefined) {
+    if (
+      !Array.isArray(o.validation) ||
+      !o.validation.every(
+        (e) =>
+          typeof e === 'object' &&
+          e !== null &&
+          nonEmptyString((e as Record<string, unknown>).command) &&
+          typeof (e as Record<string, unknown>).outcome === 'string',
+      )
+    ) {
+      fail('validation must be an array of { command, outcome }');
+    }
+  }
+  if (o.notes !== undefined && !isStringArray(o.notes)) {
+    fail('notes must be an array of strings');
+  }
+  const done: DoneOutcome = outcome as DoneOutcome;
+  const payload: DonePayload = {
+    actionable: done !== 'blocked',
+    outcome: done,
+    summary: (o.summary as string).trim(),
+  };
+  if (typeof o.commit_message === 'string') payload.commit_message = o.commit_message;
+  if (typeof o.reason === 'string') payload.reason = o.reason;
+  if (o.validation !== undefined) {
+    payload.validation = o.validation as DonePayload['validation'];
+  }
+  if (o.notes !== undefined) payload.notes = o.notes as string[];
+  return payload;
+}
+
+/** reviewer — produces the same verdict the script's `finish_review` tool yields. */
+export function parseReviewerArtifact(raw: unknown): ReviewerVerdict {
+  const o = asObject(raw);
+  if (typeof o.approved !== 'boolean') fail('approved must be a boolean');
+  if (!nonEmptyString(o.comment)) fail('comment is required');
+  return { approved: o.approved, comment: o.comment };
+}
+
+function parseRefinerAction(a: unknown, idx: number): RefinerArtifactAction {
+  const o = asObject(a);
+  switch (o.type) {
+    case 'create':
+      if (!nonEmptyString(o.title) || !nonEmptyString(o.description)) {
+        fail(`actions[${idx}] create requires title and description`);
+      }
+      return { type: 'create', title: o.title as string, description: o.description as string };
+    case 'keep':
+    case 'mark_stale':
+      if (!nonEmptyString(o.existing_key) || !nonEmptyString(o.reason)) {
+        fail(`actions[${idx}] ${o.type} requires existing_key and reason`);
+      }
+      return {
+        type: o.type,
+        existing_key: o.existing_key as string,
+        reason: o.reason as string,
+      };
+    case 'noop':
+      if (!nonEmptyString(o.reason)) fail(`actions[${idx}] noop requires reason`);
+      return { type: 'noop', reason: o.reason as string };
+    default:
+      return fail(`actions[${idx}] has unknown type ${String(o.type)}`);
+  }
+}
+
+/** refiner — produces the same `RefinerOutput`-shaped object the script yields. */
+export function parseRefinerArtifact(raw: unknown): RefinerArtifact {
+  const o = asObject(raw);
+  if (!Array.isArray(o.actions) || o.actions.length === 0) {
+    fail('actions must be a non-empty array');
+  }
+  if (!isStringArray(o.touch_paths)) fail('touch_paths must be an array of strings');
+  if (o.output_locale !== 'en' && o.output_locale !== 'fr') {
+    fail("output_locale must be 'en' or 'fr'");
+  }
+  if (!nonEmptyString(o.audit_summary)) fail('audit_summary is required');
+  if (o.attachments !== undefined && !isStringArray(o.attachments)) {
+    fail('attachments must be an array of strings');
+  }
+  const out: RefinerArtifact = {
+    actions: (o.actions as unknown[]).map(parseRefinerAction),
+    touch_paths: o.touch_paths,
+    output_locale: o.output_locale,
+    audit_summary: o.audit_summary,
+  };
+  if (o.attachments !== undefined) out.attachments = o.attachments;
+  if (o.cost_estimate !== undefined) {
+    out.cost_estimate = o.cost_estimate as Record<string, unknown>;
+  }
+  return out;
+}
+
+export type ClaudeCodeArtifact = DonePayload | ReviewerVerdict | RefinerArtifact;
+
+/** Dispatches the artifact to the role's parser. Fail-closed on an unknown role. */
+export function parseClaudeCodeArtifact(role: FerryRole, raw: unknown): ClaudeCodeArtifact {
+  switch (role) {
+    case 'developer':
+    case 'iterator':
+      return parseDevIterArtifact(raw);
+    case 'reviewer':
+      return parseReviewerArtifact(raw);
+    case 'refiner':
+      return parseRefinerArtifact(raw);
+    default:
+      throw new Error(`unknown ferry role: ${String(role)}`);
+  }
+}
+
+const DEV_ITER_SHAPE =
+  '{ "outcome": "implemented" | "already_satisfied" | "blocked", "summary": string, ' +
+  '"commit_message"?: string, "reason"?: string, ' +
+  '"validation"?: [{ "command": string, "outcome": string }], "notes"?: string[] }';
+
+const REVIEWER_SHAPE = '{ "approved": boolean, "comment": string }';
+
+const REFINER_SHAPE =
+  '{ "actions": [...], "touch_paths": string[], "output_locale": "en" | "fr", ' +
+  '"audit_summary": string }';
+
+/**
+ * The transport instruction appended to the (verbatim) initial prompt by the
+ * wrapper. It does NOT rewrite `prompts/<agent>.md` — it tells the LLM how to
+ * terminate on this path (write the artifact) since the `done`/`finish_review`
+ * tools are absent here.
+ */
+export function outcomePromptSuffix(role: FerryRole): string {
+  const header =
+    `\n\n---\nFINAL OUTPUT (claude-code path): the \`done\`/\`finish_review\` tools are ` +
+    `not available here. As your LAST action, write your result as a single JSON object ` +
+    `to \`${CC_OUTPUT_ARTIFACT_PATH}\`, then stop.`;
+  if (role === 'reviewer') {
+    return `${header} Shape: ${REVIEWER_SHAPE}`;
+  }
+  if (role === 'refiner') {
+    return `${header} Shape: ${REFINER_SHAPE} (same as the bundled refiner JSON contract).`;
+  }
+  // developer / iterator
+  const access = ROLE_ACCESS[role]; // referenced so the read-write contract is explicit
+  return (
+    `${header} Commit and push your work with \`git\` first (there is no ` +
+    `\`commit_progress\` tool on this path; access=${access}). Then write: ${DEV_ITER_SHAPE}`
+  );
+}

--- a/src/lib/claude-code/output-artifact.ts
+++ b/src/lib/claude-code/output-artifact.ts
@@ -24,6 +24,11 @@
  */
 
 import type { DonePayload, DoneOutcome } from '../llm/agent-loop/types.js';
+import type {
+  RefinerAction,
+  RefinerCostEstimate,
+  RefinerOutput,
+} from '../../agents/refiner/schema.js';
 import type { FerryRole } from './tool-profiles.js';
 import { ROLE_ACCESS } from './tool-profiles.js';
 
@@ -36,21 +41,14 @@ export interface ReviewerVerdict {
   comment: string;
 }
 
-/** Refiner terminal output — mirrors `REFINER_OUTPUT_SCHEMA` (src/agents/refiner/schema.ts). */
-export interface RefinerArtifact {
-  actions: RefinerArtifactAction[];
-  touch_paths: string[];
-  output_locale: 'en' | 'fr';
-  audit_summary: string;
-  attachments?: string[];
-  cost_estimate?: Record<string, unknown>;
-}
-
-type RefinerArtifactAction =
-  | { type: 'create'; title: string; description: string }
-  | { type: 'keep'; existing_key: string; reason: string }
-  | { type: 'mark_stale'; existing_key: string; reason: string }
-  | { type: 'noop'; reason: string };
+/**
+ * Refiner terminal output — alias of `RefinerOutput` from
+ * `src/agents/refiner/schema.ts`, the single source of truth for the script
+ * and claude-code paths. Re-exported so that any future schema change (new
+ * action variant, additional required field, widened locale set, etc.)
+ * propagates to both execution paths without silent drift.
+ */
+export type RefinerArtifact = RefinerOutput;
 
 const DONE_OUTCOMES: readonly DoneOutcome[] = ['implemented', 'already_satisfied', 'blocked'];
 
@@ -121,7 +119,7 @@ export function parseReviewerArtifact(raw: unknown): ReviewerVerdict {
   return { approved: o.approved, comment: o.comment };
 }
 
-function parseRefinerAction(a: unknown, idx: number): RefinerArtifactAction {
+function parseRefinerAction(a: unknown, idx: number): RefinerAction {
   const o = asObject(a);
   switch (o.type) {
     case 'create':
@@ -147,6 +145,32 @@ function parseRefinerAction(a: unknown, idx: number): RefinerArtifactAction {
   }
 }
 
+function parseRefinerCostEstimate(raw: unknown): RefinerCostEstimate {
+  const o = asObject(raw);
+  if (typeof o.loUsd !== 'number' || !Number.isFinite(o.loUsd) || o.loUsd < 0) {
+    fail('cost_estimate.loUsd must be a non-negative number');
+  }
+  if (typeof o.hiUsd !== 'number' || !Number.isFinite(o.hiUsd) || o.hiUsd < 0) {
+    fail('cost_estimate.hiUsd must be a non-negative number');
+  }
+  if (o.confidence !== 'low' && o.confidence !== 'medium' && o.confidence !== 'high') {
+    fail("cost_estimate.confidence must be 'low', 'medium', or 'high'");
+  }
+  if (
+    typeof o.baselineRuns !== 'number' ||
+    !Number.isInteger(o.baselineRuns) ||
+    o.baselineRuns < 0
+  ) {
+    fail('cost_estimate.baselineRuns must be a non-negative integer');
+  }
+  return {
+    loUsd: o.loUsd,
+    hiUsd: o.hiUsd,
+    confidence: o.confidence,
+    baselineRuns: o.baselineRuns,
+  };
+}
+
 /** refiner — produces the same `RefinerOutput`-shaped object the script yields. */
 export function parseRefinerArtifact(raw: unknown): RefinerArtifact {
   const o = asObject(raw);
@@ -169,7 +193,7 @@ export function parseRefinerArtifact(raw: unknown): RefinerArtifact {
   };
   if (o.attachments !== undefined) out.attachments = o.attachments;
   if (o.cost_estimate !== undefined) {
-    out.cost_estimate = o.cost_estimate as Record<string, unknown>;
+    out.cost_estimate = parseRefinerCostEstimate(o.cost_estimate);
   }
   return out;
 }

--- a/src/lib/claude-code/tool-profiles.test.ts
+++ b/src/lib/claude-code/tool-profiles.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ROLE_PROMPT_NAME,
+  ROLE_ACCESS,
+  READ_ONLY_NATIVE_TOOLS,
+  READ_WRITE_NATIVE_TOOLS,
+  nativeToolsForRole,
+  type FerryRole,
+} from './tool-profiles.js';
+
+const ALL_ROLES: FerryRole[] = ['refiner', 'developer', 'reviewer', 'iterator'];
+
+describe('ROLE_PROMPT_NAME', () => {
+  it('maps each role to the prompt name buildSystem() uses today', () => {
+    // Verbatim reuse: these are the exact names the agent code passes to buildSystem().
+    expect(ROLE_PROMPT_NAME).toEqual({
+      refiner: 'refiner',
+      developer: 'dev',
+      reviewer: 'review',
+      iterator: 'iterate',
+    });
+  });
+});
+
+describe('ROLE_ACCESS (parity table)', () => {
+  it('marks refiner and reviewer read-only (no LLM writes)', () => {
+    expect(ROLE_ACCESS.refiner).toBe('read-only');
+    expect(ROLE_ACCESS.reviewer).toBe('read-only');
+  });
+
+  it('marks developer and iterator read-write', () => {
+    expect(ROLE_ACCESS.developer).toBe('read-write');
+    expect(ROLE_ACCESS.iterator).toBe('read-write');
+  });
+});
+
+describe('nativeToolsForRole', () => {
+  it('gives refiner/reviewer the read-only native tool set (no Bash/Write/Edit)', () => {
+    for (const role of ['refiner', 'reviewer'] as const) {
+      const tools = nativeToolsForRole(role);
+      expect(tools).toEqual([...READ_ONLY_NATIVE_TOOLS]);
+      expect(tools).not.toContain('Bash');
+      expect(tools).not.toContain('Write');
+      expect(tools).not.toContain('Edit');
+    }
+  });
+
+  it('gives developer/iterator the native Bash/Read/Write/Edit/Glob/Grep set', () => {
+    for (const role of ['developer', 'iterator'] as const) {
+      expect(nativeToolsForRole(role)).toEqual(['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep']);
+    }
+  });
+
+  it('read-only set is a strict subset of the read-write set', () => {
+    for (const t of READ_ONLY_NATIVE_TOOLS) {
+      expect(READ_WRITE_NATIVE_TOOLS).toContain(t);
+    }
+    expect(READ_WRITE_NATIVE_TOOLS.length).toBeGreaterThan(READ_ONLY_NATIVE_TOOLS.length);
+  });
+
+  it('returns a fresh array (mutating the result never leaks into the constants)', () => {
+    const a = nativeToolsForRole('developer');
+    a.push('Mutated');
+    expect(nativeToolsForRole('developer')).not.toContain('Mutated');
+  });
+
+  it('covers every role', () => {
+    for (const role of ALL_ROLES) {
+      expect(nativeToolsForRole(role).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('throws on an unknown role (fail-closed)', () => {
+    expect(() => nativeToolsForRole('hacker' as FerryRole)).toThrow(/unknown ferry role/i);
+  });
+});

--- a/src/lib/claude-code/tool-profiles.ts
+++ b/src/lib/claude-code/tool-profiles.ts
@@ -1,0 +1,60 @@
+/**
+ * Per-agent tool profiles for the claude-code-action execution path.
+ *
+ * This encodes the parity table from issue #302 / ADR-0006 §2:
+ *   - Refiner / Reviewer are READ-ONLY — they read (Jira/GitHub via MCP, files
+ *     via native read tools) and emit a structured verdict; they perform NO
+ *     LLM-driven writes. All side effects are deterministic wrapper steps.
+ *   - Developer / Iterator are READ-WRITE — they use the native Claude Code
+ *     tools `Bash/Read/Write/Edit/Glob/Grep` plus consumer MCP servers.
+ *
+ * These are the *native* Claude Code core tool names (as accepted by
+ * `claude_args --allowedTools`). MCP tool allowlisting is handled separately
+ * in `mcp-config.ts`.
+ */
+
+export type FerryRole = 'refiner' | 'developer' | 'reviewer' | 'iterator';
+
+export type ToolAccess = 'read-only' | 'read-write';
+
+/**
+ * The exact prompt name each role passes to `buildSystem()` today. Used so the
+ * claude-code path resolves the *same* bundled prompt (`prompts/<name>.md` +
+ * `prompts/<name>.extra.md`) verbatim — no rewrite.
+ */
+export const ROLE_PROMPT_NAME: Record<FerryRole, string> = {
+  refiner: 'refiner',
+  developer: 'dev',
+  reviewer: 'review',
+  iterator: 'iterate',
+};
+
+export const ROLE_ACCESS: Record<FerryRole, ToolAccess> = {
+  refiner: 'read-only',
+  reviewer: 'read-only',
+  developer: 'read-write',
+  iterator: 'read-write',
+};
+
+/** Native tools a read-only agent may use: file inspection only. */
+export const READ_ONLY_NATIVE_TOOLS = ['Read', 'Glob', 'Grep'] as const;
+
+/** Native tools a read-write agent may use: the full Ferry code-tool surface. */
+export const READ_WRITE_NATIVE_TOOLS = ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep'] as const;
+
+function isFerryRole(role: string): role is FerryRole {
+  return Object.prototype.hasOwnProperty.call(ROLE_ACCESS, role);
+}
+
+/**
+ * Returns the native Claude Code tool allowlist for a role. Fail-closed:
+ * an unrecognised role throws rather than defaulting to broad access.
+ */
+export function nativeToolsForRole(role: FerryRole): string[] {
+  if (!isFerryRole(role)) {
+    throw new Error(`unknown ferry role: ${String(role)}`);
+  }
+  return ROLE_ACCESS[role] === 'read-only'
+    ? [...READ_ONLY_NATIVE_TOOLS]
+    : [...READ_WRITE_NATIVE_TOOLS];
+}


### PR DESCRIPTION
Closes #302. Part of #299 (ADR-0006 / decisions/0002 §C).

## Scope

A **standalone, fully unit-tested mapping library** (`src/lib/claude-code/`) for the `claude-code-action` execution path. Pure and deterministic. **Not wired into any workflow** — siblings #300 (routing resolver) and #301 (contract wrapper steps) are still open; ADR-0006 is "Accepted — not yet implemented" with a hard test-first-before-enable constraint, so this lands inert and consumable, with zero behavior change for existing consumers.

## What's here

| File | Responsibility |
|---|---|
| `tool-profiles.ts` | Parity table: refiner/reviewer **read-only** (`Read/Glob/Grep`), developer/iterator **read-write** (`Bash/Read/Write/Edit/Glob/Grep`). Fail-closed on unknown role. `ROLE_PROMPT_NAME` pins the exact `buildSystem()` names. |
| `mcp-config.ts` | Ferry `McpServerConfig[]` (stdio/http) → `claude-code-action` `--mcp-config` JSON + `mcp__<server>[__<tool>]` allowlist. Fail-closed on duplicate server name. |
| `output-artifact.ts` | `.ferry/cc-output.json` contract. Fail-closed parsers reproducing the **exact script outcomes**: `done`→`DonePayload`, `finish_review`→`ReviewerVerdict`, refiner→`RefinerArtifact`. Terminal-output transport suffix (no prompt rewrite); documents that `commit_progress` is in-loop `git`, not a terminal artifact. |
| `claude-args.ts` | `--append-system-prompt` (system **verbatim**) + `--allowedTools` + `--mcp-config` + optional `--max-turns`/`--model`. |
| `job.ts` | `buildClaudeCodeJob()` ties it together; auth **exclusively** via `claude_code_oauth_token` (`anthropic_api_key` forbidden — ADR-0006 §6, asserted by test). |

## Acceptance criteria (#302)

- ✅ **Prompts reused verbatim (no rewrite):** system = `buildSystem(<role>)` → `--append-system-prompt`; initial = existing `initialPrompt` builders → action `prompt:` (the additive terminal-output suffix is transport, not a prompt edit; `prompts/*.md` untouched).
- ✅ **Per-agent parity table satisfied:** read-only refiner/reviewer, native `Bash/Read/Write/Edit/Glob/Grep` for developer/iterator, capability-filtered consumer MCP via `--mcp-config`.
- ✅ **Output JSON contract identical to script outcomes:** parsers return the existing `DonePayload`/verdict/refiner shapes, fail-closed (a throw = hard `blocked`, mirroring the script's fail-closed schema validation).

## Design notes

- Output transport = **file artifact** (`.ferry/cc-output.json`) per maintainer decision — transport-agnostic and trivially unit-testable, vs. coupling to the action's `structured_output` internals.
- No `lib`→`agents` layering inversion: the module owns the path's contract types and reuses `DonePayload` from `lib`; `RefinerArtifact`/`ReviewerVerdict` mirror `REFINER_OUTPUT_SCHEMA` / `finish_review` (documented).
- Out of scope (other sub-issues): routing (#300), envelope/audit/transition wrapper steps (#301), no-auto-merge `--disallowedTools` hardening (#303), `ferry-init` path choice + secret (#304).

## Verification

- 69 new unit tests (TDD: tests written before each module).
- Full suite: **1883 passed / 132 files**, no regressions.
- `typecheck` ✅ · `eslint` ✅ · `prettier` ✅ · `gitleaks` ✅ (no leaks).
- `build:ferry` produces no module-related bundle changes (nothing imports it yet — path inert by design); pre-existing source↔bundle drift on `main` deliberately excluded to keep scope surgical.