### PR TITLE
feat(cli): ferry-update MIGRATIONS requires-secrets credential gate (closes #305)

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -24,6 +24,26 @@ forge: gitlab
 - **(action)** GitLab-only follow-up …
 ```
 
+Optionally declare secrets the consumer must have set for the transition by
+adding a `requires-secrets:` line (parallel to `forge:`, comma- and/or
+whitespace-separated). This is a **general mechanism**: any release that
+introduces a newly-required secret uses it — it is not tied to one feature.
+
+```markdown
+## v0.X.x → v0.Y.0
+
+requires-secrets: SOME_NEW_TOKEN
+```
+
+`ferry-update` stays **credential-silent for code-only ranges** (no
+`requires-secrets:` → no prompt, credentials untouched). When the crossed
+range declares one or more required secrets, it diffs them against
+`gh secret list` and, **only for the missing ones**, prompts in an
+interactive run (or, in a non-interactive run, stays on the bundled script
+with no breakage and prints a mandatory follow-up to re-run interactively).
+An explicit `execution_path: script` in `ferry.config.json` is always
+respected. See ADR-0006 §7 and `docs/decisions/0002` §G.
+
 Each bullet should be one of:
 
 - `(action)` — something the consumer must do manually (new secret, Jira rule change, etc.)

--- a/src/cli/update/credential-gate-run.test.ts
+++ b/src/cli/update/credential-gate-run.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runCredentialGate } from './credential-gate-run.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'ferry-cgr-'));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true, retryDelay: 50 });
+});
+
+function writeMigrations(content: string): string {
+  const f = join(dir, 'MIGRATIONS.md');
+  writeFileSync(f, content, 'utf8');
+  return f;
+}
+function writeConfig(content: string): void {
+  writeFileSync(join(dir, 'ferry.config.json'), content, 'utf8');
+}
+function writeSetupFile(): void {
+  writeFileSync(
+    join(dir, 'ferry-jira-automation-setup.md'),
+    'POST `https://api.github.com/repos/acme/widgets/dispatches`\n',
+    'utf8',
+  );
+}
+
+const SILENT_DEPS = {
+  listSecrets: () => [],
+  promptSecret: async () => '',
+  setRepoSecret: () => undefined,
+};
+
+describe('runCredentialGate', () => {
+  it('code-only range → silent: ran=false, no prompts, no follow-ups', async () => {
+    const mig = writeMigrations(`## v0.1.0 → v0.2.0\n- **(info)** internal only\n`);
+    writeSetupFile();
+    const promptSecret = vi.fn(async () => 'x');
+    const setRepoSecret = vi.fn();
+    const r = await runCredentialGate({
+      repoRoot: dir,
+      fromVersion: 'v0.1.0',
+      toVersion: 'v0.2.0',
+      interactive: true,
+      dryRun: false,
+      migrationsPath: mig,
+      listSecrets: () => ['UNRELATED'],
+      promptSecret,
+      setRepoSecret,
+    });
+    expect(r.ran).toBe(false);
+    expect(r.followUps).toEqual([]);
+    expect(promptSecret).not.toHaveBeenCalled();
+    expect(setRepoSecret).not.toHaveBeenCalled();
+  });
+
+  it('declared + already set → adopts: writes execution_path, no prompt', async () => {
+    const mig = writeMigrations(
+      `## v0.1.0 → v0.2.0\nrequires-secrets: CLAUDE_CODE_OAUTH_TOKEN\n\n- **(action)** a\n`,
+    );
+    writeSetupFile();
+    writeConfig('{\n  "audit_issue": 9\n}\n');
+    const promptSecret = vi.fn(async () => 'x');
+    const r = await runCredentialGate({
+      repoRoot: dir,
+      fromVersion: 'v0.1.0',
+      toVersion: 'v0.2.0',
+      interactive: false,
+      dryRun: false,
+      migrationsPath: mig,
+      listSecrets: () => ['CLAUDE_CODE_OAUTH_TOKEN'],
+      promptSecret,
+      setRepoSecret: () => undefined,
+    });
+    expect(r.ran).toBe(true);
+    expect(promptSecret).not.toHaveBeenCalled();
+    const cfg = JSON.parse(readFileSync(join(dir, 'ferry.config.json'), 'utf8'));
+    expect(cfg.execution_path).toBe('claude-code');
+  });
+
+  it('declared + missing + interactive → prompts ONLY the missing, then adopts', async () => {
+    const mig = writeMigrations(
+      `## v0.1.0 → v0.2.0\nrequires-secrets: CLAUDE_CODE_OAUTH_TOKEN, OTHER\n\n- **(action)** a\n`,
+    );
+    writeSetupFile();
+    writeConfig('{\n  "audit_issue": 9\n}\n');
+    const promptSecret = vi.fn(async () => 'tok-value');
+    const setRepoSecret = vi.fn();
+    const r = await runCredentialGate({
+      repoRoot: dir,
+      fromVersion: 'v0.1.0',
+      toVersion: 'v0.2.0',
+      interactive: true,
+      dryRun: false,
+      migrationsPath: mig,
+      listSecrets: () => ['OTHER'],
+      promptSecret,
+      setRepoSecret,
+    });
+    expect(r.ran).toBe(true);
+    expect(promptSecret).toHaveBeenCalledTimes(1);
+    expect(promptSecret).toHaveBeenCalledWith('CLAUDE_CODE_OAUTH_TOKEN');
+    expect(setRepoSecret).toHaveBeenCalledWith(
+      'acme/widgets',
+      'CLAUDE_CODE_OAUTH_TOKEN',
+      'tok-value',
+    );
+    const cfg = JSON.parse(readFileSync(join(dir, 'ferry.config.json'), 'utf8'));
+    expect(cfg.execution_path).toBe('claude-code');
+  });
+
+  it('declared + missing + non-interactive → stay on script + mandatory follow-up, no write', async () => {
+    const mig = writeMigrations(
+      `## v0.1.0 → v0.2.0\nrequires-secrets: CLAUDE_CODE_OAUTH_TOKEN\n\n- **(action)** a\n`,
+    );
+    writeSetupFile();
+    writeConfig('{\n  "audit_issue": 9\n}\n');
+    const r = await runCredentialGate({
+      repoRoot: dir,
+      fromVersion: 'v0.1.0',
+      toVersion: 'v0.2.0',
+      interactive: false,
+      dryRun: false,
+      migrationsPath: mig,
+      ...SILENT_DEPS,
+    });
+    expect(r.ran).toBe(true);
+    expect(r.followUps.join('\n')).toContain('CLAUDE_CODE_OAUTH_TOKEN');
+    const cfg = JSON.parse(readFileSync(join(dir, 'ferry.config.json'), 'utf8'));
+    expect(cfg.execution_path).toBeUndefined();
+  });
+
+  it('explicit execution_path: script → respected, never overridden', async () => {
+    const mig = writeMigrations(
+      `## v0.1.0 → v0.2.0\nrequires-secrets: CLAUDE_CODE_OAUTH_TOKEN\n\n- **(action)** a\n`,
+    );
+    writeSetupFile();
+    writeConfig('{\n  "execution_path": "script"\n}\n');
+    const r = await runCredentialGate({
+      repoRoot: dir,
+      fromVersion: 'v0.1.0',
+      toVersion: 'v0.2.0',
+      interactive: true,
+      dryRun: false,
+      migrationsPath: mig,
+      listSecrets: () => ['CLAUDE_CODE_OAUTH_TOKEN'],
+      promptSecret: async () => 'x',
+      setRepoSecret: () => undefined,
+    });
+    expect(r.ran).toBe(true);
+    const cfg = JSON.parse(readFileSync(join(dir, 'ferry.config.json'), 'utf8'));
+    expect(cfg.execution_path).toBe('script');
+  });
+
+  it('dry-run never prompts or writes even when satisfied', async () => {
+    const mig = writeMigrations(
+      `## v0.1.0 → v0.2.0\nrequires-secrets: CLAUDE_CODE_OAUTH_TOKEN\n\n- **(action)** a\n`,
+    );
+    writeSetupFile();
+    writeConfig('{\n  "audit_issue": 9\n}\n');
+    const promptSecret = vi.fn(async () => 'x');
+    const setRepoSecret = vi.fn();
+    const r = await runCredentialGate({
+      repoRoot: dir,
+      fromVersion: 'v0.1.0',
+      toVersion: 'v0.2.0',
+      interactive: false,
+      dryRun: true,
+      migrationsPath: mig,
+      listSecrets: () => ['CLAUDE_CODE_OAUTH_TOKEN'],
+      promptSecret,
+      setRepoSecret,
+    });
+    expect(r.ran).toBe(true);
+    expect(promptSecret).not.toHaveBeenCalled();
+    expect(setRepoSecret).not.toHaveBeenCalled();
+    const cfg = JSON.parse(readFileSync(join(dir, 'ferry.config.json'), 'utf8'));
+    expect(cfg.execution_path).toBeUndefined();
+  });
+
+  it('repo cannot be resolved → defers with an actionable follow-up, no write', async () => {
+    const mig = writeMigrations(
+      `## v0.1.0 → v0.2.0\nrequires-secrets: CLAUDE_CODE_OAUTH_TOKEN\n\n- **(action)** a\n`,
+    );
+    // No ferry-jira-automation-setup.md → owner/repo unknown.
+    writeConfig('{\n  "audit_issue": 9\n}\n');
+    const r = await runCredentialGate({
+      repoRoot: dir,
+      fromVersion: 'v0.1.0',
+      toVersion: 'v0.2.0',
+      interactive: true,
+      dryRun: false,
+      migrationsPath: mig,
+      ...SILENT_DEPS,
+    });
+    expect(r.ran).toBe(true);
+    expect(r.followUps.join('\n')).toMatch(/CLAUDE_CODE_OAUTH_TOKEN/);
+    const cfg = JSON.parse(readFileSync(join(dir, 'ferry.config.json'), 'utf8'));
+    expect(cfg.execution_path).toBeUndefined();
+  });
+});

