### PR TITLE
feat: enforce anthropicOnly as hard gate in resolveExecutionPath (closes #329)

### DIFF
--- a/.github/actions/ferry-route/action.yml
+++ b/.github/actions/ferry-route/action.yml
@@ -25,7 +25,7 @@ outputs:
     description: Resolved execution path — `script` or `claude-code`
     value: ${{ steps.route.outputs.path }}
   reason:
-    description: Reason for the decision — `default`, `label`, or `heuristic`
+    description: Reason for the decision — `default`, `label`, `heuristic`, or `provider-gate`
     value: ${{ steps.route.outputs.reason }}
 runs:
   using: composite

--- a/.github/actions/ferry-route/route-action.js
+++ b/.github/actions/ferry-route/route-action.js
@@ -1356,6 +1356,9 @@ function resolveExecutionPath(input) {
   if (input.configuredPath === "script") {
     return { path: "script", reason: "default" };
   }
+  if (!input.anthropicOnly) {
+    return { path: "script", reason: "provider-gate" };
+  }
   if (input.labelOverride !== void 0) {
     return { path: input.labelOverride, reason: "label" };
   }

--- a/src/cli/doctor/checks/claude-code-path.test.ts
+++ b/src/cli/doctor/checks/claude-code-path.test.ts
@@ -126,4 +126,29 @@ describe('checkClaudeCodePath', () => {
     await checkClaudeCodePath({ repoRoot: root, repo: 'owner/repo' });
     expect(mockExecSync).not.toHaveBeenCalled();
   });
+
+  it('is yellow when execution_path is claude-code but a model uses a non-Anthropic provider (issue #329)', async () => {
+    writeConfig(root, {
+      execution_path: 'claude-code',
+      models: {
+        refiner: { provider: 'anthropic', model: 'claude-sonnet-4-5' },
+        dev: { provider: 'openai', model: 'gpt-5' },
+        review: { provider: 'anthropic', model: 'claude-sonnet-4-5' },
+        iterate: { provider: 'anthropic', model: 'claude-sonnet-4-5' },
+      },
+    });
+    const res = await checkClaudeCodePath({ repoRoot: root, repo: 'owner/repo' });
+    expect(res.status).toBe('yellow');
+    expect(res.detail.toLowerCase()).toContain('provider');
+    expect(res.detail).toContain('provider-gate');
+  });
+
+  it('does not warn about providers when execution_path is script (mixed-provider is valid for script)', async () => {
+    writeConfig(root, {
+      execution_path: 'script',
+      models: { dev: { provider: 'openai', model: 'gpt-5' } },
+    });
+    const res = await checkClaudeCodePath({ repoRoot: root, repo: 'owner/repo' });
+    expect(res.status).toBe('skip');
+  });
 });

