### PR TITLE
feat(routing): wire execution-path decision into consumer workflows (ADR-0006 §3)

### DIFF
--- a/.github/actions/ferry-route/action.yml
+++ b/.github/actions/ferry-route/action.yml
@@ -1,0 +1,50 @@
+name: Ferry — Resolve Execution Path
+description: >
+  Decides whether the agent run takes the bundled-script path or the
+  `claude-code-action` path (ADR-0006 §3, issue #300). Exposes the decision
+  to the wrapping workflow via the `path` and `reason` outputs. Self-contained;
+  no `.ferry/` needed in the consumer workspace.
+inputs:
+  payload:
+    description: JSON-encoded event envelope payload
+    required: true
+  role:
+    description: Agent role (refiner | developer | reviewer | iterator)
+    required: true
+  jira_base_url:
+    description: Jira base URL
+    required: true
+  jira_email:
+    description: Jira account email
+    required: true
+  jira_api_token:
+    description: Jira API token
+    required: true
+outputs:
+  path:
+    description: Resolved execution path — `script` or `claude-code`
+    value: ${{ steps.route.outputs.path }}
+  reason:
+    description: Reason for the decision — `default`, `label`, or `heuristic`
+    value: ${{ steps.route.outputs.reason }}
+runs:
+  using: composite
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+      with:
+        node-version: '20'
+    - name: Install Ferry action dependencies
+      shell: bash
+      run: npm ci --prefer-offline
+      working-directory: ${{ github.action_path }}
+    - name: Resolve execution path
+      id: route
+      shell: bash
+      run: node ${{ github.action_path }}/route-action.js
+      env:
+        FERRY_ENVELOPE_PAYLOAD: ${{ inputs.payload }}
+        FERRY_AGENT_ROLE: ${{ inputs.role }}
+        FERRY_JIRA_BASE_URL: ${{ inputs.jira_base_url }}
+        FERRY_JIRA_EMAIL: ${{ inputs.jira_email }}
+        FERRY_JIRA_API_TOKEN: ${{ inputs.jira_api_token }}

--- a/.github/actions/ferry-route/package-lock.json
+++ b/.github/actions/ferry-route/package-lock.json
@@ -1,0 +1,102 @@
+{
+  "name": "ferry-route-action",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ferry-route-action",
+      "version": "0.0.0",
+      "dependencies": {
+        "ajv": "^8.0.0",
+        "ajv-formats": "^3.0.1",
+        "yaml": "^2.6.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/.github/actions/ferry-route/package.json
+++ b/.github/actions/ferry-route/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ferry-route-action",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "ajv": "^8.0.0",
+    "ajv-formats": "^3.0.1",
+    "yaml": "^2.6.0"
+  }
+}

--- a/.github/actions/ferry-route/route-action.js
+++ b/.github/actions/ferry-route/route-action.js
@@ -1,0 +1,1499 @@
+// src/lib/dispatch/route-action.ts
+import { appendFileSync } from "node:fs";
+
+// src/lib/envelope/validate.ts
+import { createRequire } from "module";
+
+// src/lib/errors/index.ts
+var FerryError = class extends Error {
+  constructor(code, context) {
+    super(`[ferry:${code}]${context ? ` ${JSON.stringify(context)}` : ""}`);
+    this.code = code;
+    this.context = context;
+    this.name = "FerryError";
+  }
+  code;
+  context;
+};
+
+// src/lib/envelope/validate.ts
+var _require = createRequire(import.meta.url);
+var eventSchema = _require("./schemas/event.v1.schema.json");
+var ajvModule = _require("ajv/dist/2020");
+var ajvInstance = new ajvModule.Ajv2020({ strict: true });
+_require("ajv-formats").default(ajvInstance);
+var validateFn = ajvInstance.compile(eventSchema);
+function validateEnvelope(raw) {
+  if (!validateFn(raw)) {
+    const safePaths = (validateFn.errors ?? []).map((e) => `${e.instancePath} ${e.keyword}`);
+    throw new FerryError("state-invariant", { paths: safePaths });
+  }
+  const envelope = raw;
+  if (envelope.instructions !== void 0) {
+    const cap = parseInt(process.env.FERRY_ENVELOPE_INSTRUCTIONS_CHARS ?? "", 10) || 2e3;
+    envelope.instructions = envelope.instructions.slice(0, cap);
+  }
+  return envelope;
+}
+
+// src/lib/io/spend-cap.ts
+function classifyHttpStatus(status) {
+  if (status === 429 || status === 402) return "spend-cap";
+  if (status >= 500) return "transient";
+  if (status >= 200 && status < 300) return "ok";
+  if (status >= 400) return "spend-cap";
+  return "transient";
+}
+
+// src/lib/io/jira-rest.ts
+var JiraRestClient = class {
+  constructor(baseUrl, email, apiToken) {
+    this.baseUrl = baseUrl;
+    this.authHeader = `Basic ${Buffer.from(`${email}:${apiToken}`).toString("base64")}`;
+  }
+  baseUrl;
+  authHeader;
+  subtaskTypeCache = /* @__PURE__ */ new Map();
+  get baseHeaders() {
+    return { Authorization: this.authHeader, Accept: "application/json" };
+  }
+  throwForStatus(status) {
+    const cls = classifyHttpStatus(status);
+    if (cls === "spend-cap") throw new FerryError("spend-cap", { status });
+    if (cls === "transient") throw new FerryError("transient", { status });
+  }
+  async getIssue(key) {
+    const response = await fetch(
+      `${this.baseUrl}/rest/api/3/issue/${key}?fields=summary,description,comment,labels,issuetype`,
+      { method: "GET", headers: this.baseHeaders }
+    );
+    this.throwForStatus(response.status);
+    return response.json();
+  }
+  async postComment(key, adfBody) {
+    const response = await fetch(`${this.baseUrl}/rest/api/3/issue/${key}/comment`, {
+      method: "POST",
+      headers: { ...this.baseHeaders, "Content-Type": "application/json" },
+      body: JSON.stringify({ body: adfBody })
+    });
+    this.throwForStatus(response.status);
+    return response.json();
+  }
+  async putComment(key, commentId, adfBody) {
+    const response = await fetch(`${this.baseUrl}/rest/api/3/issue/${key}/comment/${commentId}`, {
+      method: "PUT",
+      headers: { ...this.baseHeaders, "Content-Type": "application/json" },
+      body: JSON.stringify({ body: adfBody })
+    });
+    this.throwForStatus(response.status);
+    return response.json();
+  }
+  async resolveSubtaskTypeName(projectKey) {
+    const cached = this.subtaskTypeCache.get(projectKey);
+    if (cached !== void 0) return cached;
+    const response = await fetch(
+      `${this.baseUrl}/rest/api/3/issue/createmeta/${projectKey}/issuetypes`,
+      { method: "GET", headers: this.baseHeaders }
+    );
+    this.throwForStatus(response.status);
+    const data = await response.json();
+    const subtaskType = data.issueTypes.find((t) => t.subtask);
+    if (!subtaskType) {
+      throw new FerryError("state-invariant", { reason: "no-subtask-issuetype", projectKey });
+    }
+    this.subtaskTypeCache.set(projectKey, subtaskType.name);
+    return subtaskType.name;
+  }
+  async createSubtask(parentKey, summary, adfDescription) {
+    const projectKey = parentKey.split("-")[0];
+    const issuetypeName = await this.resolveSubtaskTypeName(projectKey);
+    const response = await fetch(`${this.baseUrl}/rest/api/3/issue`, {
+      method: "POST",
+      headers: { ...this.baseHeaders, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        fields: {
+          project: { key: projectKey },
+          parent: { key: parentKey },
+          summary,
+          issuetype: { name: issuetypeName },
+          description: adfDescription
+        }
+      })
+    });
+    this.throwForStatus(response.status);
+    return response.json();
+  }
+  async addLabel(key, label) {
+    const response = await fetch(`${this.baseUrl}/rest/api/3/issue/${key}`, {
+      method: "PUT",
+      headers: { ...this.baseHeaders, "Content-Type": "application/json" },
+      body: JSON.stringify({ update: { labels: [{ add: label }] } })
+    });
+    this.throwForStatus(response.status);
+  }
+  async getTransitions(key) {
+    const response = await fetch(`${this.baseUrl}/rest/api/3/issue/${key}/transitions`, {
+      method: "GET",
+      headers: this.baseHeaders
+    });
+    this.throwForStatus(response.status);
+    return response.json();
+  }
+  async postTransition(key, transitionId) {
+    const response = await fetch(`${this.baseUrl}/rest/api/3/issue/${key}/transitions`, {
+      method: "POST",
+      headers: { ...this.baseHeaders, "Content-Type": "application/json" },
+      body: JSON.stringify({ transition: { id: transitionId } })
+    });
+    this.throwForStatus(response.status);
+  }
+  async getSubtasks(parentKey) {
+    const jql = encodeURIComponent(`parent=${parentKey} ORDER BY created ASC`);
+    const response = await fetch(
+      `${this.baseUrl}/rest/api/3/search?jql=${jql}&fields=summary&maxResults=50`,
+      { method: "GET", headers: this.baseHeaders }
+    );
+    if (!response.ok) return [];
+    const data = await response.json();
+    return (data.issues ?? []).map((i) => `- [${i.key}] ${i.fields.summary}`);
+  }
+  async getSubtaskDetails(parentKey) {
+    const jql = encodeURIComponent(`parent=${parentKey} ORDER BY created ASC`);
+    const response = await fetch(
+      `${this.baseUrl}/rest/api/3/search?jql=${jql}&fields=summary,description,status&maxResults=50`,
+      { method: "GET", headers: this.baseHeaders }
+    );
+    if (!response.ok) return [];
+    const data = await response.json();
+    return (data.issues ?? []).map((i) => ({
+      key: i.key,
+      title: i.fields.summary,
+      descriptionAdf: i.fields.description,
+      status: i.fields.status.name
+    }));
+  }
+};
+
+// src/lib/config.ts
+import { existsSync, readFileSync } from "node:fs";
+import * as path from "node:path";
+import { createRequire as createRequire2 } from "node:module";
+var _require2 = createRequire2(import.meta.url);
+var DEFAULT_FERRY_CONFIG = {
+  models: {
+    refiner: { provider: "anthropic", model: "claude-sonnet-4-6" },
+    dev: { provider: "anthropic", model: "claude-opus-4-5" },
+    review: { provider: "anthropic", model: "claude-sonnet-4-6" },
+    iterate: { provider: "anthropic", model: "claude-sonnet-4-6" }
+  },
+  limits: {
+    max_iterations: 3,
+    max_agent_iterations: 200,
+    max_tokens_per_run: 5e5,
+    max_tokens_per_message: 16384,
+    max_cost_eur_per_run: 10,
+    bash_timeout_ms: 6e4,
+    bash_timeout_max_ms: 3e5,
+    grep_timeout_ms: 3e4,
+    anthropic_verify_timeout_ms: 1e4,
+    jira_retry_base_delay_ms: 2e3,
+    jira_retry_max_attempts: 3,
+    envelope_instructions_chars: 2e3,
+    project_snippet_bytes: 2048,
+    agent_extension_bytes: 4096,
+    tldr_total_chars: 500,
+    tldr_verdict_chars: 40,
+    file_display_chars: 4e4,
+    refiner_subtask_cap: 12,
+    refiner_touch_paths_cap: 20,
+    reviewer_max_iterations: 40,
+    reviewer_max_tokens: 16384,
+    reconciler_stale_window_minutes: 20
+  },
+  ticket_types: {
+    refine_allowlist: ["Story", "Bug", "Spike"],
+    dev_allowlist: ["Story", "Bug", "Spike"]
+  },
+  git: {
+    base_branch: null,
+    target_branch: null,
+    working_branch_prefix: "ferry/"
+  },
+  workflow: {
+    agents: {
+      refiner: { trigger_column: "Refinement", auto_transition: null },
+      developer: { trigger_column: "In Development", auto_transition: "In Review" },
+      reviewer: {
+        trigger_column: "In Review",
+        auto_transition_approve: null,
+        auto_transition_changes: "Changes Requested"
+      },
+      iterator: { trigger_column: "Changes Requested", auto_transition: "In Review" }
+    }
+  },
+  routing: {
+    claude_code_round_trip_threshold: 2
+  }
+};
+function validateProvider(val, fieldPath) {
+  if (val !== "anthropic" && val !== "openai" && val !== "google") {
+    return [`${fieldPath}: must be "anthropic", "openai", or "google"`];
+  }
+  return [];
+}
+function validateLlmRoute(val, fieldPath) {
+  if (!val || typeof val !== "object") return [`${fieldPath}: must be an object`];
+  const r = val;
+  return [
+    ...validateProvider(r.provider, `${fieldPath}.provider`),
+    ...typeof r.model !== "string" || r.model.length === 0 ? [`${fieldPath}.model: must be a non-empty string`] : []
+  ];
+}
+function validatePosInt(val, fieldPath) {
+  if (typeof val !== "number" || !Number.isInteger(val) || val <= 0) {
+    return [`${fieldPath}: must be a positive integer`];
+  }
+  return [];
+}
+function validatePosNumber(val, fieldPath) {
+  if (typeof val !== "number" || val <= 0) {
+    return [`${fieldPath}: must be a positive number`];
+  }
+  return [];
+}
+function validateStringArray(val, fieldPath) {
+  if (!Array.isArray(val) || val.some((v) => typeof v !== "string")) {
+    return [`${fieldPath}: must be an array of strings`];
+  }
+  return [];
+}
+function validateStringOrNull(val, fieldPath) {
+  if (val !== null && typeof val !== "string") {
+    return [`${fieldPath}: must be a string or null`];
+  }
+  return [];
+}
+function validateWorkflowAgentBase(val, fieldPath) {
+  if (!val || typeof val !== "object") return [`${fieldPath}: must be an object`];
+  const v = val;
+  if (v.trigger_column !== void 0 && typeof v.trigger_column !== "string") {
+    return [`${fieldPath}.trigger_column: must be a string`];
+  }
+  return [];
+}
+function validateWorkflow(val) {
+  if (!val || typeof val !== "object") return ["workflow: must be an object"];
+  const w = val;
+  const errs = [];
+  if (w.agents === void 0) return errs;
+  if (!w.agents || typeof w.agents !== "object") {
+    errs.push("workflow.agents: must be an object");
+    return errs;
+  }
+  const agents = w.agents;
+  if (agents.refiner !== void 0) {
+    errs.push(...validateWorkflowAgentBase(agents.refiner, "workflow.agents.refiner"));
+  }
+  if (agents.developer !== void 0) {
+    errs.push(...validateWorkflowAgentBase(agents.developer, "workflow.agents.developer"));
+    const dev = agents.developer;
+    if ("auto_transition" in dev && dev.auto_transition !== void 0) {
+      errs.push(
+        ...validateStringOrNull(dev.auto_transition, "workflow.agents.developer.auto_transition")
+      );
+    }
+  }
+  if (agents.reviewer !== void 0) {
+    errs.push(...validateWorkflowAgentBase(agents.reviewer, "workflow.agents.reviewer"));
+    const rev = agents.reviewer;
+    if ("auto_transition_approve" in rev && rev.auto_transition_approve !== void 0) {
+      errs.push(
+        ...validateStringOrNull(
+          rev.auto_transition_approve,
+          "workflow.agents.reviewer.auto_transition_approve"
+        )
+      );
+    }
+    if ("auto_transition_changes" in rev && rev.auto_transition_changes !== void 0) {
+      errs.push(
+        ...validateStringOrNull(
+          rev.auto_transition_changes,
+          "workflow.agents.reviewer.auto_transition_changes"
+        )
+      );
+    }
+  }
+  if (agents.iterator !== void 0) {
+    errs.push(...validateWorkflowAgentBase(agents.iterator, "workflow.agents.iterator"));
+    const iter = agents.iterator;
+    if ("auto_transition" in iter && iter.auto_transition !== void 0) {
+      errs.push(
+        ...validateStringOrNull(iter.auto_transition, "workflow.agents.iterator.auto_transition")
+      );
+    }
+  }
+  return errs;
+}
+function validateConfigShape(raw) {
+  if (!raw || typeof raw !== "object") return ["config: must be an object"];
+  const c = raw;
+  const errs = [];
+  if (c.models !== void 0) {
+    if (!c.models || typeof c.models !== "object") {
+      errs.push("models: must be an object");
+    } else {
+      const m = c.models;
+      for (const key of ["refiner", "dev", "review", "iterate"]) {
+        if (m[key] !== void 0) {
+          errs.push(...validateLlmRoute(m[key], `models.${String(key)}`));
+        }
+      }
+    }
+  }
+  if (c.limits !== void 0) {
+    if (!c.limits || typeof c.limits !== "object") {
+      errs.push("limits: must be an object");
+    } else {
+      const l = c.limits;
+      if (l.max_iterations !== void 0)
+        errs.push(...validatePosInt(l.max_iterations, "limits.max_iterations"));
+      if (l.max_agent_iterations !== void 0)
+        errs.push(...validatePosInt(l.max_agent_iterations, "limits.max_agent_iterations"));
+      if (l.max_tokens_per_run !== void 0)
+        errs.push(...validatePosInt(l.max_tokens_per_run, "limits.max_tokens_per_run"));
+      if (l.max_tokens_per_message !== void 0)
+        errs.push(...validatePosInt(l.max_tokens_per_message, "limits.max_tokens_per_message"));
+      if (l.max_cost_eur_per_run !== void 0)
+        errs.push(...validatePosNumber(l.max_cost_eur_per_run, "limits.max_cost_eur_per_run"));
+      if (l.bash_timeout_ms !== void 0)
+        errs.push(...validatePosInt(l.bash_timeout_ms, "limits.bash_timeout_ms"));
+      if (l.bash_timeout_max_ms !== void 0)
+        errs.push(...validatePosInt(l.bash_timeout_max_ms, "limits.bash_timeout_max_ms"));
+      if (l.grep_timeout_ms !== void 0)
+        errs.push(...validatePosInt(l.grep_timeout_ms, "limits.grep_timeout_ms"));
+      if (l.anthropic_verify_timeout_ms !== void 0)
+        errs.push(
+          ...validatePosInt(l.anthropic_verify_timeout_ms, "limits.anthropic_verify_timeout_ms")
+        );
+      if (l.jira_retry_base_delay_ms !== void 0)
+        errs.push(...validatePosInt(l.jira_retry_base_delay_ms, "limits.jira_retry_base_delay_ms"));
+      if (l.jira_retry_max_attempts !== void 0)
+        errs.push(...validatePosInt(l.jira_retry_max_attempts, "limits.jira_retry_max_attempts"));
+      if (l.envelope_instructions_chars !== void 0)
+        errs.push(
+          ...validatePosInt(l.envelope_instructions_chars, "limits.envelope_instructions_chars")
+        );
+      if (l.project_snippet_bytes !== void 0)
+        errs.push(...validatePosInt(l.project_snippet_bytes, "limits.project_snippet_bytes"));
+      if (l.agent_extension_bytes !== void 0)
+        errs.push(...validatePosInt(l.agent_extension_bytes, "limits.agent_extension_bytes"));
+      if (l.tldr_total_chars !== void 0)
+        errs.push(...validatePosInt(l.tldr_total_chars, "limits.tldr_total_chars"));
+      if (l.tldr_verdict_chars !== void 0)
+        errs.push(...validatePosInt(l.tldr_verdict_chars, "limits.tldr_verdict_chars"));
+      if (l.file_display_chars !== void 0)
+        errs.push(...validatePosInt(l.file_display_chars, "limits.file_display_chars"));
+      if (l.refiner_subtask_cap !== void 0)
+        errs.push(...validatePosInt(l.refiner_subtask_cap, "limits.refiner_subtask_cap"));
+      if (l.refiner_touch_paths_cap !== void 0)
+        errs.push(...validatePosInt(l.refiner_touch_paths_cap, "limits.refiner_touch_paths_cap"));
+      if (l.reviewer_max_iterations !== void 0)
+        errs.push(...validatePosInt(l.reviewer_max_iterations, "limits.reviewer_max_iterations"));
+      if (l.reviewer_max_tokens !== void 0)
+        errs.push(...validatePosInt(l.reviewer_max_tokens, "limits.reviewer_max_tokens"));
+      if (l.reconciler_stale_window_minutes !== void 0)
+        errs.push(
+          ...validatePosInt(
+            l.reconciler_stale_window_minutes,
+            "limits.reconciler_stale_window_minutes"
+          )
+        );
+    }
+  }
+  if (c.ticket_types !== void 0) {
+    if (!c.ticket_types || typeof c.ticket_types !== "object") {
+      errs.push("ticket_types: must be an object");
+    } else {
+      const t = c.ticket_types;
+      if (t.refine_allowlist !== void 0)
+        errs.push(...validateStringArray(t.refine_allowlist, "ticket_types.refine_allowlist"));
+      if (t.dev_allowlist !== void 0)
+        errs.push(...validateStringArray(t.dev_allowlist, "ticket_types.dev_allowlist"));
+    }
+  }
+  if (c.git !== void 0) {
+    if (!c.git || typeof c.git !== "object" || Array.isArray(c.git)) {
+      errs.push("git: must be an object");
+    } else {
+      const g = c.git;
+      if (g.base_branch !== void 0 && g.base_branch !== null && typeof g.base_branch !== "string") {
+        errs.push("git.base_branch: must be a string or null");
+      }
+      if (g.base_branch !== void 0 && typeof g.base_branch === "string" && g.base_branch.trim() === "") {
+        errs.push("git.base_branch: must be a non-empty string or null");
+      }
+      if (g.target_branch !== void 0 && g.target_branch !== null && typeof g.target_branch !== "string") {
+        errs.push("git.target_branch: must be a string or null");
+      }
+      if (g.target_branch !== void 0 && typeof g.target_branch === "string" && g.target_branch.trim() === "") {
+        errs.push("git.target_branch: must be a non-empty string or null");
+      }
+      if (g.working_branch_prefix !== void 0) {
+        if (typeof g.working_branch_prefix === "string") {
+          if (g.working_branch_prefix.length === 0) {
+            errs.push("git.working_branch_prefix: must be a non-empty string");
+          }
+        } else if (g.working_branch_prefix !== null && typeof g.working_branch_prefix === "object" && !Array.isArray(g.working_branch_prefix)) {
+          const mapping = g.working_branch_prefix;
+          if (!("default" in mapping)) {
+            errs.push('git.working_branch_prefix: mapping must include a "default" key');
+          }
+          for (const [k, v] of Object.entries(mapping)) {
+            if (typeof v !== "string" || v.length === 0) {
+              errs.push(`git.working_branch_prefix.${k}: must be a non-empty string`);
+            }
+          }
+        } else {
+          errs.push(
+            'git.working_branch_prefix: must be a non-empty string or a mapping object with a "default" key'
+          );
+        }
+      }
+    }
+  }
+  if (c.labels !== void 0) {
+    if (!c.labels || typeof c.labels !== "object" || Array.isArray(c.labels)) {
+      errs.push("labels: must be an object mapping label names to capability entries");
+    } else {
+      for (const [labelName, entry] of Object.entries(c.labels)) {
+        const fieldPath = `labels.${labelName}`;
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+          errs.push(`${fieldPath}: must be an object`);
+          continue;
+        }
+        const e = entry;
+        if (e.mcp_servers !== void 0)
+          errs.push(...validateStringArray(e.mcp_servers, `${fieldPath}.mcp_servers`));
+        if (e.tools !== void 0) errs.push(...validateStringArray(e.tools, `${fieldPath}.tools`));
+      }
+    }
+  }
+  if (c.workflow !== void 0) {
+    errs.push(...validateWorkflow(c.workflow));
+  }
+  if (c.safety !== void 0) {
+    if (!c.safety || typeof c.safety !== "object" || Array.isArray(c.safety)) {
+      errs.push("safety: must be an object");
+    } else {
+      const s = c.safety;
+      if (s.allow_skip_review !== void 0 && typeof s.allow_skip_review !== "boolean") {
+        errs.push("safety.allow_skip_review: must be a boolean");
+      }
+    }
+  }
+  if (c.execution_path !== void 0 && c.execution_path !== "script" && c.execution_path !== "claude-code") {
+    errs.push('execution_path: must be "script" or "claude-code"');
+  }
+  if (c.routing !== void 0) {
+    if (!c.routing || typeof c.routing !== "object" || Array.isArray(c.routing)) {
+      errs.push("routing: must be an object");
+    } else {
+      const r = c.routing;
+      if (r.claude_code_round_trip_threshold !== void 0) {
+        errs.push(
+          ...validatePosInt(
+            r.claude_code_round_trip_threshold,
+            "routing.claude_code_round_trip_threshold"
+          )
+        );
+      }
+    }
+  }
+  return errs;
+}
+function readJsonConfig(filePath) {
+  const raw = readFileSync(filePath, "utf8");
+  try {
+    return JSON.parse(raw);
+  } catch (e) {
+    throw new FerryError("state-invariant", {
+      reason: "invalid-ferry-config",
+      file: path.basename(filePath),
+      error: e.message
+    });
+  }
+}
+function readYamlConfig(filePath) {
+  let parseYaml;
+  try {
+    const mod = _require2("yaml");
+    parseYaml = mod.parse;
+  } catch {
+    throw new FerryError("state-invariant", {
+      reason: "invalid-ferry-config",
+      file: path.basename(filePath),
+      error: 'YAML config requires the "yaml" package: npm install yaml'
+    });
+  }
+  const raw = readFileSync(filePath, "utf8");
+  try {
+    return parseYaml(raw);
+  } catch (e) {
+    throw new FerryError("state-invariant", {
+      reason: "invalid-ferry-config",
+      file: path.basename(filePath),
+      error: e.message
+    });
+  }
+}
+function findAndReadConfigFile(repoRoot) {
+  const candidates = [
+    { file: "ferry.config.json", reader: readJsonConfig },
+    { file: "ferry.config.yaml", reader: readYamlConfig },
+    { file: "ferry.config.yml", reader: readYamlConfig }
+  ];
+  for (const { file, reader } of candidates) {
+    const filePath = path.join(repoRoot, file);
+    if (!existsSync(filePath)) continue;
+    return reader(filePath);
+  }
+  return null;
+}
+function mergeWithDefaults(raw) {
+  const m = raw.models ?? {};
+  const l = raw.limits ?? {};
+  const t = raw.ticket_types ?? {};
+  const g = raw.git ?? {};
+  const route = (val, def) => {
+    if (!val || typeof val !== "object") return def;
+    const r = val;
+    return {
+      provider: r.provider ?? def.provider,
+      model: r.model ?? def.model
+    };
+  };
+  const num = (val, def) => typeof val === "number" ? val : def;
+  const strArr = (val, def) => Array.isArray(val) ? val : def;
+  const nullableStr = (val, def) => {
+    if (val === null) return null;
+    if (typeof val === "string") return val;
+    return def;
+  };
+  const labelsRaw = raw.labels;
+  let labels;
+  if (labelsRaw && typeof labelsRaw === "object" && !Array.isArray(labelsRaw)) {
+    labels = {};
+    for (const [name, entry] of Object.entries(labelsRaw)) {
+      if (entry && typeof entry === "object" && !Array.isArray(entry)) {
+        const e = entry;
+        labels[name] = {
+          ...Array.isArray(e.mcp_servers) ? { mcp_servers: e.mcp_servers } : {},
+          ...Array.isArray(e.tools) ? { tools: e.tools } : {}
+        };
+      }
+    }
+  }
+  return {
+    models: {
+      refiner: route(m.refiner, DEFAULT_FERRY_CONFIG.models.refiner),
+      dev: route(m.dev, DEFAULT_FERRY_CONFIG.models.dev),
+      review: route(m.review, DEFAULT_FERRY_CONFIG.models.review),
+      iterate: route(m.iterate, DEFAULT_FERRY_CONFIG.models.iterate)
+    },
+    limits: {
+      max_iterations: num(l.max_iterations, DEFAULT_FERRY_CONFIG.limits.max_iterations),
+      max_agent_iterations: num(
+        l.max_agent_iterations,
+        DEFAULT_FERRY_CONFIG.limits.max_agent_iterations
+      ),
+      max_tokens_per_run: num(l.max_tokens_per_run, DEFAULT_FERRY_CONFIG.limits.max_tokens_per_run),
+      max_tokens_per_message: num(
+        l.max_tokens_per_message,
+        DEFAULT_FERRY_CONFIG.limits.max_tokens_per_message
+      ),
+      max_cost_eur_per_run: num(
+        l.max_cost_eur_per_run,
+        DEFAULT_FERRY_CONFIG.limits.max_cost_eur_per_run
+      ),
+      bash_timeout_ms: num(l.bash_timeout_ms, DEFAULT_FERRY_CONFIG.limits.bash_timeout_ms),
+      bash_timeout_max_ms: num(
+        l.bash_timeout_max_ms,
+        DEFAULT_FERRY_CONFIG.limits.bash_timeout_max_ms
+      ),
+      grep_timeout_ms: num(l.grep_timeout_ms, DEFAULT_FERRY_CONFIG.limits.grep_timeout_ms),
+      anthropic_verify_timeout_ms: num(
+        l.anthropic_verify_timeout_ms,
+        DEFAULT_FERRY_CONFIG.limits.anthropic_verify_timeout_ms
+      ),
+      jira_retry_base_delay_ms: num(
+        l.jira_retry_base_delay_ms,
+        DEFAULT_FERRY_CONFIG.limits.jira_retry_base_delay_ms
+      ),
+      jira_retry_max_attempts: num(
+        l.jira_retry_max_attempts,
+        DEFAULT_FERRY_CONFIG.limits.jira_retry_max_attempts
+      ),
+      envelope_instructions_chars: num(
+        l.envelope_instructions_chars,
+        DEFAULT_FERRY_CONFIG.limits.envelope_instructions_chars
+      ),
+      project_snippet_bytes: num(
+        l.project_snippet_bytes,
+        DEFAULT_FERRY_CONFIG.limits.project_snippet_bytes
+      ),
+      agent_extension_bytes: num(
+        l.agent_extension_bytes,
+        DEFAULT_FERRY_CONFIG.limits.agent_extension_bytes
+      ),
+      tldr_total_chars: num(l.tldr_total_chars, DEFAULT_FERRY_CONFIG.limits.tldr_total_chars),
+      tldr_verdict_chars: num(l.tldr_verdict_chars, DEFAULT_FERRY_CONFIG.limits.tldr_verdict_chars),
+      file_display_chars: num(l.file_display_chars, DEFAULT_FERRY_CONFIG.limits.file_display_chars),
+      refiner_subtask_cap: num(
+        l.refiner_subtask_cap,
+        DEFAULT_FERRY_CONFIG.limits.refiner_subtask_cap
+      ),
+      refiner_touch_paths_cap: num(
+        l.refiner_touch_paths_cap,
+        DEFAULT_FERRY_CONFIG.limits.refiner_touch_paths_cap
+      ),
+      reviewer_max_iterations: num(
+        l.reviewer_max_iterations,
+        DEFAULT_FERRY_CONFIG.limits.reviewer_max_iterations
+      ),
+      reviewer_max_tokens: num(
+        l.reviewer_max_tokens,
+        DEFAULT_FERRY_CONFIG.limits.reviewer_max_tokens
+      ),
+      reconciler_stale_window_minutes: num(
+        l.reconciler_stale_window_minutes,
+        DEFAULT_FERRY_CONFIG.limits.reconciler_stale_window_minutes
+      )
+    },
+    ticket_types: {
+      refine_allowlist: strArr(
+        t.refine_allowlist,
+        DEFAULT_FERRY_CONFIG.ticket_types.refine_allowlist
+      ),
+      dev_allowlist: strArr(t.dev_allowlist, DEFAULT_FERRY_CONFIG.ticket_types.dev_allowlist)
+    },
+    git: {
+      base_branch: "base_branch" in g ? nullableStr(g.base_branch, null) : DEFAULT_FERRY_CONFIG.git.base_branch,
+      target_branch: "target_branch" in g ? nullableStr(g.target_branch, null) : DEFAULT_FERRY_CONFIG.git.target_branch,
+      working_branch_prefix: typeof g.working_branch_prefix === "string" ? g.working_branch_prefix : g.working_branch_prefix !== null && typeof g.working_branch_prefix === "object" && !Array.isArray(g.working_branch_prefix) ? g.working_branch_prefix : DEFAULT_FERRY_CONFIG.git.working_branch_prefix
+    },
+    ...labels !== void 0 ? { labels } : {},
+    workflow: mergeWorkflow(raw.workflow),
+    ...raw.execution_path === "script" || raw.execution_path === "claude-code" ? { execution_path: raw.execution_path } : {},
+    routing: {
+      claude_code_round_trip_threshold: num(
+        raw.routing?.claude_code_round_trip_threshold,
+        DEFAULT_FERRY_CONFIG.routing.claude_code_round_trip_threshold
+      )
+    },
+    ...raw.safety && typeof raw.safety === "object" && !Array.isArray(raw.safety) ? {
+      safety: {
+        ...typeof raw.safety.allow_skip_review === "boolean" ? {
+          allow_skip_review: raw.safety.allow_skip_review
+        } : {}
+      }
+    } : {}
+  };
+}
+function mergeWorkflow(rawWorkflow) {
+  const def = DEFAULT_FERRY_CONFIG.workflow;
+  if (!rawWorkflow || typeof rawWorkflow !== "object") return def;
+  const w = rawWorkflow;
+  if (!w.agents || typeof w.agents !== "object") return def;
+  const agents = w.agents;
+  const str = (val, def2) => typeof val === "string" ? val : def2;
+  const strOrNull = (obj, key, def2) => key in obj ? obj[key] === null ? null : typeof obj[key] === "string" ? obj[key] : def2 : def2;
+  const refinerRaw = agents.refiner && typeof agents.refiner === "object" ? agents.refiner : {};
+  const devRaw = agents.developer && typeof agents.developer === "object" ? agents.developer : {};
+  const revRaw = agents.reviewer && typeof agents.reviewer === "object" ? agents.reviewer : {};
+  const iterRaw = agents.iterator && typeof agents.iterator === "object" ? agents.iterator : {};
+  return {
+    agents: {
+      refiner: {
+        trigger_column: str(refinerRaw.trigger_column, def.agents.refiner.trigger_column),
+        auto_transition: null
+      },
+      developer: {
+        trigger_column: str(devRaw.trigger_column, def.agents.developer.trigger_column),
+        auto_transition: strOrNull(devRaw, "auto_transition", def.agents.developer.auto_transition)
+      },
+      reviewer: {
+        trigger_column: str(revRaw.trigger_column, def.agents.reviewer.trigger_column),
+        auto_transition_approve: strOrNull(
+          revRaw,
+          "auto_transition_approve",
+          def.agents.reviewer.auto_transition_approve
+        ),
+        auto_transition_changes: strOrNull(
+          revRaw,
+          "auto_transition_changes",
+          def.agents.reviewer.auto_transition_changes
+        )
+      },
+      iterator: {
+        trigger_column: str(iterRaw.trigger_column, def.agents.iterator.trigger_column),
+        auto_transition: strOrNull(iterRaw, "auto_transition", def.agents.iterator.auto_transition)
+      }
+    }
+  };
+}
+function applyEnvOverrides(cfg) {
+  const models = { ...cfg.models };
+  const limits = { ...cfg.limits };
+  const providerFromEnv = (val) => {
+    if (val === "anthropic" || val === "openai" || val === "google") return val;
+    return void 0;
+  };
+  const refinerProvider = providerFromEnv(process.env.FERRY_REFINER_PROVIDER);
+  if (refinerProvider) models.refiner = { ...models.refiner, provider: refinerProvider };
+  if (process.env.FERRY_REFINER_MODEL) {
+    models.refiner = { ...models.refiner, model: process.env.FERRY_REFINER_MODEL };
+  }
+  const devProvider = providerFromEnv(process.env.FERRY_DEV_PROVIDER);
+  if (devProvider) models.dev = { ...models.dev, provider: devProvider };
+  if (process.env.FERRY_DEV_MODEL) {
+    models.dev = { ...models.dev, model: process.env.FERRY_DEV_MODEL };
+  }
+  const reviewProvider = providerFromEnv(process.env.FERRY_REVIEW_PROVIDER);
+  if (reviewProvider) models.review = { ...models.review, provider: reviewProvider };
+  if (process.env.FERRY_REVIEW_MODEL) {
+    models.review = { ...models.review, model: process.env.FERRY_REVIEW_MODEL };
+  }
+  const iterProvider = providerFromEnv(process.env.FERRY_ITER_PROVIDER);
+  if (iterProvider) models.iterate = { ...models.iterate, provider: iterProvider };
+  if (process.env.FERRY_ITER_MODEL) {
+    models.iterate = { ...models.iterate, model: process.env.FERRY_ITER_MODEL };
+  }
+  const maxAgentIter = parseInt(process.env.FERRY_DEV_MAX_ITERATIONS ?? "", 10);
+  if (Number.isFinite(maxAgentIter)) limits.max_agent_iterations = maxAgentIter;
+  const maxInputTok = parseInt(process.env.FERRY_DEV_MAX_INPUT_TOKENS ?? "", 10);
+  if (Number.isFinite(maxInputTok)) limits.max_tokens_per_run = maxInputTok;
+  const maxTok = parseInt(process.env.FERRY_DEV_MAX_TOKENS ?? "", 10);
+  if (Number.isFinite(maxTok)) limits.max_tokens_per_message = maxTok;
+  const maxCost = parseFloat(process.env.FERRY_MAX_COST_EUR_PER_RUN ?? "");
+  if (Number.isFinite(maxCost)) limits.max_cost_eur_per_run = maxCost;
+  const envInt = (key) => {
+    const v = parseInt(process.env[key] ?? "", 10);
+    return Number.isFinite(v) ? v : void 0;
+  };
+  const bashTimeoutMs = envInt("FERRY_BASH_TIMEOUT_MS");
+  if (bashTimeoutMs !== void 0) limits.bash_timeout_ms = bashTimeoutMs;
+  const bashTimeoutMaxMs = envInt("FERRY_BASH_TIMEOUT_MAX_MS");
+  if (bashTimeoutMaxMs !== void 0) limits.bash_timeout_max_ms = bashTimeoutMaxMs;
+  const grepTimeoutMs = envInt("FERRY_GREP_TIMEOUT_MS");
+  if (grepTimeoutMs !== void 0) limits.grep_timeout_ms = grepTimeoutMs;
+  const anthropicVerifyTimeoutMs = envInt("FERRY_ANTHROPIC_VERIFY_TIMEOUT_MS");
+  if (anthropicVerifyTimeoutMs !== void 0)
+    limits.anthropic_verify_timeout_ms = anthropicVerifyTimeoutMs;
+  const jiraRetryBaseDelayMs = envInt("FERRY_JIRA_RETRY_BASE_DELAY_MS");
+  if (jiraRetryBaseDelayMs !== void 0) limits.jira_retry_base_delay_ms = jiraRetryBaseDelayMs;
+  const jiraRetryMaxAttempts = envInt("FERRY_JIRA_RETRY_MAX_ATTEMPTS");
+  if (jiraRetryMaxAttempts !== void 0) limits.jira_retry_max_attempts = jiraRetryMaxAttempts;
+  const envelopeInstructionsChars = envInt("FERRY_ENVELOPE_INSTRUCTIONS_CHARS");
+  if (envelopeInstructionsChars !== void 0)
+    limits.envelope_instructions_chars = envelopeInstructionsChars;
+  const projectSnippetBytes = envInt("FERRY_PROJECT_SNIPPET_BYTES");
+  if (projectSnippetBytes !== void 0) limits.project_snippet_bytes = projectSnippetBytes;
+  const agentExtensionBytes = envInt("FERRY_AGENT_EXTENSION_BYTES");
+  if (agentExtensionBytes !== void 0) limits.agent_extension_bytes = agentExtensionBytes;
+  const tldrTotalChars = envInt("FERRY_TLDR_TOTAL_CHARS");
+  if (tldrTotalChars !== void 0) limits.tldr_total_chars = tldrTotalChars;
+  const tldrVerdictChars = envInt("FERRY_TLDR_VERDICT_CHARS");
+  if (tldrVerdictChars !== void 0) limits.tldr_verdict_chars = tldrVerdictChars;
+  const fileDisplayChars = envInt("FERRY_FILE_DISPLAY_CHARS");
+  if (fileDisplayChars !== void 0) limits.file_display_chars = fileDisplayChars;
+  const refinerSubtaskCap = envInt("FERRY_REFINER_SUBTASK_CAP");
+  if (refinerSubtaskCap !== void 0) limits.refiner_subtask_cap = refinerSubtaskCap;
+  const refinerTouchPathsCap = envInt("FERRY_REFINER_TOUCH_PATHS_CAP");
+  if (refinerTouchPathsCap !== void 0) limits.refiner_touch_paths_cap = refinerTouchPathsCap;
+  const reviewerMaxIterations = envInt("FERRY_REVIEWER_MAX_ITERATIONS");
+  if (reviewerMaxIterations !== void 0) limits.reviewer_max_iterations = reviewerMaxIterations;
+  const reviewerMaxTokens = envInt("FERRY_REVIEWER_MAX_TOKENS");
+  if (reviewerMaxTokens !== void 0) limits.reviewer_max_tokens = reviewerMaxTokens;
+  const reconcilerStaleWindowMinutes = envInt("FERRY_RECONCILER_STALE_WINDOW_MINUTES");
+  if (reconcilerStaleWindowMinutes !== void 0)
+    limits.reconciler_stale_window_minutes = reconcilerStaleWindowMinutes;
+  process.env.FERRY_BASH_TIMEOUT_MS = String(limits.bash_timeout_ms);
+  process.env.FERRY_BASH_TIMEOUT_MAX_MS = String(limits.bash_timeout_max_ms);
+  process.env.FERRY_GREP_TIMEOUT_MS = String(limits.grep_timeout_ms);
+  process.env.FERRY_ANTHROPIC_VERIFY_TIMEOUT_MS = String(limits.anthropic_verify_timeout_ms);
+  process.env.FERRY_JIRA_RETRY_BASE_DELAY_MS = String(limits.jira_retry_base_delay_ms);
+  process.env.FERRY_JIRA_RETRY_MAX_ATTEMPTS = String(limits.jira_retry_max_attempts);
+  process.env.FERRY_ENVELOPE_INSTRUCTIONS_CHARS = String(limits.envelope_instructions_chars);
+  process.env.FERRY_PROJECT_SNIPPET_BYTES = String(limits.project_snippet_bytes);
+  process.env.FERRY_AGENT_EXTENSION_BYTES = String(limits.agent_extension_bytes);
+  process.env.FERRY_TLDR_TOTAL_CHARS = String(limits.tldr_total_chars);
+  process.env.FERRY_TLDR_VERDICT_CHARS = String(limits.tldr_verdict_chars);
+  process.env.FERRY_FILE_DISPLAY_CHARS = String(limits.file_display_chars);
+  process.env.FERRY_REFINER_SUBTASK_CAP = String(limits.refiner_subtask_cap);
+  process.env.FERRY_REFINER_TOUCH_PATHS_CAP = String(limits.refiner_touch_paths_cap);
+  process.env.FERRY_REVIEWER_MAX_ITERATIONS = String(limits.reviewer_max_iterations);
+  process.env.FERRY_REVIEWER_MAX_TOKENS = String(limits.reviewer_max_tokens);
+  process.env.FERRY_RECONCILER_STALE_WINDOW_MINUTES = String(
+    limits.reconciler_stale_window_minutes
+  );
+  return { ...cfg, models, limits };
+}
+function loadFerryConfig(repoRoot) {
+  const root = repoRoot ?? process.env.GITHUB_WORKSPACE ?? process.cwd();
+  const raw = findAndReadConfigFile(root);
+  if (raw === null) {
+    return applyEnvOverrides(DEFAULT_FERRY_CONFIG);
+  }
+  const errors = validateConfigShape(raw);
+  if (errors.length > 0) {
+    throw new FerryError("state-invariant", {
+      reason: "invalid-ferry-config",
+      errors
+    });
+  }
+  return applyEnvOverrides(mergeWithDefaults(raw));
+}
+
+// src/lib/labels/capabilities.ts
+var FORCE_TYPE_LABELS = Object.freeze({
+  "ferry:type:force-bug": "Bug",
+  "ferry:type:force-spike": "Spike",
+  "ferry:type:force-story": "Story"
+});
+var ENABLE_TASK_LABEL = "ferry:type:enable-task";
+var AS_LABEL_PREFIX = "ferry:as/";
+var AS_TYPE_LABELS = Object.freeze({
+  bug: "Bug",
+  spike: "Spike",
+  story: "Story"
+});
+var BUILTIN_TYPE_LABELS = /* @__PURE__ */ new Set([
+  ENABLE_TASK_LABEL,
+  ...Object.keys(FORCE_TYPE_LABELS),
+  ...Object.keys(AS_TYPE_LABELS).map((s) => `${AS_LABEL_PREFIX}${s}`)
+]);
+function resolveTypeOverrides(labels) {
+  let bypassTaskSkip = false;
+  let typeOverride;
+  let forceLabel;
+  for (const label of labels) {
+    if (label === ENABLE_TASK_LABEL) {
+      bypassTaskSkip = true;
+    } else if (Object.prototype.hasOwnProperty.call(FORCE_TYPE_LABELS, label)) {
+      typeOverride = FORCE_TYPE_LABELS[label];
+      forceLabel = label;
+    }
+  }
+  return { bypassTaskSkip, typeOverride, forceLabel };
+}
+function isBuiltinTypeLabel(label) {
+  return BUILTIN_TYPE_LABELS.has(label);
+}
+
+// src/lib/labels/overrides.ts
+var AGENT_PHASES = /* @__PURE__ */ new Set(["refiner", "dev", "review", "iterate"]);
+var PHASES_ORDERED = ["refiner", "dev", "review", "iterate"];
+var LLM_PROVIDERS = /* @__PURE__ */ new Set(["anthropic", "openai", "google"]);
+var BRANCH_NAME_REGEX = /^[a-zA-Z0-9._/-]+$/;
+var LabelConflictError = class extends Error {
+  label1;
+  label2;
+  field;
+  constructor(label1, label2, field) {
+    super(`Conflicting ferry labels for "${field}": "${label1}" and "${label2}"`);
+    this.name = "LabelConflictError";
+    this.label1 = label1;
+    this.label2 = label2;
+    this.field = field;
+  }
+};
+function parsePositiveFloat(s) {
+  const n = Number(s);
+  return Number.isFinite(n) && n > 0 ? n : void 0;
+}
+function parsePositiveInt(s) {
+  const n = Number(s);
+  return Number.isInteger(n) && n > 0 ? n : void 0;
+}
+var MCP_LABEL_PREFIX = "ferry:mcp/";
+var PROFILE_LABEL_PREFIX = "ferry:profile/";
+var KNOWN_STATUS_LABELS = /* @__PURE__ */ new Set([
+  "ferry:refining",
+  "ferry:developing",
+  "ferry:reviewing",
+  "ferry:iterating",
+  "ferry:ready",
+  "ferry:approved",
+  "ferry:cancelled",
+  "ferry:blocked",
+  "ferry:spend-cap",
+  "ferry:audit-log:active"
+]);
+var SKIP_PHASE_ALIASES = Object.freeze({
+  refiner: "refiner",
+  dev: "dev",
+  review: "review",
+  iter: "iterate",
+  // alias from issue #239 — "iter" maps to the Iterator phase
+  iterate: "iterate"
+});
+function isKnownNonOverrideLabel(label) {
+  if (isBuiltinTypeLabel(label)) return true;
+  if (KNOWN_STATUS_LABELS.has(label)) return true;
+  if (label.startsWith("ferry:cost-estimate:")) return true;
+  if (label.startsWith(MCP_LABEL_PREFIX)) return true;
+  if (label.startsWith(PROFILE_LABEL_PREFIX)) return true;
+  return false;
+}
+function resolveTicketOverrides(labels, logger2, options) {
+  const typeOverrides = resolveTypeOverrides(labels);
+  let asLabel;
+  let asTypeValue;
+  for (const label of labels) {
+    if (!label.startsWith(AS_LABEL_PREFIX)) continue;
+    const suffix = label.slice(AS_LABEL_PREFIX.length);
+    const mapped = AS_TYPE_LABELS[suffix];
+    if (mapped === void 0) {
+      logger2?.warn("unknown suffix in ferry:as label", { label, suffix });
+      continue;
+    }
+    if (asTypeValue !== void 0 && asTypeValue !== mapped) {
+      throw new LabelConflictError(asLabel, label, "typeOverride");
+    }
+    if (asTypeValue === void 0) {
+      asTypeValue = mapped;
+      asLabel = label;
+    }
+  }
+  if (asTypeValue !== void 0) {
+    if (typeOverrides.typeOverride !== void 0 && typeOverrides.typeOverride !== asTypeValue) {
+      throw new LabelConflictError(typeOverrides.forceLabel, asLabel, "typeOverride");
+    }
+    typeOverrides.typeOverride = asTypeValue;
+    typeOverrides.forceLabel = asLabel;
+  }
+  const modelOverrides = {};
+  const modelSources = {};
+  const providerSources = {};
+  let blanketModel;
+  let blanketModelSource;
+  let blanketProvider;
+  let blanketProviderSource;
+  let budgetMaxCostLabel;
+  let budgetMaxTokensLabel;
+  let budgetMaxCostEur;
+  let budgetMaxTokens;
+  let budgetEurLabel;
+  let budgetEur;
+  let maxIterationsLabel;
+  let maxIterations;
+  let maxTokensLabel;
+  let maxTokens;
+  let thinkingLabel;
+  let thinking;
+  let reviewRubricLabel;
+  let reviewRubric;
+  let noPr = false;
+  let paused = false;
+  let noAutoTransition = false;
+  let dryRun = false;
+  let readOnly = false;
+  let hasClaudeCode = false;
+  let hasNoClaudeCode = false;
+  const skipPhases = [];
+  let baseBranchLabel;
+  let baseBranch;
+  let targetBranchLabel;
+  let targetBranch;
+  let prDraftLabel;
+  let prDraft;
+  for (const label of labels) {
+    if (!label.startsWith("ferry:")) continue;
+    if (isKnownNonOverrideLabel(label)) continue;
+    if (label.startsWith("ferry:model/")) {
+      const rest = label.slice("ferry:model/".length);
+      if (!rest) {
+        logger2?.warn("malformed ferry:model label (empty model name)", { label });
+        continue;
+      }
+      const slashIdx = rest.indexOf("/");
+      if (slashIdx < 0) {
+        if (blanketModelSource !== void 0) {
+          throw new LabelConflictError(blanketModelSource, label, "model");
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
+        continue;
+      }
+      const firstSegment = rest.slice(0, slashIdx);
+      const remainder = rest.slice(slashIdx + 1);
+      if (AGENT_PHASES.has(firstSegment)) {
+        const p = firstSegment;
+        if (!remainder) {
+          logger2?.warn("empty model-id in ferry:model label", { label });
+          continue;
+        }
+        if (modelSources[p] !== void 0) {
+          throw new LabelConflictError(modelSources[p], label, `model.${firstSegment}`);
+        }
+        modelSources[p] = label;
+        modelOverrides[p] = { ...modelOverrides[p], model: remainder };
+      } else {
+        if (blanketModelSource !== void 0) {
+          throw new LabelConflictError(blanketModelSource, label, "model");
+        }
+        blanketModel = rest;
+        blanketModelSource = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:provider/")) {
+      const parts = label.slice("ferry:provider/".length).split("/");
+      if (parts.length === 1) {
+        const provider2 = parts[0];
+        if (!LLM_PROVIDERS.has(provider2)) {
+          logger2?.warn("unknown provider in blanket ferry:provider label", { label, provider: provider2 });
+          continue;
+        }
+        if (blanketProviderSource !== void 0) {
+          throw new LabelConflictError(blanketProviderSource, label, "provider");
+        }
+        blanketProvider = provider2;
+        blanketProviderSource = label;
+        continue;
+      }
+      if (parts.length !== 2) {
+        logger2?.warn(
+          "malformed ferry:provider label (expected ferry:provider/<provider> or ferry:provider/<phase>/<provider>)",
+          { label }
+        );
+        continue;
+      }
+      const [phase, provider] = parts;
+      if (!AGENT_PHASES.has(phase)) {
+        logger2?.warn("unknown phase in ferry:provider label", { label, phase });
+        continue;
+      }
+      if (!LLM_PROVIDERS.has(provider)) {
+        logger2?.warn("unknown provider in ferry:provider label", { label, provider });
+        continue;
+      }
+      const p = phase;
+      if (providerSources[p] !== void 0) {
+        throw new LabelConflictError(providerSources[p], label, `provider.${phase}`);
+      }
+      providerSources[p] = label;
+      modelOverrides[p] = {
+        ...modelOverrides[p],
+        provider
+      };
+      continue;
+    }
+    if (label.startsWith("ferry:budget/")) {
+      const rest = label.slice("ferry:budget/".length);
+      if (rest.startsWith("max-cost/")) {
+        const raw = rest.slice("max-cost/".length);
+        const val2 = parsePositiveFloat(raw);
+        if (val2 === void 0) {
+          logger2?.warn("invalid cost value in ferry:budget/max-cost label", { label });
+          continue;
+        }
+        if (budgetMaxCostLabel !== void 0) {
+          throw new LabelConflictError(budgetMaxCostLabel, label, "budget.maxCostEurPerRun");
+        }
+        budgetMaxCostLabel = label;
+        budgetMaxCostEur = val2;
+        continue;
+      }
+      if (rest.startsWith("max-tokens/")) {
+        const raw = rest.slice("max-tokens/".length);
+        const val2 = parsePositiveInt(raw);
+        if (val2 === void 0) {
+          logger2?.warn("invalid token count in ferry:budget/max-tokens label", { label });
+          continue;
+        }
+        if (budgetMaxTokensLabel !== void 0) {
+          throw new LabelConflictError(budgetMaxTokensLabel, label, "budget.maxTokensPerRun");
+        }
+        budgetMaxTokensLabel = label;
+        budgetMaxTokens = val2;
+        continue;
+      }
+      const val = parsePositiveInt(rest);
+      if (val === void 0) {
+        logger2?.warn("invalid EUR value in ferry:budget label (expected positive integer)", {
+          label
+        });
+        continue;
+      }
+      if (budgetEurLabel !== void 0) {
+        throw new LabelConflictError(budgetEurLabel, label, "budgetEur");
+      }
+      budgetEurLabel = label;
+      budgetEur = val;
+      continue;
+    }
+    if (label.startsWith("ferry:max-iterations/")) {
+      const raw = label.slice("ferry:max-iterations/".length);
+      const val = parsePositiveInt(raw);
+      if (val === void 0) {
+        logger2?.warn("invalid count in ferry:max-iterations label", { label });
+        continue;
+      }
+      if (maxIterationsLabel !== void 0) {
+        throw new LabelConflictError(maxIterationsLabel, label, "maxIterations");
+      }
+      maxIterationsLabel = label;
+      maxIterations = val;
+      continue;
+    }
+    if (label.startsWith("ferry:max-tokens/")) {
+      const raw = label.slice("ferry:max-tokens/".length);
+      const val = parsePositiveInt(raw);
+      if (val === void 0) {
+        logger2?.warn("invalid count in ferry:max-tokens label", { label });
+        continue;
+      }
+      if (maxTokensLabel !== void 0) {
+        throw new LabelConflictError(maxTokensLabel, label, "maxTokens");
+      }
+      maxTokensLabel = label;
+      maxTokens = val;
+      continue;
+    }
+    if (label.startsWith("ferry:skip/")) {
+      const suffix = label.slice("ferry:skip/".length);
+      const phase = SKIP_PHASE_ALIASES[suffix];
+      if (phase === void 0) {
+        logger2?.warn("unknown phase in ferry:skip label", { label, phase: suffix });
+        continue;
+      }
+      if (phase === "review" && options?.allowSkipReview !== true) {
+        logger2?.warn(
+          "ferry:skip/review ignored \u2014 requires safety.allow_skip_review opt-in in ferry.config.yaml",
+          { label }
+        );
+        continue;
+      }
+      if (!skipPhases.includes(phase)) skipPhases.push(phase);
+      continue;
+    }
+    if (label === "ferry:no-auto-transition") {
+      noAutoTransition = true;
+      continue;
+    }
+    if (label.startsWith("ferry:thinking/")) {
+      const suffix = label.slice("ferry:thinking/".length);
+      let val;
+      if (suffix === "on") val = "on";
+      else if (suffix === "off") val = "off";
+      else if (suffix === "extended") val = "extended";
+      if (val === void 0) {
+        logger2?.warn("unknown suffix in ferry:thinking label", { label, suffix });
+        continue;
+      }
+      if (thinking !== void 0 && thinking !== val) {
+        throw new LabelConflictError(thinkingLabel, label, "thinking");
+      }
+      if (thinking === void 0) {
+        thinking = val;
+        thinkingLabel = label;
+      }
+      continue;
+    }
+    if (label === "ferry:strict-review" || label === "ferry:lenient-review") {
+      const val = label === "ferry:strict-review" ? "strict" : "lenient";
+      if (reviewRubric !== void 0 && reviewRubric !== val) {
+        throw new LabelConflictError(reviewRubricLabel, label, "reviewRubric");
+      }
+      if (reviewRubric === void 0) {
+        reviewRubric = val;
+        reviewRubricLabel = label;
+      }
+      continue;
+    }
+    if (label === "ferry:git/no-pr") {
+      noPr = true;
+      continue;
+    }
+    if (label.startsWith("ferry:base/")) {
+      const branch = label.slice("ferry:base/".length);
+      if (!BRANCH_NAME_REGEX.test(branch)) {
+        logger2?.warn("invalid branch name in ferry:base label (expected ^[a-zA-Z0-9._/-]+$)", {
+          label
+        });
+        continue;
+      }
+      if (baseBranch !== void 0 && baseBranch !== branch) {
+        throw new LabelConflictError(baseBranchLabel, label, "git.baseBranch");
+      }
+      if (baseBranch === void 0) {
+        baseBranch = branch;
+        baseBranchLabel = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:target/")) {
+      const branch = label.slice("ferry:target/".length);
+      if (!BRANCH_NAME_REGEX.test(branch)) {
+        logger2?.warn("invalid branch name in ferry:target label (expected ^[a-zA-Z0-9._/-]+$)", {
+          label
+        });
+        continue;
+      }
+      if (targetBranch !== void 0 && targetBranch !== branch) {
+        throw new LabelConflictError(targetBranchLabel, label, "git.targetBranch");
+      }
+      if (targetBranch === void 0) {
+        targetBranch = branch;
+        targetBranchLabel = label;
+      }
+      continue;
+    }
+    if (label.startsWith("ferry:pr/")) {
+      const suffix = label.slice("ferry:pr/".length);
+      let val;
+      if (suffix === "draft") val = true;
+      else if (suffix === "ready") val = false;
+      if (val === void 0) {
+        logger2?.warn("unknown suffix in ferry:pr label (expected draft or ready)", {
+          label,
+          suffix
+        });
+        continue;
+      }
+      if (prDraft !== void 0 && prDraft !== val) {
+        throw new LabelConflictError(prDraftLabel, label, "git.prDraft");
+      }
+      if (prDraft === void 0) {
+        prDraft = val;
+        prDraftLabel = label;
+      }
+      continue;
+    }
+    if (label === "ferry:paused") {
+      paused = true;
+      continue;
+    }
+    if (label === "ferry:dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (label === "ferry:read-only") {
+      readOnly = true;
+      continue;
+    }
+    if (label === "ferry:claude-code") {
+      hasClaudeCode = true;
+      continue;
+    }
+    if (label === "ferry:no-claude-code") {
+      hasNoClaudeCode = true;
+      continue;
+    }
+    logger2?.warn("unknown ferry override label ignored", { label });
+  }
+  const claudeCodePath = hasClaudeCode && !hasNoClaudeCode ? "claude-code" : hasClaudeCode || hasNoClaudeCode ? "script" : void 0;
+  if (blanketModel !== void 0) {
+    for (const phase of PHASES_ORDERED) {
+      if (modelSources[phase] === void 0) {
+        modelOverrides[phase] = { ...modelOverrides[phase], model: blanketModel };
+      }
+    }
+  }
+  if (blanketProvider !== void 0) {
+    for (const phase of PHASES_ORDERED) {
+      if (providerSources[phase] === void 0) {
+        modelOverrides[phase] = { ...modelOverrides[phase], provider: blanketProvider };
+      }
+    }
+  }
+  const hasModelOverrides = Object.keys(modelOverrides).length > 0;
+  const hasBudget = budgetMaxCostEur !== void 0 || budgetMaxTokens !== void 0;
+  const hasGit = noPr || baseBranch !== void 0 || targetBranch !== void 0 || prDraft !== void 0;
+  const gitOverride = hasGit ? {
+    ...noPr ? { noPr: true } : {},
+    ...baseBranch !== void 0 ? { baseBranch } : {},
+    ...targetBranch !== void 0 ? { targetBranch } : {},
+    ...prDraft !== void 0 ? { prDraft } : {}
+  } : void 0;
+  return {
+    ...typeOverrides,
+    ...hasModelOverrides ? { modelOverrides } : {},
+    ...hasBudget ? {
+      budget: {
+        ...budgetMaxCostEur !== void 0 ? { maxCostEurPerRun: budgetMaxCostEur } : {},
+        ...budgetMaxTokens !== void 0 ? { maxTokensPerRun: budgetMaxTokens } : {}
+      }
+    } : {},
+    ...budgetEur !== void 0 ? { budgetEur } : {},
+    ...maxIterations !== void 0 ? { maxIterations } : {},
+    ...maxTokens !== void 0 ? { maxTokens } : {},
+    ...skipPhases.length > 0 ? { skipPhases } : {},
+    ...noAutoTransition ? { noAutoTransition: true } : {},
+    ...thinking !== void 0 ? { thinking } : {},
+    ...reviewRubric !== void 0 ? { reviewRubric } : {},
+    ...gitOverride ? { git: gitOverride } : {},
+    ...paused ? { paused: true } : {},
+    ...dryRun ? { dryRun: true } : {},
+    ...readOnly ? { readOnly: true } : {},
+    ...claudeCodePath !== void 0 ? { claudeCodePath } : {}
+  };
+}
+
+// src/lib/cc-wrappers/contract.ts
+function markerRoleToken(role) {
+  return role === "developer" ? "dev" : role;
+}
+
+// src/lib/cc-wrappers/routing.ts
+var HEURISTIC_ROLES = /* @__PURE__ */ new Set(["developer", "iterator"]);
+function isAnthropicOnlyConfig(cfg) {
+  const m = cfg.models;
+  return m.refiner.provider === "anthropic" && m.dev.provider === "anthropic" && m.review.provider === "anthropic" && m.iterate.provider === "anthropic";
+}
+function resolveExecutionPath(input) {
+  if (input.configuredPath === "script") {
+    return { path: "script", reason: "default" };
+  }
+  if (input.labelOverride !== void 0) {
+    return { path: input.labelOverride, reason: "label" };
+  }
+  const defaultPath = input.configuredPath === "claude-code" || input.anthropicOnly ? "claude-code" : "script";
+  if (defaultPath === "script" && HEURISTIC_ROLES.has(input.role) && input.roundTripThreshold > 0 && input.priorRoundTrips >= input.roundTripThreshold) {
+    return { path: "claude-code", reason: "heuristic" };
+  }
+  return { path: defaultPath, reason: "default" };
+}
+function formatExecutionPathAudit(role, runId, decision) {
+  return `[ferry:${markerRoleToken(role)}:${runId}] execution-path: ${decision.path} (reason: ${decision.reason})`;
+}
+
+// src/lib/logger/index.ts
+function isDebugEnabled() {
+  return process.env.LOG_VERBOSITY === "debug";
+}
+function isPretty() {
+  return process.env.LOG_FORMAT === "pretty";
+}
+function buildRecord(level, correlationId, component, message, bindings, meta) {
+  return {
+    level,
+    ts: (/* @__PURE__ */ new Date()).toISOString(),
+    correlation_id: correlationId,
+    component,
+    message,
+    ...bindings,
+    ...meta
+  };
+}
+function writeRecord(record) {
+  if (isPretty()) {
+    const { level, ts, correlation_id, component, message, ...rest } = record;
+    const extras = Object.keys(rest).length > 0 ? `  ${JSON.stringify(rest)}` : "";
+    process.stderr.write(
+      `${ts}  ${level.toUpperCase().padEnd(5)}  [${component}]  ${correlation_id ? `(${correlation_id})  ` : ""}${message}${extras}
+`
+    );
+  } else {
+    process.stderr.write(JSON.stringify(record) + "\n");
+  }
+}
+function makeLogger(correlationId, component, bindings = {}, _writeRecord = writeRecord) {
+  function log(level, message, meta) {
+    if (level === "debug" && !isDebugEnabled()) return;
+    _writeRecord(buildRecord(level, correlationId, component, message, bindings, meta));
+  }
+  return {
+    debug: (msg, meta) => log("debug", msg, meta),
+    info: (msg, meta) => log("info", msg, meta),
+    warn: (msg, meta) => log("warn", msg, meta),
+    error: (msg, meta) => log("error", msg, meta),
+    child: (newBindings) => makeLogger(correlationId, component, { ...bindings, ...newBindings }, _writeRecord)
+  };
+}
+function createLogger(correlationId, component = "ferry") {
+  return makeLogger(correlationId, component);
+}
+
+// src/lib/dispatch/route-action.ts
+var VALID_ROLES = ["refiner", "developer", "reviewer", "iterator"];
+var logger = createLogger("", "ferry:route");
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    logger.error(`${name} is not set`);
+    process.exit(1);
+  }
+  return v;
+}
+function parseRole(raw) {
+  if (!raw || !VALID_ROLES.includes(raw)) {
+    logger.error("FERRY_AGENT_ROLE is invalid", {
+      valid: VALID_ROLES.join(", "),
+      got: raw ?? "(unset)"
+    });
+    process.exit(1);
+  }
+  return raw;
+}
+function writeOutput(name, value) {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (!outputFile) {
+    process.stdout.write(`${name}=${value}
+`);
+    return;
+  }
+  appendFileSync(outputFile, `${name}=${value}
+`);
+}
+async function runRouteAction() {
+  const raw = requireEnv("FERRY_ENVELOPE_PAYLOAD");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    logger.error("FERRY_ENVELOPE_PAYLOAD is not valid JSON");
+    process.exit(1);
+  }
+  const envelope = validateEnvelope(parsed);
+  const role = parseRole(process.env.FERRY_AGENT_ROLE);
+  const config = loadFerryConfig(process.cwd());
+  const jiraBaseUrl = requireEnv("FERRY_JIRA_BASE_URL");
+  const jiraEmail = requireEnv("FERRY_JIRA_EMAIL");
+  const jiraApiToken = requireEnv("FERRY_JIRA_API_TOKEN");
+  const jira = new JiraRestClient(jiraBaseUrl, jiraEmail, jiraApiToken);
+  const issue = await jira.getIssue(envelope.ticket_key);
+  const overrides = resolveTicketOverrides(issue.fields.labels ?? [], logger, {
+    allowSkipReview: config.safety?.allow_skip_review === true
+  });
+  const decision = resolveExecutionPath({
+    configuredPath: config.execution_path,
+    anthropicOnly: isAnthropicOnlyConfig(config),
+    labelOverride: overrides.claudeCodePath,
+    role,
+    // #FOLLOW-UP: derive priorRoundTrips from the audit issue's `[ferry:iterator:*]
+    // complete. Pushed fixes to PR#…` markers (same source `countPriorIterations`
+    // uses in src/agents/reviewer/changes-guard.ts). Stubbed to 0 here so the
+    // heuristic-escalation branch never fires until that loader lands.
+    priorRoundTrips: 0,
+    roundTripThreshold: config.routing.claude_code_round_trip_threshold
+  });
+  writeOutput("path", decision.path);
+  writeOutput("reason", decision.reason);
+  process.stdout.write(`${formatExecutionPathAudit(role, envelope.event_id, decision)}
+`);
+  return decision;
+}
+var invokedDirectly = typeof process !== "undefined" && process.argv[1]?.endsWith("route-action.js");
+if (invokedDirectly) {
+  void runRouteAction().catch((err) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`ferry-route: ${msg}
+`);
+    process.exit(1);
+  });
+}
+export {
+  runRouteAction
+};