--- a/src/cli/update/credential-gate-run.ts
+++ b/src/cli/update/credential-gate-run.ts
@@ -1,0 +1,159 @@
+import { askSecret, printSuccess, printSkip, printWarn, print } from '../init/prompt.js';
+import { listExistingSecrets, setSecret } from '../init/steps/secrets.js';
+import { extractJiraConfigFromSetupFile } from './extract-jira-config.js';
+import { getRequiredSecretsForRange } from './migrations.js';
+import { evaluateCredentialGate } from './credential-gate.js';
+import { readExecutionPath, applyClaudeCodeExecutionPath } from './exec-path.js';
+import type { ForgeKind } from '../lib/forge.js';
+
+/**
+ * Orchestrates the manifest-driven credential gate during `ferry-update`
+ * (GitHub flow). Pure decision logic lives in `credential-gate.ts`; this
+ * module wires it to real IO (secret listing/prompting, config write) and
+ * keeps every external dependency injectable so it is unit-testable without
+ * touching `gh` or a TTY.
+ *
+ * Credential-silent for code-only ranges: when the crossed MIGRATIONS.md
+ * range declares no `requires-secrets:`, this returns immediately with no
+ * output — preserving the "never re-prompts for credentials" property.
+ */
+export interface CredentialGateRunOptions {
+  repoRoot: string;
+  fromVersion: string;
+  toVersion: string;
+  /** True when `ferry-update` may prompt (TTY, not --yes). */
+  interactive: boolean;
+  dryRun: boolean;
+  /** Override MIGRATIONS.md location (tests). */
+  migrationsPath?: string;
+  /** Injectable IO (defaults wrap the real `gh`-backed helpers). */
+  listSecrets?: (repo: string) => string[];
+  promptSecret?: (name: string) => Promise<string>;
+  setRepoSecret?: (repo: string, name: string, value: string) => void;
+}
+
+export interface CredentialGateRunResult {
+  /** False when the range is code-only (silent path). */
+  ran: boolean;
+  /** Follow-up lines to append to "Manual follow-ups required". */
+  followUps: string[];
+}
+
+export async function runCredentialGate(
+  opts: CredentialGateRunOptions,
+): Promise<CredentialGateRunResult> {
+  const listSecrets = opts.listSecrets ?? listExistingSecrets;
+  const promptSecret = opts.promptSecret ?? ((name) => askSecret(`Enter value for ${name}`));
+  const setRepoSecret = opts.setRepoSecret ?? setSecret;
+
+  const requiredSecrets = getRequiredSecretsForRange(opts.fromVersion, opts.toVersion, {
+    forge: 'github' as ForgeKind,
+    migrationsPath: opts.migrationsPath,
+  });
+
+  // Code-only update: stay completely silent (property preserved).
+  if (requiredSecrets.length === 0) {
+    return { ran: false, followUps: [] };
+  }
+
+  const followUps: string[] = [];
+
+  const jira = extractJiraConfigFromSetupFile(opts.repoRoot);
+  const repo = jira ? `${jira.owner}/${jira.repo}` : undefined;
+  const existingSecrets = repo ? listSecrets(repo) : [];
+  const explicitExecutionPath = readExecutionPath(opts.repoRoot);
+
+  // Without a resolvable repo we can neither list nor set secrets — force the
+  // deferral path so nothing is adopted blindly.
+  const canPrompt = opts.interactive && !opts.dryRun && repo !== undefined;
+
+  const result = evaluateCredentialGate({
+    requiredSecrets,
+    existingSecrets,
+    interactive: canPrompt,
+    explicitExecutionPath,
+  });
+
+  print('');
+  print('════════════════════════════════════════');
+  print('  Credential gate (MIGRATIONS requires-secrets)');
+  print('════════════════════════════════════════');
+
+  if (!repo && result.outcome !== 'explicit-script') {
+    printWarn(
+      'Could not determine the GitHub repo from ferry-jira-automation-setup.md — ' +
+        'cannot check or set secrets automatically.',
+    );
+  }
+
+  const adopt = (): void => {
+    if (opts.dryRun) {
+      printSkip('[dry-run] would set execution_path: claude-code in ferry.config.json');
+      return;
+    }
+    const applied = applyClaudeCodeExecutionPath(opts.repoRoot);
+    if (applied === 'written') {
+      printSuccess('execution_path set to claude-code in ferry.config.json');
+    } else if (applied === 'already-claude-code') {
+      printSkip('execution_path already claude-code — nothing to do');
+    } else {
+      followUps.push(
+        'Set `execution_path: claude-code` in ferry.config.yaml (no ferry.config.json ' +
+          'found) to adopt the new execution path, or re-run `ferry-init`.',
+      );
+    }
+  };
+
+  switch (result.outcome) {
+    case 'explicit-script':
+      printSkip('execution_path: script set explicitly — credential gate skipped; path unchanged.');
+      break;
+
+    case 'satisfied':
+      printSuccess(`Required secret(s) already set: ${requiredSecrets.join(', ')}`);
+      adopt();
+      break;
+
+    case 'prompt-missing': {
+      printWarn(`Missing required secret(s): ${result.missing.join(', ')}`);
+      let allProvided = true;
+      for (const name of result.missing) {
+        const value = (await promptSecret(name)).trim();
+        if (!value) {
+          allProvided = false;
+          printWarn(`No value entered for ${name} — skipped.`);
+          continue;
+        }
+        try {
+          setRepoSecret(repo!, name, value);
+          printSuccess(`Set ${name}`);
+        } catch (err) {
+          allProvided = false;
+          const msg = err instanceof Error ? err.message : String(err);
+          printWarn(`Failed to set ${name}: ${msg}`);
+        }
+      }
+      if (allProvided) {
+        adopt();
+      } else {
+        followUps.push(
+          `Provide the remaining required secret(s) and re-run \`ferry-update\` ` +
+            `to adopt the new execution path. Ferry stays on the bundled script until then.`,
+        );
+      }
+      break;
+    }
+
+    case 'stay-on-script':
+      printWarn(result.followUp ?? 'Required secrets missing — staying on the script path.');
+      if (result.followUp) followUps.push(result.followUp);
+      break;
+
+    case 'silent':
+      // unreachable — handled by the early return above.
+      break;
+  }
+
+  print('');
+  return { ran: true, followUps };
+}

