### PR TITLE
feat(uninstall): remove new composite dirs and add interactive OAuth secret flow

### DIFF
--- a/docs/decisions/0002-claude-code-path-parity-analysis.md
+++ b/docs/decisions/0002-claude-code-path-parity-analysis.md
@@ -103,10 +103,31 @@ else is reused.
 
 ## F. Destruction (`ferry-uninstall`)
 
-| Element                                            | Class | Notes                                                                                               |
-| -------------------------------------------------- | ----- | --------------------------------------------------------------------------------------------------- |
-| Remove `workflows/ferry-*.yml`, secrets, variables | ✅    | Mechanism reused.                                                                                   |
-| Remove `CLAUDE_CODE_OAUTH_TOKEN`                   | ➕    | Add the new secret to the uninstall removal list, otherwise a stale subscription token is orphaned. |
+| Element                                            | Class | Notes                                                                                                                                                                                                                                                                                                                        |
+| -------------------------------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Remove `workflows/ferry-*.yml`, secrets, variables | ✅    | Mechanism reused.                                                                                                                                                                                                                                                                                                            |
+| Remove `CLAUDE_CODE_OAUTH_TOKEN`                   | ➕    | Interactive-only, never under `--yes`. The bulk-removal list intentionally **excludes** this secret; it is gated behind a dedicated second confirmation prompt (see [Amendment (PR #343)](#amendment-pr-343)). Deleting the secret removes the GitHub repo value only — the underlying Anthropic OAuth token is not revoked. |
+
+### Amendment (PR #343)
+
+The original row above said "Add the new secret to the uninstall removal list".
+This was superseded by [#337](https://github.com/big-emotion/ferry/issues/337) /
+[PR #343](https://github.com/big-emotion/ferry/pull/343) to the following
+contract:
+
+- **Interactive-only, never under `--yes`.** `ferry-uninstall --yes` never
+  deletes `CLAUDE_CODE_OAUTH_TOKEN`, even if the secret is present. In
+  interactive mode, the user must explicitly confirm a dedicated second prompt
+  (the main "Proceed with removal?" prompt is not sufficient).
+- **Tradeoff: orphaned token possible.** If a consumer runs the uninstall
+  non-interactively (CI / `--yes`), the secret stays. This is preferred to the
+  reverse failure mode (silently losing a credential the consumer may still
+  intend to use elsewhere).
+- **Manual cleanup path.** After uninstall, the consumer can:
+  - Re-issue: `claude setup-token` → `gh secret set CLAUDE_CODE_OAUTH_TOKEN`
+  - Or remove it themselves: `gh secret delete CLAUDE_CODE_OAUTH_TOKEN --repo <owner>/<repo>`
+  - And, to fully revoke the underlying OAuth token (not just the GitHub repo
+    secret value), follow up at <https://console.anthropic.com>.
 
 ## G. Existing consumers (migration via `ferry-update`)
 

--- a/src/cli/uninstall/detect.ts
+++ b/src/cli/uninstall/detect.ts
@@ -26,9 +26,15 @@ export const ANTHROPIC_SECRET = 'ANTHROPIC_API_KEY';
 /**
  * Ferry-provisioned subscription OAuth token for the claude-code execution
  * path (ADR-0006 §6). Removal requires interactive confirmation — never
- * auto-removed in --yes mode because revoking an OAuth subscription is
- * irreversible. Use detectOAuthSecret / removeSecrets([CLAUDE_CODE_OAUTH_SECRET])
- * after explicit user consent.
+ * auto-removed in --yes mode.
+ *
+ * Note: deleting this secret only removes the value stored in the GitHub repo;
+ * it does **not** revoke the underlying Anthropic OAuth token, which remains
+ * valid and can be re-added with `claude setup-token` + `gh secret set`. To
+ * fully revoke, follow up at https://console.anthropic.com after deletion.
+ *
+ * Use detectOAuthSecret / removeSecrets([CLAUDE_CODE_OAUTH_SECRET]) after
+ * explicit user consent.
  */
 export const CLAUDE_CODE_OAUTH_SECRET = 'CLAUDE_CODE_OAUTH_TOKEN';
 

--- a/src/cli/uninstall/detect.ts
+++ b/src/cli/uninstall/detect.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import type { WorkflowItem, AuditIssueState } from './types.js';
+import type { WorkflowItem, CompositeActionItem, AuditIssueState } from './types.js';
 
 export const FERRY_WORKFLOW_FILES = [
   'ferry-refine.yml',
@@ -25,13 +25,15 @@ export const FERRY_SECRETS = [
 export const ANTHROPIC_SECRET = 'ANTHROPIC_API_KEY';
 /**
  * Ferry-provisioned subscription OAuth token for the claude-code execution
- * path (ADR-0006 §6). Created via `claude setup-token` specifically for Ferry,
- * so it is removed by default — leaving it would orphan a stale subscription
- * token (decisions/0002 §F). This is unlike ANTHROPIC_API_KEY, which may be a
- * consumer's general-purpose key and is therefore gated behind
- * --include-anthropic.
+ * path (ADR-0006 §6). Removal requires interactive confirmation — never
+ * auto-removed in --yes mode because revoking an OAuth subscription is
+ * irreversible. Use detectOAuthSecret / removeSecrets([CLAUDE_CODE_OAUTH_SECRET])
+ * after explicit user consent.
  */
 export const CLAUDE_CODE_OAUTH_SECRET = 'CLAUDE_CODE_OAUTH_TOKEN';
+
+/** Composite action directories added by ferry-init in v0.13.0 (ADR-0006). */
+export const FERRY_COMPOSITE_DIRS = ['ferry-route', 'ferry-cc-prepare', 'ferry-cc-apply'];
 export const FERRY_VARIABLE = 'FERRY_AUDIT_ISSUE';
 export const AUDIT_LABEL = 'ferry:audit-log:active';
 
@@ -40,6 +42,14 @@ export function detectWorkflows(repoRoot: string): WorkflowItem[] {
   return FERRY_WORKFLOW_FILES.map((filename) => ({
     filename,
     present: existsSync(join(workflowDir, filename)),
+  }));
+}
+
+export function detectCompositeActions(repoRoot: string): CompositeActionItem[] {
+  const actionsDir = join(repoRoot, '.github', 'actions');
+  return FERRY_COMPOSITE_DIRS.map((dirname) => ({
+    dirname,
+    present: existsSync(join(actionsDir, dirname)),
   }));
 }
 
@@ -66,12 +76,13 @@ function listSecrets(repo: string): string[] {
 
 export function detectSecrets(repo: string, includeAnthropic: boolean): string[] {
   const all = listSecrets(repo);
-  const targets = [
-    ...FERRY_SECRETS,
-    CLAUDE_CODE_OAUTH_SECRET,
-    ...(includeAnthropic ? [ANTHROPIC_SECRET] : []),
-  ];
+  const targets = [...FERRY_SECRETS, ...(includeAnthropic ? [ANTHROPIC_SECRET] : [])];
   return targets.filter((s) => all.includes(s));
+}
+
+/** Returns true if CLAUDE_CODE_OAUTH_TOKEN exists in the repo's secrets. */
+export function detectOAuthSecret(repo: string): boolean {
+  return listSecrets(repo).includes(CLAUDE_CODE_OAUTH_SECRET);
 }
 
 function listVariables(repo: string): Array<{ name: string; value: string }> {

--- a/src/cli/uninstall/execute.ts
+++ b/src/cli/uninstall/execute.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process';
-import { unlinkSync, readFileSync, writeFileSync } from 'node:fs';
+import { unlinkSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import type { WorkflowItem, AuditIssueState } from './types.js';
+import type { WorkflowItem, CompositeActionItem, AuditIssueState } from './types.js';
 import { AUDIT_LABEL } from './detect.js';
 
 export interface ExecOptions {
@@ -33,6 +33,32 @@ export function removeWorkflows(
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       opts.onError(`Failed to delete ${wf.filename}: ${msg}`);
+    }
+  }
+}
+
+export function removeCompositeActions(
+  repoRoot: string,
+  actions: CompositeActionItem[],
+  opts: ExecOptions,
+): void {
+  const actionsDir = join(repoRoot, '.github', 'actions');
+  for (const action of actions) {
+    if (!action.present) {
+      opts.onSkip(`.github/actions/${action.dirname}/ not present — skipping`);
+      continue;
+    }
+    if (opts.dryRun) {
+      opts.onAction(`[dry-run] Would delete .github/actions/${action.dirname}/`);
+      continue;
+    }
+    const dest = join(actionsDir, action.dirname);
+    try {
+      rmSync(dest, { recursive: true });
+      opts.onAction(`Deleted .github/actions/${action.dirname}/`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      opts.onError(`Failed to delete .github/actions/${action.dirname}/: ${msg}`);
     }
   }
 }

--- a/src/cli/uninstall/index.ts
+++ b/src/cli/uninstall/index.ts
@@ -36,6 +36,7 @@ import {
 } from './execute.js';
 import { resolveForgeFromArgv } from '../lib/forge.js';
 import { runGitlabUninstall } from './gitlab/run.js';
+import { shouldRemoveOAuth } from './oauth-gate.js';
 import type { UninstallOptions } from './types.js';
 
 const TOTAL_STEPS = 4;
@@ -276,14 +277,19 @@ Exit code: 0 on success, 1 on any error.
     }
   }
 
-  let removeOAuthSecretFlag = false;
+  let confirmed = false;
   if (!opts.yes && oauthSecretPresent) {
     print('');
-    removeOAuthSecretFlag = await confirm(
-      `Also remove ${CLAUDE_CODE_OAUTH_SECRET}? (OAuth subscription token — revocation is irreversible)`,
+    confirmed = await confirm(
+      `Also remove ${CLAUDE_CODE_OAUTH_SECRET}? (Deletes the GitHub repo secret only — does not revoke the underlying Anthropic OAuth token. To fully revoke, follow up at https://console.anthropic.com.)`,
       false,
     );
   }
+  const removeOAuthSecretFlag = shouldRemoveOAuth({
+    yes: opts.yes,
+    oauthSecretPresent,
+    confirmed,
+  });
 
   closePrompt();
 

--- a/src/cli/uninstall/index.ts
+++ b/src/cli/uninstall/index.ts
@@ -13,17 +13,21 @@ import {
 } from '../init/prompt.js';
 import {
   detectWorkflows,
+  detectCompositeActions,
   detectCodeownersBlock,
   detectSecrets,
+  detectOAuthSecret,
   detectVariables,
   detectAuditIssueNumber,
   detectAuditIssue,
   ANTHROPIC_SECRET,
+  CLAUDE_CODE_OAUTH_SECRET,
   FERRY_VARIABLE,
   AUDIT_LABEL,
 } from './detect.js';
 import {
   removeWorkflows,
+  removeCompositeActions,
   removeCodeownersBlock,
   removeSecrets,
   removeVariable,
@@ -124,13 +128,16 @@ Options:
 
 What is removed by default:
   • .github/workflows/ferry-*.yml (6 workflow files)
+  • .github/actions/ferry-route/, ferry-cc-prepare/, ferry-cc-apply/ (composite actions)
   • Ferry entries in .github/CODEOWNERS (file kept; only Ferry lines removed)
   • Repo secrets: FERRY_APP_ID, FERRY_PRIVATE_KEY, FERRY_JIRA_BASE_URL,
                   FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN,
-                  FERRY_REVIEW_TRANSITION_ID, FERRY_ITER_TRANSITION_ID,
-                  CLAUDE_CODE_OAUTH_TOKEN (claude-code path; if present)
+                  FERRY_REVIEW_TRANSITION_ID, FERRY_ITER_TRANSITION_ID
   • Repo variable: ${FERRY_VARIABLE}
   • Label '${AUDIT_LABEL}' removed from audit-log issue (issue NOT closed)
+
+What requires interactive confirmation (never removed in --yes mode):
+  • CLAUDE_CODE_OAUTH_TOKEN — OAuth subscription token; prompted individually
 
 What is NOT touched:
   • ${ANTHROPIC_SECRET} (use --include-anthropic to also remove)
@@ -174,18 +181,26 @@ Exit code: 0 on success, 1 on any error.
   print('');
 
   const workflows = detectWorkflows(opts.repoRoot);
+  const compositeActions = detectCompositeActions(opts.repoRoot);
   const codeownersHasFerry = detectCodeownersBlock(opts.repoRoot);
   const secrets = opts.keepSecrets ? [] : detectSecrets(opts.repo, opts.includeAnthropic);
+  const oauthSecretPresent = opts.keepSecrets ? false : detectOAuthSecret(opts.repo);
   const variables = opts.keepSecrets ? [] : detectVariables(opts.repo);
   const auditIssueNumber = detectAuditIssueNumber(opts.repo);
   const auditIssue =
     auditIssueNumber !== null ? detectAuditIssue(opts.repo, auditIssueNumber) : null;
 
   const presentWorkflows = workflows.filter((w) => w.present);
+  const presentComposites = compositeActions.filter((a) => a.present);
   const hasWorkflowChanges =
-    !opts.keepWorkflows && (presentWorkflows.length > 0 || codeownersHasFerry);
+    !opts.keepWorkflows &&
+    (presentWorkflows.length > 0 || presentComposites.length > 0 || codeownersHasFerry);
   const hasAnything =
-    hasWorkflowChanges || secrets.length > 0 || variables.length > 0 || auditIssue !== null;
+    hasWorkflowChanges ||
+    secrets.length > 0 ||
+    oauthSecretPresent ||
+    variables.length > 0 ||
+    auditIssue !== null;
 
   if (!hasAnything) {
     print('Nothing to remove — Ferry does not appear to be installed.');
@@ -199,6 +214,9 @@ Exit code: 0 on success, 1 on any error.
     for (const wf of presentWorkflows) {
       print(`  ✓ .github/workflows/${wf.filename}`);
     }
+    for (const ca of presentComposites) {
+      print(`  ✓ .github/actions/${ca.dirname}/`);
+    }
     if (codeownersHasFerry) {
       print('  ✓ Ferry block in .github/CODEOWNERS  (file kept; only Ferry lines removed)');
     }
@@ -207,6 +225,16 @@ Exit code: 0 on success, 1 on any error.
   if (secrets.length > 0) {
     const formatted = secrets.join(', ');
     print(`  ✓ Repo secrets: ${formatted}`);
+  }
+
+  if (oauthSecretPresent) {
+    if (opts.yes) {
+      print(
+        `  • ${CLAUDE_CODE_OAUTH_SECRET} — skipped in --yes mode (requires interactive consent)`,
+      );
+    } else {
+      print(`  ✓ ${CLAUDE_CODE_OAUTH_SECRET} (will confirm interactively)`);
+    }
   }
 
   if (variables.length > 0) {
@@ -248,6 +276,15 @@ Exit code: 0 on success, 1 on any error.
     }
   }
 
+  let removeOAuthSecretFlag = false;
+  if (!opts.yes && oauthSecretPresent) {
+    print('');
+    removeOAuthSecretFlag = await confirm(
+      `Also remove ${CLAUDE_CODE_OAUTH_SECRET}? (OAuth subscription token — revocation is irreversible)`,
+      false,
+    );
+  }
+
   closePrompt();
 
   const errors: string[] = [];
@@ -261,12 +298,15 @@ Exit code: 0 on success, 1 on any error.
     },
   };
 
-  // ── Step 1: Workflows ─────────────────────────────────────────────────────
-  printStep(1, TOTAL_STEPS, 'Removing workflow files');
+  // ── Step 1: Workflows & composite actions ────────────────────────────────
+  printStep(1, TOTAL_STEPS, 'Removing workflow files and composite actions');
   if (opts.keepWorkflows) {
-    printSkip('--keep-workflows: leaving workflow files and CODEOWNERS in place');
+    printSkip(
+      '--keep-workflows: leaving workflow files, composite actions, and CODEOWNERS in place',
+    );
   } else {
     removeWorkflows(opts.repoRoot, workflows, execOpts);
+    removeCompositeActions(opts.repoRoot, compositeActions, execOpts);
     removeCodeownersBlock(opts.repoRoot, execOpts);
   }
 
@@ -276,6 +316,11 @@ Exit code: 0 on success, 1 on any error.
     printSkip('--keep-secrets: leaving all secrets in place');
   } else {
     removeSecrets(opts.repo, secrets, execOpts);
+    if (removeOAuthSecretFlag) {
+      removeSecrets(opts.repo, [CLAUDE_CODE_OAUTH_SECRET], execOpts);
+    } else if (oauthSecretPresent) {
+      printSkip(`${CLAUDE_CODE_OAUTH_SECRET}: not removed (requires explicit interactive consent)`);
+    }
   }
 
   // ── Step 3: Variables ─────────────────────────────────────────────────────
@@ -304,15 +349,32 @@ Exit code: 0 on success, 1 on any error.
   print('  Uninstall complete!');
   print('════════════════════════════════════════');
   print('');
+  print('What was removed:');
+  if (!opts.keepWorkflows) {
+    const removedWf = presentWorkflows.length;
+    const removedCa = presentComposites.length;
+    if (removedWf > 0) print(`  ✓ ${removedWf} workflow file(s) from .github/workflows/`);
+    if (removedCa > 0) print(`  ✓ ${removedCa} composite action(s) from .github/actions/`);
+    if (codeownersHasFerry) print('  ✓ Ferry entries from .github/CODEOWNERS');
+  }
+  if (secrets.length > 0) print(`  ✓ Secrets: ${secrets.join(', ')}`);
+  if (removeOAuthSecretFlag) print(`  ✓ Secret: ${CLAUDE_CODE_OAUTH_SECRET}`);
+  if (variables.length > 0) print(`  ✓ Variable: ${variables.join(', ')}`);
+  print('');
   print('Remaining manual steps:');
+  let step = 1;
+  if (oauthSecretPresent && !removeOAuthSecretFlag) {
+    print(`  ${step++}. Remove ${CLAUDE_CODE_OAUTH_SECRET} if desired:`);
+    print(`     gh secret delete ${CLAUDE_CODE_OAUTH_SECRET} --repo ${opts.repo}`);
+  }
   if (!opts.includeAnthropic) {
-    print(`  1. Decide whether to delete the ${ANTHROPIC_SECRET} secret`);
+    print(`  ${step++}. Decide whether to delete the ${ANTHROPIC_SECRET} secret`);
     print(`     (gh secret delete ${ANTHROPIC_SECRET} --repo ${opts.repo})`);
   }
-  print('  2. Disable or delete the 4 Jira Automation rules in the Jira UI');
+  print(`  ${step++}. Disable or delete the 4 Jira Automation rules in the Jira UI`);
   print('     (Project settings → Automation)');
-  print('  3. Uninstall the GitHub App at https://github.com/settings/installations');
-  print('  4. Review repo-level workflow permissions if desired');
+  print(`  ${step++}. Uninstall the GitHub App at https://github.com/settings/installations`);
+  print(`  ${step}. Review repo-level workflow permissions if desired`);
   print('');
 
   if (errors.length > 0) {

--- a/src/cli/uninstall/oauth-gate.ts
+++ b/src/cli/uninstall/oauth-gate.ts
@@ -1,0 +1,20 @@
+/**
+ * Pure decision helper that enforces the headline safety invariant of the
+ * uninstall OAuth flow (PR #343):
+ *
+ *  - Under `--yes` (non-interactive) the `CLAUDE_CODE_OAUTH_TOKEN` repo secret
+ *    is **never** removed, even if it is present.
+ *  - In interactive mode, removal happens **only** when the user explicitly
+ *    confirms the dedicated second prompt.
+ *  - If the secret is not present, removal is always a no-op.
+ *
+ * Extracted from `index.ts` so it can be exercised in isolation without
+ * triggering the CLI's top-level `main()` invocation.
+ */
+export function shouldRemoveOAuth(params: {
+  yes: boolean;
+  oauthSecretPresent: boolean;
+  confirmed: boolean;
+}): boolean {
+  return !params.yes && params.oauthSecretPresent && params.confirmed;
+}

--- a/src/cli/uninstall/types.ts
+++ b/src/cli/uninstall/types.ts
@@ -14,6 +14,11 @@ export interface WorkflowItem {
   present: boolean;
 }
 
+export interface CompositeActionItem {
+  dirname: string;
+  present: boolean;
+}
+
 export interface AuditIssueState {
   number: number;
   hasLabel: boolean;

--- a/src/cli/uninstall/uninstall.test.ts
+++ b/src/cli/uninstall/uninstall.test.ts
@@ -11,9 +11,12 @@ vi.mock('node:child_process', () => ({
 
 import {
   detectWorkflows,
+  detectCompositeActions,
   detectCodeownersBlock,
   detectSecrets,
+  detectOAuthSecret,
   FERRY_WORKFLOW_FILES,
+  FERRY_COMPOSITE_DIRS,
   FERRY_SECRETS,
   ANTHROPIC_SECRET,
   CLAUDE_CODE_OAUTH_SECRET,
@@ -21,6 +24,7 @@ import {
 } from './detect.js';
 import {
   removeWorkflows,
+  removeCompositeActions,
   removeCodeownersBlock,
   removeSecrets,
   removeVariable,
@@ -51,6 +55,7 @@ function makeOpts(overrides?: Partial<ExecOptions>): ExecOptions & {
 function makeTempRepo(): string {
   const dir = mkdtempSync(join(tmpdir(), 'ferry-uninstall-test-'));
   mkdirSync(join(dir, '.github', 'workflows'), { recursive: true });
+  mkdirSync(join(dir, '.github', 'actions'), { recursive: true });
   return dir;
 }
 
@@ -171,24 +176,18 @@ describe('detectSecrets', () => {
     expect(detectSecrets('owner/repo', false)).toEqual(['FERRY_APP_ID', 'FERRY_PRIVATE_KEY']);
   });
 
-  it('removes CLAUDE_CODE_OAUTH_SECRET by default (claude-code path token, not orphaned)', () => {
+  it('does NOT include CLAUDE_CODE_OAUTH_SECRET — handled separately with interactive confirmation', () => {
     mockSpawnSync.mockReturnValue(
       spawnOk(
         JSON.stringify([...FERRY_SECRETS, CLAUDE_CODE_OAUTH_SECRET].map((name) => ({ name }))),
       ),
     );
     const secrets = detectSecrets('owner/repo', false);
-    expect(secrets).toContain(CLAUDE_CODE_OAUTH_SECRET);
-  });
-
-  it('does not include CLAUDE_CODE_OAUTH_SECRET when it is not set in the repo', () => {
-    mockSpawnSync.mockReturnValue(spawnOk(JSON.stringify(FERRY_SECRETS.map((name) => ({ name })))));
-    const secrets = detectSecrets('owner/repo', false);
     expect(secrets).not.toContain(CLAUDE_CODE_OAUTH_SECRET);
-    expect(secrets).toEqual([...FERRY_SECRETS]);
+    expect(secrets).toHaveLength(FERRY_SECRETS.length);
   });
 
-  it('removes both CLAUDE_CODE_OAUTH_SECRET and ANTHROPIC_SECRET when includeAnthropic is true', () => {
+  it('does not include CLAUDE_CODE_OAUTH_SECRET even when includeAnthropic is true', () => {
     mockSpawnSync.mockReturnValue(
       spawnOk(
         JSON.stringify(
@@ -197,9 +196,145 @@ describe('detectSecrets', () => {
       ),
     );
     const secrets = detectSecrets('owner/repo', true);
-    expect(secrets).toContain(CLAUDE_CODE_OAUTH_SECRET);
+    expect(secrets).not.toContain(CLAUDE_CODE_OAUTH_SECRET);
     expect(secrets).toContain(ANTHROPIC_SECRET);
-    expect(secrets).toHaveLength(FERRY_SECRETS.length + 2);
+    expect(secrets).toHaveLength(FERRY_SECRETS.length + 1);
+  });
+});
+
+// ── detectOAuthSecret ─────────────────────────────────────────────────────────
+
+describe('detectOAuthSecret', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns true when CLAUDE_CODE_OAUTH_TOKEN is present', () => {
+    mockSpawnSync.mockReturnValue(spawnOk(JSON.stringify([{ name: CLAUDE_CODE_OAUTH_SECRET }])));
+    expect(detectOAuthSecret('owner/repo')).toBe(true);
+  });
+
+  it('returns false when CLAUDE_CODE_OAUTH_TOKEN is absent', () => {
+    mockSpawnSync.mockReturnValue(spawnOk(JSON.stringify(FERRY_SECRETS.map((name) => ({ name })))));
+    expect(detectOAuthSecret('owner/repo')).toBe(false);
+  });
+
+  it('returns false when gh CLI fails', () => {
+    mockSpawnSync.mockReturnValue(spawnFail('gh: not found'));
+    expect(detectOAuthSecret('owner/repo')).toBe(false);
+  });
+});
+
+// ── detectCompositeActions ────────────────────────────────────────────────────
+
+describe('detectCompositeActions', () => {
+  it('marks all composites as not present in an empty actions dir', () => {
+    const dir = makeTempRepo();
+    const result = detectCompositeActions(dir);
+    expect(result).toHaveLength(FERRY_COMPOSITE_DIRS.length);
+    for (const item of result) {
+      expect(item.present).toBe(false);
+    }
+    cleanup(dir);
+  });
+
+  it('detects present composite action directories', () => {
+    const dir = makeTempRepo();
+    mkdirSync(join(dir, '.github', 'actions', 'ferry-route'), { recursive: true });
+    mkdirSync(join(dir, '.github', 'actions', 'ferry-cc-prepare'), { recursive: true });
+
+    const result = detectCompositeActions(dir);
+    expect(result.find((a) => a.dirname === 'ferry-route')?.present).toBe(true);
+    expect(result.find((a) => a.dirname === 'ferry-cc-prepare')?.present).toBe(true);
+    expect(result.find((a) => a.dirname === 'ferry-cc-apply')?.present).toBe(false);
+
+    cleanup(dir);
+  });
+
+  it('returns all 3 ferry composite dir names', () => {
+    const dir = makeTempRepo();
+    const names = detectCompositeActions(dir).map((a) => a.dirname);
+    expect(names).toContain('ferry-route');
+    expect(names).toContain('ferry-cc-prepare');
+    expect(names).toContain('ferry-cc-apply');
+    cleanup(dir);
+  });
+});
+
+// ── removeCompositeActions ────────────────────────────────────────────────────
+
+describe('removeCompositeActions', () => {
+  it('deletes present composite action directories', () => {
+    const dir = makeTempRepo();
+    const actionsDir = join(dir, '.github', 'actions');
+    mkdirSync(join(actionsDir, 'ferry-route'), { recursive: true });
+    writeFileSync(join(actionsDir, 'ferry-route', 'action.yml'), 'name: test', 'utf8');
+    mkdirSync(join(actionsDir, 'ferry-cc-prepare'), { recursive: true });
+
+    const opts = makeOpts();
+    removeCompositeActions(dir, detectCompositeActions(dir), opts);
+
+    expect(existsSync(join(actionsDir, 'ferry-route'))).toBe(false);
+    expect(existsSync(join(actionsDir, 'ferry-cc-prepare'))).toBe(false);
+    expect(opts.actions).toContain('Deleted .github/actions/ferry-route/');
+    expect(opts.actions).toContain('Deleted .github/actions/ferry-cc-prepare/');
+
+    cleanup(dir);
+  });
+
+  it('skips composite dirs that are not present', () => {
+    const dir = makeTempRepo();
+    const opts = makeOpts();
+    removeCompositeActions(dir, detectCompositeActions(dir), opts);
+
+    expect(opts.actions).toHaveLength(0);
+    expect(opts.skips.length).toBe(FERRY_COMPOSITE_DIRS.length);
+
+    cleanup(dir);
+  });
+
+  it('dry-run does not delete composite dirs', () => {
+    const dir = makeTempRepo();
+    const actionsDir = join(dir, '.github', 'actions');
+    mkdirSync(join(actionsDir, 'ferry-cc-apply'), { recursive: true });
+
+    const opts = makeOpts({ dryRun: true });
+    removeCompositeActions(dir, detectCompositeActions(dir), opts);
+
+    expect(existsSync(join(actionsDir, 'ferry-cc-apply'))).toBe(true);
+    expect(opts.actions.some((a) => a.includes('[dry-run]'))).toBe(true);
+
+    cleanup(dir);
+  });
+
+  it('handles partial install — deletes present, skips missing', () => {
+    const dir = makeTempRepo();
+    const actionsDir = join(dir, '.github', 'actions');
+    mkdirSync(join(actionsDir, 'ferry-route'), { recursive: true });
+
+    const opts = makeOpts();
+    removeCompositeActions(dir, detectCompositeActions(dir), opts);
+
+    expect(existsSync(join(actionsDir, 'ferry-route'))).toBe(false);
+    expect(opts.actions.filter((a) => a.startsWith('Deleted'))).toHaveLength(1);
+    expect(opts.skips.filter((s) => s.includes('not present'))).toHaveLength(
+      FERRY_COMPOSITE_DIRS.length - 1,
+    );
+
+    cleanup(dir);
+  });
+
+  it('removes CLAUDE_CODE_OAUTH_SECRET when explicitly passed to removeSecrets', () => {
+    mockSpawnSync.mockReturnValue(spawnOk());
+    const opts = makeOpts();
+    removeSecrets('owner/repo', [CLAUDE_CODE_OAUTH_SECRET], opts);
+
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'gh',
+      ['secret', 'delete', CLAUDE_CODE_OAUTH_SECRET, '--repo', 'owner/repo'],
+      expect.any(Object),
+    );
+    expect(opts.actions).toContain(`Deleted secret ${CLAUDE_CODE_OAUTH_SECRET}`);
   });
 });
 

--- a/src/cli/uninstall/uninstall.test.ts
+++ b/src/cli/uninstall/uninstall.test.ts
@@ -31,6 +31,7 @@ import {
   handleAuditIssue,
   type ExecOptions,
 } from './execute.js';
+import { shouldRemoveOAuth } from './oauth-gate.js';
 
 function makeOpts(overrides?: Partial<ExecOptions>): ExecOptions & {
   actions: string[];
@@ -323,19 +324,6 @@ describe('removeCompositeActions', () => {
 
     cleanup(dir);
   });
-
-  it('removes CLAUDE_CODE_OAUTH_SECRET when explicitly passed to removeSecrets', () => {
-    mockSpawnSync.mockReturnValue(spawnOk());
-    const opts = makeOpts();
-    removeSecrets('owner/repo', [CLAUDE_CODE_OAUTH_SECRET], opts);
-
-    expect(mockSpawnSync).toHaveBeenCalledWith(
-      'gh',
-      ['secret', 'delete', CLAUDE_CODE_OAUTH_SECRET, '--repo', 'owner/repo'],
-      expect.any(Object),
-    );
-    expect(opts.actions).toContain(`Deleted secret ${CLAUDE_CODE_OAUTH_SECRET}`);
-  });
 });
 
 // ── removeWorkflows ───────────────────────────────────────────────────────────
@@ -559,6 +547,19 @@ describe('removeSecrets', () => {
       expect.any(Object),
     );
   });
+
+  it('removes CLAUDE_CODE_OAUTH_SECRET when explicitly passed to removeSecrets', () => {
+    mockSpawnSync.mockReturnValue(spawnOk());
+    const opts = makeOpts();
+    removeSecrets('owner/repo', [CLAUDE_CODE_OAUTH_SECRET], opts);
+
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'gh',
+      ['secret', 'delete', CLAUDE_CODE_OAUTH_SECRET, '--repo', 'owner/repo'],
+      expect.any(Object),
+    );
+    expect(opts.actions).toContain(`Deleted secret ${CLAUDE_CODE_OAUTH_SECRET}`);
+  });
 });
 
 // ── removeVariable ────────────────────────────────────────────────────────────
@@ -655,5 +656,49 @@ describe('handleAuditIssue', () => {
     handleAuditIssue('owner/repo', { number: 42, hasLabel: true }, false, opts);
 
     expect(opts.errors.some((e) => e.includes('#42'))).toBe(true);
+  });
+});
+
+// ── shouldRemoveOAuth (headline safety invariant for CLAUDE_CODE_OAUTH_TOKEN) ──
+
+describe('shouldRemoveOAuth', () => {
+  // Headline guarantee: --yes mode must NEVER remove the OAuth token,
+  // regardless of presence or any spurious "confirmed" flag.
+  it('never removes the OAuth token under --yes when present and confirmed=true', () => {
+    expect(shouldRemoveOAuth({ yes: true, oauthSecretPresent: true, confirmed: true })).toBe(false);
+  });
+
+  it('never removes the OAuth token under --yes when present and confirmed=false', () => {
+    expect(shouldRemoveOAuth({ yes: true, oauthSecretPresent: true, confirmed: false })).toBe(
+      false,
+    );
+  });
+
+  it('never removes the OAuth token under --yes when absent', () => {
+    expect(shouldRemoveOAuth({ yes: true, oauthSecretPresent: false, confirmed: true })).toBe(
+      false,
+    );
+    expect(shouldRemoveOAuth({ yes: true, oauthSecretPresent: false, confirmed: false })).toBe(
+      false,
+    );
+  });
+
+  it('removes the OAuth token in interactive mode only when present and explicitly confirmed', () => {
+    expect(shouldRemoveOAuth({ yes: false, oauthSecretPresent: true, confirmed: true })).toBe(true);
+  });
+
+  it('does not remove the OAuth token in interactive mode when the user declines', () => {
+    expect(shouldRemoveOAuth({ yes: false, oauthSecretPresent: true, confirmed: false })).toBe(
+      false,
+    );
+  });
+
+  it('does not remove the OAuth token in interactive mode when the secret is not present', () => {
+    expect(shouldRemoveOAuth({ yes: false, oauthSecretPresent: false, confirmed: true })).toBe(
+      false,
+    );
+    expect(shouldRemoveOAuth({ yes: false, oauthSecretPresent: false, confirmed: false })).toBe(
+      false,
+    );
   });
 });


### PR DESCRIPTION
Implements #337: extends ferry-uninstall to delete .github/actions/ferry-route/, ferry-cc-prepare/, ferry-cc-apply/ and adds interactive CLAUDE_CODE_OAUTH_TOKEN removal flow (never auto-removed in --yes mode).

Generated with [Claude Code](https://claude.ai/code)