### PR TITLE
feat: deterministic execution-path resolver (closes #300)

### DIFF
--- a/.ferry/agent.js
+++ b/.ferry/agent.js
@@ -646,6 +646,9 @@ var DEFAULT_FERRY_CONFIG = {
       },
       iterator: { trigger_column: "Changes Requested", auto_transition: "In Review" }
     }
+  },
+  routing: {
+    claude_code_round_trip_threshold: 2
   }
 };
 function validateProvider(val, fieldPath) {
@@ -904,6 +907,24 @@ function validateConfigShape(raw) {
       }
     }
   }
+  if (c.execution_path !== void 0 && c.execution_path !== "script" && c.execution_path !== "claude-code") {
+    errs.push('execution_path: must be "script" or "claude-code"');
+  }
+  if (c.routing !== void 0) {
+    if (!c.routing || typeof c.routing !== "object" || Array.isArray(c.routing)) {
+      errs.push("routing: must be an object");
+    } else {
+      const r = c.routing;
+      if (r.claude_code_round_trip_threshold !== void 0) {
+        errs.push(
+          ...validatePosInt(
+            r.claude_code_round_trip_threshold,
+            "routing.claude_code_round_trip_threshold"
+          )
+        );
+      }
+    }
+  }
   return errs;
 }
 function readJsonConfig(filePath) {
@@ -1078,6 +1099,13 @@ function mergeWithDefaults(raw) {
     },
     ...labels !== void 0 ? { labels } : {},
     workflow: mergeWorkflow(raw.workflow),
+    ...raw.execution_path === "script" || raw.execution_path === "claude-code" ? { execution_path: raw.execution_path } : {},
+    routing: {
+      claude_code_round_trip_threshold: num(
+        raw.routing?.claude_code_round_trip_threshold,
+        DEFAULT_FERRY_CONFIG.routing.claude_code_round_trip_threshold
+      )
+    },
     ...raw.safety && typeof raw.safety === "object" && !Array.isArray(raw.safety) ? {
       safety: {
         ...typeof raw.safety.allow_skip_review === "boolean" ? {
@@ -5980,6 +6008,8 @@ function resolveTicketOverrides(labels, logger, options) {
   let noAutoTransition = false;
   let dryRun = false;
   let readOnly = false;
+  let hasClaudeCode = false;
+  let hasNoClaudeCode = false;
   const skipPhases = [];
   let baseBranchLabel;
   let baseBranch;
@@ -6263,8 +6293,17 @@ function resolveTicketOverrides(labels, logger, options) {
       readOnly = true;
       continue;
     }
+    if (label === "ferry:claude-code") {
+      hasClaudeCode = true;
+      continue;
+    }
+    if (label === "ferry:no-claude-code") {
+      hasNoClaudeCode = true;
+      continue;
+    }
     logger?.warn("unknown ferry override label ignored", { label });
   }
+  const claudeCodePath = hasClaudeCode && !hasNoClaudeCode ? "claude-code" : hasClaudeCode || hasNoClaudeCode ? "script" : void 0;
   if (blanketModel !== void 0) {
     for (const phase of PHASES_ORDERED) {
       if (modelSources[phase] === void 0) {
@@ -6307,7 +6346,8 @@ function resolveTicketOverrides(labels, logger, options) {
     ...gitOverride ? { git: gitOverride } : {},
     ...paused ? { paused: true } : {},
     ...dryRun ? { dryRun: true } : {},
-    ...readOnly ? { readOnly: true } : {}
+    ...readOnly ? { readOnly: true } : {},
+    ...claudeCodePath !== void 0 ? { claudeCodePath } : {}
   };
 }
 function applyTicketOverrides(cfg, overrides) {
@@ -6362,7 +6402,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.git?.baseBranch !== void 0 || overrides.git?.targetBranch !== void 0 || overrides.git?.prDraft !== void 0 || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.git?.baseBranch !== void 0 || overrides.git?.targetBranch !== void 0 || overrides.git?.prDraft !== void 0 || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true || overrides.claudeCodePath !== void 0;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6383,6 +6423,7 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if (overrides.paused) payload.paused = true;
   if (overrides.dryRun) payload.dryRun = true;
   if (overrides.readOnly) payload.readOnly = true;
+  if (overrides.claudeCodePath !== void 0) payload.claudeCodePath = overrides.claudeCodePath;
   const body = `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
   return applyDryRunMarker(body, overrides.dryRun);
 }

--- a/.github/actions/ferry-run-developer/agent.js
+++ b/.github/actions/ferry-run-developer/agent.js
@@ -646,6 +646,9 @@ var DEFAULT_FERRY_CONFIG = {
       },
       iterator: { trigger_column: "Changes Requested", auto_transition: "In Review" }
     }
+  },
+  routing: {
+    claude_code_round_trip_threshold: 2
   }
 };
 function validateProvider(val, fieldPath) {
@@ -904,6 +907,24 @@ function validateConfigShape(raw) {
       }
     }
   }
+  if (c.execution_path !== void 0 && c.execution_path !== "script" && c.execution_path !== "claude-code") {
+    errs.push('execution_path: must be "script" or "claude-code"');
+  }
+  if (c.routing !== void 0) {
+    if (!c.routing || typeof c.routing !== "object" || Array.isArray(c.routing)) {
+      errs.push("routing: must be an object");
+    } else {
+      const r = c.routing;
+      if (r.claude_code_round_trip_threshold !== void 0) {
+        errs.push(
+          ...validatePosInt(
+            r.claude_code_round_trip_threshold,
+            "routing.claude_code_round_trip_threshold"
+          )
+        );
+      }
+    }
+  }
   return errs;
 }
 function readJsonConfig(filePath) {
@@ -1078,6 +1099,13 @@ function mergeWithDefaults(raw) {
     },
     ...labels !== void 0 ? { labels } : {},
     workflow: mergeWorkflow(raw.workflow),
+    ...raw.execution_path === "script" || raw.execution_path === "claude-code" ? { execution_path: raw.execution_path } : {},
+    routing: {
+      claude_code_round_trip_threshold: num(
+        raw.routing?.claude_code_round_trip_threshold,
+        DEFAULT_FERRY_CONFIG.routing.claude_code_round_trip_threshold
+      )
+    },
     ...raw.safety && typeof raw.safety === "object" && !Array.isArray(raw.safety) ? {
       safety: {
         ...typeof raw.safety.allow_skip_review === "boolean" ? {
@@ -5980,6 +6008,8 @@ function resolveTicketOverrides(labels, logger, options) {
   let noAutoTransition = false;
   let dryRun = false;
   let readOnly = false;
+  let hasClaudeCode = false;
+  let hasNoClaudeCode = false;
   const skipPhases = [];
   let baseBranchLabel;
   let baseBranch;
@@ -6263,8 +6293,17 @@ function resolveTicketOverrides(labels, logger, options) {
       readOnly = true;
       continue;
     }
+    if (label === "ferry:claude-code") {
+      hasClaudeCode = true;
+      continue;
+    }
+    if (label === "ferry:no-claude-code") {
+      hasNoClaudeCode = true;
+      continue;
+    }
     logger?.warn("unknown ferry override label ignored", { label });
   }
+  const claudeCodePath = hasClaudeCode && !hasNoClaudeCode ? "claude-code" : hasClaudeCode || hasNoClaudeCode ? "script" : void 0;
   if (blanketModel !== void 0) {
     for (const phase of PHASES_ORDERED) {
       if (modelSources[phase] === void 0) {
@@ -6307,7 +6346,8 @@ function resolveTicketOverrides(labels, logger, options) {
     ...gitOverride ? { git: gitOverride } : {},
     ...paused ? { paused: true } : {},
     ...dryRun ? { dryRun: true } : {},
-    ...readOnly ? { readOnly: true } : {}
+    ...readOnly ? { readOnly: true } : {},
+    ...claudeCodePath !== void 0 ? { claudeCodePath } : {}
   };
 }
 function applyTicketOverrides(cfg, overrides) {
@@ -6362,7 +6402,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.git?.baseBranch !== void 0 || overrides.git?.targetBranch !== void 0 || overrides.git?.prDraft !== void 0 || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.git?.baseBranch !== void 0 || overrides.git?.targetBranch !== void 0 || overrides.git?.prDraft !== void 0 || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true || overrides.claudeCodePath !== void 0;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6383,6 +6423,7 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if (overrides.paused) payload.paused = true;
   if (overrides.dryRun) payload.dryRun = true;
   if (overrides.readOnly) payload.readOnly = true;
+  if (overrides.claudeCodePath !== void 0) payload.claudeCodePath = overrides.claudeCodePath;
   const body = `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
   return applyDryRunMarker(body, overrides.dryRun);
 }

--- a/.github/actions/ferry-run-iterator/agent.js
+++ b/.github/actions/ferry-run-iterator/agent.js
@@ -646,6 +646,9 @@ var DEFAULT_FERRY_CONFIG = {
       },
       iterator: { trigger_column: "Changes Requested", auto_transition: "In Review" }
     }
+  },
+  routing: {
+    claude_code_round_trip_threshold: 2
   }
 };
 function validateProvider(val, fieldPath) {
@@ -904,6 +907,24 @@ function validateConfigShape(raw) {
       }
     }
   }
+  if (c.execution_path !== void 0 && c.execution_path !== "script" && c.execution_path !== "claude-code") {
+    errs.push('execution_path: must be "script" or "claude-code"');
+  }
+  if (c.routing !== void 0) {
+    if (!c.routing || typeof c.routing !== "object" || Array.isArray(c.routing)) {
+      errs.push("routing: must be an object");
+    } else {
+      const r = c.routing;
+      if (r.claude_code_round_trip_threshold !== void 0) {
+        errs.push(
+          ...validatePosInt(
+            r.claude_code_round_trip_threshold,
+            "routing.claude_code_round_trip_threshold"
+          )
+        );
+      }
+    }
+  }
   return errs;
 }
 function readJsonConfig(filePath) {
@@ -1078,6 +1099,13 @@ function mergeWithDefaults(raw) {
     },
     ...labels !== void 0 ? { labels } : {},
     workflow: mergeWorkflow(raw.workflow),
+    ...raw.execution_path === "script" || raw.execution_path === "claude-code" ? { execution_path: raw.execution_path } : {},
+    routing: {
+      claude_code_round_trip_threshold: num(
+        raw.routing?.claude_code_round_trip_threshold,
+        DEFAULT_FERRY_CONFIG.routing.claude_code_round_trip_threshold
+      )
+    },
     ...raw.safety && typeof raw.safety === "object" && !Array.isArray(raw.safety) ? {
       safety: {
         ...typeof raw.safety.allow_skip_review === "boolean" ? {
@@ -5980,6 +6008,8 @@ function resolveTicketOverrides(labels, logger, options) {
   let noAutoTransition = false;
   let dryRun = false;
   let readOnly = false;
+  let hasClaudeCode = false;
+  let hasNoClaudeCode = false;
   const skipPhases = [];
   let baseBranchLabel;
   let baseBranch;
@@ -6263,8 +6293,17 @@ function resolveTicketOverrides(labels, logger, options) {
       readOnly = true;
       continue;
     }
+    if (label === "ferry:claude-code") {
+      hasClaudeCode = true;
+      continue;
+    }
+    if (label === "ferry:no-claude-code") {
+      hasNoClaudeCode = true;
+      continue;
+    }
     logger?.warn("unknown ferry override label ignored", { label });
   }
+  const claudeCodePath = hasClaudeCode && !hasNoClaudeCode ? "claude-code" : hasClaudeCode || hasNoClaudeCode ? "script" : void 0;
   if (blanketModel !== void 0) {
     for (const phase of PHASES_ORDERED) {
       if (modelSources[phase] === void 0) {
@@ -6307,7 +6346,8 @@ function resolveTicketOverrides(labels, logger, options) {
     ...gitOverride ? { git: gitOverride } : {},
     ...paused ? { paused: true } : {},
     ...dryRun ? { dryRun: true } : {},
-    ...readOnly ? { readOnly: true } : {}
+    ...readOnly ? { readOnly: true } : {},
+    ...claudeCodePath !== void 0 ? { claudeCodePath } : {}
   };
 }
 function applyTicketOverrides(cfg, overrides) {
@@ -6362,7 +6402,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.git?.baseBranch !== void 0 || overrides.git?.targetBranch !== void 0 || overrides.git?.prDraft !== void 0 || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.git?.baseBranch !== void 0 || overrides.git?.targetBranch !== void 0 || overrides.git?.prDraft !== void 0 || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true || overrides.claudeCodePath !== void 0;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6383,6 +6423,7 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if (overrides.paused) payload.paused = true;
   if (overrides.dryRun) payload.dryRun = true;
   if (overrides.readOnly) payload.readOnly = true;
+  if (overrides.claudeCodePath !== void 0) payload.claudeCodePath = overrides.claudeCodePath;
   const body = `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
   return applyDryRunMarker(body, overrides.dryRun);
 }

--- a/.github/actions/ferry-run-refiner/agent.js
+++ b/.github/actions/ferry-run-refiner/agent.js
@@ -646,6 +646,9 @@ var DEFAULT_FERRY_CONFIG = {
       },
       iterator: { trigger_column: "Changes Requested", auto_transition: "In Review" }
     }
+  },
+  routing: {
+    claude_code_round_trip_threshold: 2
   }
 };
 function validateProvider(val, fieldPath) {
@@ -904,6 +907,24 @@ function validateConfigShape(raw) {
       }
     }
   }
+  if (c.execution_path !== void 0 && c.execution_path !== "script" && c.execution_path !== "claude-code") {
+    errs.push('execution_path: must be "script" or "claude-code"');
+  }
+  if (c.routing !== void 0) {
+    if (!c.routing || typeof c.routing !== "object" || Array.isArray(c.routing)) {
+      errs.push("routing: must be an object");
+    } else {
+      const r = c.routing;
+      if (r.claude_code_round_trip_threshold !== void 0) {
+        errs.push(
+          ...validatePosInt(
+            r.claude_code_round_trip_threshold,
+            "routing.claude_code_round_trip_threshold"
+          )
+        );
+      }
+    }
+  }
   return errs;
 }
 function readJsonConfig(filePath) {
@@ -1078,6 +1099,13 @@ function mergeWithDefaults(raw) {
     },
     ...labels !== void 0 ? { labels } : {},
     workflow: mergeWorkflow(raw.workflow),
+    ...raw.execution_path === "script" || raw.execution_path === "claude-code" ? { execution_path: raw.execution_path } : {},
+    routing: {
+      claude_code_round_trip_threshold: num(
+        raw.routing?.claude_code_round_trip_threshold,
+        DEFAULT_FERRY_CONFIG.routing.claude_code_round_trip_threshold
+      )
+    },
     ...raw.safety && typeof raw.safety === "object" && !Array.isArray(raw.safety) ? {
       safety: {
         ...typeof raw.safety.allow_skip_review === "boolean" ? {
@@ -5980,6 +6008,8 @@ function resolveTicketOverrides(labels, logger, options) {
   let noAutoTransition = false;
   let dryRun = false;
   let readOnly = false;
+  let hasClaudeCode = false;
+  let hasNoClaudeCode = false;
   const skipPhases = [];
   let baseBranchLabel;
   let baseBranch;
@@ -6263,8 +6293,17 @@ function resolveTicketOverrides(labels, logger, options) {
       readOnly = true;
       continue;
     }
+    if (label === "ferry:claude-code") {
+      hasClaudeCode = true;
+      continue;
+    }
+    if (label === "ferry:no-claude-code") {
+      hasNoClaudeCode = true;
+      continue;
+    }
     logger?.warn("unknown ferry override label ignored", { label });
   }
+  const claudeCodePath = hasClaudeCode && !hasNoClaudeCode ? "claude-code" : hasClaudeCode || hasNoClaudeCode ? "script" : void 0;
   if (blanketModel !== void 0) {
     for (const phase of PHASES_ORDERED) {
       if (modelSources[phase] === void 0) {
@@ -6307,7 +6346,8 @@ function resolveTicketOverrides(labels, logger, options) {
     ...gitOverride ? { git: gitOverride } : {},
     ...paused ? { paused: true } : {},
     ...dryRun ? { dryRun: true } : {},
-    ...readOnly ? { readOnly: true } : {}
+    ...readOnly ? { readOnly: true } : {},
+    ...claudeCodePath !== void 0 ? { claudeCodePath } : {}
   };
 }
 function applyTicketOverrides(cfg, overrides) {
@@ -6362,7 +6402,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.git?.baseBranch !== void 0 || overrides.git?.targetBranch !== void 0 || overrides.git?.prDraft !== void 0 || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.git?.baseBranch !== void 0 || overrides.git?.targetBranch !== void 0 || overrides.git?.prDraft !== void 0 || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true || overrides.claudeCodePath !== void 0;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6383,6 +6423,7 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if (overrides.paused) payload.paused = true;
   if (overrides.dryRun) payload.dryRun = true;
   if (overrides.readOnly) payload.readOnly = true;
+  if (overrides.claudeCodePath !== void 0) payload.claudeCodePath = overrides.claudeCodePath;
   const body = `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
   return applyDryRunMarker(body, overrides.dryRun);
 }

--- a/.github/actions/ferry-run-reviewer/agent.js
+++ b/.github/actions/ferry-run-reviewer/agent.js
@@ -646,6 +646,9 @@ var DEFAULT_FERRY_CONFIG = {
       },
       iterator: { trigger_column: "Changes Requested", auto_transition: "In Review" }
     }
+  },
+  routing: {
+    claude_code_round_trip_threshold: 2
   }
 };
 function validateProvider(val, fieldPath) {
@@ -904,6 +907,24 @@ function validateConfigShape(raw) {
       }
     }
   }
+  if (c.execution_path !== void 0 && c.execution_path !== "script" && c.execution_path !== "claude-code") {
+    errs.push('execution_path: must be "script" or "claude-code"');
+  }
+  if (c.routing !== void 0) {
+    if (!c.routing || typeof c.routing !== "object" || Array.isArray(c.routing)) {
+      errs.push("routing: must be an object");
+    } else {
+      const r = c.routing;
+      if (r.claude_code_round_trip_threshold !== void 0) {
+        errs.push(
+          ...validatePosInt(
+            r.claude_code_round_trip_threshold,
+            "routing.claude_code_round_trip_threshold"
+          )
+        );
+      }
+    }
+  }
   return errs;
 }
 function readJsonConfig(filePath) {
@@ -1078,6 +1099,13 @@ function mergeWithDefaults(raw) {
     },
     ...labels !== void 0 ? { labels } : {},
     workflow: mergeWorkflow(raw.workflow),
+    ...raw.execution_path === "script" || raw.execution_path === "claude-code" ? { execution_path: raw.execution_path } : {},
+    routing: {
+      claude_code_round_trip_threshold: num(
+        raw.routing?.claude_code_round_trip_threshold,
+        DEFAULT_FERRY_CONFIG.routing.claude_code_round_trip_threshold
+      )
+    },
     ...raw.safety && typeof raw.safety === "object" && !Array.isArray(raw.safety) ? {
       safety: {
         ...typeof raw.safety.allow_skip_review === "boolean" ? {
@@ -5980,6 +6008,8 @@ function resolveTicketOverrides(labels, logger, options) {
   let noAutoTransition = false;
   let dryRun = false;
   let readOnly = false;
+  let hasClaudeCode = false;
+  let hasNoClaudeCode = false;
   const skipPhases = [];
   let baseBranchLabel;
   let baseBranch;
@@ -6263,8 +6293,17 @@ function resolveTicketOverrides(labels, logger, options) {
       readOnly = true;
       continue;
     }
+    if (label === "ferry:claude-code") {
+      hasClaudeCode = true;
+      continue;
+    }
+    if (label === "ferry:no-claude-code") {
+      hasNoClaudeCode = true;
+      continue;
+    }
     logger?.warn("unknown ferry override label ignored", { label });
   }
+  const claudeCodePath = hasClaudeCode && !hasNoClaudeCode ? "claude-code" : hasClaudeCode || hasNoClaudeCode ? "script" : void 0;
   if (blanketModel !== void 0) {
     for (const phase of PHASES_ORDERED) {
       if (modelSources[phase] === void 0) {
@@ -6307,7 +6346,8 @@ function resolveTicketOverrides(labels, logger, options) {
     ...gitOverride ? { git: gitOverride } : {},
     ...paused ? { paused: true } : {},
     ...dryRun ? { dryRun: true } : {},
-    ...readOnly ? { readOnly: true } : {}
+    ...readOnly ? { readOnly: true } : {},
+    ...claudeCodePath !== void 0 ? { claudeCodePath } : {}
   };
 }
 function applyTicketOverrides(cfg, overrides) {
@@ -6362,7 +6402,7 @@ function applyTicketOverrides(cfg, overrides) {
   return { ...cfg, models, limits };
 }
 function hasNonDefaultOverrides(overrides) {
-  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.git?.baseBranch !== void 0 || overrides.git?.targetBranch !== void 0 || overrides.git?.prDraft !== void 0 || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true;
+  return overrides.bypassTaskSkip || overrides.typeOverride !== void 0 || overrides.modelOverrides !== void 0 || overrides.budget !== void 0 || overrides.budgetEur !== void 0 || overrides.maxIterations !== void 0 || overrides.maxTokens !== void 0 || (overrides.skipPhases?.length ?? 0) > 0 || overrides.noAutoTransition === true || overrides.thinking !== void 0 || overrides.reviewRubric !== void 0 || overrides.git?.noPr === true || overrides.git?.baseBranch !== void 0 || overrides.git?.targetBranch !== void 0 || overrides.git?.prDraft !== void 0 || overrides.paused === true || overrides.dryRun === true || overrides.readOnly === true || overrides.claudeCodePath !== void 0;
 }
 function buildOverridesAuditComment(role, runId, overrides) {
   const payload = {};
@@ -6383,6 +6423,7 @@ function buildOverridesAuditComment(role, runId, overrides) {
   if (overrides.paused) payload.paused = true;
   if (overrides.dryRun) payload.dryRun = true;
   if (overrides.readOnly) payload.readOnly = true;
+  if (overrides.claudeCodePath !== void 0) payload.claudeCodePath = overrides.claudeCodePath;
   const body = `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
   return applyDryRunMarker(body, overrides.dryRun);
 }

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -34,7 +34,31 @@
     },
     {
       "id": "1118649",
-      "rationale": "Pre-existing advisory in protobufjs (transitive dep via @google/genai → protobufjs@^7.5.4). No patched protobufjs release yet, and @google/genai’s latest 2.2.0 still pins the same range. Ferry only uses @google/genai to call Gemini APIs over Google's gRPC endpoints — protobuf messages are never decoded from untrusted sources. Remove when @google/genai bumps to a patched protobufjs."
+      "rationale": "Pre-existing advisory in protobufjs (transitive dep via @google/genai → protobufjs@^7.5.4). No patched protobufjs release yet, and @google/genai’s latest 2.2.0 still pins the same range. Ferry only uses @google/genai to call Gemini APIs over Google’s gRPC endpoints — protobuf messages are never decoded from untrusted sources. Remove when @google/genai bumps to a patched protobufjs."
+    },
+    {
+      "id": "1118924",
+      "rationale": "Pre-existing advisory in protobufjs (transitive dep via @google/genai → protobufjs@^7.5.4). No patched protobufjs release yet, and @google/genai’s latest 2.2.0 still pins the same range. Ferry only uses @google/genai to call Gemini APIs over Google’s gRPC endpoints — protobuf messages are never decoded from untrusted sources. Remove when @google/genai bumps to a patched protobufjs."
+    },
+    {
+      "id": "1118926",
+      "rationale": "Pre-existing advisory in protobufjs (transitive dep via @google/genai → protobufjs@^7.5.4). No patched protobufjs release yet, and @google/genai’s latest 2.2.0 still pins the same range. Ferry only uses @google/genai to call Gemini APIs over Google’s gRPC endpoints — protobuf messages are never decoded from untrusted sources. Remove when @google/genai bumps to a patched protobufjs."
+    },
+    {
+      "id": "1118928",
+      "rationale": "Pre-existing advisory in protobufjs (transitive dep via @google/genai → protobufjs@^7.5.4). No patched protobufjs release yet, and @google/genai’s latest 2.2.0 still pins the same range. Ferry only uses @google/genai to call Gemini APIs over Google’s gRPC endpoints — protobuf messages are never decoded from untrusted sources. Remove when @google/genai bumps to a patched protobufjs."
+    },
+    {
+      "id": "1118930",
+      "rationale": "Pre-existing advisory in protobufjs (transitive dep via @google/genai → protobufjs@^7.5.4). No patched protobufjs release yet, and @google/genai’s latest 2.2.0 still pins the same range. Ferry only uses @google/genai to call Gemini APIs over Google’s gRPC endpoints — protobuf messages are never decoded from untrusted sources. Remove when @google/genai bumps to a patched protobufjs."
+    },
+    {
+      "id": "1118932",
+      "rationale": "Pre-existing advisory in protobufjs (transitive dep via @google/genai → protobufjs@^7.5.4). No patched protobufjs release yet, and @google/genai’s latest 2.2.0 still pins the same range. Ferry only uses @google/genai to call Gemini APIs over Google’s gRPC endpoints — protobuf messages are never decoded from untrusted sources. Remove when @google/genai bumps to a patched protobufjs."
+    },
+    {
+      "id": "1118935",
+      "rationale": "Pre-existing advisory in protobufjs (transitive dep via @google/genai → protobufjs@^7.5.4). No patched protobufjs release yet, and @google/genai’s latest 2.2.0 still pins the same range. Ferry only uses @google/genai to call Gemini APIs over Google’s gRPC endpoints — protobuf messages are never decoded from untrusted sources. Remove when @google/genai bumps to a patched protobufjs."
     }
   ]
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -545,6 +545,26 @@ Let a Jira ticket run Ferry without producing side effects — to validate promp
 
 **Use case:** validate a new MCP server configuration or refined prompt by running the full agent loop on a real ticket without touching the repo or the Jira board.
 
+##### Execution-path routing (`ferry:claude-code`, `ferry:no-claude-code`)
+
+> **Experimental — resolver only.** These labels and config keys are recognised today but only take effect once the `claude-code-action` path itself ships (epic [#299](https://github.com/big-emotion/ferry/issues/299), #302). Until then every consumer runs the bundled-script path regardless. See [Execution paths & accepted divergences](#execution-paths--accepted-divergences-experimental).
+
+Which execution path an agent run takes is decided by a deterministic resolver ([ADR-0006](./adr/0006-claude-code-action-execution-path.md) §3, [#300](https://github.com/big-emotion/ferry/issues/300)). Precedence, highest first:
+
+1. **Explicit `execution_path: "script"`** in `ferry.config.*` — a hard lock; never overridden by the label or the heuristic.
+2. **Per-ticket label** — `ferry:claude-code` forces the claude-code-action path; `ferry:no-claude-code` forces the bundled script. Both labels present is **not** a `LabelConflictError`: it fails closed to the safe `script` path.
+3. **Automatic heuristic** — a `developer` / `iterator` run with `priorRoundTrips >= routing.claude_code_round_trip_threshold` escalates an otherwise-script default to claude-code.
+4. **Conditional default** — explicit `execution_path: "claude-code"`, else `claude-code` for an Anthropic-only consumer, else `script`.
+
+The resolved path **and the reason** (`label` / `heuristic` / `default`) are recorded in the audit comment so the Reconciler observes which path ran and why.
+
+| Config key                                  | Default     | Effect                                                                                                  |
+| ------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------- |
+| `execution_path`                            | _(unset)_   | `"script"` (hard lock) or `"claude-code"` (explicit). Unset → conditional default applies.               |
+| `routing.claude_code_round_trip_threshold`  | `2`         | Positive integer N for the developer/iterator escalation heuristic.                                      |
+
+`ferry:claude-code` only _selects_ the path — it does not provision the `CLAUDE_CODE_OAUTH_TOKEN` the path needs. The hard invariants (cost-governance auto-pause, no-auto-merge) apply regardless of how the path was chosen.
+
 ##### Extended thinking (`ferry:thinking/*`)
 
 | Label                     | Effect                                                                                 |

--- a/src/labels/allowlist.ts
+++ b/src/labels/allowlist.ts
@@ -48,6 +48,8 @@ export const LABELS_ALLOWLIST = [
   'ferry:no-auto-transition',
   'ferry:dry-run',
   'ferry:read-only',
+  'ferry:claude-code',
+  'ferry:no-claude-code',
   'ferry:thinking/',
   'ferry:thinking/on',
   'ferry:thinking/off',

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -2,16 +2,17 @@
 
 Each module has exactly one responsibility. If you are not sure where to put new code, read the description; if it does not fit, propose a new module rather than stretching an existing one.
 
-| Module | Single responsibility |
-|---|---|
-| `agent-runtime/` | Shared shell for agent entrypoints: env loading, prompt assembly, git checkpointing, secret-scan wiring, GitHub context bootstrap. |
-| `audit/` | Emit one idempotency-guarded audit comment per run to the configured GitHub issue. |
-| `dispatch/` | Phase → workflow routing table, GHA-backed `CIRunner` abstraction, dry-run helpers, cancel-in-progress policy assertions, and the task-skip composite-action entrypoint. |
-| `envelope/` | Validate incoming `repository_dispatch` payloads against the JSON schema. |
-| `errors/` | `FerryError` class and structured error codes. |
-| `io/` | All external I/O: GitHub Octokit helpers, Jira REST client, comment upsert, idempotency-marker string utilities, retry, spend-cap classification, TLDR summarisation, and the tracker abstraction. |
-| `labels/` | Resolve ticket labels against `ferry.config` to derive MCP servers and tool allowlists per run. |
-| `llm/` | LLM provider clients (Anthropic, OpenAI, Google), `call` / `pricing` helpers, the Anthropic agent loop, and `delimitUntrusted` for prompt injection defence. |
-| `mcp/` | MCP server bootstrap helpers (composing pool, secret expansion). |
-| `prompts/` | Resolve prompt paths from the bundled action directory or the local repo, plus optional project-context snippet loading. |
-| `safety/` | Gitleaks-based secret scanner (`scanWithGitleaks`). |
+| Module           | Single responsibility                                                                                                                                                                                          |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agent-runtime/` | Shared shell for agent entrypoints: env loading, prompt assembly, git checkpointing, secret-scan wiring, GitHub context bootstrap.                                                                             |
+| `audit/`         | Emit one idempotency-guarded audit comment per run to the configured GitHub issue.                                                                                                                             |
+| `cc-wrappers/`   | Deterministic contract wrapper steps for the claude-code execution path: fail-closed agent-output schema validation, byte-exact audit/transition decision, and the idempotency-gated apply step (ADR-0006 §2). |
+| `dispatch/`      | Phase → workflow routing table, GHA-backed `CIRunner` abstraction, dry-run helpers, cancel-in-progress policy assertions, and the task-skip composite-action entrypoint.                                       |
+| `envelope/`      | Validate incoming `repository_dispatch` payloads against the JSON schema.                                                                                                                                      |
+| `errors/`        | `FerryError` class and structured error codes.                                                                                                                                                                 |
+| `io/`            | All external I/O: GitHub Octokit helpers, Jira REST client, comment upsert, idempotency-marker string utilities, retry, spend-cap classification, TLDR summarisation, and the tracker abstraction.             |
+| `labels/`        | Resolve ticket labels against `ferry.config` to derive MCP servers and tool allowlists per run.                                                                                                                |
+| `llm/`           | LLM provider clients (Anthropic, OpenAI, Google), `call` / `pricing` helpers, the Anthropic agent loop, and `delimitUntrusted` for prompt injection defence.                                                   |
+| `mcp/`           | MCP server bootstrap helpers (composing pool, secret expansion).                                                                                                                                               |
+| `prompts/`       | Resolve prompt paths from the bundled action directory or the local repo, plus optional project-context snippet loading.                                                                                       |
+| `safety/`        | Gitleaks-based secret scanner (`scanWithGitleaks`).                                                                                                                                                            |

--- a/src/lib/cc-wrappers/agent-output.test.ts
+++ b/src/lib/cc-wrappers/agent-output.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { validateAgentOutput } from './agent-output.js';
+import { FerryError } from '../errors/index.js';
+
+const DEV_OK = {
+  version: 'v1',
+  role: 'developer',
+  outcome: 'implemented',
+  summary: 'Implemented the feature',
+  pr_url: 'https://github.com/o/r/pull/7',
+};
+
+const REVIEWER_OK = {
+  version: 'v1',
+  role: 'reviewer',
+  verdict: 'approved',
+  review_comment: '**Verdict**: Approved\n\nLooks good.',
+  summary: 'Ready to merge',
+};
+
+const ITERATOR_OK = {
+  version: 'v1',
+  role: 'iterator',
+  outcome: 'implemented',
+  summary: 'Addressed findings',
+  pr_number: 7,
+};
+
+const REFINER_OK = {
+  version: 'v1',
+  role: 'refiner',
+  result: 'refined',
+  summary: 'Reconciled sub-tasks',
+  created: 2,
+  kept: 1,
+  staled: 0,
+};
+
+describe('validateAgentOutput — happy paths', () => {
+  it('accepts a developer artifact', () => {
+    expect(validateAgentOutput(DEV_OK)).toEqual(DEV_OK);
+  });
+
+  it('accepts a reviewer artifact', () => {
+    expect(validateAgentOutput(REVIEWER_OK)).toEqual(REVIEWER_OK);
+  });
+
+  it('accepts an iterator artifact', () => {
+    expect(validateAgentOutput(ITERATOR_OK)).toEqual(ITERATOR_OK);
+  });
+
+  it('accepts a refiner refined artifact', () => {
+    expect(validateAgentOutput(REFINER_OK)).toEqual(REFINER_OK);
+  });
+
+  it('accepts a refiner noop artifact', () => {
+    const noop = { version: 'v1', role: 'refiner', result: 'noop', summary: 's', noop_reason: 'r' };
+    expect(validateAgentOutput(noop)).toEqual(noop);
+  });
+
+  it('accepts a JSON string artifact (as written to a file by the action)', () => {
+    expect(validateAgentOutput(JSON.stringify(DEV_OK))).toEqual(DEV_OK);
+  });
+
+  it('accepts a blocked developer artifact with a reason', () => {
+    const blocked = {
+      version: 'v1',
+      role: 'developer',
+      outcome: 'blocked',
+      summary: 's',
+      reason: 'missing API key',
+    };
+    expect(validateAgentOutput(blocked)).toEqual(blocked);
+  });
+});
+
+describe('validateAgentOutput — fail-closed', () => {
+  it('throws FerryError state-invariant for non-JSON string', () => {
+    expect(() => validateAgentOutput('{ not json')).toThrow(FerryError);
+  });
+
+  it('throws for a missing role', () => {
+    expect(() => validateAgentOutput({ version: 'v1', summary: 's' })).toThrow(FerryError);
+  });
+
+  it('throws for an unknown role', () => {
+    expect(() => validateAgentOutput({ version: 'v1', role: 'planner', summary: 's' })).toThrow(
+      FerryError,
+    );
+  });
+
+  it('throws for a wrong version', () => {
+    expect(() => validateAgentOutput({ ...DEV_OK, version: 'v2' })).toThrow(FerryError);
+  });
+
+  it('throws for an invalid developer outcome', () => {
+    expect(() => validateAgentOutput({ ...DEV_OK, outcome: 'maybe' })).toThrow(FerryError);
+  });
+
+  it('throws for an invalid reviewer verdict', () => {
+    expect(() => validateAgentOutput({ ...REVIEWER_OK, verdict: 'lgtm' })).toThrow(FerryError);
+  });
+
+  it('throws for additional properties (strict contract)', () => {
+    expect(() => validateAgentOutput({ ...DEV_OK, injected: 'x' })).toThrow(FerryError);
+  });
+
+  it('throws for a reviewer artifact missing review_comment', () => {
+    expect(() =>
+      validateAgentOutput({ version: 'v1', role: 'reviewer', verdict: 'approved', summary: 's' }),
+    ).toThrow(FerryError);
+  });
+
+  it('throws for an empty summary', () => {
+    expect(() => validateAgentOutput({ ...DEV_OK, summary: '' })).toThrow(FerryError);
+  });
+
+  it('does NOT leak raw field values in the error (NFR-S1)', () => {
+    try {
+      validateAgentOutput({ ...DEV_OK, summary: 'SECRET-LEAK-TOKEN', outcome: 'nope' });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(FerryError);
+      const msg = (err as FerryError).message;
+      expect(msg).not.toContain('SECRET-LEAK-TOKEN');
+    }
+  });
+});

--- a/src/lib/cc-wrappers/agent-output.ts
+++ b/src/lib/cc-wrappers/agent-output.ts
@@ -1,0 +1,107 @@
+/**
+ * Structured agent-output schema validation for the claude-code execution path.
+ *
+ * The claude-code-action reasoning core writes a single terminal JSON artifact
+ * instead of calling the bundled `done` / `finish_review` tools. This module
+ * validates that artifact fail-closed (ADR-0006 §2, decisions/0002 §B/§C):
+ * an invalid or missing artifact throws `FerryError('state-invariant')` with
+ * AJV instance paths only — never raw field values (mirrors
+ * `src/lib/envelope/validate.ts`, NFR-S1).
+ */
+import { createRequire } from 'module';
+import type { ValidateFunction } from 'ajv';
+import { FerryError } from '../errors/index.js';
+
+const _require = createRequire(import.meta.url);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const outputSchema: Record<string, any> = _require('../../schemas/agent-output.v1.schema.json');
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const ajvModule = _require('ajv/dist/2020') as {
+  Ajv2020: new (opts?: any) => { compile: (s: any) => ValidateFunction };
+};
+const ajvInstance = new ajvModule.Ajv2020({ strict: true });
+(_require('ajv-formats') as any).default(ajvInstance);
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+const validateFn: ValidateFunction = ajvInstance.compile(outputSchema);
+
+export type AgentOutputRole = 'developer' | 'iterator' | 'reviewer' | 'refiner';
+export type DeveloperOutcome = 'implemented' | 'already_satisfied' | 'blocked';
+export type ReviewerVerdict = 'approved' | 'changes_requested';
+export type RefinerResult = 'refined' | 'noop';
+
+export interface DeveloperAgentOutput {
+  version: 'v1';
+  role: 'developer';
+  outcome: DeveloperOutcome;
+  summary: string;
+  reason?: string;
+  pr_url?: string;
+}
+
+export interface IteratorAgentOutput {
+  version: 'v1';
+  role: 'iterator';
+  outcome: DeveloperOutcome;
+  summary: string;
+  reason?: string;
+  pr_number?: number;
+}
+
+export interface ReviewerAgentOutput {
+  version: 'v1';
+  role: 'reviewer';
+  verdict: ReviewerVerdict;
+  review_comment: string;
+  summary: string;
+}
+
+export interface RefinerAgentOutput {
+  version: 'v1';
+  role: 'refiner';
+  result: RefinerResult;
+  summary: string;
+  created?: number;
+  kept?: number;
+  staled?: number;
+  noop_reason?: string;
+}
+
+export type AgentOutputV1 =
+  | DeveloperAgentOutput
+  | IteratorAgentOutput
+  | ReviewerAgentOutput
+  | RefinerAgentOutput;
+
+/**
+ * Parses + validates the terminal agent artifact. `raw` may be a JSON string
+ * (as written to a file by the action) or an already-parsed object.
+ *
+ * Fail-closed: malformed JSON or any schema violation throws
+ * `FerryError('state-invariant')` carrying only AJV instance paths.
+ */
+export function validateAgentOutput(raw: unknown): AgentOutputV1 {
+  let candidate: unknown = raw;
+  if (typeof raw === 'string') {
+    try {
+      candidate = JSON.parse(raw);
+    } catch {
+      throw new FerryError('state-invariant', {
+        reason: 'agent-output-invalid',
+        paths: ['/ not-json'],
+      });
+    }
+  }
+
+  if (!validateFn(candidate)) {
+    const safePaths = (validateFn.errors ?? []).map((e) => `${e.instancePath} ${e.keyword}`);
+    throw new FerryError('state-invariant', {
+      reason: 'agent-output-invalid',
+      paths: safePaths,
+    });
+  }
+
+  return candidate as AgentOutputV1;
+}

--- a/src/lib/cc-wrappers/apply.test.ts
+++ b/src/lib/cc-wrappers/apply.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { applyContract, checkContractIdempotency } from './apply.js';
+import { InMemoryTracker } from '../io/tracker/in-memory.js';
+import { FerryError } from '../errors/index.js';
+import type { ContractDecision } from './contract.js';
+import type { TrackerIssue } from '../io/tracker/types.js';
+
+const ISSUE: TrackerIssue = {
+  key: 'PROJ-1',
+  summary: 's',
+  description: 'd',
+  comments: [],
+  labels: [],
+  issueType: 'Story',
+  issueTypeRaw: 'Story',
+};
+
+const ENV = (k: string): string =>
+  ({
+    FERRY_REVIEW_TRANSITION_ID: 'TR-REVIEW',
+    FERRY_ITER_TRANSITION_ID: 'TR-ITER',
+    FERRY_APPROVE_TRANSITION_ID: 'TR-APPROVE',
+  })[k] ?? '';
+
+describe('checkContractIdempotency', () => {
+  it('skips when the marker is already present in a prior comment', () => {
+    expect(
+      checkContractIdempotency('[ferry:dev:abc1234]', ['noise', 'x [ferry:dev:abc1234] y']).skipped,
+    ).toBe(true);
+  });
+  it('does not skip when the marker is absent', () => {
+    expect(checkContractIdempotency('[ferry:dev:abc1234]', ['unrelated']).skipped).toBe(false);
+  });
+});
+
+describe('applyContract', () => {
+  let tracker: InMemoryTracker;
+  beforeEach(() => {
+    tracker = new InMemoryTracker();
+    tracker.seed(ISSUE);
+  });
+
+  const run = (
+    decision: ContractDecision,
+    over: Partial<Parameters<typeof applyContract>[0]> = {},
+  ) =>
+    applyContract({
+      tracker,
+      ticketKey: 'PROJ-1',
+      marker: '[ferry:dev:abc1234]',
+      existingComments: [],
+      decision,
+      getEnv: ENV,
+      ...over,
+    });
+
+  it('developer FR18: transition is posted BEFORE the audit comment', async () => {
+    const decision: ContractDecision = {
+      comment: '[ferry:dev:abc1234] Implementation complete — PR: x. Moved to Review.',
+      labels: [],
+      transitions: [{ transitionIdEnv: 'FERRY_REVIEW_TRANSITION_ID', when: 'before-comment' }],
+      exitCode: 0,
+    };
+    const res = await run(decision);
+    expect(res).toEqual({ skipped: false, emitted: true, exitCode: 0 });
+    expect(tracker.postedTransitions).toEqual([{ key: 'PROJ-1', transitionId: 'TR-REVIEW' }]);
+    expect(tracker.postedComments).toEqual([{ key: 'PROJ-1', body: decision.comment }]);
+  });
+
+  it('reviewer FR24: transition is posted AFTER the audit comment', async () => {
+    const decision: ContractDecision = {
+      comment: '[ferry:reviewer:abc1234] Approved. PR#7 is ready to merge.',
+      labels: [],
+      transitions: [{ transitionIdEnv: 'FERRY_APPROVE_TRANSITION_ID', when: 'after-comment' }],
+      exitCode: 0,
+    };
+    await run(decision, { marker: '[ferry:reviewer:abc1234]' });
+    // Comment must land before the transition (parity with review-action.ts).
+    expect(tracker.postedComments).toEqual([{ key: 'PROJ-1', body: decision.comment }]);
+    expect(tracker.postedTransitions).toEqual([{ key: 'PROJ-1', transitionId: 'TR-APPROVE' }]);
+  });
+
+  it('blocked: adds ferry:blocked label, posts comment, no transition, exit 1', async () => {
+    const decision: ContractDecision = {
+      comment: '[ferry:dev:abc1234] 🚨 BLOCKED — x. Manual intervention required.',
+      labels: ['ferry:blocked'],
+      transitions: [],
+      exitCode: 1,
+    };
+    const res = await run(decision);
+    expect(res.exitCode).toBe(1);
+    expect(tracker.addedLabels).toEqual([{ key: 'PROJ-1', label: 'ferry:blocked' }]);
+    expect(tracker.postedComments).toHaveLength(1);
+    expect(tracker.postedTransitions).toEqual([]);
+  });
+
+  it('idempotency: skips all writes when the marker already exists', async () => {
+    const decision: ContractDecision = {
+      comment: '[ferry:dev:abc1234] Implementation complete — PR: x.',
+      labels: ['ferry:blocked'],
+      transitions: [{ transitionIdEnv: 'FERRY_REVIEW_TRANSITION_ID', when: 'before-comment' }],
+      exitCode: 0,
+    };
+    const res = await run(decision, {
+      existingComments: ['earlier [ferry:dev:abc1234] run'],
+    });
+    expect(res).toEqual({ skipped: true, emitted: false, exitCode: 0 });
+    expect(tracker.postedComments).toEqual([]);
+    expect(tracker.postedTransitions).toEqual([]);
+    expect(tracker.addedLabels).toEqual([]);
+  });
+
+  it('dry-run: suppresses ALL external writes (decisions/0002 §D)', async () => {
+    const decision: ContractDecision = {
+      comment: '[ferry:dev:abc1234] Implementation complete — PR: x. Moved to Review.',
+      labels: ['ferry:blocked'],
+      transitions: [{ transitionIdEnv: 'FERRY_REVIEW_TRANSITION_ID', when: 'before-comment' }],
+      exitCode: 0,
+    };
+    const res = await run(decision, { dryRun: true });
+    expect(res).toEqual({ skipped: false, emitted: false, exitCode: 0 });
+    expect(tracker.postedComments).toEqual([]);
+    expect(tracker.postedTransitions).toEqual([]);
+    expect(tracker.addedLabels).toEqual([]);
+  });
+
+  it('the emitted audit comment carries the marker (post-step idempotency)', async () => {
+    const decision: ContractDecision = {
+      comment: '[ferry:dev:abc1234] Implementation complete — PR: x.',
+      labels: [],
+      transitions: [],
+      exitCode: 0,
+    };
+    await run(decision);
+    // A subsequent run with the now-existing comment must skip.
+    const second = await run(decision, {
+      existingComments: [tracker.postedComments[0].body],
+    });
+    expect(second.skipped).toBe(true);
+  });
+
+  it('fail-closed: a planned transition with a missing secret throws (requireEnv parity)', async () => {
+    const decision: ContractDecision = {
+      comment: '[ferry:dev:abc1234] Implementation complete — PR: x.',
+      labels: [],
+      transitions: [{ transitionIdEnv: 'FERRY_REVIEW_TRANSITION_ID', when: 'before-comment' }],
+      exitCode: 0,
+    };
+    await expect(
+      applyContract({
+        tracker,
+        ticketKey: 'PROJ-1',
+        marker: '[ferry:dev:abc1234]',
+        existingComments: [],
+        decision,
+        getEnv: (k) => {
+          throw new FerryError('state-invariant', { reason: 'missing-env', key: k });
+        },
+      }),
+    ).rejects.toThrow(FerryError);
+  });
+});

--- a/src/lib/cc-wrappers/apply.ts
+++ b/src/lib/cc-wrappers/apply.ts
@@ -1,0 +1,108 @@
+/**
+ * Idempotency-gated effecting steps for the claude-code execution path.
+ *
+ * These are the deterministic wrapper steps that bracket the
+ * `claude-code-action` job (ADR-0006 §2). They perform the Jira-side audit +
+ * transition writes the bundled script performs in-process today, but as a
+ * non-LLM post-step:
+ *
+ *   pre-step  : skip if the audit marker is already present (byEventId /
+ *               byPrHeadSha + checkIdempotencyMarker — reused verbatim).
+ *   post-step : add labels → before-comment transition (FR18/FR28) →
+ *               fingerprinted audit comment → after-comment transition (FR24).
+ *
+ * The audit comment is emitted *here*, by Ferry — never by the LLM (ADR-0004:
+ * the Reconciler depends on these markers being deterministic).
+ *
+ * `ferry:dry-run` suppresses *all* external writes on this path
+ * (decisions/0002 §D): the decision is still computed (and logged) but no
+ * comment / transition / label is posted.
+ */
+import { checkIdempotencyMarker, type IdempotencyCheckResult } from '../io/idempotency.js';
+import { requireEnv } from '../agent-runtime/env.js';
+import type { IssueTracker } from '../io/tracker/types.js';
+import type { ContractDecision } from './contract.js';
+
+/**
+ * Pre-step + post-step idempotency check. A re-run finds the marker the prior
+ * run embedded in its audit comment and skips — same mechanism, same marker
+ * format as the script path.
+ */
+export function checkContractIdempotency(
+  marker: string,
+  existingComments: string[],
+): IdempotencyCheckResult {
+  return checkIdempotencyMarker(marker, existingComments);
+}
+
+export interface ApplyContractDeps {
+  tracker: Pick<IssueTracker, 'postComment' | 'postTransition' | 'addLabel'>;
+  ticketKey: string;
+  marker: string;
+  /** Existing Jira issue comments — scanned for the idempotency marker. */
+  existingComments: string[];
+  decision: ContractDecision;
+  dryRun?: boolean;
+  /** Resolves a transition-ID secret. Defaults to `requireEnv` (fail-closed). */
+  getEnv?: (key: string) => string;
+  logger?: { info: (msg: string, meta?: Record<string, unknown>) => void };
+}
+
+export interface ApplyContractResult {
+  /** True when a prior run already emitted this marker (no writes performed). */
+  skipped: boolean;
+  /** True when the audit comment was actually posted. */
+  emitted: boolean;
+  /** Process exit code parity (1 for `blocked`). */
+  exitCode: 0 | 1;
+}
+
+/**
+ * Performs the idempotency-gated audit + transition writes for one agent run.
+ * Pure decision lives in `contract.ts`; this only sequences the IO.
+ */
+export async function applyContract(deps: ApplyContractDeps): Promise<ApplyContractResult> {
+  const { tracker, ticketKey, marker, existingComments, decision, dryRun } = deps;
+  const getEnv = deps.getEnv ?? requireEnv;
+  const log = deps.logger;
+
+  // ── pre/post idempotency ──────────────────────────────────────────────────
+  if (checkIdempotencyMarker(marker, existingComments).skipped) {
+    log?.info('cc-wrapper: already processed, skipping', { marker });
+    return { skipped: true, emitted: false, exitCode: decision.exitCode };
+  }
+
+  // ── dry-run: suppress ALL external writes (decisions/0002 §D) ──────────────
+  if (dryRun === true) {
+    log?.info('cc-wrapper: DRY_RUN — suppressed audit/transition/label', {
+      comment: decision.comment,
+      labels: decision.labels,
+      transitions: decision.transitions.map((t) => t.transitionIdEnv),
+    });
+    return { skipped: false, emitted: false, exitCode: decision.exitCode };
+  }
+
+  // ── labels (e.g. ferry:blocked) ───────────────────────────────────────────
+  for (const label of decision.labels) {
+    await tracker.addLabel(ticketKey, label);
+  }
+
+  // ── before-comment transitions (FR18 dev / FR28 iterator) ─────────────────
+  for (const t of decision.transitions) {
+    if (t.when === 'before-comment') {
+      await tracker.postTransition(ticketKey, getEnv(t.transitionIdEnv));
+    }
+  }
+
+  // ── fingerprinted audit comment — emitted by Ferry, never the LLM ─────────
+  await tracker.postComment(ticketKey, decision.comment);
+
+  // ── after-comment transitions (FR24 reviewer) ─────────────────────────────
+  for (const t of decision.transitions) {
+    if (t.when === 'after-comment') {
+      await tracker.postTransition(ticketKey, getEnv(t.transitionIdEnv));
+    }
+  }
+
+  return { skipped: false, emitted: true, exitCode: decision.exitCode };
+}

--- a/src/lib/cc-wrappers/contract.test.ts
+++ b/src/lib/cc-wrappers/contract.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decideContract,
+  markerRoleToken,
+  resolveContractMarker,
+  type ContractContext,
+} from './contract.js';
+import { FerryError } from '../errors/index.js';
+import type {
+  DeveloperAgentOutput,
+  IteratorAgentOutput,
+  ReviewerAgentOutput,
+  RefinerAgentOutput,
+} from './agent-output.js';
+
+const SHA = 'abc1234def5678';
+const SHA7 = 'abc1234';
+
+describe('markerRoleToken', () => {
+  it('maps developer to dev, others to role (script parity)', () => {
+    expect(markerRoleToken('developer')).toBe('dev');
+    expect(markerRoleToken('iterator')).toBe('iterator');
+    expect(markerRoleToken('reviewer')).toBe('reviewer');
+    expect(markerRoleToken('refiner')).toBe('refiner');
+  });
+});
+
+describe('resolveContractMarker — byte-identical to script keying', () => {
+  it('developer keys on branch head SHA (7) with dev token', () => {
+    expect(resolveContractMarker('developer', { eventId: 'E1', branchHeadSha: SHA })).toBe(
+      `[ferry:dev:${SHA7}]`,
+    );
+  });
+  it('developer falls back to event id when no branch head SHA', () => {
+    expect(resolveContractMarker('developer', { eventId: 'E1' })).toBe('[ferry:dev:E1]');
+  });
+  it('iterator keys on PR head SHA (7)', () => {
+    expect(resolveContractMarker('iterator', { eventId: 'E1', prHeadSha: SHA })).toBe(
+      `[ferry:iterator:${SHA7}]`,
+    );
+  });
+  it('reviewer keys on PR head SHA (7)', () => {
+    expect(resolveContractMarker('reviewer', { eventId: 'E1', prHeadSha: SHA })).toBe(
+      `[ferry:reviewer:${SHA7}]`,
+    );
+  });
+  it('refiner keys on event id', () => {
+    expect(resolveContractMarker('refiner', { eventId: 'EVT-9' })).toBe('[ferry:refiner:EVT-9]');
+  });
+  it('throws fail-closed when iterator/reviewer marker lacks a PR head SHA', () => {
+    expect(() => resolveContractMarker('iterator', { eventId: 'E1' })).toThrow(FerryError);
+    expect(() => resolveContractMarker('reviewer', { eventId: 'E1' })).toThrow(FerryError);
+  });
+});
+
+const baseCtx = (over: Partial<ContractContext> = {}): ContractContext => ({
+  marker: '[ferry:dev:abc1234]',
+  gates: {},
+  ...over,
+});
+
+describe('decideContract — developer (FR18)', () => {
+  const dev = (o: Partial<DeveloperAgentOutput>): DeveloperAgentOutput => ({
+    version: 'v1',
+    role: 'developer',
+    outcome: 'implemented',
+    summary: 's',
+    ...o,
+  });
+
+  it('implemented + auto-transition → "Implementation complete" + Moved to Review + FR18 before-comment', () => {
+    const d = decideContract(
+      dev({ outcome: 'implemented' }),
+      baseCtx({ prUrl: 'https://x/pr/7', gates: { shouldAutoTransition: true } }),
+    );
+    expect(d.comment).toBe(
+      '[ferry:dev:abc1234] Implementation complete — PR: https://x/pr/7. Moved to Review.',
+    );
+    expect(d.transitions).toEqual([
+      { transitionIdEnv: 'FERRY_REVIEW_TRANSITION_ID', when: 'before-comment' },
+    ]);
+    expect(d.exitCode).toBe(0);
+    expect(d.labels).toEqual([]);
+  });
+
+  it('implemented + no-auto-transition label → skipped note, no transition', () => {
+    const d = decideContract(
+      dev({}),
+      baseCtx({ prUrl: 'https://x/pr/7', gates: { noAutoTransition: true } }),
+    );
+    expect(d.comment).toBe(
+      '[ferry:dev:abc1234] Implementation complete — PR: https://x/pr/7. FR18 auto-transition skipped (ferry:no-auto-transition).',
+    );
+    expect(d.transitions).toEqual([]);
+  });
+
+  it('implemented + no gate → bare comment, no note', () => {
+    const d = decideContract(dev({}), baseCtx({ prUrl: 'https://x/pr/7' }));
+    expect(d.comment).toBe('[ferry:dev:abc1234] Implementation complete — PR: https://x/pr/7.');
+  });
+
+  it('already_satisfied → verification-PR wording', () => {
+    const d = decideContract(
+      dev({ outcome: 'already_satisfied' }),
+      baseCtx({ prUrl: 'https://x/pr/7', gates: { shouldAutoTransition: true } }),
+    );
+    expect(d.comment).toBe(
+      '[ferry:dev:abc1234] Spec already satisfied — verification PR: https://x/pr/7. Moved to Review.',
+    );
+  });
+
+  it('blocked → BLOCKED comment + ferry:blocked label + exit 1, no transition', () => {
+    const d = decideContract(
+      dev({ outcome: 'blocked', reason: 'missing creds' }),
+      baseCtx({ gates: { shouldAutoTransition: true } }),
+    );
+    expect(d.comment).toBe(
+      '[ferry:dev:abc1234] 🚨 BLOCKED — missing creds. Manual intervention required.',
+    );
+    expect(d.labels).toEqual(['ferry:blocked']);
+    expect(d.transitions).toEqual([]);
+    expect(d.exitCode).toBe(1);
+  });
+
+  it('blocked without reason → "no reason given" (script parity)', () => {
+    const d = decideContract(dev({ outcome: 'blocked' }), baseCtx());
+    expect(d.comment).toBe(
+      '[ferry:dev:abc1234] 🚨 BLOCKED — no reason given. Manual intervention required.',
+    );
+  });
+
+  it('fail-closed: implemented without a PR url throws (assertDevOutputContract parity)', () => {
+    expect(() => decideContract(dev({ outcome: 'implemented' }), baseCtx())).toThrow(FerryError);
+  });
+
+  it('uses pr_url from the artifact when ctx.prUrl is absent', () => {
+    const d = decideContract(dev({ pr_url: 'https://art/pr/9' }), baseCtx());
+    expect(d.comment).toBe('[ferry:dev:abc1234] Implementation complete — PR: https://art/pr/9.');
+  });
+});
+
+describe('decideContract — iterator (FR28)', () => {
+  const M = '[ferry:iterator:abc1234]';
+  const iter = (o: Partial<IteratorAgentOutput>): IteratorAgentOutput => ({
+    version: 'v1',
+    role: 'iterator',
+    outcome: 'implemented',
+    summary: 's',
+    pr_number: 7,
+    ...o,
+  });
+
+  it('implemented → "Iteration N complete" with priorIterations+1 + Moved back to Review', () => {
+    const d = decideContract(
+      iter({}),
+      baseCtx({ marker: M, priorIterations: 2, gates: { shouldAutoTransition: true } }),
+    );
+    expect(d.comment).toBe(
+      `${M} Iteration 3 complete. Pushed fixes to PR#7. Moved back to Review.`,
+    );
+    expect(d.transitions).toEqual([
+      { transitionIdEnv: 'FERRY_REVIEW_TRANSITION_ID', when: 'before-comment' },
+    ]);
+  });
+
+  it('implemented, no prior iterations → Iteration 1', () => {
+    const d = decideContract(iter({}), baseCtx({ marker: M }));
+    expect(d.comment).toBe(`${M} Iteration 1 complete. Pushed fixes to PR#7.`);
+    expect(d.transitions).toEqual([]);
+  });
+
+  it('already_satisfied → findings-addressed wording', () => {
+    const d = decideContract(
+      iter({ outcome: 'already_satisfied' }),
+      baseCtx({ marker: M, gates: { noAutoTransition: true } }),
+    );
+    expect(d.comment).toBe(
+      `${M} Findings already addressed — no changes needed. Pushed to PR#7. FR28 auto-transition skipped (ferry:no-auto-transition).`,
+    );
+  });
+
+  it('blocked → BLOCKED + ferry:blocked + exit 1', () => {
+    const d = decideContract(
+      iter({ outcome: 'blocked', reason: 'conflict' }),
+      baseCtx({ marker: M }),
+    );
+    expect(d.comment).toBe(`${M} 🚨 BLOCKED — conflict. Manual intervention required.`);
+    expect(d.labels).toEqual(['ferry:blocked']);
+    expect(d.exitCode).toBe(1);
+  });
+
+  it('fail-closed: implemented without a PR number throws', () => {
+    expect(() =>
+      decideContract(
+        { version: 'v1', role: 'iterator', outcome: 'implemented', summary: 's' },
+        baseCtx({ marker: M }),
+      ),
+    ).toThrow(FerryError);
+  });
+});
+
+describe('decideContract — reviewer (FR24)', () => {
+  const M = '[ferry:reviewer:abc1234]';
+  const rev = (o: Partial<ReviewerAgentOutput>): ReviewerAgentOutput => ({
+    version: 'v1',
+    role: 'reviewer',
+    verdict: 'approved',
+    review_comment: 'LGTM',
+    summary: 's',
+    ...o,
+  });
+
+  it('approved → ready-to-merge comment + FR24 approve after-comment + prComment passthrough', () => {
+    const d = decideContract(
+      rev({ verdict: 'approved' }),
+      baseCtx({ marker: M, prNumber: 7, gates: { shouldTransitionApprove: true } }),
+    );
+    expect(d.comment).toBe(`${M} Approved. PR#7 is ready to merge.`);
+    expect(d.transitions).toEqual([
+      { transitionIdEnv: 'FERRY_APPROVE_TRANSITION_ID', when: 'after-comment' },
+    ]);
+    expect(d.prComment).toBe('LGTM');
+  });
+
+  it('approved, transition gated off → no transition', () => {
+    const d = decideContract(rev({}), baseCtx({ marker: M, prNumber: 7 }));
+    expect(d.transitions).toEqual([]);
+  });
+
+  it('changes_requested under cap → iteration X/cap + Moved to Dev Iteration + FR24 changes', () => {
+    const d = decideContract(
+      rev({ verdict: 'changes_requested', review_comment: 'fix it' }),
+      baseCtx({
+        marker: M,
+        prNumber: 7,
+        priorIterations: 1,
+        cap: 5,
+        gates: { shouldTransitionChanges: true },
+      }),
+    );
+    expect(d.comment).toBe(
+      `${M} Changes requested (iteration 2/5). Moved to Dev Iteration. See PR#7 for details.`,
+    );
+    expect(d.transitions).toEqual([
+      { transitionIdEnv: 'FERRY_ITER_TRANSITION_ID', when: 'after-comment' },
+    ]);
+    expect(d.prComment).toBe('fix it');
+  });
+
+  it('changes_requested under cap, gate off → no "Moved" note, no transition', () => {
+    const d = decideContract(
+      rev({ verdict: 'changes_requested' }),
+      baseCtx({ marker: M, prNumber: 7, priorIterations: 0, cap: 3 }),
+    );
+    expect(d.comment).toBe(`${M} Changes requested (iteration 1/3). See PR#7 for details.`);
+    expect(d.transitions).toEqual([]);
+  });
+
+  it('changes_requested at cap → re-review/manual-move wording, no transition', () => {
+    const d = decideContract(
+      rev({ verdict: 'changes_requested' }),
+      baseCtx({
+        marker: M,
+        prNumber: 7,
+        priorIterations: 5,
+        cap: 5,
+        gates: { shouldTransitionChanges: true },
+      }),
+    );
+    expect(d.comment).toBe(
+      `${M} Changes requested (re-review). Iteration cap (5) reached; see PR#7 and move ticket manually.`,
+    );
+    expect(d.transitions).toEqual([]);
+  });
+
+  it('fail-closed: reviewer without a PR number throws', () => {
+    expect(() => decideContract(rev({}), baseCtx({ marker: M }))).toThrow(FerryError);
+  });
+});
+
+describe('decideContract — refiner (no FR transition)', () => {
+  const M = '[ferry:refiner:EVT-9]';
+  const ref = (o: Partial<RefinerAgentOutput>): RefinerAgentOutput => ({
+    version: 'v1',
+    role: 'refiner',
+    result: 'refined',
+    summary: 's',
+    ...o,
+  });
+
+  it('refined → created/kept/staled + run link, no transition', () => {
+    const d = decideContract(
+      ref({ created: 2, kept: 1, staled: 3 }),
+      baseCtx({ marker: M, runLink: 'https://run/1' }),
+    );
+    expect(d.comment).toBe(
+      `${M} Refined. Created 2, kept 1, staled 3 sub-task(s). See run: https://run/1`,
+    );
+    expect(d.transitions).toEqual([]);
+  });
+
+  it('refined with missing counts → defaults to 0', () => {
+    const d = decideContract(ref({}), baseCtx({ marker: M, runLink: 'https://run/1' }));
+    expect(d.comment).toBe(
+      `${M} Refined. Created 0, kept 0, staled 0 sub-task(s). See run: https://run/1`,
+    );
+  });
+
+  it('noop → existing N still valid, trimmed reason', () => {
+    const d = decideContract(
+      ref({ result: 'noop', noop_reason: 'all valid' }),
+      baseCtx({ marker: M, subtaskCount: 4 }),
+    );
+    expect(d.comment).toBe(
+      `${M} No changes needed — existing 4 sub-task(s) still valid. all valid`,
+    );
+  });
+
+  it('noop without a reason → trailing space trimmed (script parity)', () => {
+    const d = decideContract(ref({ result: 'noop' }), baseCtx({ marker: M, subtaskCount: 0 }));
+    expect(d.comment).toBe(`${M} No changes needed — existing 0 sub-task(s) still valid.`);
+  });
+
+  it('fail-closed: refined without a run link throws', () => {
+    expect(() => decideContract(ref({}), baseCtx({ marker: M }))).toThrow(FerryError);
+  });
+});

--- a/src/lib/cc-wrappers/contract.ts
+++ b/src/lib/cc-wrappers/contract.ts
@@ -1,0 +1,266 @@
+/**
+ * Deterministic contract decision for the claude-code execution path.
+ *
+ * Given a validated terminal agent artifact (see `agent-output.ts`) plus the
+ * resolved gating flags, this **pure** function reproduces — byte-for-byte —
+ * the audit comment, Jira labels, terminal exit code, and FR18/FR24/FR28
+ * transition plan the bundled script path emits today
+ * (`src/agents/{developer,iterator,reviewer,refiner}/*-action.ts`).
+ *
+ * Acceptance contract (#301): audit markers and transitions must be
+ * byte-identical to the script path so the Reconciler (ADR-0004) is
+ * unaffected. This module owns the *decision*; `apply.ts` performs the
+ * idempotency-gated IO. The LLM never produces audit markers or transitions.
+ */
+import { byEventId, byPrHeadSha } from '../agent-runtime/idempotency.js';
+import { FerryError } from '../errors/index.js';
+import type { AgentOutputRole, AgentOutputV1 } from './agent-output.js';
+
+export type TransitionIdEnv =
+  | 'FERRY_REVIEW_TRANSITION_ID'
+  | 'FERRY_ITER_TRANSITION_ID'
+  | 'FERRY_APPROVE_TRANSITION_ID';
+
+export interface TransitionPlan {
+  /** Transition-ID secret to require + post (reused install-time secrets). */
+  transitionIdEnv: TransitionIdEnv;
+  /**
+   * Ordering relative to the audit comment. The script path posts the FR18
+   * (dev) / FR28 (iterator) transition *before* the terminal Jira comment,
+   * and the FR24 (reviewer) transition *after* it — preserved here.
+   */
+  when: 'before-comment' | 'after-comment';
+}
+
+export interface ContractDecision {
+  /** Full audit comment body, marker-prefixed (`[ferry:<role>:<run-id>] …`). */
+  comment: string;
+  /** Jira labels to add (e.g. `ferry:blocked`). */
+  labels: string[];
+  /** FR18 / FR24 / FR28 transition plan (empty when none applies). */
+  transitions: TransitionPlan[];
+  /**
+   * Optional GitHub PR body (reviewer `review_comment`). Surfaced as
+   * pass-through metadata for the action job (#302) — `apply.ts` only
+   * performs the Jira-side audit/transition writes this issue (#301) owns.
+   */
+  prComment?: string;
+  /** Process exit code parity: 1 for `blocked`, else 0. */
+  exitCode: 0 | 1;
+}
+
+export interface MarkerContext {
+  eventId: string;
+  /** Developer keys on the branch head SHA when known, else the event id. */
+  branchHeadSha?: string;
+  /** Iterator + reviewer key on the PR head SHA. */
+  prHeadSha?: string;
+}
+
+export interface ContractContext {
+  marker: string;
+  gates: {
+    /** Developer FR18 / iterator FR28 auto-transition gate. */
+    shouldAutoTransition?: boolean;
+    noAutoTransition?: boolean;
+    /** Reviewer FR24 approve gate. */
+    shouldTransitionApprove?: boolean;
+    /** Reviewer FR24 changes gate. */
+    shouldTransitionChanges?: boolean;
+  };
+  prUrl?: string;
+  prNumber?: number;
+  priorIterations?: number;
+  cap?: number;
+  runLink?: string;
+  subtaskCount?: number;
+}
+
+/** Marker role token. Developer uses `dev` (script parity), others = role. */
+export function markerRoleToken(role: AgentOutputRole): string {
+  return role === 'developer' ? 'dev' : role;
+}
+
+/**
+ * Computes the byte-identical idempotency / audit marker for `role`, matching
+ * the per-agent keying the script path uses:
+ *  - developer → branch head SHA (7) when known, else event id; token `dev`
+ *  - iterator  → PR head SHA (7)
+ *  - reviewer  → PR head SHA (7)
+ *  - refiner   → event id
+ */
+export function resolveContractMarker(role: AgentOutputRole, ctx: MarkerContext): string {
+  switch (role) {
+    case 'developer':
+      return ctx.branchHeadSha
+        ? byPrHeadSha('dev', ctx.branchHeadSha)
+        : byEventId('dev', ctx.eventId);
+    case 'iterator':
+      if (!ctx.prHeadSha)
+        throw new FerryError('state-invariant', { reason: 'missing-context', need: 'prHeadSha' });
+      return byPrHeadSha('iterator', ctx.prHeadSha);
+    case 'reviewer':
+      if (!ctx.prHeadSha)
+        throw new FerryError('state-invariant', { reason: 'missing-context', need: 'prHeadSha' });
+      return byPrHeadSha('reviewer', ctx.prHeadSha);
+    case 'refiner':
+      return byEventId('refiner', ctx.eventId);
+  }
+}
+
+function requireCtx<T>(value: T | undefined, need: string, role: string, outcome: string): T {
+  if (value === undefined || value === null || value === '') {
+    throw new FerryError('state-invariant', {
+      reason: 'output-contract',
+      role,
+      outcome,
+      need,
+    });
+  }
+  return value;
+}
+
+function devTransitionNote(g: ContractContext['gates']): string {
+  if (g.shouldAutoTransition) return ' Moved to Review.';
+  if (g.noAutoTransition) return ' FR18 auto-transition skipped (ferry:no-auto-transition).';
+  return '';
+}
+
+function iterTransitionNote(g: ContractContext['gates']): string {
+  if (g.shouldAutoTransition) return ' Moved back to Review.';
+  if (g.noAutoTransition) return ' FR28 auto-transition skipped (ferry:no-auto-transition).';
+  return '';
+}
+
+/**
+ * Pure byte-exact reproduction of the script path's terminal audit comment,
+ * labels, transition plan and exit code for the claude-code path.
+ */
+export function decideContract(output: AgentOutputV1, ctx: ContractContext): ContractDecision {
+  const m = ctx.marker;
+  const g = ctx.gates;
+
+  switch (output.role) {
+    case 'developer': {
+      if (output.outcome === 'blocked') {
+        const reason = output.reason ?? 'no reason given';
+        return {
+          comment: `${m} 🚨 BLOCKED — ${reason}. Manual intervention required.`,
+          labels: ['ferry:blocked'],
+          transitions: [],
+          exitCode: 1,
+        };
+      }
+      const prUrl = requireCtx(ctx.prUrl ?? output.pr_url, 'pr_url', 'developer', output.outcome);
+      const tn = devTransitionNote(g);
+      const transitions: TransitionPlan[] = g.shouldAutoTransition
+        ? [{ transitionIdEnv: 'FERRY_REVIEW_TRANSITION_ID', when: 'before-comment' }]
+        : [];
+      const comment =
+        output.outcome === 'already_satisfied'
+          ? `${m} Spec already satisfied — verification PR: ${prUrl}.${tn}`
+          : `${m} Implementation complete — PR: ${prUrl}.${tn}`;
+      return { comment, labels: [], transitions, exitCode: 0 };
+    }
+
+    case 'iterator': {
+      if (output.outcome === 'blocked') {
+        const reason = output.reason ?? 'no reason given';
+        return {
+          comment: `${m} 🚨 BLOCKED — ${reason}. Manual intervention required.`,
+          labels: ['ferry:blocked'],
+          transitions: [],
+          exitCode: 1,
+        };
+      }
+      const prNumber = requireCtx(
+        ctx.prNumber ?? output.pr_number,
+        'pr_number',
+        'iterator',
+        output.outcome,
+      );
+      const tn = iterTransitionNote(g);
+      const transitions: TransitionPlan[] = g.shouldAutoTransition
+        ? [{ transitionIdEnv: 'FERRY_REVIEW_TRANSITION_ID', when: 'before-comment' }]
+        : [];
+      if (output.outcome === 'already_satisfied') {
+        return {
+          comment: `${m} Findings already addressed — no changes needed. Pushed to PR#${prNumber}.${tn}`,
+          labels: [],
+          transitions,
+          exitCode: 0,
+        };
+      }
+      const nextIteration = Math.max(0, ctx.priorIterations ?? 0) + 1;
+      return {
+        comment: `${m} Iteration ${nextIteration} complete. Pushed fixes to PR#${prNumber}.${tn}`,
+        labels: [],
+        transitions,
+        exitCode: 0,
+      };
+    }
+
+    case 'reviewer': {
+      const prNumber = requireCtx(ctx.prNumber, 'prNumber', 'reviewer', output.verdict);
+      if (output.verdict === 'approved') {
+        const transitions: TransitionPlan[] = g.shouldTransitionApprove
+          ? [{ transitionIdEnv: 'FERRY_APPROVE_TRANSITION_ID', when: 'after-comment' }]
+          : [];
+        return {
+          comment: `${m} Approved. PR#${prNumber} is ready to merge.`,
+          labels: [],
+          transitions,
+          prComment: output.review_comment,
+          exitCode: 0,
+        };
+      }
+      const cap = requireCtx(ctx.cap, 'cap', 'reviewer', output.verdict);
+      const priorIterations = ctx.priorIterations ?? 0;
+      const capReached = priorIterations >= cap;
+      if (capReached) {
+        return {
+          comment: `${m} Changes requested (re-review). Iteration cap (${cap}) reached; see PR#${prNumber} and move ticket manually.`,
+          labels: [],
+          transitions: [],
+          prComment: output.review_comment,
+          exitCode: 0,
+        };
+      }
+      const changesNote = g.shouldTransitionChanges ? ' Moved to Dev Iteration.' : '';
+      const transitions: TransitionPlan[] = g.shouldTransitionChanges
+        ? [{ transitionIdEnv: 'FERRY_ITER_TRANSITION_ID', when: 'after-comment' }]
+        : [];
+      return {
+        comment: `${m} Changes requested (iteration ${priorIterations + 1}/${cap}).${changesNote} See PR#${prNumber} for details.`,
+        labels: [],
+        transitions,
+        prComment: output.review_comment,
+        exitCode: 0,
+      };
+    }
+
+    case 'refiner': {
+      if (output.result === 'noop') {
+        const subtaskCount = ctx.subtaskCount ?? 0;
+        const reason = output.noop_reason ?? '';
+        return {
+          comment:
+            `${m} No changes needed — existing ${subtaskCount} sub-task(s) still valid. ${reason}`.trimEnd(),
+          labels: [],
+          transitions: [],
+          exitCode: 0,
+        };
+      }
+      const runLink = requireCtx(ctx.runLink, 'runLink', 'refiner', output.result);
+      const created = output.created ?? 0;
+      const kept = output.kept ?? 0;
+      const staled = output.staled ?? 0;
+      return {
+        comment: `${m} Refined. Created ${created}, kept ${kept}, staled ${staled} sub-task(s). See run: ${runLink}`,
+        labels: [],
+        transitions: [],
+        exitCode: 0,
+      };
+    }
+  }
+}

--- a/src/lib/cc-wrappers/index.ts
+++ b/src/lib/cc-wrappers/index.ts
@@ -26,3 +26,10 @@ export type {
 
 export { applyContract, checkContractIdempotency } from './apply.js';
 export type { ApplyContractDeps, ApplyContractResult } from './apply.js';
+
+export {
+  resolveExecutionPath,
+  isAnthropicOnlyConfig,
+  formatExecutionPathAudit,
+} from './routing.js';
+export type { ExecutionPathDecision, ExecutionPathReason, ExecutionPathInput } from './routing.js';

--- a/src/lib/cc-wrappers/index.ts
+++ b/src/lib/cc-wrappers/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Deterministic contract wrapper steps for the claude-code execution path
+ * (ADR-0006 §2, issue #301). Public surface consumed by the action job (#302).
+ */
+export { validateAgentOutput } from './agent-output.js';
+export type {
+  AgentOutputV1,
+  AgentOutputRole,
+  DeveloperAgentOutput,
+  IteratorAgentOutput,
+  ReviewerAgentOutput,
+  RefinerAgentOutput,
+  DeveloperOutcome,
+  ReviewerVerdict,
+  RefinerResult,
+} from './agent-output.js';
+
+export { decideContract, markerRoleToken, resolveContractMarker } from './contract.js';
+export type {
+  ContractDecision,
+  ContractContext,
+  MarkerContext,
+  TransitionPlan,
+  TransitionIdEnv,
+} from './contract.js';
+
+export { applyContract, checkContractIdempotency } from './apply.js';
+export type { ApplyContractDeps, ApplyContractResult } from './apply.js';

--- a/src/lib/cc-wrappers/routing.test.ts
+++ b/src/lib/cc-wrappers/routing.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveExecutionPath,
+  isAnthropicOnlyConfig,
+  formatExecutionPathAudit,
+  type ExecutionPathInput,
+} from './routing.js';
+import { DEFAULT_FERRY_CONFIG } from '../config.js';
+import type { FerryConfig } from '../config.js';
+
+function input(over: Partial<ExecutionPathInput> = {}): ExecutionPathInput {
+  return {
+    configuredPath: undefined,
+    anthropicOnly: true,
+    labelOverride: undefined,
+    role: 'developer',
+    priorRoundTrips: 0,
+    roundTripThreshold: 2,
+    ...over,
+  };
+}
+
+describe('resolveExecutionPath — explicit script lock (acceptance: never overridden)', () => {
+  it('explicit script wins over a claude-code label', () => {
+    expect(
+      resolveExecutionPath(input({ configuredPath: 'script', labelOverride: 'claude-code' })),
+    ).toEqual({ path: 'script', reason: 'default' });
+  });
+
+  it('explicit script wins over the heuristic', () => {
+    expect(
+      resolveExecutionPath(
+        input({ configuredPath: 'script', role: 'iterator', priorRoundTrips: 99 }),
+      ),
+    ).toEqual({ path: 'script', reason: 'default' });
+  });
+
+  it('explicit script wins even for an Anthropic-only consumer', () => {
+    expect(resolveExecutionPath(input({ configuredPath: 'script', anthropicOnly: true }))).toEqual({
+      path: 'script',
+      reason: 'default',
+    });
+  });
+});
+
+describe('resolveExecutionPath — Jira label override (precedence over heuristic + default)', () => {
+  it('ferry:claude-code label → claude-code (reason label)', () => {
+    expect(
+      resolveExecutionPath(input({ labelOverride: 'claude-code', anthropicOnly: false })),
+    ).toEqual({ path: 'claude-code', reason: 'label' });
+  });
+
+  it('ferry:no-claude-code label → script (reason label), even Anthropic-only', () => {
+    expect(resolveExecutionPath(input({ labelOverride: 'script', anthropicOnly: true }))).toEqual({
+      path: 'script',
+      reason: 'label',
+    });
+  });
+
+  it('label overrides an explicit claude-code config', () => {
+    expect(
+      resolveExecutionPath(input({ configuredPath: 'claude-code', labelOverride: 'script' })),
+    ).toEqual({ path: 'script', reason: 'label' });
+  });
+
+  it('label beats the heuristic', () => {
+    expect(
+      resolveExecutionPath(
+        input({ labelOverride: 'script', role: 'developer', priorRoundTrips: 50 }),
+      ),
+    ).toEqual({ path: 'script', reason: 'label' });
+  });
+
+  it('conflicting labels arrive pre-collapsed to script (safe path)', () => {
+    // resolveTicketOverrides collapses ferry:claude-code + ferry:no-claude-code
+    // to claudeCodePath === 'script'; the resolver simply honours it.
+    expect(resolveExecutionPath(input({ labelOverride: 'script' }))).toEqual({
+      path: 'script',
+      reason: 'label',
+    });
+  });
+});
+
+describe('resolveExecutionPath — automatic heuristic (role + round-trips ≥ N)', () => {
+  it('developer at threshold escalates to claude-code (reason heuristic)', () => {
+    expect(
+      resolveExecutionPath(
+        input({
+          anthropicOnly: false,
+          role: 'developer',
+          priorRoundTrips: 2,
+          roundTripThreshold: 2,
+        }),
+      ),
+    ).toEqual({ path: 'claude-code', reason: 'heuristic' });
+  });
+
+  it('iterator above threshold escalates to claude-code', () => {
+    expect(
+      resolveExecutionPath(
+        input({
+          anthropicOnly: false,
+          role: 'iterator',
+          priorRoundTrips: 5,
+          roundTripThreshold: 2,
+        }),
+      ),
+    ).toEqual({ path: 'claude-code', reason: 'heuristic' });
+  });
+
+  it('below threshold does not escalate (non-Anthropic → script default)', () => {
+    expect(
+      resolveExecutionPath(
+        input({
+          anthropicOnly: false,
+          role: 'developer',
+          priorRoundTrips: 1,
+          roundTripThreshold: 2,
+        }),
+      ),
+    ).toEqual({ path: 'script', reason: 'default' });
+  });
+
+  it('refiner never escalates via the heuristic', () => {
+    expect(
+      resolveExecutionPath(
+        input({
+          anthropicOnly: false,
+          role: 'refiner',
+          priorRoundTrips: 99,
+          roundTripThreshold: 2,
+        }),
+      ),
+    ).toEqual({ path: 'script', reason: 'default' });
+  });
+
+  it('reviewer never escalates via the heuristic', () => {
+    expect(
+      resolveExecutionPath(
+        input({
+          anthropicOnly: false,
+          role: 'reviewer',
+          priorRoundTrips: 99,
+          roundTripThreshold: 2,
+        }),
+      ),
+    ).toEqual({ path: 'script', reason: 'default' });
+  });
+
+  it('a non-positive threshold disables the heuristic', () => {
+    expect(
+      resolveExecutionPath(
+        input({
+          anthropicOnly: false,
+          role: 'developer',
+          priorRoundTrips: 99,
+          roundTripThreshold: 0,
+        }),
+      ),
+    ).toEqual({ path: 'script', reason: 'default' });
+  });
+
+  it('the heuristic never downgrades an already-claude-code default', () => {
+    // configured claude-code, developer below threshold → still claude-code, reason default
+    expect(
+      resolveExecutionPath(
+        input({ configuredPath: 'claude-code', role: 'developer', priorRoundTrips: 0 }),
+      ),
+    ).toEqual({ path: 'claude-code', reason: 'default' });
+  });
+});
+
+describe('resolveExecutionPath — conditional default', () => {
+  it('Anthropic-only consumer (unset config) → claude-code', () => {
+    expect(resolveExecutionPath(input({ anthropicOnly: true, role: 'refiner' }))).toEqual({
+      path: 'claude-code',
+      reason: 'default',
+    });
+  });
+
+  it('non-Anthropic consumer (unset config) → script', () => {
+    expect(resolveExecutionPath(input({ anthropicOnly: false, role: 'reviewer' }))).toEqual({
+      path: 'script',
+      reason: 'default',
+    });
+  });
+
+  it('explicit claude-code config → claude-code (reason default)', () => {
+    expect(
+      resolveExecutionPath(input({ configuredPath: 'claude-code', anthropicOnly: false })),
+    ).toEqual({ path: 'claude-code', reason: 'default' });
+  });
+});
+
+describe('isAnthropicOnlyConfig', () => {
+  it('true for the all-Anthropic default config', () => {
+    expect(isAnthropicOnlyConfig(DEFAULT_FERRY_CONFIG)).toBe(true);
+  });
+
+  it('false when any agent uses a non-Anthropic provider', () => {
+    const cfg: FerryConfig = {
+      ...DEFAULT_FERRY_CONFIG,
+      models: {
+        ...DEFAULT_FERRY_CONFIG.models,
+        dev: { provider: 'openai', model: 'gpt-5' },
+      },
+    };
+    expect(isAnthropicOnlyConfig(cfg)).toBe(false);
+  });
+
+  it('false when an agent uses Google', () => {
+    const cfg: FerryConfig = {
+      ...DEFAULT_FERRY_CONFIG,
+      models: {
+        ...DEFAULT_FERRY_CONFIG.models,
+        review: { provider: 'google', model: 'gemini-2.5-pro' },
+      },
+    };
+    expect(isAnthropicOnlyConfig(cfg)).toBe(false);
+  });
+});
+
+describe('formatExecutionPathAudit', () => {
+  it('emits the fingerprinted marker with path and reason', () => {
+    expect(
+      formatExecutionPathAudit('reviewer', 'run-abc', { path: 'claude-code', reason: 'label' }),
+    ).toBe('[ferry:reviewer:run-abc] execution-path: claude-code (reason: label)');
+  });
+
+  it('uses the dev marker token for the developer role (script parity)', () => {
+    expect(
+      formatExecutionPathAudit('developer', 'r1', { path: 'script', reason: 'heuristic' }),
+    ).toBe('[ferry:dev:r1] execution-path: script (reason: heuristic)');
+  });
+});

--- a/src/lib/cc-wrappers/routing.ts
+++ b/src/lib/cc-wrappers/routing.ts
@@ -1,0 +1,120 @@
+/**
+ * Deterministic execution-path resolver (ADR-0006 §3, issue #300).
+ *
+ * Decides whether an agent run takes the bundled-script path or the
+ * `claude-code-action` path, and records *why*. The function is **pure**:
+ * the caller supplies the resolved gating inputs (config-derived provider
+ * fact, the per-ticket label override from `resolveTicketOverrides`, and the
+ * prior round-trip count derived from audit comments — the same mechanism
+ * `cc-wrappers/contract.ts` uses for `priorIterations`). No IO, no clock.
+ *
+ * Resolution order (highest precedence first), per ADR-0006 §3:
+ *   1. Explicit `execution_path: script` in ferry.config — a **hard lock**;
+ *      never overridden by the label or the heuristic.
+ *   2. Per-ticket Jira label (`ferry:claude-code` / `ferry:no-claude-code`).
+ *      Conflicting labels are already collapsed to the safe `script` path by
+ *      `resolveTicketOverrides` (no `LabelConflictError`).
+ *   3. Automatic heuristic — escalates an *otherwise-script* default to
+ *      claude-code when `role ∈ {developer, iterator}` AND
+ *      `priorRoundTrips >= N`.
+ *   4. Conditional default — explicit `claude-code`, else `claude-code` for
+ *      an Anthropic-only consumer, else `script`.
+ *
+ * The recorded reason (`label` / `heuristic` / `default`) is emitted into the
+ * audit comment marker by `formatExecutionPathAudit` so the Reconciler
+ * (ADR-0004) observes which path ran and why.
+ */
+import type { ExecutionPath, FerryConfig } from '../config.js';
+import type { AgentOutputRole } from './agent-output.js';
+import { markerRoleToken } from './contract.js';
+
+export type ExecutionPathReason = 'label' | 'heuristic' | 'default';
+
+export interface ExecutionPathDecision {
+  path: ExecutionPath;
+  reason: ExecutionPathReason;
+}
+
+export interface ExecutionPathInput {
+  /**
+   * `ferry.config.execution_path`. `undefined` → the conditional default
+   * applies; `'script'` → hard lock; `'claude-code'` → explicit but still
+   * adjustable by the per-ticket label.
+   */
+  configuredPath: ExecutionPath | undefined;
+  /** True when every configured agent provider is Anthropic (see `isAnthropicOnlyConfig`). */
+  anthropicOnly: boolean;
+  /**
+   * Per-ticket override resolved from `ferry:claude-code` /
+   * `ferry:no-claude-code` (`TicketOverrides.claudeCodePath`). Conflicting
+   * labels arrive already collapsed to `'script'`.
+   */
+  labelOverride?: ExecutionPath;
+  role: AgentOutputRole;
+  /** Prior Ferry round-trips for this ticket (caller derives from audit comments). */
+  priorRoundTrips: number;
+  /** Heuristic round-trip threshold N (`routing.claude_code_round_trip_threshold`). */
+  roundTripThreshold: number;
+}
+
+/** Roles eligible for the automatic claude-code escalation heuristic (ADR-0006 §3.2). */
+const HEURISTIC_ROLES: ReadonlySet<AgentOutputRole> = new Set(['developer', 'iterator']);
+
+/**
+ * True when all four configured agent providers are Anthropic — the
+ * precondition for the claude-code conditional default (ADR-0006 §1). A
+ * single OpenAI/Google agent keeps the consumer on the multi-provider
+ * script path.
+ */
+export function isAnthropicOnlyConfig(cfg: FerryConfig): boolean {
+  const m = cfg.models;
+  return (
+    m.refiner.provider === 'anthropic' &&
+    m.dev.provider === 'anthropic' &&
+    m.review.provider === 'anthropic' &&
+    m.iterate.provider === 'anthropic'
+  );
+}
+
+/** Pure, deterministic execution-path decision. See module doc for precedence. */
+export function resolveExecutionPath(input: ExecutionPathInput): ExecutionPathDecision {
+  // 1. Explicit `execution_path: script` is a hard lock — never overridden.
+  if (input.configuredPath === 'script') {
+    return { path: 'script', reason: 'default' };
+  }
+
+  // 2. Per-ticket Jira label (conflicting pair already collapsed to 'script').
+  if (input.labelOverride !== undefined) {
+    return { path: input.labelOverride, reason: 'label' };
+  }
+
+  // 3/4. Conditional default, then heuristic escalation of a script default.
+  const defaultPath: ExecutionPath =
+    input.configuredPath === 'claude-code' || input.anthropicOnly ? 'claude-code' : 'script';
+
+  if (
+    defaultPath === 'script' &&
+    HEURISTIC_ROLES.has(input.role) &&
+    input.roundTripThreshold > 0 &&
+    input.priorRoundTrips >= input.roundTripThreshold
+  ) {
+    return { path: 'claude-code', reason: 'heuristic' };
+  }
+
+  return { path: defaultPath, reason: 'default' };
+}
+
+/**
+ * Formats the execution-path decision as a fingerprinted audit-comment line
+ * following the standard `[ferry:<role>:<run-id>] …` convention (developer
+ * uses the `dev` marker token for script parity). Consumed by the contract
+ * apply step on the claude-code path so the resolved route + reason land in
+ * the audit log.
+ */
+export function formatExecutionPathAudit(
+  role: AgentOutputRole,
+  runId: string,
+  decision: ExecutionPathDecision,
+): string {
+  return `[ferry:${markerRoleToken(role)}:${runId}] execution-path: ${decision.path} (reason: ${decision.reason})`;
+}

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -769,3 +769,49 @@ describe('parseFerryConfigJson', () => {
     expect(cfg.models.dev.model).toBe('claude-haiku-4-5-20251001');
   });
 });
+
+describe('execution_path + routing config (ADR-0006, #300)', () => {
+  it('defaults: execution_path is unset (conditional default) and routing threshold is 2', () => {
+    const cfg = parseFerryConfigJson('{}');
+    expect(cfg.execution_path).toBeUndefined();
+    expect(cfg.routing.claude_code_round_trip_threshold).toBe(2);
+  });
+
+  it('DEFAULT_FERRY_CONFIG carries the routing default and no execution_path', () => {
+    expect(DEFAULT_FERRY_CONFIG.execution_path).toBeUndefined();
+    expect(DEFAULT_FERRY_CONFIG.routing.claude_code_round_trip_threshold).toBe(2);
+  });
+
+  it('parses execution_path "script"', () => {
+    const cfg = parseFerryConfigJson(JSON.stringify({ execution_path: 'script' }));
+    expect(cfg.execution_path).toBe('script');
+  });
+
+  it('parses execution_path "claude-code"', () => {
+    const cfg = parseFerryConfigJson(JSON.stringify({ execution_path: 'claude-code' }));
+    expect(cfg.execution_path).toBe('claude-code');
+  });
+
+  it('parses a custom routing threshold', () => {
+    const cfg = parseFerryConfigJson(
+      JSON.stringify({ routing: { claude_code_round_trip_threshold: 5 } }),
+    );
+    expect(cfg.routing.claude_code_round_trip_threshold).toBe(5);
+  });
+
+  it('rejects an unknown execution_path value', () => {
+    expect(() => parseFerryConfigJson(JSON.stringify({ execution_path: 'agent-sdk' }))).toThrow(
+      FerryError,
+    );
+  });
+
+  it('rejects a non-positive routing threshold', () => {
+    expect(() =>
+      parseFerryConfigJson(JSON.stringify({ routing: { claude_code_round_trip_threshold: 0 } })),
+    ).toThrow(FerryError);
+  });
+
+  it('rejects a non-object routing', () => {
+    expect(() => parseFerryConfigJson(JSON.stringify({ routing: 'fast' }))).toThrow(FerryError);
+  });
+});

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -10,6 +10,30 @@ export interface LlmRoute {
   model: string;
 }
 
+/**
+ * Which execution path the four agents run on (ADR-0006).
+ * - `script`: the bundled multi-provider deterministic agent loop.
+ * - `claude-code`: the `anthropics/claude-code-action` reasoning core,
+ *   bracketed by deterministic Ferry contract steps. Anthropic-only.
+ *
+ * When `FerryConfig.execution_path` is left unset, the resolver applies the
+ * *conditional default* (claude-code for Anthropic-only consumers, script
+ * otherwise — see `resolveExecutionPath`). An explicit `script` is a hard
+ * lock that the per-ticket label / heuristic never override.
+ */
+export type ExecutionPath = 'script' | 'claude-code';
+
+/** Deterministic execution-path routing knobs (ADR-0006 §3, #300). */
+export interface RoutingConfig {
+  /**
+   * Round-trip threshold N for the automatic claude-code escalation
+   * heuristic: a developer/iterator run with `priorRoundTrips >= N`
+   * escalates to the claude-code path (unless a label or an explicit
+   * `execution_path: script` takes precedence). Positive integer.
+   */
+  claude_code_round_trip_threshold: number;
+}
+
 export interface LabelCapability {
   mcp_servers?: string[];
   tools?: string[];
@@ -130,6 +154,15 @@ export interface FerryConfig {
    *   without the repo owner's consent.
    */
   safety?: SafetyConfig;
+  /**
+   * Explicit install-time execution-path choice (ADR-0006 point 6). When
+   * unset, the resolver applies the conditional default. An explicit
+   * `script` is a hard lock — never overridden by the per-ticket label or
+   * the round-trip heuristic.
+   */
+  execution_path?: ExecutionPath;
+  /** Deterministic execution-path routing knobs (#300). Always present (defaulted). */
+  routing: RoutingConfig;
 }
 
 export interface SafetyConfig {
@@ -187,6 +220,9 @@ export const DEFAULT_FERRY_CONFIG: FerryConfig = {
       },
       iterator: { trigger_column: 'Changes Requested', auto_transition: 'In Review' },
     },
+  },
+  routing: {
+    claude_code_round_trip_threshold: 2,
   },
 };
 
@@ -491,6 +527,30 @@ function validateConfigShape(raw: unknown): ValidationError[] {
     }
   }
 
+  if (
+    c.execution_path !== undefined &&
+    c.execution_path !== 'script' &&
+    c.execution_path !== 'claude-code'
+  ) {
+    errs.push('execution_path: must be "script" or "claude-code"');
+  }
+
+  if (c.routing !== undefined) {
+    if (!c.routing || typeof c.routing !== 'object' || Array.isArray(c.routing)) {
+      errs.push('routing: must be an object');
+    } else {
+      const r = c.routing as Record<string, unknown>;
+      if (r.claude_code_round_trip_threshold !== undefined) {
+        errs.push(
+          ...validatePosInt(
+            r.claude_code_round_trip_threshold,
+            'routing.claude_code_round_trip_threshold',
+          ),
+        );
+      }
+    }
+  }
+
   return errs;
 }
 
@@ -695,6 +755,15 @@ function mergeWithDefaults(raw: RawConfig): FerryConfig {
     },
     ...(labels !== undefined ? { labels } : {}),
     workflow: mergeWorkflow(raw.workflow),
+    ...(raw.execution_path === 'script' || raw.execution_path === 'claude-code'
+      ? { execution_path: raw.execution_path }
+      : {}),
+    routing: {
+      claude_code_round_trip_threshold: num(
+        (raw.routing as Record<string, unknown> | undefined)?.claude_code_round_trip_threshold,
+        DEFAULT_FERRY_CONFIG.routing.claude_code_round_trip_threshold,
+      ),
+    },
     ...(raw.safety && typeof raw.safety === 'object' && !Array.isArray(raw.safety)
       ? {
           safety: {

--- a/src/lib/labels/capabilities.ts
+++ b/src/lib/labels/capabilities.ts
@@ -176,6 +176,24 @@ export interface TicketOverrides {
    * even the Refiner's Jira sub-task writes are suppressed (per dryRun gating).
    */
   readOnly?: boolean;
+
+  // --- ferry:claude-code / ferry:no-claude-code (execution path) ---
+
+  /**
+   * Per-ticket execution-path override (ADR-0006 §3, #300).
+   * - `ferry:claude-code`    → 'claude-code' (force the claude-code-action path).
+   * - `ferry:no-claude-code` → 'script' (force the bundled script path).
+   *
+   * Conflicting labels (both present) resolve to the **safe path** `'script'`
+   * — deliberately, this pair does NOT throw `LabelConflictError`: a routing
+   * ambiguity must fail closed onto the deterministic script path rather than
+   * block the ticket.
+   *
+   * Consumed by `resolveExecutionPath` (src/lib/cc-wrappers/routing.ts): it
+   * takes precedence over the heuristic and the conditional default, but an
+   * explicit `execution_path: script` in ferry.config still wins.
+   */
+  claudeCodePath?: 'claude-code' | 'script';
 }
 
 /** Built-in label → normalised issue type mapping. Order matters: last match wins. */

--- a/src/lib/labels/overrides.test.ts
+++ b/src/lib/labels/overrides.test.ts
@@ -1436,3 +1436,57 @@ describe('applyDryRunMarker', () => {
     expect(out).toBe('[ferry:developer:run1] [dry-run] line1\nline2');
   });
 });
+
+// ------------------------------------------------------------------
+// ferry:claude-code / ferry:no-claude-code (execution-path override, #300)
+// ------------------------------------------------------------------
+
+describe('resolveTicketOverrides — ferry:claude-code / ferry:no-claude-code', () => {
+  it('is undefined when neither label is present', () => {
+    expect(resolveTicketOverrides([]).claudeCodePath).toBeUndefined();
+  });
+
+  it('ferry:claude-code → claudeCodePath "claude-code"', () => {
+    expect(resolveTicketOverrides(['ferry:claude-code']).claudeCodePath).toBe('claude-code');
+  });
+
+  it('ferry:no-claude-code → claudeCodePath "script"', () => {
+    expect(resolveTicketOverrides(['ferry:no-claude-code']).claudeCodePath).toBe('script');
+  });
+
+  it('conflicting labels resolve to the safe path (script) WITHOUT throwing', () => {
+    expect(() =>
+      resolveTicketOverrides(['ferry:claude-code', 'ferry:no-claude-code']),
+    ).not.toThrow();
+    expect(
+      resolveTicketOverrides(['ferry:claude-code', 'ferry:no-claude-code']).claudeCodePath,
+    ).toBe('script');
+    // order-independent
+    expect(
+      resolveTicketOverrides(['ferry:no-claude-code', 'ferry:claude-code']).claudeCodePath,
+    ).toBe('script');
+  });
+
+  it('does not emit an unknown-label warning for either label', () => {
+    const { logger, records } = createTestLogger('t', 'test');
+    resolveTicketOverrides(['ferry:claude-code', 'ferry:no-claude-code'], logger);
+    expect(records.some((rec) => rec.level === 'warn')).toBe(false);
+  });
+
+  it('counts toward hasNonDefaultOverrides', () => {
+    expect(hasNonDefaultOverrides(resolveTicketOverrides(['ferry:claude-code']))).toBe(true);
+    expect(hasNonDefaultOverrides(resolveTicketOverrides(['ferry:no-claude-code']))).toBe(true);
+  });
+
+  it('is recorded in the overrides audit comment', () => {
+    const body = buildOverridesAuditComment(
+      'developer',
+      'run1',
+      resolveTicketOverrides(['ferry:claude-code']),
+    );
+    expect(body).toContain('[ferry:developer:run1] overrides applied:');
+    expect(JSON.parse(body.split('overrides applied: ')[1])).toMatchObject({
+      claudeCodePath: 'claude-code',
+    });
+  });
+});

--- a/src/lib/labels/overrides.ts
+++ b/src/lib/labels/overrides.ts
@@ -190,6 +190,8 @@ export function resolveTicketOverrides(
   let noAutoTransition = false;
   let dryRun = false;
   let readOnly = false;
+  let hasClaudeCode = false;
+  let hasNoClaudeCode = false;
   const skipPhases: AgentPhase[] = [];
 
   let baseBranchLabel: string | undefined;
@@ -521,9 +523,30 @@ export function resolveTicketOverrides(
       continue;
     }
 
+    // ferry:claude-code / ferry:no-claude-code — per-ticket execution-path override.
+    // Conflicting labels are NOT a LabelConflictError: a routing ambiguity must
+    // fail closed onto the safe script path (resolved after the loop).
+    if (label === 'ferry:claude-code') {
+      hasClaudeCode = true;
+      continue;
+    }
+    if (label === 'ferry:no-claude-code') {
+      hasNoClaudeCode = true;
+      continue;
+    }
+
     // Unrecognised ferry:* label in override namespace — log and ignore
     logger?.warn('unknown ferry override label ignored', { label });
   }
+
+  // Resolve the execution-path override. Order-independent and fail-closed:
+  // any conflict (both labels present) collapses to the safe script path.
+  const claudeCodePath: 'claude-code' | 'script' | undefined =
+    hasClaudeCode && !hasNoClaudeCode
+      ? 'claude-code'
+      : hasClaudeCode || hasNoClaudeCode
+        ? 'script'
+        : undefined;
 
   // Apply blanket model/provider to phases not already overridden per-phase.
   // Per-phase labels take precedence: blanket only fills phases with no explicit per-phase override.
@@ -578,6 +601,7 @@ export function resolveTicketOverrides(
     ...(paused ? { paused: true } : {}),
     ...(dryRun ? { dryRun: true } : {}),
     ...(readOnly ? { readOnly: true } : {}),
+    ...(claudeCodePath !== undefined ? { claudeCodePath } : {}),
   };
 }
 
@@ -675,7 +699,8 @@ export function hasNonDefaultOverrides(overrides: TicketOverrides): boolean {
     overrides.git?.prDraft !== undefined ||
     overrides.paused === true ||
     overrides.dryRun === true ||
-    overrides.readOnly === true
+    overrides.readOnly === true ||
+    overrides.claudeCodePath !== undefined
   );
 }
 
@@ -718,6 +743,7 @@ export function buildOverridesAuditComment(
   if (overrides.paused) payload.paused = true;
   if (overrides.dryRun) payload.dryRun = true;
   if (overrides.readOnly) payload.readOnly = true;
+  if (overrides.claudeCodePath !== undefined) payload.claudeCodePath = overrides.claudeCodePath;
 
   const body = `[ferry:${role}:${runId}] overrides applied: ${JSON.stringify(payload)}`;
   return applyDryRunMarker(body, overrides.dryRun);

--- a/src/schemas/agent-output.v1.schema.json
+++ b/src/schemas/agent-output.v1.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ferry.dev/schemas/agent-output.v1.json",
+  "title": "Ferry claude-code agent output (v1)",
+  "description": "Terminal structured-JSON artifact written by the claude-code-action reasoning core. The deterministic post-step parses and validates it (fail-closed) before emitting audit/transitions — the LLM never emits audit markers or transitions itself (ADR-0006 §2, ADR-0004).",
+  "type": "object",
+  "required": ["version", "role"],
+  "properties": {
+    "version": { "const": "v1" }
+  },
+  "oneOf": [
+    {
+      "type": "object",
+      "required": ["version", "role", "outcome", "summary"],
+      "additionalProperties": false,
+      "properties": {
+        "version": { "const": "v1" },
+        "role": { "const": "developer" },
+        "outcome": { "enum": ["implemented", "already_satisfied", "blocked"] },
+        "summary": { "type": "string", "minLength": 1, "maxLength": 2000 },
+        "reason": { "type": "string", "minLength": 1, "maxLength": 2000 },
+        "pr_url": { "type": "string", "minLength": 1, "maxLength": 500 }
+      }
+    },
+    {
+      "type": "object",
+      "required": ["version", "role", "outcome", "summary"],
+      "additionalProperties": false,
+      "properties": {
+        "version": { "const": "v1" },
+        "role": { "const": "iterator" },
+        "outcome": { "enum": ["implemented", "already_satisfied", "blocked"] },
+        "summary": { "type": "string", "minLength": 1, "maxLength": 2000 },
+        "reason": { "type": "string", "minLength": 1, "maxLength": 2000 },
+        "pr_number": { "type": "integer", "minimum": 1 }
+      }
+    },
+    {
+      "type": "object",
+      "required": ["version", "role", "verdict", "review_comment", "summary"],
+      "additionalProperties": false,
+      "properties": {
+        "version": { "const": "v1" },
+        "role": { "const": "reviewer" },
+        "verdict": { "enum": ["approved", "changes_requested"] },
+        "review_comment": { "type": "string", "minLength": 1, "maxLength": 65536 },
+        "summary": { "type": "string", "minLength": 1, "maxLength": 2000 }
+      }
+    },
+    {
+      "type": "object",
+      "required": ["version", "role", "result", "summary"],
+      "additionalProperties": false,
+      "properties": {
+        "version": { "const": "v1" },
+        "role": { "const": "refiner" },
+        "result": { "enum": ["refined", "noop"] },
+        "summary": { "type": "string", "minLength": 1, "maxLength": 2000 },
+        "created": { "type": "integer", "minimum": 0 },
+        "kept": { "type": "integer", "minimum": 0 },
+        "staled": { "type": "integer", "minimum": 0 },
+        "noop_reason": { "type": "string", "minLength": 1, "maxLength": 2000 }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #300. Part of epic #299 (ADR-0006 §1/§3, decisions/0002 §B).

## Scope

The **deterministic execution-path resolver only** — decides whether an agent run takes the bundled-script path or the `claude-code-action` path, and records *why*. The path itself is **not** wired into the action job yet (#302); the new label/config are recognised but **inert** until the path ships, so this PR cannot regress any consumer.

## What landed

**Config (`src/lib/config.ts`)**
- `ExecutionPath` type; optional `execution_path` key (`unset` → conditional default; `"script"` → hard lock; `"claude-code"` → explicit).
- Required `routing.claude_code_round_trip_threshold` (default **2**), with merge parsing + validation. Zero-config still deep-equals `DEFAULT_FERRY_CONFIG`.

**Label override (`src/lib/labels/{capabilities,overrides}.ts`)**
- `ferry:claude-code` / `ferry:no-claude-code` resolved through the existing `resolveTicketOverrides` into `TicketOverrides.claudeCodePath`.
- Conflicting pair **fails closed to the safe `script` path** — deliberately *not* a `LabelConflictError` (a routing ambiguity must not block the ticket). Order-independent.
- Wired into `hasNonDefaultOverrides` + `buildOverridesAuditComment`; added to the labels allowlist.

**Resolver (`src/lib/cc-wrappers/routing.ts`)**
- `resolveExecutionPath` — pure/deterministic. Precedence: explicit-`script` lock → label → heuristic (`role ∈ {developer,iterator}` AND `priorRoundTrips >= N`) → conditional default (`claude-code` for Anthropic-only, else `script`). The heuristic only *escalates* an otherwise-script default; it never downgrades.
- `isAnthropicOnlyConfig`; `formatExecutionPathAudit` emits the resolved route + reason (`label`/`heuristic`/`default`) into the `[ferry:<role>:<run-id>]` audit marker.

## Acceptance criteria

- [x] Resolver is pure/deterministic, unit-tested (TDD) for **every** precedence case incl. conflicting labels → safe path (`script`).
- [x] `execution_path` config key + N threshold honored; explicit `script` never overridden (covered by dedicated tests).
- [x] Reason string emitted into the audit comment marker (`formatExecutionPathAudit`, tested).

## Verification

- Typecheck, ESLint, Prettier: green.
- Full suite: **1909 passed** (config +8, overrides +6, routing +23 new).
- `.ferry/` + `.github/actions/**` bundles rebuilt via `npm run build:ferry`.

## Out of scope (other #299 sub-issues)

Wiring the resolver into the action job / wrapper pipeline (#302), install-time path choice (#304), upgrade gate (#305). This PR only delivers the resolver primitive + its config/label inputs.