--- a/src/cli/update/credential-gate.test.ts
+++ b/src/cli/update/credential-gate.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateCredentialGate } from './credential-gate.js';
+
+// Full coverage of the migration matrix in decisions/0002 §G:
+//
+// | Situation on `ferry-update`                         | Outcome                       |
+// | --------------------------------------------------- | ----------------------------- |
+// | Crossed range has no `requires-secrets:` (code-only) | Silent — no prompt, untouched |
+// | Declares secret, already set                         | Auto-adopts (default applied) |
+// | Declares it, missing, interactive                    | Prompts only missing → adopt  |
+// | Declares it, missing, non-interactive                | Stays on script + follow-up   |
+// | `execution_path: script` explicitly set              | Respected — never overridden  |
+
+describe('evaluateCredentialGate — decisions/0002 §G matrix', () => {
+  it('row 1 — code-only range → silent, no adoption, property preserved', () => {
+    const r = evaluateCredentialGate({
+      requiredSecrets: [],
+      existingSecrets: ['CLAUDE_CODE_OAUTH_TOKEN'],
+      interactive: true,
+    });
+    expect(r.outcome).toBe('silent');
+    expect(r.adopt).toBe(false);
+    expect(r.missing).toEqual([]);
+    expect(r.followUp).toBeUndefined();
+  });
+
+  it('row 2 — required secret already set → satisfied, adopt', () => {
+    const r = evaluateCredentialGate({
+      requiredSecrets: ['CLAUDE_CODE_OAUTH_TOKEN'],
+      existingSecrets: ['FERRY_APP_ID', 'CLAUDE_CODE_OAUTH_TOKEN'],
+      interactive: false,
+    });
+    expect(r.outcome).toBe('satisfied');
+    expect(r.adopt).toBe(true);
+    expect(r.missing).toEqual([]);
+  });
+
+  it('row 3 — missing + interactive → prompt only the missing, then adopt', () => {
+    const r = evaluateCredentialGate({
+      requiredSecrets: ['CLAUDE_CODE_OAUTH_TOKEN', 'OTHER_SECRET'],
+      existingSecrets: ['OTHER_SECRET'],
+      interactive: true,
+    });
+    expect(r.outcome).toBe('prompt-missing');
+    expect(r.adopt).toBe(true);
+    expect(r.missing).toEqual(['CLAUDE_CODE_OAUTH_TOKEN']);
+  });
+
+  it('row 4 — missing + non-interactive → stay on script + mandatory follow-up', () => {
+    const r = evaluateCredentialGate({
+      requiredSecrets: ['CLAUDE_CODE_OAUTH_TOKEN'],
+      existingSecrets: [],
+      interactive: false,
+    });
+    expect(r.outcome).toBe('stay-on-script');
+    expect(r.adopt).toBe(false);
+    expect(r.missing).toEqual(['CLAUDE_CODE_OAUTH_TOKEN']);
+    expect(r.followUp).toBeDefined();
+    expect(r.followUp).toContain('CLAUDE_CODE_OAUTH_TOKEN');
+  });
+
+  it('row 5 — explicit execution_path: script is respected even when satisfied', () => {
+    const r = evaluateCredentialGate({
+      requiredSecrets: ['CLAUDE_CODE_OAUTH_TOKEN'],
+      existingSecrets: ['CLAUDE_CODE_OAUTH_TOKEN'],
+      interactive: true,
+      explicitExecutionPath: 'script',
+    });
+    expect(r.outcome).toBe('explicit-script');
+    expect(r.adopt).toBe(false);
+  });
+
+  it('row 5 takes precedence over row 4 (explicit script, missing, non-interactive)', () => {
+    const r = evaluateCredentialGate({
+      requiredSecrets: ['CLAUDE_CODE_OAUTH_TOKEN'],
+      existingSecrets: [],
+      interactive: false,
+      explicitExecutionPath: 'script',
+    });
+    expect(r.outcome).toBe('explicit-script');
+    expect(r.adopt).toBe(false);
+    expect(r.followUp).toBeUndefined();
+  });
+
+  it('an explicit non-script execution_path does not suppress the gate', () => {
+    const r = evaluateCredentialGate({
+      requiredSecrets: ['CLAUDE_CODE_OAUTH_TOKEN'],
+      existingSecrets: ['CLAUDE_CODE_OAUTH_TOKEN'],
+      interactive: true,
+      explicitExecutionPath: 'claude-code',
+    });
+    expect(r.outcome).toBe('satisfied');
+    expect(r.adopt).toBe(true);
+  });
+
+  it('computes the missing set as required minus existing, order preserved', () => {
+    const r = evaluateCredentialGate({
+      requiredSecrets: ['A', 'B', 'C'],
+      existingSecrets: ['B'],
+      interactive: true,
+    });
+    expect(r.missing).toEqual(['A', 'C']);
+  });
+
+  it('is a general mechanism — works for any secret name, not just cc', () => {
+    const r = evaluateCredentialGate({
+      requiredSecrets: ['SOME_FUTURE_SECRET'],
+      existingSecrets: [],
+      interactive: false,
+    });
+    expect(r.outcome).toBe('stay-on-script');
+    expect(r.followUp).toContain('SOME_FUTURE_SECRET');
+  });
+});