--- a/src/cli/doctor/checks/claude-code-path.ts
+++ b/src/cli/doctor/checks/claude-code-path.ts
@@ -49,6 +49,23 @@ export function resolveExecutionPath(repoRoot: string): ExecutionPath {
 }
 
 /**
+ * Returns true when the raw config has any model phase configured with a
+ * non-Anthropic provider. Used to warn when execution_path: claude-code is set
+ * alongside a mixed-provider config (ADR-0006 §1, issue #329).
+ */
+function hasMixedProviders(raw: Record<string, unknown>): boolean {
+  const models = raw['models'] as Record<string, unknown> | undefined;
+  if (!models) return false;
+  for (const phase of ['refiner', 'dev', 'review', 'iterate']) {
+    const phaseConf = models[phase] as Record<string, unknown> | undefined;
+    if (phaseConf?.['provider'] && phaseConf['provider'] !== 'anthropic') {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Validity heuristic: a `claude setup-token` OAuth token is not a normal
  * Anthropic API key. ADR-0006 §6 forbids `ANTHROPIC_API_KEY` on the
  * claude-code path, so a value shaped like `sk-ant-api…` is a misconfiguration.
@@ -72,6 +89,19 @@ export async function checkClaudeCodePath(opts: {
       label: LABEL,
       status: 'skip',
       detail: `execution_path = script — ${OAUTH_SECRET} not required for the bundled-script path`,
+    };
+  }
+
+  // Provider/path mismatch (ADR-0006 §1, issue #329): the claude-code path
+  // requires an Anthropic-only config. The runtime resolver will gate to
+  // 'script' (provider-gate) if any agent uses a non-Anthropic provider.
+  const raw = readConfigRaw(repoRoot);
+  if (raw && hasMixedProviders(raw)) {
+    return {
+      label: LABEL,
+      status: 'yellow',
+      detail: `execution_path = claude-code, but at least one agent provider is not Anthropic — the claude-code path requires an Anthropic-only config (ADR-0006 §1). The resolver will gate to 'script' at runtime (reason: provider-gate).`,
+      remedy: `Set all agent providers to 'anthropic' in ferry.config, or change execution_path to 'script'.`,
     };
   }
 

--- a/src/lib/cc-wrappers/routing.test.ts
+++ b/src/lib/cc-wrappers/routing.test.ts
@@ -44,9 +44,9 @@ describe('resolveExecutionPath — explicit script lock (acceptance: never overr
 });
 
 describe('resolveExecutionPath — Jira label override (precedence over heuristic + default)', () => {
-  it('ferry:claude-code label → claude-code (reason label)', () => {
+  it('ferry:claude-code label → claude-code (reason label) for Anthropic-only consumer', () => {
     expect(
-      resolveExecutionPath(input({ labelOverride: 'claude-code', anthropicOnly: false })),
+      resolveExecutionPath(input({ labelOverride: 'claude-code', anthropicOnly: true })),
     ).toEqual({ path: 'claude-code', reason: 'label' });
   });
 
@@ -81,8 +81,42 @@ describe('resolveExecutionPath — Jira label override (precedence over heuristi
   });
 });
 
+describe('resolveExecutionPath — provider gate (anthropicOnly === false, issue #329)', () => {
+  it('mixed-provider config + ferry:claude-code label → script (reason provider-gate)', () => {
+    // Acceptance criterion: label override is a no-op when anthropicOnly is false.
+    expect(
+      resolveExecutionPath(input({ anthropicOnly: false, labelOverride: 'claude-code' })),
+    ).toEqual({ path: 'script', reason: 'provider-gate' });
+  });
+
+  it('explicit claude-code config + non-Anthropic provider → script (reason provider-gate)', () => {
+    expect(
+      resolveExecutionPath(input({ anthropicOnly: false, configuredPath: 'claude-code' })),
+    ).toEqual({ path: 'script', reason: 'provider-gate' });
+  });
+
+  it('provider gate fires before the label override (label is a no-op)', () => {
+    // Both ferry:claude-code and ferry:no-claude-code: gate wins either way.
+    expect(resolveExecutionPath(input({ anthropicOnly: false, labelOverride: 'script' }))).toEqual({
+      path: 'script',
+      reason: 'provider-gate',
+    });
+  });
+
+  it('provider gate does NOT fire for Anthropic-only consumers', () => {
+    // Anthropic-only: label override is honoured normally.
+    expect(
+      resolveExecutionPath(input({ anthropicOnly: true, labelOverride: 'claude-code' })),
+    ).toEqual({ path: 'claude-code', reason: 'label' });
+  });
+});
+
 describe('resolveExecutionPath — automatic heuristic (role + round-trips ≥ N)', () => {
-  it('developer at threshold escalates to claude-code (reason heuristic)', () => {
+  // NOTE: the provider gate (step 2) intercepts all non-Anthropic consumers before
+  // reaching the heuristic. The heuristic is currently dead code for anthropicOnly:false
+  // inputs (provider-gate fires first). These tests verify the gate takes precedence.
+
+  it('non-Anthropic developer at threshold → provider-gate (not heuristic)', () => {
     expect(
       resolveExecutionPath(
         input({
@@ -92,10 +126,10 @@ describe('resolveExecutionPath — automatic heuristic (role + round-trips ≥ N
           roundTripThreshold: 2,
         }),
       ),
-    ).toEqual({ path: 'claude-code', reason: 'heuristic' });
+    ).toEqual({ path: 'script', reason: 'provider-gate' });
   });
 
-  it('iterator above threshold escalates to claude-code', () => {
+  it('non-Anthropic iterator above threshold → provider-gate (not heuristic)', () => {
     expect(
       resolveExecutionPath(
         input({
@@ -105,10 +139,10 @@ describe('resolveExecutionPath — automatic heuristic (role + round-trips ≥ N
           roundTripThreshold: 2,
         }),
       ),
-    ).toEqual({ path: 'claude-code', reason: 'heuristic' });
+    ).toEqual({ path: 'script', reason: 'provider-gate' });
   });
 
-  it('below threshold does not escalate (non-Anthropic → script default)', () => {
+  it('non-Anthropic developer below threshold → provider-gate', () => {
     expect(
       resolveExecutionPath(
         input({
@@ -118,10 +152,10 @@ describe('resolveExecutionPath — automatic heuristic (role + round-trips ≥ N
           roundTripThreshold: 2,
         }),
       ),
-    ).toEqual({ path: 'script', reason: 'default' });
+    ).toEqual({ path: 'script', reason: 'provider-gate' });
   });
 
-  it('refiner never escalates via the heuristic', () => {
+  it('non-Anthropic refiner → provider-gate', () => {
     expect(
       resolveExecutionPath(
         input({
@@ -131,10 +165,10 @@ describe('resolveExecutionPath — automatic heuristic (role + round-trips ≥ N
           roundTripThreshold: 2,
         }),
       ),
-    ).toEqual({ path: 'script', reason: 'default' });
+    ).toEqual({ path: 'script', reason: 'provider-gate' });
   });
 
-  it('reviewer never escalates via the heuristic', () => {
+  it('non-Anthropic reviewer → provider-gate', () => {
     expect(
       resolveExecutionPath(
         input({
@@ -144,10 +178,10 @@ describe('resolveExecutionPath — automatic heuristic (role + round-trips ≥ N
           roundTripThreshold: 2,
         }),
       ),
-    ).toEqual({ path: 'script', reason: 'default' });
+    ).toEqual({ path: 'script', reason: 'provider-gate' });
   });
 
-  it('a non-positive threshold disables the heuristic', () => {
+  it('non-Anthropic non-positive threshold → provider-gate', () => {
     expect(
       resolveExecutionPath(
         input({
@@ -157,7 +191,7 @@ describe('resolveExecutionPath — automatic heuristic (role + round-trips ≥ N
           roundTripThreshold: 0,
         }),
       ),
-    ).toEqual({ path: 'script', reason: 'default' });
+    ).toEqual({ path: 'script', reason: 'provider-gate' });
   });
 
   it('the heuristic never downgrades an already-claude-code default', () => {
@@ -178,17 +212,17 @@ describe('resolveExecutionPath — conditional default', () => {
     });
   });
 
-  it('non-Anthropic consumer (unset config) → script', () => {
+  it('non-Anthropic consumer (unset config) → script (reason provider-gate)', () => {
     expect(resolveExecutionPath(input({ anthropicOnly: false, role: 'reviewer' }))).toEqual({
       path: 'script',
-      reason: 'default',
+      reason: 'provider-gate',
     });
   });
 
-  it('explicit claude-code config → claude-code (reason default)', () => {
+  it('explicit claude-code config with non-Anthropic provider → script (reason provider-gate)', () => {
     expect(
       resolveExecutionPath(input({ configuredPath: 'claude-code', anthropicOnly: false })),
-    ).toEqual({ path: 'claude-code', reason: 'default' });
+    ).toEqual({ path: 'script', reason: 'provider-gate' });
   });
 });
 

--- a/src/lib/cc-wrappers/routing.ts
+++ b/src/lib/cc-wrappers/routing.ts
@@ -11,24 +11,32 @@
  * Resolution order (highest precedence first), per ADR-0006 §3:
  *   1. Explicit `execution_path: script` in ferry.config — a **hard lock**;
  *      never overridden by the label or the heuristic.
- *   2. Per-ticket Jira label (`ferry:claude-code` / `ferry:no-claude-code`).
+ *   2. Provider gate — when `anthropicOnly === false`, returns `script` with
+ *      reason `'provider-gate'`; the per-ticket label override is ignored (the
+ *      caller is responsible for emitting a warn). Invariant: the claude-code
+ *      path is unavailable when any agent provider is not Anthropic (ADR-0006
+ *      §1, §6, issue #329).
+ *   3. Per-ticket Jira label (`ferry:claude-code` / `ferry:no-claude-code`).
  *      Conflicting labels are already collapsed to the safe `script` path by
  *      `resolveTicketOverrides` (no `LabelConflictError`).
- *   3. Automatic heuristic — escalates an *otherwise-script* default to
+ *   4. Automatic heuristic — escalates an *otherwise-script* default to
  *      claude-code when `role ∈ {developer, iterator}` AND
- *      `priorRoundTrips >= N`.
- *   4. Conditional default — explicit `claude-code`, else `claude-code` for
+ *      `priorRoundTrips >= N`. NOTE: with step 2 in place this branch is only
+ *      reachable when `anthropicOnly === true`, which already yields a
+ *      `claude-code` conditional default — the heuristic is currently dead code.
+ *      Retained for forward compatibility if the provider gate is ever relaxed.
+ *   5. Conditional default — explicit `claude-code`, else `claude-code` for
  *      an Anthropic-only consumer, else `script`.
  *
- * The recorded reason (`label` / `heuristic` / `default`) is emitted into the
- * audit comment marker by `formatExecutionPathAudit` so the Reconciler
- * (ADR-0004) observes which path ran and why.
+ * The recorded reason (`label` / `heuristic` / `default` / `provider-gate`) is
+ * emitted into the audit comment marker by `formatExecutionPathAudit` so the
+ * Reconciler (ADR-0004) observes which path ran and why.
  */
 import type { ExecutionPath, FerryConfig } from '../config.js';
 import type { AgentOutputRole } from './agent-output.js';
 import { markerRoleToken } from './contract.js';
 
-export type ExecutionPathReason = 'label' | 'heuristic' | 'default';
+export type ExecutionPathReason = 'label' | 'heuristic' | 'default' | 'provider-gate';
 
 export interface ExecutionPathDecision {
   path: ExecutionPath;
@@ -83,12 +91,21 @@ export function resolveExecutionPath(input: ExecutionPathInput): ExecutionPathDe
     return { path: 'script', reason: 'default' };
   }
 
-  // 2. Per-ticket Jira label (conflicting pair already collapsed to 'script').
+  // 2. Provider gate (ADR-0006 §1, §6, issue #329): the claude-code path is
+  //    unavailable when any configured agent provider is not Anthropic, regardless
+  //    of the per-ticket label or the configured path. When a ferry:claude-code
+  //    label is present and silently ignored, the caller is responsible for
+  //    emitting a warn (the resolver stays pure — it returns the decision only).
+  if (!input.anthropicOnly) {
+    return { path: 'script', reason: 'provider-gate' };
+  }
+
+  // 3. Per-ticket Jira label (conflicting pair already collapsed to 'script').
   if (input.labelOverride !== undefined) {
     return { path: input.labelOverride, reason: 'label' };
   }
 
-  // 3/4. Conditional default, then heuristic escalation of a script default.
+  // 4/5. Conditional default, then heuristic escalation of a script default.
   const defaultPath: ExecutionPath =
     input.configuredPath === 'claude-code' || input.anthropicOnly ? 'claude-code' : 'script';
 
@@ -110,6 +127,14 @@ export function resolveExecutionPath(input: ExecutionPathInput): ExecutionPathDe
  * uses the `dev` marker token for script parity). Consumed by the contract
  * apply step on the claude-code path so the resolved route + reason land in
  * the audit log.
+ *
+ * Recorded `reason` values:
+ *   - `default`       — config-explicit or Anthropic-only conditional default.
+ *   - `label`         — per-ticket `ferry:claude-code` / `ferry:no-claude-code`.
+ *   - `heuristic`     — automatic round-trip escalation.
+ *   - `provider-gate` — blocked because at least one agent provider is not
+ *                       Anthropic; the claude-code path requires an
+ *                       Anthropic-only config (ADR-0006 §1, §6, issue #329).
  */
 export function formatExecutionPathAudit(
   role: AgentOutputRole,

--- a/src/lib/dispatch/route-action.ts
+++ b/src/lib/dispatch/route-action.ts
@@ -16,7 +16,7 @@
  *
  * Outputs (written to GITHUB_OUTPUT):
  *   - path     'script' | 'claude-code'
- *   - reason   'default' | 'label' | 'heuristic'
+ *   - reason   'default' | 'label' | 'heuristic' | 'provider-gate'
  *
  * Heuristic-driven escalation is intentionally **disabled in this version**
  * (`priorRoundTrips` is stubbed to 0): label + config-driven routing land first

--- a/src/lib/labels/capabilities.ts
+++ b/src/lib/labels/capabilities.ts
@@ -192,6 +192,13 @@ export interface TicketOverrides {
    * Consumed by `resolveExecutionPath` (src/lib/cc-wrappers/routing.ts): it
    * takes precedence over the heuristic and the conditional default, but an
    * explicit `execution_path: script` in ferry.config still wins.
+   *
+   * **Provider gate (issue #329):** the `ferry:claude-code` override is
+   * honoured **only when `anthropicOnly === true`**. When any agent's configured
+   * provider is not Anthropic, the resolver returns
+   * `{ path: 'script', reason: 'provider-gate' }` and the label is a logged
+   * no-op — the caller emits a warn. This ensures the claude-code path is never
+   * activated without the Anthropic token infrastructure (ADR-0006 §6).
    */
   claudeCodePath?: 'claude-code' | 'script';
 }


### PR DESCRIPTION
Closes #329.

## Summary

- Add `'provider-gate'` to `ExecutionPathReason` union and insert it as step 2 in the resolver: when `anthropicOnly === false`, return `{ path: 'script', reason: 'provider-gate' }` before the per-ticket label override is consulted
- Update module docstring, `formatExecutionPathAudit` docstring, and `TicketOverrides.claudeCodePath` docstring to reflect new precedence
- Mirror gate in `ferry-doctor`: yellow warning when `execution_path: claude-code` + mixed providers
- New `provider-gate` describe block in `routing.test.ts` (4 tests, incl. acceptance criterion); all existing `anthropicOnly: false` expectations updated

## Test plan

- [x] `2094 passed` via `npm test`
- [x] TypeScript `tsc --noEmit` passes
- [x] ESLint + Prettier pass
- [x] Pre-push hook "all gates green"

Generated with [Claude Code](https://claude.ai/code)