--- a/.github/actions/ferry-route/schemas/event.v1.schema.json
+++ b/.github/actions/ferry-route/schemas/event.v1.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ferry.dev/schemas/event.v1.json",
+  "type": "object",
+  "required": ["version", "event_id", "ticket_key", "phase", "source", "ts"],
+  "properties": {
+    "version": { "const": "v1" },
+    "event_id": { "type": "string", "minLength": 4, "maxLength": 100, "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
+    "ticket_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+-\\d+$" },
+    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile"] },
+    "source": {
+      "enum": ["jira-column", "jira-label", "jira-mention", "reconciler"]
+    },
+    "instructions": { "type": "string" },
+    "ticket_type": { "enum": ["Story", "Task", "Bug", "Spike"] },
+    "issue_type": { "type": "string" },
+    "ts": { "type": "string", "minLength": 1 }
+  },
+  "additionalProperties": false
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Ferry uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Routing decision wired into consumer workflows** (first half of the claude-code path activation, ADR-0006 §3, follow-up to #300/#302). The four agent workflows in `examples/consumer-setup/workflows/` now run a `route` job before the agent: it calls a new `big-emotion/ferry/.github/actions/ferry-route` composite (entry point `src/lib/dispatch/route-action.ts`), which wraps the existing pure `resolveExecutionPath` resolver, fetches the ticket's Jira labels, loads `ferry.config`, and exposes a `path` output (`script` | `claude-code`) + a `reason` output. Each agent job is now split into `run-agent` (gated `if: path == 'script'`) and a `run-agent-claude-code` placeholder (gated `if: path == 'claude-code'`) that fails loudly with a clear error — actual `anthropics/claude-code-action@v1` invocation lands in a follow-up PR. Heuristic-driven escalation (`priorRoundTrips`) is intentionally stubbed to 0 in this version; label + config-driven routing land first. `src/cli/init/templates.ts` is **not** mirrored in this change (follow-up): consumers using `ferry-init`-generated workflows still get the pre-route shape until that lands.
+
 ---
 
 ## [0.12.0] — 2026-05-20

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -53,6 +53,13 @@ If there are no consumer-visible changes, omit the section (or note `(none — i
 
 ---
 
+## v0.12.x → v0.13.0
+
+- **(action)** **New `ferry-route` job** introduced ahead of every agent run in the four consumer workflows (`ferry-refine.yml`, `ferry-dev.yml`, `ferry-review.yml`, `ferry-iterate.yml`). It calls `big-emotion/ferry/.github/actions/ferry-route` and exposes a `path` output (`script` | `claude-code`) consumed by an `if:` on the agent jobs. Consumers using the bundled `examples/consumer-setup/workflows/` stubs pick this up automatically via `ferry-update` once `src/cli/init/templates.ts` is mirrored (tracked in the follow-up PR for the templates). Until then, copy the four workflow stubs from `examples/consumer-setup/workflows/` by hand if you want the routing decision wired. The routing-only PR is safe to ignore — without the four workflows updated, every run stays on the script path (the existing behaviour).
+- **(info)** A `run-agent-claude-code` placeholder job is added alongside `run-agent` in each workflow. It is gated by `if: needs.route.outputs.path == 'claude-code'` and **fails loudly** with a clear error if reached. The actual `anthropics/claude-code-action@v1` invocation lands in a follow-up PR. If you want to opt into the claude-code path before that PR ships, leave `execution_path` unset in `ferry.config.yaml` and remove any `ferry:claude-code` labels — Ferry stays on the script path by default for mixed-provider configs.
+
+---
+
 ## v0.10.x → v0.11.0
 
 - **(info)** **GitLab support added behind an `FERRY_FORGE=gitlab` flag — experimental.** GitHub users are not affected; the default forge remains GitHub Actions. The GitLab adapter is shipped under [#210](https://github.com/big-emotion/ferry/issues/210) with templates in `examples/consumer-setup-gitlab/`. The experimental flag is expected to drop once a real consumer has run a full Refiner→Developer→Reviewer→Iterator cycle in production for two weeks. Until then, the bundled artifact may break across minor releases. See the promotion checklist on #210.

--- a/examples/consumer-setup/workflows/ferry-dev.yml
+++ b/examples/consumer-setup/workflows/ferry-dev.yml
@@ -5,6 +5,8 @@
 #                   ANTHROPIC_API_KEY    — required when FERRY_DEV_PROVIDER=anthropic (default)
 #                   OPENAI_API_KEY       — required when FERRY_DEV_PROVIDER=openai
 #                   GOOGLE_API_KEY       — required when FERRY_DEV_PROVIDER=google
+#                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
+#                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path).
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_DEV_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
 #                     FERRY_DEV_PROVIDER (default: anthropic; also: openai, google)
@@ -47,9 +49,32 @@ jobs:
         with:
           payload: ${{ toJson(github.event.client_payload) }}
 
-  run-agent:
-    name: Run Developer agent
+  route:
+    name: Resolve execution path
     needs: [gate-envelope]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      path: ${{ steps.route.outputs.path }}
+      reason: ${{ steps.route.outputs.reason }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve execution path
+        id: route
+        uses: big-emotion/ferry/.github/actions/ferry-route@v0.12.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          role: developer
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+
+  run-agent:
+    name: Run Developer agent (script path)
+    needs: [route]
+    if: needs.route.outputs.path == 'script'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -96,10 +121,35 @@ jobs:
           # pre_agent_timeout_minutes: '3'
           # post_agent_command: ''  # uncomment to run cleanup after the agent
 
+  run-agent-claude-code:
+    name: Run Developer agent (claude-code path)
+    needs: [route]
+    if: needs.route.outputs.path == 'claude-code'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      # Placeholder: the claude-code-action wiring lands in a follow-up PR. The
+      # routing decision is fully implemented (this branch will be selected for
+      # `ferry:claude-code` / `execution_path: claude-code`), but the action
+      # invocation itself + the front-half loader (envelope/config/Jira/MCP)
+      # are out of scope for this change. Failing loud avoids silent skips.
+      - name: claude-code execution path not yet wired
+        shell: bash
+        run: |
+          echo "::error::Ferry routing resolved this run to the claude-code-action path," \
+            "but the claude-code execution branch is not yet wired in this Ferry release." \
+            "Set execution_path: script in ferry.config.yaml (or remove the ferry:claude-code" \
+            "label on the ticket) to use the bundled-script path. Tracked as a follow-up to" \
+            "the routing-only PR."
+          exit 1
+
   emit-audit:
     name: Emit audit line
-    needs: [run-agent]
-    if: needs.run-agent.result != 'skipped'
+    needs: [run-agent, run-agent-claude-code]
+    if: always() && (needs.run-agent.result == 'success' || needs.run-agent-claude-code.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -114,7 +164,7 @@ jobs:
           phase: dev
           run_id: ${{ github.event.client_payload.event_id }}
           model: ${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-4-6' }}
-          outcome: ${{ needs.run-agent.result }}
+          outcome: ${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
           input_tokens: ${{ needs.run-agent.outputs.input_tokens || '0' }}
           output_tokens: ${{ needs.run-agent.outputs.output_tokens || '0' }}
           cost_eur: ${{ needs.run-agent.outputs.cost_eur || '0' }}

--- a/examples/consumer-setup/workflows/ferry-iterate.yml
+++ b/examples/consumer-setup/workflows/ferry-iterate.yml
@@ -5,6 +5,8 @@
 #                   ANTHROPIC_API_KEY    — required when FERRY_ITER_PROVIDER=anthropic (default)
 #                   OPENAI_API_KEY       — required when FERRY_ITER_PROVIDER=openai
 #                   GOOGLE_API_KEY       — required when FERRY_ITER_PROVIDER=google
+#                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
+#                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path).
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_ITER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
 #                     FERRY_ITER_PROVIDER (default: anthropic; also: openai, google)
@@ -47,9 +49,32 @@ jobs:
         with:
           payload: ${{ toJson(github.event.client_payload) }}
 
-  run-agent:
-    name: Run Iterator agent
+  route:
+    name: Resolve execution path
     needs: [gate-envelope]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      path: ${{ steps.route.outputs.path }}
+      reason: ${{ steps.route.outputs.reason }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve execution path
+        id: route
+        uses: big-emotion/ferry/.github/actions/ferry-route@v0.12.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          role: iterator
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+
+  run-agent:
+    name: Run Iterator agent (script path)
+    needs: [route]
+    if: needs.route.outputs.path == 'script'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -99,10 +124,30 @@ jobs:
           # pre_agent_timeout_minutes: '3'
           # post_agent_command: ''  # uncomment to run cleanup after the agent
 
+  run-agent-claude-code:
+    name: Run Iterator agent (claude-code path)
+    needs: [route]
+    if: needs.route.outputs.path == 'claude-code'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      # Placeholder: the claude-code-action wiring lands in a follow-up PR.
+      - name: claude-code execution path not yet wired
+        shell: bash
+        run: |
+          echo "::error::Ferry routing resolved this run to the claude-code-action path," \
+            "but the claude-code execution branch is not yet wired in this Ferry release." \
+            "Set execution_path: script in ferry.config.yaml (or remove the ferry:claude-code" \
+            "label on the ticket) to use the bundled-script path."
+          exit 1
+
   emit-audit:
     name: Emit audit line
-    needs: [run-agent]
-    if: needs.run-agent.result != 'skipped'
+    needs: [run-agent, run-agent-claude-code]
+    if: always() && (needs.run-agent.result == 'success' || needs.run-agent-claude-code.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -117,7 +162,7 @@ jobs:
           phase: iterate
           run_id: ${{ github.event.client_payload.event_id }}
           model: ${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
-          outcome: ${{ needs.run-agent.result }}
+          outcome: ${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
           input_tokens: ${{ needs.run-agent.outputs.input_tokens || '0' }}
           output_tokens: ${{ needs.run-agent.outputs.output_tokens || '0' }}
           cost_eur: ${{ needs.run-agent.outputs.cost_eur || '0' }}

--- a/examples/consumer-setup/workflows/ferry-refine.yml
+++ b/examples/consumer-setup/workflows/ferry-refine.yml
@@ -4,6 +4,8 @@
 #                   ANTHROPIC_API_KEY    — required when FERRY_REFINER_PROVIDER=anthropic (default)
 #                   OPENAI_API_KEY       — required when FERRY_REFINER_PROVIDER=openai
 #                   GOOGLE_API_KEY       — required when FERRY_REFINER_PROVIDER=google
+#                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
+#                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path).
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_REFINER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
 #                     FERRY_REFINER_PROVIDER (default: anthropic; also: openai, google)
@@ -41,9 +43,32 @@ jobs:
         with:
           payload: ${{ toJson(github.event.client_payload) }}
 
-  run-agent:
-    name: Run Refiner agent
+  route:
+    name: Resolve execution path
     needs: [gate-envelope]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      path: ${{ steps.route.outputs.path }}
+      reason: ${{ steps.route.outputs.reason }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve execution path
+        id: route
+        uses: big-emotion/ferry/.github/actions/ferry-route@v0.12.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          role: refiner
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+
+  run-agent:
+    name: Run Refiner agent (script path)
+    needs: [route]
+    if: needs.route.outputs.path == 'script'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -79,10 +104,30 @@ jobs:
           # pre_agent_timeout_minutes: '3'
           # post_agent_command: ''  # uncomment to run cleanup after the agent
 
+  run-agent-claude-code:
+    name: Run Refiner agent (claude-code path)
+    needs: [route]
+    if: needs.route.outputs.path == 'claude-code'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      # Placeholder: the claude-code-action wiring lands in a follow-up PR.
+      # The routing decision is fully implemented; only the action invocation
+      # and front-half loader (envelope/config/Jira/MCP) are out of scope here.
+      - name: claude-code execution path not yet wired
+        shell: bash
+        run: |
+          echo "::error::Ferry routing resolved this run to the claude-code-action path," \
+            "but the claude-code execution branch is not yet wired in this Ferry release." \
+            "Set execution_path: script in ferry.config.yaml (or remove the ferry:claude-code" \
+            "label on the ticket) to use the bundled-script path."
+          exit 1
+
   emit-audit:
     name: Emit audit line
-    needs: [run-agent]
-    if: needs.run-agent.result != 'skipped'
+    needs: [run-agent, run-agent-claude-code]
+    if: always() && (needs.run-agent.result == 'success' || needs.run-agent-claude-code.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -97,7 +142,7 @@ jobs:
           phase: refine
           run_id: ${{ github.event.client_payload.event_id }}
           model: ${{ vars.FERRY_REFINER_MODEL || 'claude-sonnet-4-6' }}
-          outcome: ${{ needs.run-agent.result }}
+          outcome: ${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
           start_ms: ${{ github.run_id }}
           audit_issue: ${{ vars.FERRY_AUDIT_ISSUE }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/consumer-setup/workflows/ferry-review.yml
+++ b/examples/consumer-setup/workflows/ferry-review.yml
@@ -5,6 +5,8 @@
 #                   ANTHROPIC_API_KEY    — required when FERRY_REVIEW_PROVIDER=anthropic (default)
 #                   OPENAI_API_KEY       — required when FERRY_REVIEW_PROVIDER=openai
 #                   GOOGLE_API_KEY       — required when FERRY_REVIEW_PROVIDER=google
+#                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
+#                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path).
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_REVIEW_MODEL (default: claude-sonnet-4-6)
 #                     FERRY_REVIEW_PROVIDER (default: anthropic; also: openai, google)
@@ -45,9 +47,32 @@ jobs:
         with:
           payload: ${{ toJson(github.event.client_payload) }}
 
-  run-agent:
-    name: Run Reviewer agent
+  route:
+    name: Resolve execution path
     needs: [gate-envelope]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      path: ${{ steps.route.outputs.path }}
+      reason: ${{ steps.route.outputs.reason }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve execution path
+        id: route
+        uses: big-emotion/ferry/.github/actions/ferry-route@v0.12.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          role: reviewer
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+
+  run-agent:
+    name: Run Reviewer agent (script path)
+    needs: [route]
+    if: needs.route.outputs.path == 'script'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -94,10 +119,31 @@ jobs:
           # pre_agent_timeout_minutes: '3'
           # post_agent_command: ''  # uncomment to run cleanup after the agent
 
+  run-agent-claude-code:
+    name: Run Reviewer agent (claude-code path)
+    needs: [route]
+    if: needs.route.outputs.path == 'claude-code'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      checks: read
+    steps:
+      # Placeholder: the claude-code-action wiring lands in a follow-up PR.
+      - name: claude-code execution path not yet wired
+        shell: bash
+        run: |
+          echo "::error::Ferry routing resolved this run to the claude-code-action path," \
+            "but the claude-code execution branch is not yet wired in this Ferry release." \
+            "Set execution_path: script in ferry.config.yaml (or remove the ferry:claude-code" \
+            "label on the ticket) to use the bundled-script path."
+          exit 1
+
   emit-audit:
     name: Emit audit line
-    needs: [run-agent]
-    if: needs.run-agent.result != 'skipped'
+    needs: [run-agent, run-agent-claude-code]
+    if: always() && (needs.run-agent.result == 'success' || needs.run-agent-claude-code.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -112,7 +158,7 @@ jobs:
           phase: review
           run_id: ${{ github.event.client_payload.event_id }}
           model: ${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
-          outcome: ${{ needs.run-agent.result }}
+          outcome: ${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
           input_tokens: ${{ needs.run-agent.outputs.input_tokens || '0' }}
           output_tokens: ${{ needs.run-agent.outputs.output_tokens || '0' }}
           cost_eur: ${{ needs.run-agent.outputs.cost_eur || '0' }}

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "smoke:bundle": "bash scripts/smoke-bundle.sh",
     "check:fr-drift": "bash scripts/check-fr-drift.sh",
     "prepare": "husky",
-    "version": "npm run build:ferry && git add -f .ferry/ && git add .github/actions/ferry-envelope-validate/ .github/actions/ferry-emit-audit/ .github/actions/ferry-run-refiner/ .github/actions/ferry-run-developer/ .github/actions/ferry-run-reviewer/ .github/actions/ferry-run-iterator/"
+    "version": "npm run build:ferry && git add -f .ferry/ && git add .github/actions/ferry-envelope-validate/ .github/actions/ferry-emit-audit/ .github/actions/ferry-route/ .github/actions/ferry-run-refiner/ .github/actions/ferry-run-developer/ .github/actions/ferry-run-reviewer/ .github/actions/ferry-run-iterator/"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/scripts/build-ferry-actions.mjs
+++ b/scripts/build-ferry-actions.mjs
@@ -50,6 +50,11 @@ await Promise.all([
   }),
   build({
     ...shared,
+    entryPoints: ['src/lib/dispatch/route-action.ts'],
+    outfile: '.ferry/route-action.js',
+  }),
+  build({
+    ...shared,
     entryPoints: ['src/cli/agent/run.ts'],
     outfile: '.ferry/agent.js',
   }),
@@ -62,6 +67,7 @@ copyFileSync('src/schemas/event.v1.schema.json', '.ferry/schemas/event.v1.schema
 for (const f of [
   'validate-action.js',
   'skip-task-type-action.js',
+  'route-action.js',
   'agent.js',
 ]) {
   const p = `.ferry/${f}`;
@@ -131,6 +137,33 @@ writeFileSync(
   ) + '\n',
 );
 execSync('npm install --prefer-offline', { cwd: validateActionDir, stdio: 'inherit' });
+
+const routeActionDir = '.github/actions/ferry-route';
+mkdirSync(`${routeActionDir}/schemas`, { recursive: true });
+copyFileSync('.ferry/route-action.js', `${routeActionDir}/route-action.js`);
+copyFileSync(
+  'src/schemas/event.v1.schema.json',
+  `${routeActionDir}/schemas/event.v1.schema.json`,
+);
+writeFileSync(
+  `${routeActionDir}/package.json`,
+  JSON.stringify(
+    {
+      name: 'ferry-route-action',
+      version: '0.0.0',
+      private: true,
+      type: 'module',
+      dependencies: {
+        ajv: rootDeps['ajv'],
+        'ajv-formats': rootDeps['ajv-formats'],
+        yaml: '^2.6.0',
+      },
+    },
+    null,
+    2,
+  ) + '\n',
+);
+execSync('npm install --prefer-offline', { cwd: routeActionDir, stdio: 'inherit' });
 
 const emitAuditActionDir = '.github/actions/ferry-emit-audit';
 copyFileSync('.ferry/emit-audit-action.js', `${emitAuditActionDir}/emit-audit-action.js`);

--- a/src/labels/allowlist.ts
+++ b/src/labels/allowlist.ts
@@ -81,4 +81,5 @@ export const LABELS_ALLOWLIST = [
   'ferry:dev-loop',
   'ferry:review-loop',
   'ferry:tool-loop',
+  'ferry:route',
 ] as const;

--- a/src/lib/dispatch/route-action.test.ts
+++ b/src/lib/dispatch/route-action.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { runRouteAction } from './route-action.js';
+
+/**
+ * Routing-CLI integration tests (ADR-0006 §3, issue #300).
+ *
+ * Exercises the env/IO shell around the pure `resolveExecutionPath` resolver:
+ * envelope parsing, Jira label fetch (mocked), ferry.config loading (real, from
+ * a tmpdir), and GITHUB_OUTPUT writes. The pure resolver itself is unit-tested
+ * separately in src/lib/cc-wrappers/routing.test.ts — here we only assert that
+ * the right inputs reach it and the right outputs land.
+ */
+
+const ENVELOPE = {
+  version: 'v1' as const,
+  event_id: '01HZZZZZZZZZZZZZZZZZZZZZZ1',
+  ticket_key: 'TEST-1',
+  phase: 'dev' as const,
+  source: 'jira-column' as const,
+  ts: '2026-05-20T00:00:00.000Z',
+};
+
+function makeMockResponse(status: number, body?: unknown): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: () => Promise.resolve(body ?? {}),
+  } as unknown as Response;
+}
+
+function jiraIssueWith(labels: string[]): unknown {
+  return {
+    id: '10001',
+    key: ENVELOPE.ticket_key,
+    fields: {
+      summary: 'test',
+      description: null,
+      comment: { comments: [] },
+      labels,
+      issuetype: { name: 'Story' },
+    },
+  };
+}
+
+function withTempRepo(configYaml: string | null): {
+  cwd: string;
+  outputFile: string;
+  cleanup: () => void;
+} {
+  const cwd = mkdtempSync(join(tmpdir(), 'ferry-route-test-'));
+  if (configYaml !== null) {
+    writeFileSync(join(cwd, 'ferry.config.yaml'), configYaml, 'utf8');
+  }
+  // The .github dir needs to exist for some loaders that probe for it.
+  mkdirSync(join(cwd, '.github'), { recursive: true });
+  const outputFile = join(cwd, 'gh-output');
+  writeFileSync(outputFile, '', 'utf8');
+  return {
+    cwd,
+    outputFile,
+    cleanup: () => rmSync(cwd, { recursive: true, force: true }),
+  };
+}
+
+function setEnv(overrides: Record<string, string>): void {
+  for (const [k, v] of Object.entries(overrides)) {
+    vi.stubEnv(k, v);
+  }
+}
+
+const BASE_ENV = {
+  FERRY_ENVELOPE_PAYLOAD: JSON.stringify(ENVELOPE),
+  FERRY_AGENT_ROLE: 'developer',
+  FERRY_JIRA_BASE_URL: 'https://acme.atlassian.net',
+  FERRY_JIRA_EMAIL: 'bot@acme.com',
+  FERRY_JIRA_API_TOKEN: 'token',
+};
+
+describe('route-action: resolves and emits execution path', () => {
+  let originalCwd: string;
+  let tmp: ReturnType<typeof withTempRepo>;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    if (tmp) tmp.cleanup();
+  });
+
+  it('emits path=claude-code when label `ferry:claude-code` is present', async () => {
+    tmp = withTempRepo(null); // No config → defaults; the heuristic + default produce script-like behaviour.
+    process.chdir(tmp.cwd);
+    setEnv({ ...BASE_ENV, GITHUB_OUTPUT: tmp.outputFile });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(makeMockResponse(200, jiraIssueWith(['ferry:claude-code']))),
+    );
+
+    const decision = await runRouteAction();
+
+    expect(decision.path).toBe('claude-code');
+    expect(decision.reason).toBe('label');
+  });
+
+  it('emits path=script when label `ferry:no-claude-code` is present', async () => {
+    tmp = withTempRepo(null);
+    process.chdir(tmp.cwd);
+    setEnv({ ...BASE_ENV, GITHUB_OUTPUT: tmp.outputFile });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(makeMockResponse(200, jiraIssueWith(['ferry:no-claude-code']))),
+    );
+
+    const decision = await runRouteAction();
+
+    expect(decision.path).toBe('script');
+    expect(decision.reason).toBe('label');
+  });
+
+  it('emits path=script (hard lock) when ferry.config has execution_path: script, regardless of label', async () => {
+    tmp = withTempRepo('execution_path: script\n');
+    process.chdir(tmp.cwd);
+    setEnv({ ...BASE_ENV, GITHUB_OUTPUT: tmp.outputFile });
+    vi.stubGlobal(
+      'fetch',
+      // Even with the claude-code label, the explicit script lock wins.
+      vi.fn().mockResolvedValue(makeMockResponse(200, jiraIssueWith(['ferry:claude-code']))),
+    );
+
+    const decision = await runRouteAction();
+
+    expect(decision.path).toBe('script');
+    expect(decision.reason).toBe('default');
+  });
+
+  it('defaults to claude-code for an Anthropic-only config with no label override', async () => {
+    tmp = withTempRepo(
+      // Default config is already Anthropic-only (claude-sonnet for every agent),
+      // so an empty config yields the claude-code conditional default.
+      '',
+    );
+    process.chdir(tmp.cwd);
+    setEnv({ ...BASE_ENV, GITHUB_OUTPUT: tmp.outputFile });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeMockResponse(200, jiraIssueWith([]))));
+
+    const decision = await runRouteAction();
+
+    expect(decision.path).toBe('claude-code');
+    expect(decision.reason).toBe('default');
+  });
+
+  it('writes both `path` and `reason` to $GITHUB_OUTPUT in the `name=value\\n` form', async () => {
+    tmp = withTempRepo(null);
+    process.chdir(tmp.cwd);
+    setEnv({ ...BASE_ENV, GITHUB_OUTPUT: tmp.outputFile });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(makeMockResponse(200, jiraIssueWith(['ferry:claude-code']))),
+    );
+
+    await runRouteAction();
+
+    const { readFileSync } = await import('node:fs');
+    const out = readFileSync(tmp.outputFile, 'utf8');
+    expect(out).toContain('path=claude-code\n');
+    expect(out).toContain('reason=label\n');
+  });
+});

--- a/src/lib/dispatch/route-action.ts
+++ b/src/lib/dispatch/route-action.ts
@@ -1,0 +1,139 @@
+/**
+ * Execution-path routing bundled action (ADR-0006 §3, issue #300).
+ *
+ * Pre-dispatch step that decides whether the agent run takes the bundled-script
+ * path or the `claude-code-action` path, then exposes the decision to the
+ * wrapping workflow via `$GITHUB_OUTPUT`. The decision is computed by the pure
+ * `resolveExecutionPath` resolver — this file is the env/IO shell around it.
+ *
+ * Inputs (env):
+ *   - FERRY_ENVELOPE_PAYLOAD   JSON envelope from repository_dispatch
+ *   - FERRY_AGENT_ROLE         refiner | developer | reviewer | iterator
+ *   - FERRY_JIRA_BASE_URL      Jira base URL
+ *   - FERRY_JIRA_EMAIL         Jira account email
+ *   - FERRY_JIRA_API_TOKEN     Jira API token
+ *   - GITHUB_OUTPUT            GitHub Actions output file (set by the runner)
+ *
+ * Outputs (written to GITHUB_OUTPUT):
+ *   - path     'script' | 'claude-code'
+ *   - reason   'default' | 'label' | 'heuristic'
+ *
+ * Heuristic-driven escalation is intentionally **disabled in this version**
+ * (`priorRoundTrips` is stubbed to 0): label + config-driven routing land first
+ * so the architecture can be reviewed independently of the audit-log loader.
+ * The heuristic plug-in point is documented inline; #FOLLOW-UP wires it.
+ */
+import { appendFileSync } from 'node:fs';
+
+import { validateEnvelope } from '../envelope/validate.js';
+import { JiraRestClient } from '../io/jira-rest.js';
+import { loadFerryConfig } from '../config.js';
+import { resolveTicketOverrides } from '../labels/overrides.js';
+import {
+  resolveExecutionPath,
+  isAnthropicOnlyConfig,
+  formatExecutionPathAudit,
+  type ExecutionPathDecision,
+} from '../cc-wrappers/routing.js';
+import { createLogger } from '../logger/index.js';
+import type { AgentOutputRole } from '../cc-wrappers/agent-output.js';
+
+const VALID_ROLES = ['refiner', 'developer', 'reviewer', 'iterator'] as const;
+
+const logger = createLogger('', 'ferry:route');
+
+function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) {
+    logger.error(`${name} is not set`);
+    process.exit(1);
+  }
+  return v;
+}
+
+function parseRole(raw: string | undefined): AgentOutputRole {
+  if (!raw || !(VALID_ROLES as readonly string[]).includes(raw)) {
+    logger.error('FERRY_AGENT_ROLE is invalid', {
+      valid: VALID_ROLES.join(', '),
+      got: raw ?? '(unset)',
+    });
+    process.exit(1);
+  }
+  return raw as AgentOutputRole;
+}
+
+function writeOutput(name: string, value: string): void {
+  const outputFile = process.env.GITHUB_OUTPUT;
+  if (!outputFile) {
+    // Local invocation (tests, manual): fall through to stdout for visibility.
+    process.stdout.write(`${name}=${value}\n`);
+    return;
+  }
+  // GitHub Actions output file format: one `name=value` per line. Single-line
+  // values only — `path` and `reason` are always single tokens, so no need for
+  // the heredoc form.
+  appendFileSync(outputFile, `${name}=${value}\n`);
+}
+
+export async function runRouteAction(): Promise<ExecutionPathDecision> {
+  const raw = requireEnv('FERRY_ENVELOPE_PAYLOAD');
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    logger.error('FERRY_ENVELOPE_PAYLOAD is not valid JSON');
+    process.exit(1);
+  }
+  const envelope = validateEnvelope(parsed);
+  const role = parseRole(process.env.FERRY_AGENT_ROLE);
+
+  // Ferry config from the consumer repo workspace. The composite action
+  // requires the consumer to actions/checkout@v4 before invoking us, same as
+  // every other ferry-run-* composite.
+  const config = loadFerryConfig(process.cwd());
+
+  // Per-ticket label override. Jira fetch is the only network IO this action
+  // performs; the GitHub side (audit comments → priorRoundTrips) is the
+  // documented follow-up.
+  const jiraBaseUrl = requireEnv('FERRY_JIRA_BASE_URL');
+  const jiraEmail = requireEnv('FERRY_JIRA_EMAIL');
+  const jiraApiToken = requireEnv('FERRY_JIRA_API_TOKEN');
+  const jira = new JiraRestClient(jiraBaseUrl, jiraEmail, jiraApiToken);
+  const issue = await jira.getIssue(envelope.ticket_key);
+  const overrides = resolveTicketOverrides(issue.fields.labels ?? [], logger, {
+    allowSkipReview: config.safety?.allow_skip_review === true,
+  });
+
+  const decision = resolveExecutionPath({
+    configuredPath: config.execution_path,
+    anthropicOnly: isAnthropicOnlyConfig(config),
+    labelOverride: overrides.claudeCodePath,
+    role,
+    // #FOLLOW-UP: derive priorRoundTrips from the audit issue's `[ferry:iterator:*]
+    // complete. Pushed fixes to PR#…` markers (same source `countPriorIterations`
+    // uses in src/agents/reviewer/changes-guard.ts). Stubbed to 0 here so the
+    // heuristic-escalation branch never fires until that loader lands.
+    priorRoundTrips: 0,
+    roundTripThreshold: config.routing.claude_code_round_trip_threshold,
+  });
+
+  writeOutput('path', decision.path);
+  writeOutput('reason', decision.reason);
+
+  // Audit-comment line for the Reconciler (ADR-0004). Written to stdout; the
+  // consumer workflow may pipe this into the audit issue via ferry-emit-audit.
+  process.stdout.write(`${formatExecutionPathAudit(role, envelope.event_id, decision)}\n`);
+
+  return decision;
+}
+
+// Auto-invoke when this module is the process entrypoint.
+const invokedDirectly =
+  typeof process !== 'undefined' && process.argv[1]?.endsWith('route-action.js');
+if (invokedDirectly) {
+  void runRouteAction().catch((err: unknown) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`ferry-route: ${msg}\n`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Why this PR

The v0.12.0 changelog claims *"agents can now run inside `anthropics/claude-code-action@v1`"*, but inspecting the code reveals that **`resolveExecutionPath` and `buildClaudeCodeJob` have zero callers in `src/agents/**` or in any `.github/actions/*/action.yml`** — the entire claude-code path is plumbing without a workflow hook. Every Ferry run on consumers stays on the script path regardless of `execution_path` config or `ferry:claude-code` labels.

This PR ships **the first half** of activating that path: a deterministic routing decision wired into all four consumer workflows.

## What lands

### New surface

| File | Purpose |
|------|---------|
| `src/lib/dispatch/route-action.ts` | Env/IO shell around the existing pure `resolveExecutionPath` resolver. Reads envelope + role from env, loads `ferry.config`, fetches Jira labels, runs `resolveTicketOverrides`, writes `path` and `reason` to `$GITHUB_OUTPUT`. |
| `.github/actions/ferry-route/` | New composite action. Mirrors the layout of `ferry-envelope-validate`. Inputs: `payload`, `role`, `jira_*`. Outputs: `path` (`script` \| `claude-code`), `reason` (`default` \| `label` \| `heuristic`). |
| `src/lib/dispatch/route-action.test.ts` | 5 integration tests covering every decision branch (explicit `script` lock, `ferry:claude-code` label, `ferry:no-claude-code` label, anthropic-only default, `$GITHUB_OUTPUT` format). |

### Workflow refactor (job-level fork per ADR-0002 §wiring)

`examples/consumer-setup/workflows/{ferry-refine,ferry-dev,ferry-review,ferry-iterate}.yml`:

```
gate-envelope → route → ┬─ run-agent              (if path == 'script')
                        └─ run-agent-claude-code  (if path == 'claude-code')
                                                   ↓
                              emit-audit
```

The `run-agent-claude-code` job is a **placeholder that fails loudly** with a clear error so any ticket forced onto the claude-code path before the follow-up PR ships does not silently no-op.

### Build / supporting

- `scripts/build-ferry-actions.mjs` — bundles `route-action.ts` and copies it (+ event schema + minimal `package.json`) into the new composite action directory.
- `package.json` — `version` script git-adds the new composite directory on release.
- `src/labels/allowlist.ts` — allowlists the `ferry:route` logger namespace.
- `MIGRATIONS.md` — new `v0.12.x → v0.13.0` entry documenting the workflow change.
- `CHANGELOG.md` — `[Unreleased]` entry summarising the routing wiring + scope cuts.

## Deliberate scope cuts (follow-up tracking)

This PR is intentionally narrower than activating the full claude-code path in one shot. The three cuts:

1. **`priorRoundTrips` stubbed to 0** in the route action. Label + config routing land first; the heuristic-escalation branch never fires until a follow-up adds an audit-comment loader that derives the count from `[ferry:iterator:*]` markers (same source as `src/agents/reviewer/changes-guard.ts:countPriorIterations`).
2. **`src/cli/init/templates.ts` is NOT mirrored.** Consumers using `ferry-init`-generated workflows keep the pre-route shape until the templates follow. Doing them here risked `\${...}` escaping bugs in 4 template strings. The MIGRATIONS entry explicitly tells consumers to copy from `examples/consumer-setup/workflows/` by hand until then.
3. **`run-agent-claude-code` placeholder fails — actual `anthropics/claude-code-action@v1` invocation is a separate PR.** It requires a second composite action that runs the front half of the agent runtime (envelope → config → Jira → `buildSystem(role)` → existing `initialPrompt` builder → `filterMcpServers`) to feed `buildClaudeCodeJob`. That is a deliberately separate PR.

## Why this is safe to merge as-is

Without consumers manually copying the updated workflows or the templates follow-up landing, **every run stays on the existing script path** (the default for mixed-provider configs, the hard lock for `execution_path: script`). The architecture is now reviewable end-to-end with the routing decision actually flowing into a running workflow rather than living only in a unit-tested library.

## CI gate (local)

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm test` ✅ 2088/2088 tests pass
- `npm run check:bundle` ✅ no source/.ferry drift
- `gitleaks detect --no-git` on new files ✅ no leaks

## Refs

- ADR-0006 §3 — Deterministic execution-path resolution
- ADR-0002 §wiring — Path-select branch lives in consumer workflows (not composite actions)
- Closed issues this completes activation of: #300, #301, #302

## Draft status

Marked draft because: (a) the placeholder `claude-code` branch needs the follow-up PR before any consumer can actually opt into the path; (b) `templates.ts` mirror is required before merging if we want `ferry-init` to scaffold the new shape; (c) at least one end-to-end smoke test against a real consumer repo would be valuable before un-drafting.