--- a/src/cli/update/credential-gate.ts
+++ b/src/cli/update/credential-gate.ts
@@ -1,0 +1,94 @@
+/**
+ * Manifest-driven credential gate for `ferry-update` (ADR-0006 §7,
+ * decisions/0002 §G).
+ *
+ * This is a **pure decision function** — no IO, no prompting, no config
+ * writes. `ferry-update` feeds it the secrets declared by the crossed
+ * `MIGRATIONS.md` range (`requires-secrets:`), the secrets currently set on
+ * the repo, whether the run is interactive, and any explicit
+ * `execution_path` from `ferry.config.json`. It returns the matrix outcome.
+ *
+ * It is a **general mechanism**: nothing here is claude-code specific. Any
+ * future release that declares a newly-required secret reuses it unchanged.
+ */
+
+export type CredentialGateOutcome =
+  /** No `requires-secrets:` in the crossed range — credential-silent. */
+  | 'silent'
+  /** All required secrets present — adopt the conditional default. */
+  | 'satisfied'
+  /** Interactive + some missing — prompt only the missing, then adopt. */
+  | 'prompt-missing'
+  /** Non-interactive + missing — keep the script path + mandatory follow-up. */
+  | 'stay-on-script'
+  /** `execution_path: script` set explicitly — respected, never overridden. */
+  | 'explicit-script';
+
+export interface CredentialGateInput {
+  /** Secrets the crossed MIGRATIONS.md range declares as required. */
+  requiredSecrets: string[];
+  /** Secrets currently set on the repo (`gh secret list`). */
+  existingSecrets: string[];
+  /** True when `ferry-update` can prompt (TTY, not `--yes`, not `--dry-run`). */
+  interactive: boolean;
+  /** Explicit `execution_path` from `ferry.config.json`, if any. */
+  explicitExecutionPath?: string;
+}
+
+export interface CredentialGateResult {
+  outcome: CredentialGateOutcome;
+  /** Required secrets not present on the repo (order preserved). */
+  missing: string[];
+  /** Whether the conditional default should be adopted on this upgrade. */
+  adopt: boolean;
+  /** Mandatory follow-up printed when the path is deferred (stay-on-script). */
+  followUp?: string;
+}
+
+/**
+ * Resolve the credential-gate outcome. Precedence (matches decisions/0002 §G):
+ *
+ * 1. No required secrets               → `silent`
+ * 2. `execution_path: script` explicit → `explicit-script` (always respected)
+ * 3. All required present              → `satisfied`
+ * 4. Missing + interactive             → `prompt-missing`
+ * 5. Missing + non-interactive         → `stay-on-script`
+ */
+export function evaluateCredentialGate(input: CredentialGateInput): CredentialGateResult {
+  const { requiredSecrets, existingSecrets, interactive, explicitExecutionPath } = input;
+
+  // 1 — code-only range: the "never re-prompts for credentials" property.
+  if (requiredSecrets.length === 0) {
+    return { outcome: 'silent', missing: [], adopt: false };
+  }
+
+  const existing = new Set(existingSecrets);
+  const missing = requiredSecrets.filter((s) => !existing.has(s));
+
+  // 2 — an explicit script pin is never overridden by the gate.
+  if (explicitExecutionPath === 'script') {
+    return { outcome: 'explicit-script', missing, adopt: false };
+  }
+
+  // 3 — already provisioned: adopt the conditional default silently.
+  if (missing.length === 0) {
+    return { outcome: 'satisfied', missing, adopt: true };
+  }
+
+  // 4 — interactive: prompt only for the missing secrets, then adopt.
+  if (interactive) {
+    return { outcome: 'prompt-missing', missing, adopt: true };
+  }
+
+  // 5 — non-interactive: zero breakage, stay on the script path + follow-up.
+  return {
+    outcome: 'stay-on-script',
+    missing,
+    adopt: false,
+    followUp:
+      `Missing required secret(s): ${missing.join(', ')}. ` +
+      `Ferry stays on the bundled script path (no breakage). ` +
+      `Re-run \`ferry-update\` interactively (a TTY, without --yes) to provision ` +
+      `the secret(s) and adopt the new execution path.`,
+  };
+}

