### PR TITLE
docs(mcp): document GitHub, Atlassian, Prismic; defer Figma (Phase 1 of #319)

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,8 +379,8 @@ Set the `AGENT_MCP_SERVERS` environment variable (repository variable or secret)
   },
   {
     "name": "github",
-    "url": "https://api.githubcopilot.com/mcp",
-    "authorization_token": "<your-token>",
+    "url": "https://api.githubcopilot.com/mcp/",
+    "authorization_token": "<github-fine-grained-pat>",
     "allowed_tools": ["search_code", "get_file_contents"]
   }
 ]
@@ -445,46 +445,47 @@ Each stdio entry accepts:
 
 [context7](https://github.com/upstash/context7) serves up-to-date library documentation as an MCP tool. It is **enabled by default** — see [Default MCP servers](#default-mcp-servers) above. No configuration is needed unless you want to opt out or point to a custom proxy.
 
-**End-to-end example — Figma for UI refactors**
+**End-to-end example — Atlassian for context-rich tickets**
 
-This walkthrough shows how to wire Figma's MCP server so the Developer consults the linked design frame before editing UI code.
+This walkthrough shows how to wire Atlassian's remote MCP server so the Developer loads Confluence pages and linked Jira issues referenced in the ticket before editing code.
 
 **Step 1 — Declare the server in the pool** (`AGENT_MCP_SERVERS` repo variable):
 
 ```json
 [
   {
-    "name": "figma",
-    "url": "https://mcp.figma.com/mcp",
-    "authorization_token": "<your-figma-pat>",
-    "allowed_tools": ["get_node", "get_file"]
+    "name": "atlassian",
+    "url": "https://mcp.atlassian.com/v1/mcp",
+    "authorization_token": "<atlassian-rovo-api-token>",
+    "allowed_tools": ["search_confluence", "get_confluence_page", "get_jira_issue"]
   }
 ]
 ```
+
+Generate the API token from <https://id.atlassian.com/manage-profile/security/api-tokens>. Use an account with read access to the Confluence spaces and Jira projects you want Ferry to read.
 
 **Step 2 — Map a `ferry:*` label** in `ferry.config.yaml`:
 
 ```yaml
 labels:
-  ferry:mcp/figma:
-    mcp_servers: [figma]
+  ferry:mcp/atlassian:
+    mcp_servers: [atlassian]
 ```
 
 **Step 3 — Tell the agent to use it** in `prompts/dev.extra.md`:
 
 ```markdown
-## Figma design reference
+## Atlassian context
 
-When the ticket description or a comment references a Figma frame URL or node ID,
-call `figma.get_node` with that node ID **before** editing any UI component.
-Use the returned layout and style properties to guide your implementation.
-
-If no Figma link is present, skip the tool call entirely.
+When the ticket description links to a Confluence page or another Jira ticket,
+call `atlassian.get_confluence_page` or `atlassian.get_jira_issue` to load
+the linked context before planning the change. Skip the tool call when no
+such link is present.
 ```
 
-**Step 4 — Label the Jira ticket** with `ferry:mcp/figma` before moving it to _In Development_.
+**Step 4 — Label the Jira ticket** with `ferry:mcp/atlassian` before moving it to _In Development_.
 
-**Failure mode to avoid.** If `prompts/dev.extra.md` does not explicitly instruct the agent to call `figma.get_node`, the Developer may refactor the UI component without ever consulting the Figma frame — even though the tool is available. MCP tools are passive; the agent must be told when to invoke them.
+**Failure mode to avoid.** If `prompts/dev.extra.md` does not explicitly instruct the agent to call `atlassian.get_confluence_page` or `atlassian.get_jira_issue`, the Developer may plan the change without ever consulting the linked context — even though the tool is available. MCP tools are passive; the agent must be told when to invoke them.
 
 **Audit logs**
 
@@ -515,7 +516,7 @@ Then add the matching label to your Jira ticket (e.g. `ferry:mcp/context7`). Fer
 
 **Backward compatibility.** If the `labels:` section is absent from `ferry.config`, all servers in `AGENT_MCP_SERVERS` are passed through unchanged — existing behaviour is preserved.
 
-See **[docs/MCP.md](docs/MCP.md)** for the full reference: server registry, config schema, per-ticket label scoping, end-to-end Figma example, and audit log format.
+See **[docs/MCP.md](docs/MCP.md)** for the full reference: server registry, config schema, per-ticket label scoping, end-to-end Atlassian example, and audit log format.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -373,7 +373,7 @@ Maps Jira ticket labels to MCP server capabilities. If this section is omitted, 
 
 1. **Declare in the pool** — add an entry to the `AGENT_MCP_SERVERS` repo variable (HTTP/SSE example):
    ```bash
-   gh variable set AGENT_MCP_SERVERS '[{"name":"figma","url":"https://mcp.figma.com/mcp","authorization_token":"<pat>"}]'
+   gh variable set AGENT_MCP_SERVERS '[{"name":"atlassian","url":"https://mcp.atlassian.com/v1/mcp","authorization_token":"<atlassian-rovo-api-token>"}]'
    ```
    For a stdio server, use `"type":"stdio"` and `"command"` instead of `"url"`:
    ```bash

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -18,9 +18,13 @@ Known servers used with Ferry, ready to drop into `AGENT_MCP_SERVERS`:
 | Name | Transport | URL / Command | Purpose | Notes |
 | ---- | --------- | ------------- | ------- | ----- |
 | `context7` | HTTP | `https://mcp.context7.com/mcp` | Up-to-date library and framework docs | No auth required |
-| `figma` | HTTP | `https://mcp.figma.com/mcp` | Fetch design nodes and frames | Requires `authorization_token` (Figma PAT) |
+| `github` | HTTP | `https://api.githubcopilot.com/mcp/` | Repo-aware reads/writes (issues, PRs, code search, Actions) | `authorization_token` = fine-grained GitHub PAT. Toolsets can be scoped via `?toolsets=...` query string |
+| `atlassian` | HTTP | `https://mcp.atlassian.com/v1/mcp` | Jira, Confluence, Compass against the connected Atlassian Cloud site | `authorization_token` = Atlassian Rovo API token (machine-to-machine, headless-friendly). The legacy `…/v1/sse` endpoint is deprecated and stops working after 30 June 2026 |
+| `prismic` | Stdio | `npx -y @prismicio/mcp-server@latest` | Prismic content modeling, slice queries, document search | Reads Prismic project config from the runner cwd. See [Prismic MCP docs](https://prismic.io/docs/ai) for per-repository auth requirements. No hosted endpoint is published today |
 | `playwright` | Stdio | `npx @playwright/mcp` | Browser automation | Requires Playwright installed on the runner |
 | `sentry` | HTTP/Stdio | Varies | Runtime error logs and issue context | See Sentry MCP docs for auth |
+
+> **Figma is intentionally absent.** `https://mcp.figma.com/mcp` exists, but the endpoint rejects personal access tokens and the required `mcp:connect` OAuth scope is restricted to clients whitelisted by Figma (VS Code, Cursor, Claude Code, OpenAI Codex). There is no viable headless auth path for a custom integration like Ferry today. Tracked in [#325](https://github.com/big-emotion/ferry/issues/325); the per-server findings are recorded in [`docs/mcp-catalog-research.md`](mcp-catalog-research.md).
 
 Add any server above to `AGENT_MCP_SERVERS` and the corresponding label entry to `ferry.config.yaml` — see [Per-ticket capability boost](#per-ticket-capability-boost-via-jira-labels) below.
 
@@ -38,9 +42,14 @@ Set the `AGENT_MCP_SERVERS` environment variable (repository variable or secret)
   },
   {
     "name": "github",
-    "url": "https://api.githubcopilot.com/mcp",
-    "authorization_token": "<your-token>",
+    "url": "https://api.githubcopilot.com/mcp/",
+    "authorization_token": "<github-fine-grained-pat>",
     "allowed_tools": ["search_code", "get_file_contents"]
+  },
+  {
+    "name": "atlassian",
+    "url": "https://mcp.atlassian.com/v1/mcp",
+    "authorization_token": "<atlassian-rovo-api-token>"
   }
 ]
 ```
@@ -120,40 +129,43 @@ Then add the matching label to your Jira ticket (e.g. `ferry:mcp/context7`). Fer
 
 **Backward compatibility.** If the `labels:` section is absent, all servers in `AGENT_MCP_SERVERS` are passed through unchanged.
 
-## End-to-end example — Figma for UI refactors
+## End-to-end example — Atlassian for context-rich tickets
 
 **Step 1 — Declare the server** (`AGENT_MCP_SERVERS` repo variable):
 
 ```json
 [
   {
-    "name": "figma",
-    "url": "https://mcp.figma.com/mcp",
-    "authorization_token": "<your-figma-pat>",
-    "allowed_tools": ["get_node", "get_file"]
+    "name": "atlassian",
+    "url": "https://mcp.atlassian.com/v1/mcp",
+    "authorization_token": "<atlassian-rovo-api-token>",
+    "allowed_tools": ["search_confluence", "get_confluence_page", "get_jira_issue"]
   }
 ]
 ```
+
+Generate the API token from <https://id.atlassian.com/manage-profile/security/api-tokens>. Use an account with read access to the Confluence spaces and Jira projects you want Ferry to read.
 
 **Step 2 — Map a label** in `ferry.config.yaml`:
 
 ```yaml
 labels:
-  ferry:mcp/figma:
-    mcp_servers: [figma]
+  ferry:mcp/atlassian:
+    mcp_servers: [atlassian]
 ```
 
 **Step 3 — Tell the agent when to use it** in `prompts/dev.extra.md`:
 
 ```markdown
-## Figma design reference
+## Atlassian context
 
-When the ticket references a Figma frame URL or node ID,
-call `figma.get_node` before editing any UI component.
-If no Figma link is present, skip the tool call.
+When the ticket description links to a Confluence page or another Jira ticket,
+call `atlassian.get_confluence_page` or `atlassian.get_jira_issue` to load
+the linked context before planning the change. Skip the tool call when no
+such link is present.
 ```
 
-**Step 4 — Label the Jira ticket** with `ferry:mcp/figma` before moving it to _In Development_.
+**Step 4 — Label the Jira ticket** with `ferry:mcp/atlassian` before moving it to _In Development_.
 
 > MCP tools are passive — the agent must be explicitly told when to invoke them. Without instructions in `prompts/dev.extra.md`, the tool will be available but never called.
 

--- a/docs/mcp-catalog-research.md
+++ b/docs/mcp-catalog-research.md
@@ -1,0 +1,134 @@
+# MCP Catalog Research (Phase 0 of #319)
+
+Read-only reconnaissance to confirm whether each of the four MCP servers
+targeted by epic #319 ships an **official HTTP/SSE remote endpoint** that
+works from a **headless GitHub Actions runner** (no browser, no human
+interaction, no Figma Desktop app, no persistent OAuth session).
+
+This document is short-lived: it should be folded into `docs/CONFIGURATION.md`
+or deleted once Phases 1–4 ship.
+
+## Summary
+
+| Server | Remote HTTP | Headless auth | Verdict for Ferry HTTP-only path |
+|---|---|---|---|
+| **GitHub** | ✅ `https://api.githubcopilot.com/mcp/` | ✅ PAT bearer | ✅ Ship in Phase 1 |
+| **Atlassian** | ✅ `https://mcp.atlassian.com/v1/mcp` | ✅ API token (M2M) or OAuth 2.1 | ✅ Ship in Phase 1 |
+| **Figma** | ✅ `https://mcp.figma.com/mcp` | ❌ OAuth-only, `mcp:connect` scope restricted to whitelisted clients | ❌ Blocked — needs decision |
+| **Prismic** | ❌ None published | n/a (stdio only via `npx @prismicio/mcp-server`) | ❌ Blocked — needs decision |
+
+## Server-by-server findings
+
+### GitHub MCP
+
+- **Endpoint**: `https://api.githubcopilot.com/mcp/`
+- **Transport**: HTTP (streamable)
+- **Auth**: OAuth 2.1 (interactive, default) **or** PAT via
+  `Authorization: Bearer <PAT>` header (headless-friendly)
+- **Scopes**: granted by the PAT itself; subject to org PAT restrictions
+- **Tool surface**: large (issues, PRs, repos, code search, Actions, Copilot
+  knowledge); split into toolsets so consumers can scope down via
+  `?toolsets=...` query params
+- **Headless readiness**: ✅ confirmed. Standard pattern is a fine-grained
+  PAT stored as a repo secret.
+
+Sources:
+- <https://docs.github.com/en/copilot/how-tos/provide-context/use-mcp/set-up-the-github-mcp-server>
+- <https://github.com/github/github-mcp-server>
+
+### Atlassian (Rovo) MCP
+
+- **Endpoint**: `https://mcp.atlassian.com/v1/mcp`
+  (note: `https://mcp.atlassian.com/v1/sse` is **deprecated**, support ends
+  30 June 2026 — do not use)
+- **Transport**: HTTP (streamable)
+- **Auth**:
+  - OAuth 2.1 bearer (interactive flow), **or**
+  - **API token** authentication (machine-to-machine, no consent screen) —
+    designed precisely for headless / CI use cases
+- **Scope**: Jira, Confluence, Compass on the connected Atlassian Cloud site
+- **Headless readiness**: ✅ confirmed. Use API token, store as secret.
+
+Sources:
+- <https://support.atlassian.com/atlassian-rovo-mcp-server/docs/getting-started-with-the-atlassian-remote-mcp-server/>
+- <https://community.atlassian.com/forums/Atlassian-Remote-MCP-Server/Announcing-authentication-via-API-token-for-Atlassian-Rovo-MCP/ba-p/3197014>
+
+### Figma MCP
+
+- **Endpoint**: `https://mcp.figma.com/mcp` (exists, GA)
+- **Transport**: HTTP
+- **Auth**: **OAuth-only**, scope `mcp:connect`
+  - Personal access tokens are **explicitly rejected** by the endpoint
+  - The `mcp:connect` scope is **not available to general third-party OAuth
+    apps** — Figma whitelists specific MCP clients (VS Code, Cursor,
+    Claude Code, OpenAI Codex)
+- **Headless readiness**: ❌ blocked for a custom integration like Ferry
+  - No service-account / API-token path today
+  - The local stdio alternative requires the Figma Desktop app, which is
+    not installable on a GitHub Actions runner
+- **Status**: requested feature on the Figma forum; no ETA
+
+Sources:
+- <https://developers.figma.com/docs/figma-mcp-server/remote-server-installation/>
+- <https://forum.figma.com/ask-the-community-7/support-for-pat-personal-access-token-based-auth-in-figma-remote-mcp-47465>
+- <https://forum.figma.com/ask-the-community-7/oauth-less-access-to-figma-mcp-tools-47774>
+
+### Prismic MCP
+
+- **Endpoint**: none — there is no hosted Prismic MCP server
+- **Transport**: stdio only (`npx -y @prismicio/mcp-server@latest`)
+- **Auth**: handled by the local subprocess against the Prismic API
+- **Headless readiness**: stdio in a GHA runner is **technically possible**
+  (Node is available; `npx` spawns the package), but violates the epic
+  decision to ship HTTP-only
+
+Sources:
+- <https://github.com/prismicio/prismic-mcp-server>
+- <https://prismic.io/docs/ai>
+
+## Decision gate (per Phase 0 acceptance)
+
+Two servers fail the HTTP-only constraint. The epic must pick one path
+per blocked server:
+
+### Figma
+
+- **A. Defer** — drop Figma from epic #319; reopen when Figma ships either
+  PAT auth or a `mcp:connect` scope open to third-party OAuth apps.
+- **B. Stdio exception** — would require the Figma Desktop app, which is
+  **not viable in GHA runners**. Effectively the same as deferring for
+  Ferry's runtime, even if local dev could use it.
+- **C. Build a thin token-broker** — host a small service that performs
+  the OAuth dance once and proxies requests with the resulting bearer.
+  Significant new infra; out of scope for this epic.
+
+**Recommendation: A (defer Figma).** Track in a new follow-up issue.
+
+### Prismic
+
+- **A. Defer** — drop Prismic from epic #319 until an HTTP endpoint
+  exists.
+- **B. Stdio exception** — add `stdio` transport support to the catalog
+  for Prismic only. Ferry's `src/lib/mcp/pool.ts` already supports stdio;
+  the agent-loop already wires it. The Phase 1 catalog grows by one
+  branch (HTTP vs stdio). Runner needs Node (already there). Subprocess
+  per agent run, started cold, killed on exit.
+- **C. Build a thin Prismic→MCP HTTP wrapper** — net-new code, out of
+  scope.
+
+**Recommendation: B (stdio exception for Prismic).** Cheap, isolated to
+the catalog file, no architectural change. Prismic is the only server
+needing this in the foreseeable future, so the special case stays small.
+
+## Net effect on the epic
+
+If the recommendations above are accepted:
+
+- Phase 1 catalog ships **3 servers**: GitHub (HTTP), Atlassian (HTTP),
+  Prismic (stdio).
+- Figma moves to a follow-up issue gated on upstream Figma support.
+- Phases 2–4 are unaffected in scope; they wire whatever the catalog
+  exposes.
+- The "HTTP/SSE only" epic constraint becomes "HTTP/SSE preferred,
+  stdio only when no remote exists" — documented in the catalog
+  module.


### PR DESCRIPTION
## What

Doc-only update to make three new MCP servers discoverable and ready-to-paste for Ferry consumers:

- **`github`** (HTTP) — `https://api.githubcopilot.com/mcp/`, bearer = fine-grained GitHub PAT
- **`atlassian`** (HTTP) — `https://mcp.atlassian.com/v1/mcp`, bearer = Atlassian Rovo API token (machine-to-machine, no consent screen)
- **`prismic`** (stdio) — `npx -y @prismicio/mcp-server@latest`

Plus a correction to the previously-listed Figma entry: the `https://mcp.figma.com/mcp` endpoint rejects PATs, and the required `mcp:connect` OAuth scope is restricted to clients whitelisted by Figma (VS Code, Cursor, Claude Code, OpenAI Codex). There is no viable headless auth for a custom integration like Ferry today. Figma is now marked **deferred** with a link to follow-up issue #325.

## Why doc-only

The original epic (#319) Phase 1 proposed a built-in TypeScript catalog (\`src/lib/mcp/catalog.ts\`) injecting defaults into \`loadMcpServers()\`. After looking at the existing architecture:

- \`loadMcpServers()\` lives in \`src/lib/agent-runtime/env.ts\` and already parses \`AGENT_MCP_SERVERS\` (env-var JSON array)
- \`docs/MCP.md\` already documents a "Server registry" pattern that consumers paste into the env var
- The only existing \`DEFAULT_MCP_SERVERS\` entry is \`context7\`

Shipping built-in entries from code would couple Ferry releases to upstream MCP URL changes (e.g. Atlassian's deprecation of \`/v1/sse\` after 30 June 2026 would force a Ferry release if hardcoded). Documenting the canonical JSON snippets keeps Ferry decoupled and the consumer in control.

KISS won.

## Phase 0 trace

\`docs/mcp-catalog-research.md\` is included in this PR as the Phase 0 (#320) deliverable. It records the per-server evidence: official docs, auth options, headless viability, sources.

## Files changed

- \`docs/mcp-catalog-research.md\` (new) — Phase 0 reconnaissance, source of truth for the decisions
- \`docs/MCP.md\` — server registry expanded; Figma re-described accurately; HTTP example updated; end-to-end example switched from Figma to Atlassian (concretely runnable today)
- \`docs/CONFIGURATION.md\` — the figma-PAT example on line 376 now points to Atlassian, matching MCP.md

## Verification

Local:
- \`npm run typecheck\` — clean
- \`npm run lint\` — clean (with --max-old-space-size=8192)
- \`npm run format:check\` — clean
- \`npm test\` — 139 files / 2007 tests passed in 2.93s

No code changes. No new dependencies. No env-var changes.

## Closes / refs

- Closes #320 (Phase 0)
- Part of #319 (Phase 1, doc-only after the architectural assessment above)
- Follow-up #325 (Figma — re-open when upstream ships PAT or opens \`mcp:connect\`)
- Next: #322 (Reviewer agent-loop migration), #323 (Refiner agent-loop migration)