--- a/src/cli/update/exec-path.test.ts
+++ b/src/cli/update/exec-path.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { readExecutionPath, applyClaudeCodeExecutionPath } from './exec-path.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'ferry-exec-path-'));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true, retryDelay: 50 });
+});
+
+function writeJson(content: string): void {
+  writeFileSync(join(dir, 'ferry.config.json'), content, 'utf8');
+}
+
+describe('readExecutionPath', () => {
+  it('returns undefined when no ferry.config.json exists', () => {
+    expect(readExecutionPath(dir)).toBeUndefined();
+  });
+
+  it('returns undefined when the key is absent', () => {
+    writeJson('{\n  "audit_issue": 42\n}\n');
+    expect(readExecutionPath(dir)).toBeUndefined();
+  });
+
+  it('returns the configured execution_path value', () => {
+    writeJson('{\n  "execution_path": "script"\n}\n');
+    expect(readExecutionPath(dir)).toBe('script');
+  });
+
+  it('returns undefined on malformed JSON (fail-soft)', () => {
+    writeJson('{ not json');
+    expect(readExecutionPath(dir)).toBeUndefined();
+  });
+});
+
+describe('applyClaudeCodeExecutionPath', () => {
+  it('returns no-json-config when ferry.config.json is absent', () => {
+    expect(applyClaudeCodeExecutionPath(dir)).toBe('no-json-config');
+  });
+
+  it('writes execution_path: claude-code, preserving 2-space indent + field order', () => {
+    writeJson('{\n  "audit_issue": 42,\n  "limits": {\n    "max_iterations": 3\n  }\n}\n');
+    expect(applyClaudeCodeExecutionPath(dir)).toBe('written');
+    const out = readFileSync(join(dir, 'ferry.config.json'), 'utf8');
+    const parsed = JSON.parse(out);
+    expect(parsed.execution_path).toBe('claude-code');
+    // Original keys preserved and in original order; new key appended last.
+    expect(Object.keys(parsed)).toEqual(['audit_issue', 'limits', 'execution_path']);
+    expect(out).toContain('  "audit_issue": 42');
+    expect(out.endsWith('\n')).toBe(true);
+  });
+
+  it('preserves 4-space indentation when that is what the file uses', () => {
+    writeJson('{\n    "audit_issue": 7\n}\n');
+    applyClaudeCodeExecutionPath(dir);
+    const out = readFileSync(join(dir, 'ferry.config.json'), 'utf8');
+    expect(out).toContain('\n    "audit_issue": 7');
+    expect(out).toContain('\n    "execution_path": "claude-code"');
+  });
+
+  it('is idempotent — already-claude-code when already set', () => {
+    writeJson('{\n  "execution_path": "claude-code"\n}\n');
+    expect(applyClaudeCodeExecutionPath(dir)).toBe('already-claude-code');
+  });
+
+  it('overwrites a non-script, non-cc value in place (keeps position)', () => {
+    writeJson('{\n  "execution_path": "other",\n  "audit_issue": 1\n}\n');
+    expect(applyClaudeCodeExecutionPath(dir)).toBe('written');
+    const parsed = JSON.parse(readFileSync(join(dir, 'ferry.config.json'), 'utf8'));
+    expect(parsed.execution_path).toBe('claude-code');
+    expect(Object.keys(parsed)).toEqual(['execution_path', 'audit_issue']);
+  });
+});

--- a/src/cli/update/exec-path.ts
+++ b/src/cli/update/exec-path.ts
@@ -1,0 +1,68 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Minimal, format-preserving reader/writer for the `execution_path` key in a
+ * consumer's `ferry.config.json`.
+ *
+ * Scope is intentionally narrow (KISS): only `ferry.config.json` is touched.
+ * `ferry-init` generates `ferry.config.yaml`; rewriting YAML in place is out
+ * of scope here — when no JSON config exists the credential gate prints an
+ * actionable follow-up instead of guessing a YAML edit. The `execution_path`
+ * value space (`'script' | 'claude-code'`) is owned by the config schema
+ * (sibling #304); this writer stays inert until that resolver reads it.
+ */
+
+const CONFIG_FILE = 'ferry.config.json';
+
+function readJson(repoRoot: string): { raw: string; data: Record<string, unknown> } | undefined {
+  try {
+    const raw = readFileSync(join(repoRoot, CONFIG_FILE), 'utf8');
+    const data = JSON.parse(raw) as unknown;
+    if (data === null || typeof data !== 'object' || Array.isArray(data)) return undefined;
+    return { raw, data: data as Record<string, unknown> };
+  } catch {
+    return undefined;
+  }
+}
+
+/** Read `execution_path` from `ferry.config.json`. Fail-soft → undefined. */
+export function readExecutionPath(repoRoot: string): string | undefined {
+  const parsed = readJson(repoRoot);
+  const value = parsed?.data['execution_path'];
+  return typeof value === 'string' ? value : undefined;
+}
+
+/** Detect the file's indentation (spaces or a tab) from its first indented line. */
+function detectIndent(raw: string): string | number {
+  const m = raw.match(/\n(\t+|[ ]+)\S/);
+  if (!m) return 2;
+  const ws = m[1]!;
+  return ws.startsWith('\t') ? '\t' : ws.length;
+}
+
+export type ApplyExecutionPathResult = 'written' | 'already-claude-code' | 'no-json-config';
+
+/**
+ * Merge `execution_path: "claude-code"` into `ferry.config.json`, preserving
+ * the original field order (the key is updated in place if present, appended
+ * last otherwise), the original indentation, and a trailing newline.
+ */
+export function applyClaudeCodeExecutionPath(repoRoot: string): ApplyExecutionPathResult {
+  const parsed = readJson(repoRoot);
+  if (!parsed) return 'no-json-config';
+
+  if (parsed.data['execution_path'] === 'claude-code') return 'already-claude-code';
+
+  // Assigning an existing key keeps its position; a new key is appended last.
+  parsed.data['execution_path'] = 'claude-code';
+
+  const indent = detectIndent(parsed.raw);
+  const trailingNewline = parsed.raw.endsWith('\n') ? '\n' : '';
+  writeFileSync(
+    join(repoRoot, CONFIG_FILE),
+    JSON.stringify(parsed.data, null, indent) + trailingNewline,
+    'utf8',
+  );
+  return 'written';
+}

--- a/src/cli/update/index.ts
+++ b/src/cli/update/index.ts
@@ -16,6 +16,7 @@ import { workflowTemplates } from '../init/templates.js';
 import { buildManualSetupDoc } from '../init/steps/jira-bundle.js';
 import { detectInstalledVersion, computeWorkflowChanges } from './detect.js';
 import { getRelevantMigrations } from './migrations.js';
+import { runCredentialGate } from './credential-gate-run.js';
 import { extractJiraConfigFromSetupFile } from './extract-jira-config.js';
 import { resolveForgeFromArgv, type ForgeKind } from '../lib/forge.js';
 import { rewriteGitLabVersion } from './gitlab/rewriter.js';
@@ -167,6 +168,31 @@ async function runGitLabUpdate(argv: string[]): Promise<void> {
   print('');
 }
 
+/**
+ * Print the combined "Manual follow-ups required" block (MIGRATIONS.md notes
+ * for the crossed GitHub range + any credential-gate follow-ups). Returns
+ * true when anything was printed.
+ */
+function printGitHubFollowUps(fromVersion: string, toVersion: string, extra: string[]): boolean {
+  const migrations = getRelevantMigrations(fromVersion, toVersion, {
+    forge: 'github' as ForgeKind,
+  });
+  if (migrations.length === 0 && extra.length === 0) return false;
+  print('');
+  print('════════════════════════════════════════');
+  print('  Manual follow-ups required');
+  print('════════════════════════════════════════');
+  for (const note of migrations) {
+    const prefix = note.kind === 'action' ? '  [action] ' : '  [info]   ';
+    print(`${prefix}${note.message}`);
+  }
+  for (const msg of extra) {
+    print(`  [action] ${msg}`);
+  }
+  print('');
+  return true;
+}
+
 function printGitLabMigrations(fromVersion: string, toVersion: string): void {
   const migrations = getRelevantMigrations(fromVersion, toVersion, {
     forge: 'gitlab' as ForgeKind,
@@ -277,6 +303,7 @@ Exit code: 0 on success, 1 on error.
   }
   const fromVersion = config.fromVersion || detected;
   const toVersion = config.toVersion;
+  const interactive = !!process.stdin.isTTY && !config.yes;
   print(`  From: ${fromVersion}  →  To: ${toVersion}`);
 
   if (fromVersion === toVersion) {
@@ -294,7 +321,17 @@ Exit code: 0 on success, 1 on error.
 
   if (toUpdate.length === 0 && toAdd.length === 0) {
     printSkip('All workflow files already match the target version — nothing to do.');
+    // A code-only range stays silent; a range that declares a newly-required
+    // secret is still gated even when no workflow file changed (e.g. re-run).
+    const gate = await runCredentialGate({
+      repoRoot: config.repoRoot,
+      fromVersion,
+      toVersion,
+      interactive,
+      dryRun: config.dryRun,
+    });
     closePrompt();
+    if (gate.ran) printGitHubFollowUps(fromVersion, toVersion, gate.followUps);
     process.exit(0);
   }
 
@@ -331,7 +368,15 @@ Exit code: 0 on success, 1 on error.
   if (config.dryRun) {
     print('');
     print('Dry-run mode — no changes written.');
+    const gate = await runCredentialGate({
+      repoRoot: config.repoRoot,
+      fromVersion,
+      toVersion,
+      interactive,
+      dryRun: true,
+    });
     closePrompt();
+    if (gate.ran) printGitHubFollowUps(fromVersion, toVersion, gate.followUps);
     process.exit(0);
   }
 
@@ -348,6 +393,15 @@ Exit code: 0 on success, 1 on error.
       process.exit(0);
     }
   }
+
+  // ── Credential gate (must run while the prompt is still open) ──────────────
+  const gate = await runCredentialGate({
+    repoRoot: config.repoRoot,
+    fromVersion,
+    toVersion,
+    interactive,
+    dryRun: false,
+  });
 
   closePrompt();
 
@@ -386,21 +440,8 @@ Exit code: 0 on success, 1 on error.
     }
   }
 
-  // ── Migration notes ───────────────────────────────────────────────────────
-  const migrations = getRelevantMigrations(fromVersion, toVersion, {
-    forge: 'github' as ForgeKind,
-  });
-  if (migrations.length > 0) {
-    print('');
-    print('════════════════════════════════════════');
-    print('  Manual follow-ups required');
-    print('════════════════════════════════════════');
-    for (const note of migrations) {
-      const prefix = note.kind === 'action' ? '  [action] ' : '  [info]   ';
-      print(`${prefix}${note.message}`);
-    }
-    print('');
-  }
+  // ── Migration notes + credential-gate follow-ups ──────────────────────────
+  const hadFollowUps = printGitHubFollowUps(fromVersion, toVersion, gate.followUps);
 
   // ── Summary ───────────────────────────────────────────────────────────────
   print('');
@@ -414,7 +455,7 @@ Exit code: 0 on success, 1 on error.
   print('Next steps:');
   print('  1. Review git diff in .github/workflows/');
   print('  2. Commit and push — the new pinned version takes effect on the next workflow run');
-  if (migrations.length === 0) {
+  if (!hadFollowUps) {
     print('  3. No manual follow-ups required for this upgrade');
   }
   print('');

--- a/src/cli/update/migrations.test.ts
+++ b/src/cli/update/migrations.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
   getRelevantMigrations,
+  getRequiredSecretsForRange,
   parseMigrationsContent,
   filterMigrationsByForge,
 } from './migrations.js';
@@ -219,5 +220,127 @@ forge: gitlab
     cleanup(file);
     const notes = getRelevantMigrations('v9.0.0', 'v9.0.1');
     expect(Array.isArray(notes)).toBe(true);
+  });
+});
+
+// ── parseMigrationsContent — requires-secrets field ──────────────────────────
+
+describe('parseMigrationsContent — requires-secrets field', () => {
+  it('defaults requiresSecrets to [] when no annotation is present', () => {
+    const md = `## v0.1.0 → v0.2.0\n- **(info)** code-only release\n`;
+    const parsed = parseMigrationsContent(md);
+    expect(parsed[0]!.requiresSecrets).toEqual([]);
+  });
+
+  it('parses a single `requires-secrets:` value', () => {
+    const md = `## v0.1.0 → v0.2.0
+requires-secrets: CLAUDE_CODE_OAUTH_TOKEN
+
+- **(info)** new path
+`;
+    const parsed = parseMigrationsContent(md);
+    expect(parsed[0]!.requiresSecrets).toEqual(['CLAUDE_CODE_OAUTH_TOKEN']);
+  });
+
+  it('parses a comma-separated list (general mechanism, not cc-specific)', () => {
+    const md = `## v0.1.0 → v0.2.0
+requires-secrets: FOO_TOKEN, BAR_KEY,BAZ_SECRET
+
+- **(info)** multi-secret release
+`;
+    const parsed = parseMigrationsContent(md);
+    expect(parsed[0]!.requiresSecrets).toEqual(['FOO_TOKEN', 'BAR_KEY', 'BAZ_SECRET']);
+  });
+
+  it('is case-insensitive on the field name and coexists with forge:', () => {
+    const md = `## v0.1.0 → v0.2.0
+forge: github
+Requires-Secrets: NEW_SECRET
+
+- **(action)** do the thing
+`;
+    const parsed = parseMigrationsContent(md);
+    expect(parsed[0]!.forge).toBe('github');
+    expect(parsed[0]!.requiresSecrets).toEqual(['NEW_SECRET']);
+    expect(parsed[0]!.notes).toHaveLength(1);
+  });
+
+  it('ignores a requires-secrets: line that appears after the first bullet', () => {
+    const md = `## v0.1.0 → v0.2.0
+- **(info)** first
+requires-secrets: TOO_LATE
+`;
+    const parsed = parseMigrationsContent(md);
+    expect(parsed[0]!.requiresSecrets).toEqual([]);
+  });
+});
+
+// ── getRequiredSecretsForRange ───────────────────────────────────────────────
+
+describe('getRequiredSecretsForRange', () => {
+  it('returns [] for a code-only range (property: credential-silent)', () => {
+    const file = writeFixture(`## v0.1.0 → v0.2.0
+
+- **(info)** internal only
+`);
+    expect(getRequiredSecretsForRange('v0.1.0', 'v0.2.0', { migrationsPath: file })).toEqual([]);
+    cleanup(file);
+  });
+
+  it('collects the deduped union across a multi-hop crossed range', () => {
+    const file = writeFixture(`## v0.1.x → v0.2.0
+requires-secrets: CLAUDE_CODE_OAUTH_TOKEN
+
+- **(action)** a
+
+## v0.2.x → v0.3.0
+requires-secrets: CLAUDE_CODE_OAUTH_TOKEN, OTHER_SECRET
+
+- **(action)** b
+`);
+    expect(getRequiredSecretsForRange('v0.1.0', 'v0.3.0', { migrationsPath: file })).toEqual([
+      'CLAUDE_CODE_OAUTH_TOKEN',
+      'OTHER_SECRET',
+    ]);
+    cleanup(file);
+  });
+
+  it('excludes sections outside the crossed range', () => {
+    const file = writeFixture(`## v0.1.x → v0.2.0
+requires-secrets: EARLY_SECRET
+
+- **(action)** a
+
+## v0.2.x → v0.3.0
+requires-secrets: LATE_SECRET
+
+- **(action)** b
+`);
+    expect(getRequiredSecretsForRange('v0.2.0', 'v0.3.0', { migrationsPath: file })).toEqual([
+      'LATE_SECRET',
+    ]);
+    cleanup(file);
+  });
+
+  it('applies the forge filter (gitlab-only required secret skipped for github)', () => {
+    const file = writeFixture(`## v0.1.0 → v0.2.0
+forge: gitlab
+requires-secrets: GITLAB_ONLY_SECRET
+
+- **(action)** gitlab
+`);
+    expect(
+      getRequiredSecretsForRange('v0.1.0', 'v0.2.0', {
+        migrationsPath: file,
+        forge: 'github' as ForgeKind,
+      }),
+    ).toEqual([]);
+    expect(
+      getRequiredSecretsForRange('v0.1.0', 'v0.2.0', {
+        migrationsPath: file,
+        forge: 'gitlab' as ForgeKind,
+      }),
+    ).toEqual(['GITLAB_ONLY_SECRET']);
+    cleanup(file);
   });
 });

--- a/src/cli/update/migrations.ts
+++ b/src/cli/update/migrations.ts
@@ -14,6 +14,12 @@ export type MigrationForge = 'github' | 'gitlab' | 'both';
 export interface ParsedMigration {
   keyTo: string;
   forge: MigrationForge;
+  /**
+   * Secrets the consumer must have set before this version transition is safe.
+   * Declared via an optional `requires-secrets:` line (parallel to `forge:`).
+   * Empty for code-only releases — the credential gate stays silent then.
+   */
+  requiresSecrets: string[];
   notes: MigrationNote[];
 }
 
@@ -51,12 +57,28 @@ function parseForgeLine(line: string): MigrationForge | undefined {
 }
 
 /**
+ * Parse a `requires-secrets:` field (case-insensitive) from a single line.
+ * Value is a comma- and/or whitespace-separated list of secret names.
+ * Returns `undefined` when the line is not a `requires-secrets:` line.
+ */
+function parseRequiresSecretsLine(line: string): string[] | undefined {
+  const m = line.match(/^\s*requires-secrets\s*:\s*(.*)$/i);
+  if (!m) return undefined;
+  return m[1]!
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
  * Parse MIGRATIONS.md content into structured entries.
  *
  * Each `## <from> → <to>` heading starts a section. Optional `forge:` field
  * on a subsequent line declares which forge the section applies to
- * (`github`, `gitlab`, or `both`). Default is `both`. Note bullets follow
- * the existing `- **(action)** ...` / `- **(info)** ...` shape.
+ * (`github`, `gitlab`, or `both`). Default is `both`. An optional
+ * `requires-secrets:` field (parallel to `forge:`, comma/space separated)
+ * declares secrets the consumer must have set for this transition. Note
+ * bullets follow the existing `- **(action)** ...` / `- **(info)** ...` shape.
  *
  * Exported for unit tests; consumers should call `getRelevantMigrations()`.
  */
@@ -69,18 +91,23 @@ export function parseMigrationsContent(content: string): ParsedMigration[] {
     const headingMatch = line.match(/^##\s+v[\d.x]+\s*(?:→|->)\s*(v[\d.]+)/);
     if (headingMatch) {
       if (current !== null) result.push(current);
-      current = { keyTo: headingMatch[1]!, forge: 'both', notes: [] };
+      current = { keyTo: headingMatch[1]!, forge: 'both', requiresSecrets: [], notes: [] };
       continue;
     }
 
     if (current === null) continue;
 
-    // ── Optional `forge:` annotation (case-insensitive, anywhere before
-    //    the first bullet) ─────────────────────────────────────────────
+    // ── Optional `forge:` / `requires-secrets:` annotations
+    //    (case-insensitive, anywhere before the first bullet) ───────────
     if (current.notes.length === 0) {
       const forge = parseForgeLine(line);
       if (forge !== undefined) {
         current.forge = forge;
+        continue;
+      }
+      const requiresSecrets = parseRequiresSecretsLine(line);
+      if (requiresSecrets !== undefined) {
+        current.requiresSecrets = requiresSecrets;
         continue;
       }
     }
@@ -146,14 +173,44 @@ export function getRelevantMigrations(
   toVersion: string,
   options: GetRelevantMigrationsOptions = {},
 ): MigrationNote[] {
-  const all = parseMigrationsFile(options.migrationsPath);
-  const filtered = filterMigrationsByForge(all, options.forge);
-
   const notes: MigrationNote[] = [];
-  for (const { keyTo, notes: migNotes } of filtered) {
-    if (semverLt(fromVersion, keyTo) && semverLte(keyTo, toVersion)) {
-      notes.push(...migNotes);
-    }
+  for (const m of crossedMigrations(fromVersion, toVersion, options)) {
+    notes.push(...m.notes);
   }
   return notes;
+}
+
+/** Entries whose target version is in `(fromVersion, toVersion]`, forge-filtered. */
+function crossedMigrations(
+  fromVersion: string,
+  toVersion: string,
+  options: GetRelevantMigrationsOptions,
+): ParsedMigration[] {
+  const all = parseMigrationsFile(options.migrationsPath);
+  const filtered = filterMigrationsByForge(all, options.forge);
+  return filtered.filter((m) => semverLt(fromVersion, m.keyTo) && semverLte(m.keyTo, toVersion));
+}
+
+/**
+ * Collect the deduped union of `requires-secrets:` declared across every
+ * migration section crossed when upgrading `fromVersion` → `toVersion`
+ * (forge-filtered). Empty for code-only ranges — that is the property the
+ * credential gate relies on to stay silent (ADR-0006 §7, decisions/0002 §G).
+ */
+export function getRequiredSecretsForRange(
+  fromVersion: string,
+  toVersion: string,
+  options: GetRelevantMigrationsOptions = {},
+): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const m of crossedMigrations(fromVersion, toVersion, options)) {
+    for (const secret of m.requiresSecrets) {
+      if (!seen.has(secret)) {
+        seen.add(secret);
+        ordered.push(secret);
+      }
+    }
+  }
+  return ordered;
 }


### PR DESCRIPTION
Closes #305. Part of epic #299 (ADR-0006 §7, decisions/0002 §G).

## Scope

Manifest-driven credential gate in `ferry-update` + conditional default on upgrade. A **general mechanism** — nothing here is claude-code specific; any future release that introduces a newly-required secret reuses it unchanged. Lands inert and self-contained: siblings #300 (routing resolver) / #301 (contract wrappers) / #302 (action job) / #304 (`ferry-init` exec-path + config schema) are still open, so the written `execution_path` key has no reader yet — zero behavior change for existing consumers.

## What changed

| File | Responsibility |
|---|---|
| `migrations.ts` | Parse an optional `requires-secrets:` line (parallel to `forge:`, comma/space separated) → `ParsedMigration.requiresSecrets`. New `getRequiredSecretsForRange()` = deduped, forge-filtered union across the crossed version range (range predicate refactored into one shared `crossedMigrations()` helper, no behavior change to `getRelevantMigrations`). |
| `credential-gate.ts` | **Pure** decision function. Precedence: no required → `silent`; explicit `execution_path: script` → `explicit-script`; all present → `satisfied`; missing + interactive → `prompt-missing`; missing + non-interactive → `stay-on-script` (+ mandatory follow-up). |
| `exec-path.ts` | Minimal format-preserving `ferry.config.json` reader/writer for `execution_path` — original indentation (2/4-space/tab) and field order preserved, trailing newline kept, fail-soft on missing/invalid JSON. |
| `credential-gate-run.ts` | Orchestrator wiring the pure decision to injectable IO (`gh secret list`/`set`, secret prompt, config write). Silent for code-only ranges, prompts **only** the missing secrets, never overrides explicit script, defers safely when the repo can't be resolved, never writes/prompts under `--dry-run`. |
| `index.ts` | Runs the gate in the apply / dry-run / no-change paths (while the prompt is open); folds gate follow-ups into the existing "Manual follow-ups required" block. |
| `MIGRATIONS.md` | Documents the `requires-secrets:` line (general mechanism). No premature claude-code release entry — that release does not exist yet. |

## Acceptance criteria (#305)

- ✅ **Code-only update = zero credential prompts** — empty `requires-secrets:` → `runCredentialGate` returns immediately, no output, credentials untouched (property preserved, asserted by test).
- ✅ **Migration matrix (decisions/0002 §G) fully covered by tests** — all 5 rows in `credential-gate.test.ts` + end-to-end in `credential-gate-run.test.ts` (silent / satisfied / prompt-missing / stay-on-script / explicit-script, incl. precedence and dry-run).
- ✅ **General mechanism, not claude-code-specific** — the manifest line, parser, decision, and gate are secret-name agnostic (tested with arbitrary secret names).

## Notes

- Only `ferry.config.json` is written (KISS). When a consumer has `ferry.config.yaml` instead (what `ferry-init` generates), the gate emits an actionable follow-up rather than guessing a YAML edit — the `execution_path` value space / YAML persistence is owned by sibling #304.
- GitHub flow only: the GitLab path uses CI/CD variables, not `gh secret list` — out of scope here.

## TDD

Tests written first for every module. Full suite green: **130 files / 1848 tests**; `typecheck`, `eslint`, `prettier` clean on the changed files. `npm run build:ferry` produces no `.ferry/` diff (CLI changes don't touch the agent bundles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
