### PR TITLE
refactor(agent-runtime): extract per-role pre-loop setup into prepare functions (closes #330)

### DIFF
--- a/.ferry/agent.js
+++ b/.ferry/agent.js
@@ -6610,7 +6610,7 @@ ${tree}`,
   };
 }
 
-// src/agents/reviewer/rubric.ts
+// src/lib/agent-runtime/reviewer-helpers.ts
 var STRICT_DIRECTIVE = [
   "## Rubric override \u2014 strict",
   "",
@@ -6641,53 +6641,6 @@ function applyRubricToPrompt(basePrompt, rubric) {
 
 ${directive}`;
 }
-
-// src/agents/reviewer/review-loop.ts
-var MAX_PATCH_CHARS = 2e4;
-var MAX_CONTENT_CHARS = 4e4;
-var MAX_ITERATIONS = 40;
-var REVIEW_TOOL_DEFS = [
-  {
-    name: "get_file_patch",
-    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "get_file_content",
-    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "finish_review",
-    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
-    input_schema: {
-      type: "object",
-      properties: {
-        approved: {
-          type: "boolean",
-          description: "true = ready to merge, false = changes required."
-        },
-        comment: {
-          type: "string",
-          description: "Full review comment in Markdown. Follow the required format from the system prompt."
-        }
-      },
-      required: ["approved", "comment"]
-    }
-  }
-];
 function detectMergeConflicts(files) {
   const conflicted = [];
   for (const f of files) {
@@ -6699,57 +6652,6 @@ function detectMergeConflicts(files) {
 }
 function buildFileList(files) {
   return files.map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`).join("\n");
-}
-async function runReviewLoop(opts) {
-  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
-  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
-  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
-  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
-  const {
-    done: result,
-    usage,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  } = await loop.run({
-    system,
-    initialPrompt,
-    tools: REVIEW_TOOL_DEFS,
-    finishTool: "finish_review",
-    extractDone: (input) => ({
-      approved: input.approved,
-      comment: input.comment
-    }),
-    handlers: {
-      get_file_patch: (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_patch", file: filename });
-        const patch = fileMap.get(filename);
-        if (patch === void 0) return `(file not found in PR: ${filename})`;
-        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
-        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
-        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
-      },
-      get_file_content: async (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_content", file: filename });
-        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
-        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
-        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
-      }
-    },
-    maxIterations,
-    maxTokens,
-    logger
-  });
-  return {
-    result,
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  };
 }
 
 // src/lib/agent-runtime/reviewer-prepare.ts
@@ -6763,9 +6665,9 @@ function prepareReviewer(input) {
     branchName,
     typeOverride,
     reviewRubric,
-    configLabels,
-    repoRoot,
-    logger
+    capabilities,
+    idempotencyMarker,
+    repoRoot
   } = input;
   const buildSystem2 = input._buildSystem ?? buildSystem;
   const loadOptionalPrompt2 = input._loadOptionalPrompt ?? loadOptionalPrompt;
@@ -6802,9 +6704,7 @@ function prepareReviewer(input) {
     separator: "\n\n---\n\n"
   });
   const system = applyRubricToPrompt(baseSystem, reviewRubric);
-  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
   const mcpServers = [];
-  const idempotencyMarker = byPrHeadSha("reviewer", headSha);
   return {
     system,
     initialPrompt,
@@ -6821,15 +6721,15 @@ function prepareIterator(input) {
   const {
     ticketKey,
     issue,
-    headSha,
     reviewComment,
     mergeConflicts,
     existingLog,
     mcpPool,
     configLabels,
+    capabilities,
+    idempotencyMarker,
     typeOverride,
-    repoRoot,
-    logger
+    repoRoot
   } = input;
   const buildSystem2 = input._buildSystem ?? buildSystem;
   const system = buildSystem2("iterate", repoRoot);
@@ -6848,10 +6748,8 @@ ${existingLog}` : "",
     "",
     "When you have fixed all findings, call the `done` tool."
   ].filter(Boolean).join("\n");
-  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
   const hasLabelsConfig = configLabels !== void 0;
   const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
-  const idempotencyMarker = byPrHeadSha("iterator", headSha);
   return {
     system,
     initialPrompt,
@@ -10571,6 +10469,104 @@ function gateCi(input) {
   };
 }
 
+// src/agents/reviewer/review-loop.ts
+var MAX_PATCH_CHARS = 2e4;
+var MAX_CONTENT_CHARS = 4e4;
+var MAX_ITERATIONS = 40;
+var REVIEW_TOOL_DEFS = [
+  {
+    name: "get_file_patch",
+    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "get_file_content",
+    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "finish_review",
+    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
+    input_schema: {
+      type: "object",
+      properties: {
+        approved: {
+          type: "boolean",
+          description: "true = ready to merge, false = changes required."
+        },
+        comment: {
+          type: "string",
+          description: "Full review comment in Markdown. Follow the required format from the system prompt."
+        }
+      },
+      required: ["approved", "comment"]
+    }
+  }
+];
+async function runReviewLoop(opts) {
+  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
+  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
+  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
+  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
+  const {
+    done: result,
+    usage,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  } = await loop.run({
+    system,
+    initialPrompt,
+    tools: REVIEW_TOOL_DEFS,
+    finishTool: "finish_review",
+    extractDone: (input) => ({
+      approved: input.approved,
+      comment: input.comment
+    }),
+    handlers: {
+      get_file_patch: (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_patch", file: filename });
+        const patch = fileMap.get(filename);
+        if (patch === void 0) return `(file not found in PR: ${filename})`;
+        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
+        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
+        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
+      },
+      get_file_content: async (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_content", file: filename });
+        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
+        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
+        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
+      }
+    },
+    maxIterations,
+    maxTokens,
+    logger
+  });
+  return {
+    result,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  };
+}
+
 // src/agents/reviewer/changes-guard.ts
 function countPriorIterations(existingComments) {
   return existingComments.filter(
@@ -10733,9 +10729,9 @@ async function main3(envelope, logger) {
     branchName,
     typeOverride,
     reviewRubric: reviewRubricOverride,
-    configLabels: effectiveCfg.labels,
-    repoRoot: REPO_ROOT3,
-    logger
+    capabilities,
+    idempotencyMarker,
+    repoRoot: REPO_ROOT3
   });
   const { system, initialPrompt, fileMap } = prepared;
   const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
@@ -10960,6 +10956,8 @@ async function main4(envelope, logger) {
   const reviewTransitionId = shouldAutoTransition ? requireEnv("FERRY_REVIEW_TRANSITION_ID") : "";
   const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels, logger);
+  logCapabilities(logger, capabilities);
   const priorIterations = existingComments.filter(
     (c) => c.includes("[ferry:iterator:") && c.includes("complete. Pushed fixes to PR#")
   ).length;
@@ -11052,12 +11050,12 @@ async function main4(envelope, logger) {
     existingLog,
     mcpPool,
     configLabels: effectiveCfg.labels,
+    capabilities,
+    idempotencyMarker,
     typeOverride,
-    repoRoot: REPO_ROOT4,
-    logger
+    repoRoot: REPO_ROOT4
   });
-  const { system, initialPrompt, mcpServers, capabilities } = prepared;
-  logCapabilities(logger, capabilities);
+  const { system, initialPrompt, mcpServers } = prepared;
   const secretScan = makeSecretScan(REPO_ROOT4);
   const loop = createAgentLoop({
     provider: iterProvider,

--- a/.ferry/agent.js
+++ b/.ferry/agent.js
@@ -6442,6 +6442,426 @@ function buildConflictComment(role, runId, err) {
   ].join("\n");
 }
 
+// src/lib/agent-runtime/refiner-prepare.ts
+var PRIOR_RUN_MARKER = /\[ferry:refiner:[^\]]+\]/;
+async function prepareRefiner(input) {
+  const { envelope, tracker } = input;
+  const { ticket_key: ticketKey, event_id: eventId } = envelope;
+  const issue = await tracker.getIssue(ticketKey);
+  const existingSubtasks = await tracker.getSubtaskDetails(ticketKey);
+  const priorRefinerRuns = issue.comments.filter((c) => PRIOR_RUN_MARKER.test(c));
+  const runLink = `https://github.com/${process.env.GITHUB_REPO ?? "unknown"}/actions/runs/${process.env.GITHUB_RUN_ID ?? "0"}`;
+  const idempotencyMarker = byEventId("refiner", eventId);
+  return {
+    issue,
+    existingSubtasks,
+    priorRefinerRuns,
+    runLink,
+    idempotencyMarker
+  };
+}
+
+// src/lib/agent-runtime/developer-prepare.ts
+import { execFileSync as execFileSync3 } from "node:child_process";
+
+// src/lib/llm/delimit-untrusted.ts
+var OPEN = "<<<UNTRUSTED>>>";
+var CLOSE = "<<<END UNTRUSTED>>>";
+var OPEN_ESCAPE = "<<<UNTRUSTED-LITERAL>>>";
+var CLOSE_ESCAPE = "<<<END UNTRUSTED-LITERAL>>>";
+function delimitUntrusted(value) {
+  const escaped = value.split(OPEN).join(OPEN_ESCAPE).split(CLOSE).join(CLOSE_ESCAPE);
+  return `${OPEN}
+${escaped}
+${CLOSE}`;
+}
+
+// src/lib/agent-runtime/developer-prepare.ts
+var checkoutOrCreateBranchDefault = (branchName, baseBranch, repoRoot, logger) => {
+  try {
+    execFileSync3("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
+      cwd: repoRoot,
+      stdio: "pipe"
+    });
+    execFileSync3("git", ["fetch", "origin", branchName], { cwd: repoRoot });
+    execFileSync3("git", ["checkout", branchName], { cwd: repoRoot });
+    const existingLog = execFileSync3("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
+      cwd: repoRoot,
+      encoding: "utf8"
+    }).trim();
+    if (existingLog) {
+      logger.info("resuming branch", {
+        branch: branchName,
+        prior_commits: existingLog.split("\n").length
+      });
+    }
+    const branchHeadSha = execFileSync3("git", ["rev-parse", "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf8"
+    }).trim();
+    return { branchHeadSha, existingLog };
+  } catch {
+    execFileSync3("git", ["checkout", "-B", branchName], { cwd: repoRoot });
+    logger.info("created branch", { branch: branchName });
+    return { branchHeadSha: "", existingLog: "" };
+  }
+};
+async function prepareDeveloper(input) {
+  const {
+    envelope,
+    issue,
+    effectiveCfg,
+    subtasks,
+    testRunner,
+    pkgManagerHint,
+    tree,
+    typeOverride,
+    owner,
+    repo,
+    baseBranch,
+    runner,
+    mcpPool,
+    repoRoot,
+    dryRun,
+    logger
+  } = input;
+  const buildSystem2 = input._buildSystem ?? buildSystem;
+  const checkoutOrCreateBranch = input._checkoutOrCreateBranch ?? checkoutOrCreateBranchDefault;
+  const configureGitUser = input._configureGitUser ?? configureFerryGitUser;
+  const ticketKey = envelope.ticket_key;
+  const eventId = envelope.event_id;
+  const labels = issue.labels.join(", ");
+  const comments = issue.comments.map((c) => `Comment: ${c}`).join("\n");
+  const ticketBlock = buildTicketBlock(ticketKey, issue, {
+    labels,
+    comments,
+    typeOverride
+  });
+  const system = buildSystem2("dev", repoRoot, {
+    extraParts: pkgManagerHint ? [`## Detected package manager
+
+${pkgManagerHint}`] : []
+  });
+  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
+  configureGitUser(repoRoot);
+  const { branchHeadSha, existingLog } = checkoutOrCreateBranch(
+    branchName,
+    baseBranch,
+    repoRoot,
+    logger
+  );
+  const resumeContext = existingLog ? `
+EXISTING WORK ON BRANCH (already committed \u2014 skip these, only do what remains):
+${existingLog}` : "";
+  let existingPrUrl = "";
+  let existingPrContext = "";
+  if (branchHeadSha && !dryRun) {
+    try {
+      const openPrs = await runner.listPRsForBranch(owner, repo, branchName);
+      if (openPrs.length > 0) {
+        const pr = openPrs[0];
+        existingPrUrl = `https://github.com/${owner}/${repo}/pull/${pr.number}`;
+        const prRef = { owner, repo, prNumber: pr.number };
+        const prFiles = await runner.listPRFiles(prRef);
+        const fileList = prFiles.map((f) => `${f.status}: ${f.filename}`).join("\n");
+        existingPrContext = [
+          `
+EXISTING_IMPLEMENTATION:`,
+          `Open PR: ${existingPrUrl} (head: ${branchHeadSha.slice(0, 7)})`,
+          `Changed files:
+${fileList}`,
+          `If the spec is already fully satisfied by the existing code, call \`done\` with outcome="already_satisfied".`
+        ].join("\n");
+        logger.info("existing PR found", { pr: existingPrUrl, files: prFiles.length });
+      }
+    } catch {
+    }
+  }
+  const idempotencyMarker = branchHeadSha ? byPrHeadSha("dev", branchHeadSha) : byEventId("dev", eventId);
+  const baseInitialPrompt = [
+    delimitUntrusted(ticketBlock),
+    "",
+    subtasks.length > 0 ? `SUBTASKS:
+${subtasks.join("\n")}` : "SUBTASKS: (none)",
+    "",
+    `TEST_RUNNER: ${testRunner}`,
+    "",
+    `REPO TREE (depth 2):
+${tree}`,
+    "",
+    "When you have finished implementing, call the `done` tool."
+  ].join("\n");
+  const initialPrompt = baseInitialPrompt + resumeContext + existingPrContext;
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
+  const hasLabelsConfig = effectiveCfg.labels !== void 0;
+  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  return {
+    system,
+    initialPrompt,
+    baseInitialPrompt,
+    mcpServers,
+    idempotencyMarker,
+    ticketBlock,
+    subtasks,
+    capabilities,
+    branchName,
+    branchHeadSha,
+    existingPrUrl
+  };
+}
+
+// src/agents/reviewer/rubric.ts
+var STRICT_DIRECTIVE = [
+  "## Rubric override \u2014 strict",
+  "",
+  "For this review, apply a STRICTER bar than usual:",
+  "",
+  "- Block on any missing test coverage for new/changed behaviour.",
+  "- Block on missing edge-case handling, error paths, or input validation.",
+  "- Block on weak naming, dead code, or unreachable branches.",
+  "- Block on incomplete documentation when public APIs change.",
+  "- Approve only when every acceptance criterion is fully satisfied with concrete evidence."
+].join("\n");
+var LENIENT_DIRECTIVE = [
+  "## Rubric override \u2014 lenient",
+  "",
+  "For this review, apply a MORE PERMISSIVE bar than usual:",
+  "",
+  "- Approve when the acceptance criteria are met, even if minor polish is missing.",
+  "- Treat naming nits, non-blocking style issues, and stylistic preferences as comments \u2014 not blockers.",
+  "- Block only on: failing tests, unimplemented ACs, merge conflicts, committed build artefacts, or security regressions.",
+  '- Prefer "approve with comments" over "request changes" when issues are non-blocking.'
+].join("\n");
+function applyRubricToPrompt(basePrompt, rubric) {
+  if (rubric === void 0) return basePrompt;
+  const directive = rubric === "strict" ? STRICT_DIRECTIVE : LENIENT_DIRECTIVE;
+  return `${basePrompt}
+
+---
+
+${directive}`;
+}
+
+// src/agents/reviewer/review-loop.ts
+var MAX_PATCH_CHARS = 2e4;
+var MAX_CONTENT_CHARS = 4e4;
+var MAX_ITERATIONS = 40;
+var REVIEW_TOOL_DEFS = [
+  {
+    name: "get_file_patch",
+    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "get_file_content",
+    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "finish_review",
+    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
+    input_schema: {
+      type: "object",
+      properties: {
+        approved: {
+          type: "boolean",
+          description: "true = ready to merge, false = changes required."
+        },
+        comment: {
+          type: "string",
+          description: "Full review comment in Markdown. Follow the required format from the system prompt."
+        }
+      },
+      required: ["approved", "comment"]
+    }
+  }
+];
+function detectMergeConflicts(files) {
+  const conflicted = [];
+  for (const f of files) {
+    if (f.patch && /^[+].*<{7}|^[+].*={7}|^[+].*>{7}/m.test(f.patch)) {
+      conflicted.push(f.filename);
+    }
+  }
+  return conflicted;
+}
+function buildFileList(files) {
+  return files.map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`).join("\n");
+}
+async function runReviewLoop(opts) {
+  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
+  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
+  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
+  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
+  const {
+    done: result,
+    usage,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  } = await loop.run({
+    system,
+    initialPrompt,
+    tools: REVIEW_TOOL_DEFS,
+    finishTool: "finish_review",
+    extractDone: (input) => ({
+      approved: input.approved,
+      comment: input.comment
+    }),
+    handlers: {
+      get_file_patch: (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_patch", file: filename });
+        const patch = fileMap.get(filename);
+        if (patch === void 0) return `(file not found in PR: ${filename})`;
+        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
+        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
+        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
+      },
+      get_file_content: async (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_content", file: filename });
+        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
+        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
+        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
+      }
+    },
+    maxIterations,
+    maxTokens,
+    logger
+  });
+  return {
+    result,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  };
+}
+
+// src/lib/agent-runtime/reviewer-prepare.ts
+function prepareReviewer(input) {
+  const {
+    ticketKey,
+    issue,
+    pr,
+    files,
+    commits,
+    branchName,
+    typeOverride,
+    reviewRubric,
+    configLabels,
+    repoRoot,
+    logger
+  } = input;
+  const buildSystem2 = input._buildSystem ?? buildSystem;
+  const loadOptionalPrompt2 = input._loadOptionalPrompt ?? loadOptionalPrompt;
+  const headSha = pr.headSha;
+  const prNumber = pr.number;
+  const fileMap = new Map(files.map((f) => [f.filename, f.patch]));
+  const conflictedFiles = detectMergeConflicts(files);
+  const hasMergeConflicts = pr.mergeable === false || conflictedFiles.length > 0;
+  const commitLog = commits.map((c) => `${c.sha.slice(0, 7)} ${c.message.split("\n")[0]}`).join("\n");
+  const ticketBlock = buildTicketBlock(ticketKey, issue, { typeOverride });
+  const mergeConflictWarning = hasMergeConflicts ? `
+\u26A0\uFE0F  MERGE CONFLICTS DETECTED \u2014 mergeable=${String(pr.mergeable)}${conflictedFiles.length > 0 ? `, conflicted files: ${conflictedFiles.join(", ")}` : ""}` : "";
+  const initialPrompt = [
+    "## Jira Ticket",
+    delimitUntrusted(ticketBlock),
+    "",
+    "## PR Metadata",
+    `PR #${prNumber}: ${pr.title}`,
+    `Base: ${pr.baseRef} \u2190 Head: ${branchName} (${headSha.slice(0, 7)})`,
+    `Files changed: ${files.length}  Commits: ${commits.length}`,
+    mergeConflictWarning,
+    "",
+    "## Commits",
+    commitLog,
+    "",
+    "## Changed files (status  +additions  -deletions  path)",
+    buildFileList(files),
+    "",
+    "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
+    "When you have enough information, call finish_review."
+  ].filter((l) => l !== null).join("\n");
+  const baseSystem = buildSystem2("review", repoRoot, {
+    extraParts: [loadOptionalPrompt2("review-comment", repoRoot)],
+    separator: "\n\n---\n\n"
+  });
+  const system = applyRubricToPrompt(baseSystem, reviewRubric);
+  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
+  const mcpServers = [];
+  const idempotencyMarker = byPrHeadSha("reviewer", headSha);
+  return {
+    system,
+    initialPrompt,
+    mcpServers,
+    idempotencyMarker,
+    ticketBlock,
+    capabilities,
+    fileMap
+  };
+}
+
+// src/lib/agent-runtime/iterator-prepare.ts
+function prepareIterator(input) {
+  const {
+    ticketKey,
+    issue,
+    headSha,
+    reviewComment,
+    mergeConflicts,
+    existingLog,
+    mcpPool,
+    configLabels,
+    typeOverride,
+    repoRoot,
+    logger
+  } = input;
+  const buildSystem2 = input._buildSystem ?? buildSystem;
+  const system = buildSystem2("iterate", repoRoot);
+  const ticketBlock = buildTicketBlock(ticketKey, issue, { typeOverride });
+  const initialPrompt = [
+    "## Jira Ticket",
+    delimitUntrusted(ticketBlock),
+    "",
+    "## Review Findings (fix only what is listed here)",
+    delimitUntrusted(reviewComment),
+    "",
+    mergeConflicts.length > 0 ? `## Merge Conflicts (resolve these first, before fixing review findings)
+${mergeConflicts.map((f) => `- ${f}`).join("\n")}` : "",
+    existingLog ? `## Existing commits on branch
+${existingLog}` : "",
+    "",
+    "When you have fixed all findings, call the `done` tool."
+  ].filter(Boolean).join("\n");
+  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
+  const hasLabelsConfig = configLabels !== void 0;
+  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  const idempotencyMarker = byPrHeadSha("iterator", headSha);
+  return {
+    system,
+    initialPrompt,
+    mcpServers,
+    idempotencyMarker,
+    ticketBlock,
+    capabilities
+  };
+}
+
 // src/lib/dry-run.ts
 function isDryRun() {
   return process.env.FERRY_DRY_RUN === "1" || process.env.FERRY_DRY_RUN === "true";
@@ -6640,18 +7060,6 @@ function createLlmCall(route) {
 
 // src/agents/refiner/refine.ts
 import { createRequire as createRequire3 } from "module";
-
-// src/lib/llm/delimit-untrusted.ts
-var OPEN = "<<<UNTRUSTED>>>";
-var CLOSE = "<<<END UNTRUSTED>>>";
-var OPEN_ESCAPE = "<<<UNTRUSTED-LITERAL>>>";
-var CLOSE_ESCAPE = "<<<END UNTRUSTED-LITERAL>>>";
-function delimitUntrusted(value) {
-  const escaped = value.split(OPEN).join(OPEN_ESCAPE).split(CLOSE).join(CLOSE_ESCAPE);
-  return `${OPEN}
-${escaped}
-${CLOSE}`;
-}
 
 // src/agents/refiner/parse.ts
 function extractFirstJsonObject(text) {
@@ -7028,15 +7436,12 @@ function estimateTicketCost(_plan, baseline) {
 
 // src/agents/refiner/refiner-action.ts
 var REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
-var PRIOR_RUN_MARKER = /\[ferry:refiner:[^\]]+\]/;
 async function run(envelope, deps) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const logger = deps.logger ?? createLogger(eventId, "ferry:refiner-action");
   const dryRun = isDryRun() || deps.dryRun === true;
-  const issue = await deps.tracker.getIssue(ticketKey);
-  const runLink = `https://github.com/${process.env.GITHUB_REPO ?? "unknown"}/actions/runs/${process.env.GITHUB_RUN_ID ?? "0"}`;
-  const existingSubtasks = await deps.tracker.getSubtaskDetails(ticketKey);
-  const priorRefinerRuns = issue.comments.filter((c) => PRIOR_RUN_MARKER.test(c));
+  const prepared = await prepareRefiner({ envelope, tracker: deps.tracker });
+  const { issue, existingSubtasks, priorRefinerRuns, runLink, idempotencyMarker } = prepared;
   const { plan, auditSummary } = await runRefiner({
     ticket: {
       key: issue.key,
@@ -7111,7 +7516,6 @@ async function run(envelope, deps) {
     existingSubtasks,
     tracker: deps.tracker
   });
-  const idempotencyMarker = `[ferry:refiner:${eventId}]`;
   if (result.noop) {
     logger.info("noop \u2014 existing sub-tasks still valid", { ticket: ticketKey });
     await deps.tracker.postComment(
@@ -7199,7 +7603,7 @@ async function main(envelope, logger) {
 }
 
 // src/agents/developer/dev-action.ts
-import { execFileSync as execFileSync5 } from "node:child_process";
+import { execFileSync as execFileSync6 } from "node:child_process";
 import * as fsp2 from "node:fs/promises";
 import * as path6 from "node:path";
 
@@ -9093,7 +9497,7 @@ function createAgentLoop(opts) {
 
 // src/agents/developer/workspace.ts
 import { readFileSync as readFileSync5, existsSync as existsSync4 } from "node:fs";
-import { execFileSync as execFileSync3 } from "node:child_process";
+import { execFileSync as execFileSync4 } from "node:child_process";
 import * as path5 from "node:path";
 function detectTestRunner(packageJsonPath2) {
   try {
@@ -9112,7 +9516,7 @@ function detectTestRunner(packageJsonPath2) {
 }
 function repoTree(repoRoot) {
   try {
-    return execFileSync3(
+    return execFileSync4(
       "find",
       [
         repoRoot,
@@ -9204,7 +9608,7 @@ function assertDevOutputContract(outcome, outputs) {
 }
 
 // src/agents/developer/wip-finalizer.ts
-import { execFileSync as execFileSync4 } from "node:child_process";
+import { execFileSync as execFileSync5 } from "node:child_process";
 function classifyError(err) {
   if (err instanceof FerryError) {
     const reason = err.context?.reason ?? "unknown";
@@ -9243,8 +9647,8 @@ async function runWipFinalizer(opts) {
   logger.info("wip_finalizer", { code, detail, branch: branchName });
   let committed = false;
   try {
-    execFileSync4("git", ["add", "-A"], { cwd: repoRoot });
-    const status = execFileSync4("git", ["status", "--porcelain"], {
+    execFileSync5("git", ["add", "-A"], { cwd: repoRoot });
+    const status = execFileSync5("git", ["status", "--porcelain"], {
       cwd: repoRoot,
       encoding: "utf8"
     });
@@ -9253,7 +9657,7 @@ async function runWipFinalizer(opts) {
       const wipMsg = `wip(${ticketKey}): interrupted \u2014 ${code}
 
 [ferry:dev:${eventId}]`;
-      execFileSync4("git", ["commit", "-m", wipMsg], { cwd: repoRoot });
+      execFileSync5("git", ["commit", "-m", wipMsg], { cwd: repoRoot });
       committed = true;
       logger.info("wip_committed", { branch: branchName });
     } else {
@@ -9265,14 +9669,14 @@ async function runWipFinalizer(opts) {
   let pushed = false;
   if (!dryRun) {
     try {
-      execFileSync4("git", ["push", "origin", branchName, "--force-with-lease"], {
+      execFileSync5("git", ["push", "origin", branchName, "--force-with-lease"], {
         cwd: repoRoot,
         stdio: "pipe"
       });
       pushed = true;
     } catch {
       try {
-        execFileSync4("git", ["push", "origin", branchName], { cwd: repoRoot, stdio: "pipe" });
+        execFileSync5("git", ["push", "origin", branchName], { cwd: repoRoot, stdio: "pipe" });
         pushed = true;
       } catch (pushErr) {
         logger.error("wip_push_failed", { error: pushErr.message });
@@ -9398,102 +9802,36 @@ async function main2(envelope, logger) {
   const reviewTransitionId = !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
   const jiraBaseUrl = requireEnv("FERRY_JIRA_BASE_URL");
   const { provider: devProvider } = effectiveCfg.models.dev;
-  const labels = issue.labels.join(", ");
-  const comments = issue.comments.map((c) => `Comment: ${c}`).join("\n");
-  const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    labels,
-    comments,
-    typeOverride
-  });
+  const model = effectiveCfg.models.dev.model;
   const subtasks = await tracker.getSubtasks(ticketKey);
   const testRunner = detectTestRunner(packageJsonPath(REPO_ROOT2));
   const pkgManagerHint = detectPackageManager(REPO_ROOT2);
   const tree = repoTree(REPO_ROOT2);
-  const system = buildSystem("dev", REPO_ROOT2, {
-    extraParts: pkgManagerHint ? [`## Detected package manager
-
-${pkgManagerHint}`] : []
-  });
-  const model = effectiveCfg.models.dev.model;
-  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
-  configureFerryGitUser(REPO_ROOT2);
-  let resumeContext = "";
-  let branchHeadSha = "";
-  try {
-    execFileSync5("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
-      cwd: REPO_ROOT2,
-      stdio: "pipe"
-    });
-    execFileSync5("git", ["fetch", "origin", branchName], { cwd: REPO_ROOT2 });
-    execFileSync5("git", ["checkout", branchName], { cwd: REPO_ROOT2 });
-    const existingLog = execFileSync5("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
-      cwd: REPO_ROOT2,
-      encoding: "utf8"
-    }).trim();
-    if (existingLog) {
-      resumeContext = `
-EXISTING WORK ON BRANCH (already committed \u2014 skip these, only do what remains):
-${existingLog}`;
-      logger.info("resuming branch", {
-        branch: branchName,
-        prior_commits: existingLog.split("\n").length
-      });
-    }
-    branchHeadSha = execFileSync5("git", ["rev-parse", "HEAD"], {
-      cwd: REPO_ROOT2,
-      encoding: "utf8"
-    }).trim();
-  } catch {
-    execFileSync5("git", ["checkout", "-B", branchName], { cwd: REPO_ROOT2 });
-    logger.info("created branch", { branch: branchName });
-  }
-  let existingPrUrl = "";
-  let existingPrContext = "";
-  if (branchHeadSha && !dryRun) {
-    try {
-      const openPrs = await runner.listPRsForBranch(owner, repo, branchName);
-      if (openPrs.length > 0) {
-        const pr = openPrs[0];
-        existingPrUrl = `https://github.com/${owner}/${repo}/pull/${pr.number}`;
-        const prRef = { owner, repo, prNumber: pr.number };
-        const prFiles = await runner.listPRFiles(prRef);
-        const fileList = prFiles.map((f) => `${f.status}: ${f.filename}`).join("\n");
-        existingPrContext = [
-          `
-EXISTING_IMPLEMENTATION:`,
-          `Open PR: ${existingPrUrl} (head: ${branchHeadSha.slice(0, 7)})`,
-          `Changed files:
-${fileList}`,
-          `If the spec is already fully satisfied by the existing code, call \`done\` with outcome="already_satisfied".`
-        ].join("\n");
-        logger.info("existing PR found", { pr: existingPrUrl, files: prFiles.length });
-      }
-    } catch {
-    }
-  }
-  const idempotencyMarker = branchHeadSha ? `[ferry:dev:${branchHeadSha.slice(0, 7)}]` : `[ferry:dev:${eventId}]`;
-  const initialPrompt = [
-    delimitUntrusted(ticketBlock),
-    "",
-    subtasks.length > 0 ? `SUBTASKS:
-${subtasks.join("\n")}` : "SUBTASKS: (none)",
-    "",
-    `TEST_RUNNER: ${testRunner}`,
-    "",
-    `REPO TREE (depth 2):
-${tree}`,
-    "",
-    "When you have finished implementing, call the `done` tool."
-  ].join("\n");
-  const secretScan = makeSecretScan(REPO_ROOT2);
   const mcpPool = loadMcpServers();
-  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
-  const hasLabelsConfig = effectiveCfg.labels !== void 0;
-  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  const prepared = await prepareDeveloper({
+    envelope,
+    issue,
+    effectiveCfg,
+    subtasks,
+    testRunner,
+    pkgManagerHint,
+    tree,
+    typeOverride,
+    owner,
+    repo,
+    baseBranch,
+    runner,
+    mcpPool,
+    repoRoot: REPO_ROOT2,
+    dryRun,
+    logger
+  });
+  const { system, initialPrompt, mcpServers, idempotencyMarker, branchName, capabilities } = prepared;
   logCapabilities(logger, capabilities);
   if (mcpServers.length > 0) {
     logger.info("MCP servers", { servers: mcpServers.map((s) => s.name) });
   }
+  const secretScan = makeSecretScan(REPO_ROOT2);
   const allToolSchemas = [...TOOL_SCHEMAS, COMMIT_PROGRESS_SCHEMA, SPAWN_SUBAGENT_SCHEMA];
   let loop;
   loop = createAgentLoop({
@@ -9521,7 +9859,9 @@ ${tree}`,
   try {
     loopResult = await loop.run({
       system,
-      initialPrompt: initialPrompt + resumeContext + existingPrContext,
+      // `initialPrompt` already includes the resume + existing-PR context
+      // (concatenated inside `prepareDeveloper`).
+      initialPrompt,
       tools: allToolSchemas,
       repoRoot: REPO_ROOT2,
       branchName,
@@ -9618,20 +9958,20 @@ ${tree}`,
       await fsp2.writeFile(verificationPath, verificationContent, "utf8");
       verificationNoteWritten = true;
     }
-    execFileSync5("git", ["add", "-A"], { cwd: REPO_ROOT2 });
-    const finalStatus = execFileSync5("git", ["status", "--porcelain"], {
+    execFileSync6("git", ["add", "-A"], { cwd: REPO_ROOT2 });
+    const finalStatus = execFileSync6("git", ["status", "--porcelain"], {
       cwd: REPO_ROOT2,
       encoding: "utf8"
     });
     if (finalStatus.trim()) {
       await secretScan();
       const msg = resolvedOutcome === "already_satisfied" ? `chore(${ticketKey}): add verification note \u2014 spec already satisfied` : done.commit_message ?? commitMessage;
-      execFileSync5("git", ["commit", "-m", msg], { cwd: REPO_ROOT2 });
+      execFileSync6("git", ["commit", "-m", msg], { cwd: REPO_ROOT2 });
     }
     if (dryRun) {
       let diffOutput = "(no local changes)";
       try {
-        diffOutput = execFileSync5(
+        diffOutput = execFileSync6(
           "sh",
           [
             "-c",
@@ -9660,11 +10000,11 @@ ${tree}`,
       appendOutput({ ...usage, model, provider: devProvider });
       process.exit(0);
     }
-    execFileSync5("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT2 });
+    execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT2 });
     const branchPushed = true;
     summaryBranchPushed = branchName;
     try {
-      const diff = execFileSync5("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
+      const diff = execFileSync6("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
         cwd: REPO_ROOT2,
         encoding: "utf8"
       });
@@ -10231,148 +10571,6 @@ function gateCi(input) {
   };
 }
 
-// src/agents/reviewer/review-loop.ts
-var MAX_PATCH_CHARS = 2e4;
-var MAX_CONTENT_CHARS = 4e4;
-var MAX_ITERATIONS = 40;
-var REVIEW_TOOL_DEFS = [
-  {
-    name: "get_file_patch",
-    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "get_file_content",
-    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "finish_review",
-    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
-    input_schema: {
-      type: "object",
-      properties: {
-        approved: {
-          type: "boolean",
-          description: "true = ready to merge, false = changes required."
-        },
-        comment: {
-          type: "string",
-          description: "Full review comment in Markdown. Follow the required format from the system prompt."
-        }
-      },
-      required: ["approved", "comment"]
-    }
-  }
-];
-function detectMergeConflicts(files) {
-  const conflicted = [];
-  for (const f of files) {
-    if (f.patch && /^[+].*<{7}|^[+].*={7}|^[+].*>{7}/m.test(f.patch)) {
-      conflicted.push(f.filename);
-    }
-  }
-  return conflicted;
-}
-function buildFileList(files) {
-  return files.map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`).join("\n");
-}
-async function runReviewLoop(opts) {
-  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
-  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
-  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
-  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
-  const {
-    done: result,
-    usage,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  } = await loop.run({
-    system,
-    initialPrompt,
-    tools: REVIEW_TOOL_DEFS,
-    finishTool: "finish_review",
-    extractDone: (input) => ({
-      approved: input.approved,
-      comment: input.comment
-    }),
-    handlers: {
-      get_file_patch: (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_patch", file: filename });
-        const patch = fileMap.get(filename);
-        if (patch === void 0) return `(file not found in PR: ${filename})`;
-        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
-        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
-        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
-      },
-      get_file_content: async (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_content", file: filename });
-        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
-        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
-        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
-      }
-    },
-    maxIterations,
-    maxTokens,
-    logger
-  });
-  return {
-    result,
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  };
-}
-
-// src/agents/reviewer/rubric.ts
-var STRICT_DIRECTIVE = [
-  "## Rubric override \u2014 strict",
-  "",
-  "For this review, apply a STRICTER bar than usual:",
-  "",
-  "- Block on any missing test coverage for new/changed behaviour.",
-  "- Block on missing edge-case handling, error paths, or input validation.",
-  "- Block on weak naming, dead code, or unreachable branches.",
-  "- Block on incomplete documentation when public APIs change.",
-  "- Approve only when every acceptance criterion is fully satisfied with concrete evidence."
-].join("\n");
-var LENIENT_DIRECTIVE = [
-  "## Rubric override \u2014 lenient",
-  "",
-  "For this review, apply a MORE PERMISSIVE bar than usual:",
-  "",
-  "- Approve when the acceptance criteria are met, even if minor polish is missing.",
-  "- Treat naming nits, non-blocking style issues, and stylistic preferences as comments \u2014 not blockers.",
-  "- Block only on: failing tests, unimplemented ACs, merge conflicts, committed build artefacts, or security regressions.",
-  '- Prefer "approve with comments" over "request changes" when issues are non-blocking.'
-].join("\n");
-function applyRubricToPrompt(basePrompt, rubric) {
-  if (rubric === void 0) return basePrompt;
-  const directive = rubric === "strict" ? STRICT_DIRECTIVE : LENIENT_DIRECTIVE;
-  return `${basePrompt}
-
----
-
-${directive}`;
-}
-
 // src/agents/reviewer/changes-guard.ts
 function countPriorIterations(existingComments) {
   return existingComments.filter(
@@ -10459,7 +10657,6 @@ async function main3(envelope, logger) {
   const prNumber = prs[0].number;
   const pr = await runner.getPR({ owner, repo, prNumber });
   const headSha = pr.headSha;
-  const mergeable = pr.mergeable;
   const idempotencyMarker = byPrHeadSha("reviewer", headSha);
   const { skipped } = checkIdempotencyMarker(idempotencyMarker, existingComments);
   if (skipped) {
@@ -10526,40 +10723,21 @@ async function main3(envelope, logger) {
     return;
   }
   const files = await runner.listPRFiles({ owner, repo, prNumber });
-  const fileMap = new Map(files.map((f) => [f.filename, f.patch]));
-  const conflictedFiles = detectMergeConflicts(files);
-  const hasMergeConflicts = mergeable === false || conflictedFiles.length > 0;
   const commits = await runner.listPRCommits({ owner, repo, prNumber });
-  const commitLog = commits.map((c) => `${c.sha.slice(0, 7)} ${c.message.split("\n")[0]}`).join("\n");
-  const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    typeOverride
+  const prepared = prepareReviewer({
+    ticketKey,
+    issue,
+    pr,
+    files,
+    commits,
+    branchName,
+    typeOverride,
+    reviewRubric: reviewRubricOverride,
+    configLabels: effectiveCfg.labels,
+    repoRoot: REPO_ROOT3,
+    logger
   });
-  const mergeConflictWarning = hasMergeConflicts ? `
-\u26A0\uFE0F  MERGE CONFLICTS DETECTED \u2014 mergeable=${String(mergeable)}${conflictedFiles.length > 0 ? `, conflicted files: ${conflictedFiles.join(", ")}` : ""}` : "";
-  const initialPrompt = [
-    "## Jira Ticket",
-    delimitUntrusted(ticketBlock),
-    "",
-    "## PR Metadata",
-    `PR #${prNumber}: ${pr.title}`,
-    `Base: ${pr.baseRef} \u2190 Head: ${branchName} (${headSha.slice(0, 7)})`,
-    `Files changed: ${files.length}  Commits: ${commits.length}`,
-    mergeConflictWarning,
-    "",
-    "## Commits",
-    commitLog,
-    "",
-    "## Changed files (status  +additions  -deletions  path)",
-    buildFileList(files),
-    "",
-    "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
-    "When you have enough information, call finish_review."
-  ].filter((l) => l !== null).join("\n");
-  const baseSystem = buildSystem("review", REPO_ROOT3, {
-    extraParts: [loadOptionalPrompt("review-comment", REPO_ROOT3)],
-    separator: "\n\n---\n\n"
-  });
-  const system = applyRubricToPrompt(baseSystem, reviewRubricOverride);
+  const { system, initialPrompt, fileMap } = prepared;
   const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
   const {
     result: review,
@@ -10651,7 +10829,7 @@ async function main3(envelope, logger) {
 }
 
 // src/agents/iterator/iterate-action.ts
-import { execFileSync as execFileSync6 } from "node:child_process";
+import { execFileSync as execFileSync7 } from "node:child_process";
 
 // src/agents/iterator/outcome-guard.ts
 function assertIterOutputContract(outcome, outputs) {
@@ -10782,10 +10960,6 @@ async function main4(envelope, logger) {
   const reviewTransitionId = shouldAutoTransition ? requireEnv("FERRY_REVIEW_TRANSITION_ID") : "";
   const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
-  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
-  const hasLabelsConfig = effectiveCfg.labels !== void 0;
-  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
-  logCapabilities(logger, capabilities);
   const priorIterations = existingComments.filter(
     (c) => c.includes("[ferry:iterator:") && c.includes("complete. Pushed fixes to PR#")
   ).length;
@@ -10855,7 +11029,6 @@ async function main4(envelope, logger) {
     appendOutput({ input_tokens: 0, output_tokens: 0, model, provider: iterProvider });
     return;
   }
-  const system = buildSystem("iterate", REPO_ROOT4);
   configureFerryGitUser(REPO_ROOT4);
   if (checkoutExistingBranch(branchName, REPO_ROOT4) === "not-found") {
     await tracker.postComment(
@@ -10866,27 +11039,25 @@ async function main4(envelope, logger) {
     return;
   }
   const mergeConflicts = fetchAndMergeBase(baseBranch, REPO_ROOT4);
-  const existingLog = execFileSync6("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
+  const existingLog = execFileSync7("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
     cwd: REPO_ROOT4,
     encoding: "utf8"
   }).trim();
-  const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    typeOverride
+  const prepared = prepareIterator({
+    ticketKey,
+    issue,
+    headSha,
+    reviewComment,
+    mergeConflicts,
+    existingLog,
+    mcpPool,
+    configLabels: effectiveCfg.labels,
+    typeOverride,
+    repoRoot: REPO_ROOT4,
+    logger
   });
-  const initialPrompt = [
-    "## Jira Ticket",
-    delimitUntrusted(ticketBlock),
-    "",
-    "## Review Findings (fix only what is listed here)",
-    delimitUntrusted(reviewComment),
-    "",
-    mergeConflicts.length > 0 ? `## Merge Conflicts (resolve these first, before fixing review findings)
-${mergeConflicts.map((f) => `- ${f}`).join("\n")}` : "",
-    existingLog ? `## Existing commits on branch
-${existingLog}` : "",
-    "",
-    "When you have fixed all findings, call the `done` tool."
-  ].filter(Boolean).join("\n");
+  const { system, initialPrompt, mcpServers, capabilities } = prepared;
+  logCapabilities(logger, capabilities);
   const secretScan = makeSecretScan(REPO_ROOT4);
   const loop = createAgentLoop({
     provider: iterProvider,
@@ -10972,24 +11143,24 @@ ${existingLog}` : "",
     rule_ids: [],
     run_id: eventId
   });
-  execFileSync6("git", ["add", "-A"], { cwd: REPO_ROOT4 });
-  const finalStatus = execFileSync6("git", ["status", "--porcelain"], {
+  execFileSync7("git", ["add", "-A"], { cwd: REPO_ROOT4 });
+  const finalStatus = execFileSync7("git", ["status", "--porcelain"], {
     cwd: REPO_ROOT4,
     encoding: "utf8"
   }).trim();
   if (finalStatus) {
     await secretScan();
-    execFileSync6("git", ["commit", "-m", commitMessage], { cwd: REPO_ROOT4 });
+    execFileSync7("git", ["commit", "-m", commitMessage], { cwd: REPO_ROOT4 });
   }
   if (!dryRun) {
-    execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
+    execFileSync7("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
   } else {
     logger.info("DRY_RUN \u2014 skipped: git push origin branch");
   }
   const branchPushed = !dryRun;
   let iterFilesTouched = [];
   try {
-    const diff = execFileSync6("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
+    const diff = execFileSync7("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
       cwd: REPO_ROOT4,
       encoding: "utf8"
     });

--- a/.github/actions/ferry-run-developer/agent.js
+++ b/.github/actions/ferry-run-developer/agent.js
@@ -6610,7 +6610,7 @@ ${tree}`,
   };
 }
 
-// src/agents/reviewer/rubric.ts
+// src/lib/agent-runtime/reviewer-helpers.ts
 var STRICT_DIRECTIVE = [
   "## Rubric override \u2014 strict",
   "",
@@ -6641,53 +6641,6 @@ function applyRubricToPrompt(basePrompt, rubric) {
 
 ${directive}`;
 }
-
-// src/agents/reviewer/review-loop.ts
-var MAX_PATCH_CHARS = 2e4;
-var MAX_CONTENT_CHARS = 4e4;
-var MAX_ITERATIONS = 40;
-var REVIEW_TOOL_DEFS = [
-  {
-    name: "get_file_patch",
-    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "get_file_content",
-    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "finish_review",
-    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
-    input_schema: {
-      type: "object",
-      properties: {
-        approved: {
-          type: "boolean",
-          description: "true = ready to merge, false = changes required."
-        },
-        comment: {
-          type: "string",
-          description: "Full review comment in Markdown. Follow the required format from the system prompt."
-        }
-      },
-      required: ["approved", "comment"]
-    }
-  }
-];
 function detectMergeConflicts(files) {
   const conflicted = [];
   for (const f of files) {
@@ -6699,57 +6652,6 @@ function detectMergeConflicts(files) {
 }
 function buildFileList(files) {
   return files.map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`).join("\n");
-}
-async function runReviewLoop(opts) {
-  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
-  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
-  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
-  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
-  const {
-    done: result,
-    usage,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  } = await loop.run({
-    system,
-    initialPrompt,
-    tools: REVIEW_TOOL_DEFS,
-    finishTool: "finish_review",
-    extractDone: (input) => ({
-      approved: input.approved,
-      comment: input.comment
-    }),
-    handlers: {
-      get_file_patch: (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_patch", file: filename });
-        const patch = fileMap.get(filename);
-        if (patch === void 0) return `(file not found in PR: ${filename})`;
-        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
-        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
-        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
-      },
-      get_file_content: async (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_content", file: filename });
-        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
-        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
-        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
-      }
-    },
-    maxIterations,
-    maxTokens,
-    logger
-  });
-  return {
-    result,
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  };
 }
 
 // src/lib/agent-runtime/reviewer-prepare.ts
@@ -6763,9 +6665,9 @@ function prepareReviewer(input) {
     branchName,
     typeOverride,
     reviewRubric,
-    configLabels,
-    repoRoot,
-    logger
+    capabilities,
+    idempotencyMarker,
+    repoRoot
   } = input;
   const buildSystem2 = input._buildSystem ?? buildSystem;
   const loadOptionalPrompt2 = input._loadOptionalPrompt ?? loadOptionalPrompt;
@@ -6802,9 +6704,7 @@ function prepareReviewer(input) {
     separator: "\n\n---\n\n"
   });
   const system = applyRubricToPrompt(baseSystem, reviewRubric);
-  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
   const mcpServers = [];
-  const idempotencyMarker = byPrHeadSha("reviewer", headSha);
   return {
     system,
     initialPrompt,
@@ -6821,15 +6721,15 @@ function prepareIterator(input) {
   const {
     ticketKey,
     issue,
-    headSha,
     reviewComment,
     mergeConflicts,
     existingLog,
     mcpPool,
     configLabels,
+    capabilities,
+    idempotencyMarker,
     typeOverride,
-    repoRoot,
-    logger
+    repoRoot
   } = input;
   const buildSystem2 = input._buildSystem ?? buildSystem;
   const system = buildSystem2("iterate", repoRoot);
@@ -6848,10 +6748,8 @@ ${existingLog}` : "",
     "",
     "When you have fixed all findings, call the `done` tool."
   ].filter(Boolean).join("\n");
-  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
   const hasLabelsConfig = configLabels !== void 0;
   const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
-  const idempotencyMarker = byPrHeadSha("iterator", headSha);
   return {
     system,
     initialPrompt,
@@ -10571,6 +10469,104 @@ function gateCi(input) {
   };
 }
 
+// src/agents/reviewer/review-loop.ts
+var MAX_PATCH_CHARS = 2e4;
+var MAX_CONTENT_CHARS = 4e4;
+var MAX_ITERATIONS = 40;
+var REVIEW_TOOL_DEFS = [
+  {
+    name: "get_file_patch",
+    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "get_file_content",
+    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "finish_review",
+    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
+    input_schema: {
+      type: "object",
+      properties: {
+        approved: {
+          type: "boolean",
+          description: "true = ready to merge, false = changes required."
+        },
+        comment: {
+          type: "string",
+          description: "Full review comment in Markdown. Follow the required format from the system prompt."
+        }
+      },
+      required: ["approved", "comment"]
+    }
+  }
+];
+async function runReviewLoop(opts) {
+  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
+  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
+  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
+  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
+  const {
+    done: result,
+    usage,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  } = await loop.run({
+    system,
+    initialPrompt,
+    tools: REVIEW_TOOL_DEFS,
+    finishTool: "finish_review",
+    extractDone: (input) => ({
+      approved: input.approved,
+      comment: input.comment
+    }),
+    handlers: {
+      get_file_patch: (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_patch", file: filename });
+        const patch = fileMap.get(filename);
+        if (patch === void 0) return `(file not found in PR: ${filename})`;
+        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
+        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
+        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
+      },
+      get_file_content: async (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_content", file: filename });
+        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
+        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
+        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
+      }
+    },
+    maxIterations,
+    maxTokens,
+    logger
+  });
+  return {
+    result,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  };
+}
+
 // src/agents/reviewer/changes-guard.ts
 function countPriorIterations(existingComments) {
   return existingComments.filter(
@@ -10733,9 +10729,9 @@ async function main3(envelope, logger) {
     branchName,
     typeOverride,
     reviewRubric: reviewRubricOverride,
-    configLabels: effectiveCfg.labels,
-    repoRoot: REPO_ROOT3,
-    logger
+    capabilities,
+    idempotencyMarker,
+    repoRoot: REPO_ROOT3
   });
   const { system, initialPrompt, fileMap } = prepared;
   const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
@@ -10960,6 +10956,8 @@ async function main4(envelope, logger) {
   const reviewTransitionId = shouldAutoTransition ? requireEnv("FERRY_REVIEW_TRANSITION_ID") : "";
   const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels, logger);
+  logCapabilities(logger, capabilities);
   const priorIterations = existingComments.filter(
     (c) => c.includes("[ferry:iterator:") && c.includes("complete. Pushed fixes to PR#")
   ).length;
@@ -11052,12 +11050,12 @@ async function main4(envelope, logger) {
     existingLog,
     mcpPool,
     configLabels: effectiveCfg.labels,
+    capabilities,
+    idempotencyMarker,
     typeOverride,
-    repoRoot: REPO_ROOT4,
-    logger
+    repoRoot: REPO_ROOT4
   });
-  const { system, initialPrompt, mcpServers, capabilities } = prepared;
-  logCapabilities(logger, capabilities);
+  const { system, initialPrompt, mcpServers } = prepared;
   const secretScan = makeSecretScan(REPO_ROOT4);
   const loop = createAgentLoop({
     provider: iterProvider,

--- a/.github/actions/ferry-run-developer/agent.js
+++ b/.github/actions/ferry-run-developer/agent.js
@@ -6442,6 +6442,426 @@ function buildConflictComment(role, runId, err) {
   ].join("\n");
 }
 
+// src/lib/agent-runtime/refiner-prepare.ts
+var PRIOR_RUN_MARKER = /\[ferry:refiner:[^\]]+\]/;
+async function prepareRefiner(input) {
+  const { envelope, tracker } = input;
+  const { ticket_key: ticketKey, event_id: eventId } = envelope;
+  const issue = await tracker.getIssue(ticketKey);
+  const existingSubtasks = await tracker.getSubtaskDetails(ticketKey);
+  const priorRefinerRuns = issue.comments.filter((c) => PRIOR_RUN_MARKER.test(c));
+  const runLink = `https://github.com/${process.env.GITHUB_REPO ?? "unknown"}/actions/runs/${process.env.GITHUB_RUN_ID ?? "0"}`;
+  const idempotencyMarker = byEventId("refiner", eventId);
+  return {
+    issue,
+    existingSubtasks,
+    priorRefinerRuns,
+    runLink,
+    idempotencyMarker
+  };
+}
+
+// src/lib/agent-runtime/developer-prepare.ts
+import { execFileSync as execFileSync3 } from "node:child_process";
+
+// src/lib/llm/delimit-untrusted.ts
+var OPEN = "<<<UNTRUSTED>>>";
+var CLOSE = "<<<END UNTRUSTED>>>";
+var OPEN_ESCAPE = "<<<UNTRUSTED-LITERAL>>>";
+var CLOSE_ESCAPE = "<<<END UNTRUSTED-LITERAL>>>";
+function delimitUntrusted(value) {
+  const escaped = value.split(OPEN).join(OPEN_ESCAPE).split(CLOSE).join(CLOSE_ESCAPE);
+  return `${OPEN}
+${escaped}
+${CLOSE}`;
+}
+
+// src/lib/agent-runtime/developer-prepare.ts
+var checkoutOrCreateBranchDefault = (branchName, baseBranch, repoRoot, logger) => {
+  try {
+    execFileSync3("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
+      cwd: repoRoot,
+      stdio: "pipe"
+    });
+    execFileSync3("git", ["fetch", "origin", branchName], { cwd: repoRoot });
+    execFileSync3("git", ["checkout", branchName], { cwd: repoRoot });
+    const existingLog = execFileSync3("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
+      cwd: repoRoot,
+      encoding: "utf8"
+    }).trim();
+    if (existingLog) {
+      logger.info("resuming branch", {
+        branch: branchName,
+        prior_commits: existingLog.split("\n").length
+      });
+    }
+    const branchHeadSha = execFileSync3("git", ["rev-parse", "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf8"
+    }).trim();
+    return { branchHeadSha, existingLog };
+  } catch {
+    execFileSync3("git", ["checkout", "-B", branchName], { cwd: repoRoot });
+    logger.info("created branch", { branch: branchName });
+    return { branchHeadSha: "", existingLog: "" };
+  }
+};
+async function prepareDeveloper(input) {
+  const {
+    envelope,
+    issue,
+    effectiveCfg,
+    subtasks,
+    testRunner,
+    pkgManagerHint,
+    tree,
+    typeOverride,
+    owner,
+    repo,
+    baseBranch,
+    runner,
+    mcpPool,
+    repoRoot,
+    dryRun,
+    logger
+  } = input;
+  const buildSystem2 = input._buildSystem ?? buildSystem;
+  const checkoutOrCreateBranch = input._checkoutOrCreateBranch ?? checkoutOrCreateBranchDefault;
+  const configureGitUser = input._configureGitUser ?? configureFerryGitUser;
+  const ticketKey = envelope.ticket_key;
+  const eventId = envelope.event_id;
+  const labels = issue.labels.join(", ");
+  const comments = issue.comments.map((c) => `Comment: ${c}`).join("\n");
+  const ticketBlock = buildTicketBlock(ticketKey, issue, {
+    labels,
+    comments,
+    typeOverride
+  });
+  const system = buildSystem2("dev", repoRoot, {
+    extraParts: pkgManagerHint ? [`## Detected package manager
+
+${pkgManagerHint}`] : []
+  });
+  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
+  configureGitUser(repoRoot);
+  const { branchHeadSha, existingLog } = checkoutOrCreateBranch(
+    branchName,
+    baseBranch,
+    repoRoot,
+    logger
+  );
+  const resumeContext = existingLog ? `
+EXISTING WORK ON BRANCH (already committed \u2014 skip these, only do what remains):
+${existingLog}` : "";
+  let existingPrUrl = "";
+  let existingPrContext = "";
+  if (branchHeadSha && !dryRun) {
+    try {
+      const openPrs = await runner.listPRsForBranch(owner, repo, branchName);
+      if (openPrs.length > 0) {
+        const pr = openPrs[0];
+        existingPrUrl = `https://github.com/${owner}/${repo}/pull/${pr.number}`;
+        const prRef = { owner, repo, prNumber: pr.number };
+        const prFiles = await runner.listPRFiles(prRef);
+        const fileList = prFiles.map((f) => `${f.status}: ${f.filename}`).join("\n");
+        existingPrContext = [
+          `
+EXISTING_IMPLEMENTATION:`,
+          `Open PR: ${existingPrUrl} (head: ${branchHeadSha.slice(0, 7)})`,
+          `Changed files:
+${fileList}`,
+          `If the spec is already fully satisfied by the existing code, call \`done\` with outcome="already_satisfied".`
+        ].join("\n");
+        logger.info("existing PR found", { pr: existingPrUrl, files: prFiles.length });
+      }
+    } catch {
+    }
+  }
+  const idempotencyMarker = branchHeadSha ? byPrHeadSha("dev", branchHeadSha) : byEventId("dev", eventId);
+  const baseInitialPrompt = [
+    delimitUntrusted(ticketBlock),
+    "",
+    subtasks.length > 0 ? `SUBTASKS:
+${subtasks.join("\n")}` : "SUBTASKS: (none)",
+    "",
+    `TEST_RUNNER: ${testRunner}`,
+    "",
+    `REPO TREE (depth 2):
+${tree}`,
+    "",
+    "When you have finished implementing, call the `done` tool."
+  ].join("\n");
+  const initialPrompt = baseInitialPrompt + resumeContext + existingPrContext;
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
+  const hasLabelsConfig = effectiveCfg.labels !== void 0;
+  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  return {
+    system,
+    initialPrompt,
+    baseInitialPrompt,
+    mcpServers,
+    idempotencyMarker,
+    ticketBlock,
+    subtasks,
+    capabilities,
+    branchName,
+    branchHeadSha,
+    existingPrUrl
+  };
+}
+
+// src/agents/reviewer/rubric.ts
+var STRICT_DIRECTIVE = [
+  "## Rubric override \u2014 strict",
+  "",
+  "For this review, apply a STRICTER bar than usual:",
+  "",
+  "- Block on any missing test coverage for new/changed behaviour.",
+  "- Block on missing edge-case handling, error paths, or input validation.",
+  "- Block on weak naming, dead code, or unreachable branches.",
+  "- Block on incomplete documentation when public APIs change.",
+  "- Approve only when every acceptance criterion is fully satisfied with concrete evidence."
+].join("\n");
+var LENIENT_DIRECTIVE = [
+  "## Rubric override \u2014 lenient",
+  "",
+  "For this review, apply a MORE PERMISSIVE bar than usual:",
+  "",
+  "- Approve when the acceptance criteria are met, even if minor polish is missing.",
+  "- Treat naming nits, non-blocking style issues, and stylistic preferences as comments \u2014 not blockers.",
+  "- Block only on: failing tests, unimplemented ACs, merge conflicts, committed build artefacts, or security regressions.",
+  '- Prefer "approve with comments" over "request changes" when issues are non-blocking.'
+].join("\n");
+function applyRubricToPrompt(basePrompt, rubric) {
+  if (rubric === void 0) return basePrompt;
+  const directive = rubric === "strict" ? STRICT_DIRECTIVE : LENIENT_DIRECTIVE;
+  return `${basePrompt}
+
+---
+
+${directive}`;
+}
+
+// src/agents/reviewer/review-loop.ts
+var MAX_PATCH_CHARS = 2e4;
+var MAX_CONTENT_CHARS = 4e4;
+var MAX_ITERATIONS = 40;
+var REVIEW_TOOL_DEFS = [
+  {
+    name: "get_file_patch",
+    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "get_file_content",
+    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "finish_review",
+    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
+    input_schema: {
+      type: "object",
+      properties: {
+        approved: {
+          type: "boolean",
+          description: "true = ready to merge, false = changes required."
+        },
+        comment: {
+          type: "string",
+          description: "Full review comment in Markdown. Follow the required format from the system prompt."
+        }
+      },
+      required: ["approved", "comment"]
+    }
+  }
+];
+function detectMergeConflicts(files) {
+  const conflicted = [];
+  for (const f of files) {
+    if (f.patch && /^[+].*<{7}|^[+].*={7}|^[+].*>{7}/m.test(f.patch)) {
+      conflicted.push(f.filename);
+    }
+  }
+  return conflicted;
+}
+function buildFileList(files) {
+  return files.map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`).join("\n");
+}
+async function runReviewLoop(opts) {
+  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
+  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
+  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
+  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
+  const {
+    done: result,
+    usage,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  } = await loop.run({
+    system,
+    initialPrompt,
+    tools: REVIEW_TOOL_DEFS,
+    finishTool: "finish_review",
+    extractDone: (input) => ({
+      approved: input.approved,
+      comment: input.comment
+    }),
+    handlers: {
+      get_file_patch: (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_patch", file: filename });
+        const patch = fileMap.get(filename);
+        if (patch === void 0) return `(file not found in PR: ${filename})`;
+        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
+        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
+        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
+      },
+      get_file_content: async (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_content", file: filename });
+        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
+        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
+        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
+      }
+    },
+    maxIterations,
+    maxTokens,
+    logger
+  });
+  return {
+    result,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  };
+}
+
+// src/lib/agent-runtime/reviewer-prepare.ts
+function prepareReviewer(input) {
+  const {
+    ticketKey,
+    issue,
+    pr,
+    files,
+    commits,
+    branchName,
+    typeOverride,
+    reviewRubric,
+    configLabels,
+    repoRoot,
+    logger
+  } = input;
+  const buildSystem2 = input._buildSystem ?? buildSystem;
+  const loadOptionalPrompt2 = input._loadOptionalPrompt ?? loadOptionalPrompt;
+  const headSha = pr.headSha;
+  const prNumber = pr.number;
+  const fileMap = new Map(files.map((f) => [f.filename, f.patch]));
+  const conflictedFiles = detectMergeConflicts(files);
+  const hasMergeConflicts = pr.mergeable === false || conflictedFiles.length > 0;
+  const commitLog = commits.map((c) => `${c.sha.slice(0, 7)} ${c.message.split("\n")[0]}`).join("\n");
+  const ticketBlock = buildTicketBlock(ticketKey, issue, { typeOverride });
+  const mergeConflictWarning = hasMergeConflicts ? `
+\u26A0\uFE0F  MERGE CONFLICTS DETECTED \u2014 mergeable=${String(pr.mergeable)}${conflictedFiles.length > 0 ? `, conflicted files: ${conflictedFiles.join(", ")}` : ""}` : "";
+  const initialPrompt = [
+    "## Jira Ticket",
+    delimitUntrusted(ticketBlock),
+    "",
+    "## PR Metadata",
+    `PR #${prNumber}: ${pr.title}`,
+    `Base: ${pr.baseRef} \u2190 Head: ${branchName} (${headSha.slice(0, 7)})`,
+    `Files changed: ${files.length}  Commits: ${commits.length}`,
+    mergeConflictWarning,
+    "",
+    "## Commits",
+    commitLog,
+    "",
+    "## Changed files (status  +additions  -deletions  path)",
+    buildFileList(files),
+    "",
+    "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
+    "When you have enough information, call finish_review."
+  ].filter((l) => l !== null).join("\n");
+  const baseSystem = buildSystem2("review", repoRoot, {
+    extraParts: [loadOptionalPrompt2("review-comment", repoRoot)],
+    separator: "\n\n---\n\n"
+  });
+  const system = applyRubricToPrompt(baseSystem, reviewRubric);
+  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
+  const mcpServers = [];
+  const idempotencyMarker = byPrHeadSha("reviewer", headSha);
+  return {
+    system,
+    initialPrompt,
+    mcpServers,
+    idempotencyMarker,
+    ticketBlock,
+    capabilities,
+    fileMap
+  };
+}
+
+// src/lib/agent-runtime/iterator-prepare.ts
+function prepareIterator(input) {
+  const {
+    ticketKey,
+    issue,
+    headSha,
+    reviewComment,
+    mergeConflicts,
+    existingLog,
+    mcpPool,
+    configLabels,
+    typeOverride,
+    repoRoot,
+    logger
+  } = input;
+  const buildSystem2 = input._buildSystem ?? buildSystem;
+  const system = buildSystem2("iterate", repoRoot);
+  const ticketBlock = buildTicketBlock(ticketKey, issue, { typeOverride });
+  const initialPrompt = [
+    "## Jira Ticket",
+    delimitUntrusted(ticketBlock),
+    "",
+    "## Review Findings (fix only what is listed here)",
+    delimitUntrusted(reviewComment),
+    "",
+    mergeConflicts.length > 0 ? `## Merge Conflicts (resolve these first, before fixing review findings)
+${mergeConflicts.map((f) => `- ${f}`).join("\n")}` : "",
+    existingLog ? `## Existing commits on branch
+${existingLog}` : "",
+    "",
+    "When you have fixed all findings, call the `done` tool."
+  ].filter(Boolean).join("\n");
+  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
+  const hasLabelsConfig = configLabels !== void 0;
+  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  const idempotencyMarker = byPrHeadSha("iterator", headSha);
+  return {
+    system,
+    initialPrompt,
+    mcpServers,
+    idempotencyMarker,
+    ticketBlock,
+    capabilities
+  };
+}
+
 // src/lib/dry-run.ts
 function isDryRun() {
   return process.env.FERRY_DRY_RUN === "1" || process.env.FERRY_DRY_RUN === "true";
@@ -6640,18 +7060,6 @@ function createLlmCall(route) {
 
 // src/agents/refiner/refine.ts
 import { createRequire as createRequire3 } from "module";
-
-// src/lib/llm/delimit-untrusted.ts
-var OPEN = "<<<UNTRUSTED>>>";
-var CLOSE = "<<<END UNTRUSTED>>>";
-var OPEN_ESCAPE = "<<<UNTRUSTED-LITERAL>>>";
-var CLOSE_ESCAPE = "<<<END UNTRUSTED-LITERAL>>>";
-function delimitUntrusted(value) {
-  const escaped = value.split(OPEN).join(OPEN_ESCAPE).split(CLOSE).join(CLOSE_ESCAPE);
-  return `${OPEN}
-${escaped}
-${CLOSE}`;
-}
 
 // src/agents/refiner/parse.ts
 function extractFirstJsonObject(text) {
@@ -7028,15 +7436,12 @@ function estimateTicketCost(_plan, baseline) {
 
 // src/agents/refiner/refiner-action.ts
 var REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
-var PRIOR_RUN_MARKER = /\[ferry:refiner:[^\]]+\]/;
 async function run(envelope, deps) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const logger = deps.logger ?? createLogger(eventId, "ferry:refiner-action");
   const dryRun = isDryRun() || deps.dryRun === true;
-  const issue = await deps.tracker.getIssue(ticketKey);
-  const runLink = `https://github.com/${process.env.GITHUB_REPO ?? "unknown"}/actions/runs/${process.env.GITHUB_RUN_ID ?? "0"}`;
-  const existingSubtasks = await deps.tracker.getSubtaskDetails(ticketKey);
-  const priorRefinerRuns = issue.comments.filter((c) => PRIOR_RUN_MARKER.test(c));
+  const prepared = await prepareRefiner({ envelope, tracker: deps.tracker });
+  const { issue, existingSubtasks, priorRefinerRuns, runLink, idempotencyMarker } = prepared;
   const { plan, auditSummary } = await runRefiner({
     ticket: {
       key: issue.key,
@@ -7111,7 +7516,6 @@ async function run(envelope, deps) {
     existingSubtasks,
     tracker: deps.tracker
   });
-  const idempotencyMarker = `[ferry:refiner:${eventId}]`;
   if (result.noop) {
     logger.info("noop \u2014 existing sub-tasks still valid", { ticket: ticketKey });
     await deps.tracker.postComment(
@@ -7199,7 +7603,7 @@ async function main(envelope, logger) {
 }
 
 // src/agents/developer/dev-action.ts
-import { execFileSync as execFileSync5 } from "node:child_process";
+import { execFileSync as execFileSync6 } from "node:child_process";
 import * as fsp2 from "node:fs/promises";
 import * as path6 from "node:path";
 
@@ -9093,7 +9497,7 @@ function createAgentLoop(opts) {
 
 // src/agents/developer/workspace.ts
 import { readFileSync as readFileSync5, existsSync as existsSync4 } from "node:fs";
-import { execFileSync as execFileSync3 } from "node:child_process";
+import { execFileSync as execFileSync4 } from "node:child_process";
 import * as path5 from "node:path";
 function detectTestRunner(packageJsonPath2) {
   try {
@@ -9112,7 +9516,7 @@ function detectTestRunner(packageJsonPath2) {
 }
 function repoTree(repoRoot) {
   try {
-    return execFileSync3(
+    return execFileSync4(
       "find",
       [
         repoRoot,
@@ -9204,7 +9608,7 @@ function assertDevOutputContract(outcome, outputs) {
 }
 
 // src/agents/developer/wip-finalizer.ts
-import { execFileSync as execFileSync4 } from "node:child_process";
+import { execFileSync as execFileSync5 } from "node:child_process";
 function classifyError(err) {
   if (err instanceof FerryError) {
     const reason = err.context?.reason ?? "unknown";
@@ -9243,8 +9647,8 @@ async function runWipFinalizer(opts) {
   logger.info("wip_finalizer", { code, detail, branch: branchName });
   let committed = false;
   try {
-    execFileSync4("git", ["add", "-A"], { cwd: repoRoot });
-    const status = execFileSync4("git", ["status", "--porcelain"], {
+    execFileSync5("git", ["add", "-A"], { cwd: repoRoot });
+    const status = execFileSync5("git", ["status", "--porcelain"], {
       cwd: repoRoot,
       encoding: "utf8"
     });
@@ -9253,7 +9657,7 @@ async function runWipFinalizer(opts) {
       const wipMsg = `wip(${ticketKey}): interrupted \u2014 ${code}
 
 [ferry:dev:${eventId}]`;
-      execFileSync4("git", ["commit", "-m", wipMsg], { cwd: repoRoot });
+      execFileSync5("git", ["commit", "-m", wipMsg], { cwd: repoRoot });
       committed = true;
       logger.info("wip_committed", { branch: branchName });
     } else {
@@ -9265,14 +9669,14 @@ async function runWipFinalizer(opts) {
   let pushed = false;
   if (!dryRun) {
     try {
-      execFileSync4("git", ["push", "origin", branchName, "--force-with-lease"], {
+      execFileSync5("git", ["push", "origin", branchName, "--force-with-lease"], {
         cwd: repoRoot,
         stdio: "pipe"
       });
       pushed = true;
     } catch {
       try {
-        execFileSync4("git", ["push", "origin", branchName], { cwd: repoRoot, stdio: "pipe" });
+        execFileSync5("git", ["push", "origin", branchName], { cwd: repoRoot, stdio: "pipe" });
         pushed = true;
       } catch (pushErr) {
         logger.error("wip_push_failed", { error: pushErr.message });
@@ -9398,102 +9802,36 @@ async function main2(envelope, logger) {
   const reviewTransitionId = !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
   const jiraBaseUrl = requireEnv("FERRY_JIRA_BASE_URL");
   const { provider: devProvider } = effectiveCfg.models.dev;
-  const labels = issue.labels.join(", ");
-  const comments = issue.comments.map((c) => `Comment: ${c}`).join("\n");
-  const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    labels,
-    comments,
-    typeOverride
-  });
+  const model = effectiveCfg.models.dev.model;
   const subtasks = await tracker.getSubtasks(ticketKey);
   const testRunner = detectTestRunner(packageJsonPath(REPO_ROOT2));
   const pkgManagerHint = detectPackageManager(REPO_ROOT2);
   const tree = repoTree(REPO_ROOT2);
-  const system = buildSystem("dev", REPO_ROOT2, {
-    extraParts: pkgManagerHint ? [`## Detected package manager
-
-${pkgManagerHint}`] : []
-  });
-  const model = effectiveCfg.models.dev.model;
-  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
-  configureFerryGitUser(REPO_ROOT2);
-  let resumeContext = "";
-  let branchHeadSha = "";
-  try {
-    execFileSync5("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
-      cwd: REPO_ROOT2,
-      stdio: "pipe"
-    });
-    execFileSync5("git", ["fetch", "origin", branchName], { cwd: REPO_ROOT2 });
-    execFileSync5("git", ["checkout", branchName], { cwd: REPO_ROOT2 });
-    const existingLog = execFileSync5("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
-      cwd: REPO_ROOT2,
-      encoding: "utf8"
-    }).trim();
-    if (existingLog) {
-      resumeContext = `
-EXISTING WORK ON BRANCH (already committed \u2014 skip these, only do what remains):
-${existingLog}`;
-      logger.info("resuming branch", {
-        branch: branchName,
-        prior_commits: existingLog.split("\n").length
-      });
-    }
-    branchHeadSha = execFileSync5("git", ["rev-parse", "HEAD"], {
-      cwd: REPO_ROOT2,
-      encoding: "utf8"
-    }).trim();
-  } catch {
-    execFileSync5("git", ["checkout", "-B", branchName], { cwd: REPO_ROOT2 });
-    logger.info("created branch", { branch: branchName });
-  }
-  let existingPrUrl = "";
-  let existingPrContext = "";
-  if (branchHeadSha && !dryRun) {
-    try {
-      const openPrs = await runner.listPRsForBranch(owner, repo, branchName);
-      if (openPrs.length > 0) {
-        const pr = openPrs[0];
-        existingPrUrl = `https://github.com/${owner}/${repo}/pull/${pr.number}`;
-        const prRef = { owner, repo, prNumber: pr.number };
-        const prFiles = await runner.listPRFiles(prRef);
-        const fileList = prFiles.map((f) => `${f.status}: ${f.filename}`).join("\n");
-        existingPrContext = [
-          `
-EXISTING_IMPLEMENTATION:`,
-          `Open PR: ${existingPrUrl} (head: ${branchHeadSha.slice(0, 7)})`,
-          `Changed files:
-${fileList}`,
-          `If the spec is already fully satisfied by the existing code, call \`done\` with outcome="already_satisfied".`
-        ].join("\n");
-        logger.info("existing PR found", { pr: existingPrUrl, files: prFiles.length });
-      }
-    } catch {
-    }
-  }
-  const idempotencyMarker = branchHeadSha ? `[ferry:dev:${branchHeadSha.slice(0, 7)}]` : `[ferry:dev:${eventId}]`;
-  const initialPrompt = [
-    delimitUntrusted(ticketBlock),
-    "",
-    subtasks.length > 0 ? `SUBTASKS:
-${subtasks.join("\n")}` : "SUBTASKS: (none)",
-    "",
-    `TEST_RUNNER: ${testRunner}`,
-    "",
-    `REPO TREE (depth 2):
-${tree}`,
-    "",
-    "When you have finished implementing, call the `done` tool."
-  ].join("\n");
-  const secretScan = makeSecretScan(REPO_ROOT2);
   const mcpPool = loadMcpServers();
-  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
-  const hasLabelsConfig = effectiveCfg.labels !== void 0;
-  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  const prepared = await prepareDeveloper({
+    envelope,
+    issue,
+    effectiveCfg,
+    subtasks,
+    testRunner,
+    pkgManagerHint,
+    tree,
+    typeOverride,
+    owner,
+    repo,
+    baseBranch,
+    runner,
+    mcpPool,
+    repoRoot: REPO_ROOT2,
+    dryRun,
+    logger
+  });
+  const { system, initialPrompt, mcpServers, idempotencyMarker, branchName, capabilities } = prepared;
   logCapabilities(logger, capabilities);
   if (mcpServers.length > 0) {
     logger.info("MCP servers", { servers: mcpServers.map((s) => s.name) });
   }
+  const secretScan = makeSecretScan(REPO_ROOT2);
   const allToolSchemas = [...TOOL_SCHEMAS, COMMIT_PROGRESS_SCHEMA, SPAWN_SUBAGENT_SCHEMA];
   let loop;
   loop = createAgentLoop({
@@ -9521,7 +9859,9 @@ ${tree}`,
   try {
     loopResult = await loop.run({
       system,
-      initialPrompt: initialPrompt + resumeContext + existingPrContext,
+      // `initialPrompt` already includes the resume + existing-PR context
+      // (concatenated inside `prepareDeveloper`).
+      initialPrompt,
       tools: allToolSchemas,
       repoRoot: REPO_ROOT2,
       branchName,
@@ -9618,20 +9958,20 @@ ${tree}`,
       await fsp2.writeFile(verificationPath, verificationContent, "utf8");
       verificationNoteWritten = true;
     }
-    execFileSync5("git", ["add", "-A"], { cwd: REPO_ROOT2 });
-    const finalStatus = execFileSync5("git", ["status", "--porcelain"], {
+    execFileSync6("git", ["add", "-A"], { cwd: REPO_ROOT2 });
+    const finalStatus = execFileSync6("git", ["status", "--porcelain"], {
       cwd: REPO_ROOT2,
       encoding: "utf8"
     });
     if (finalStatus.trim()) {
       await secretScan();
       const msg = resolvedOutcome === "already_satisfied" ? `chore(${ticketKey}): add verification note \u2014 spec already satisfied` : done.commit_message ?? commitMessage;
-      execFileSync5("git", ["commit", "-m", msg], { cwd: REPO_ROOT2 });
+      execFileSync6("git", ["commit", "-m", msg], { cwd: REPO_ROOT2 });
     }
     if (dryRun) {
       let diffOutput = "(no local changes)";
       try {
-        diffOutput = execFileSync5(
+        diffOutput = execFileSync6(
           "sh",
           [
             "-c",
@@ -9660,11 +10000,11 @@ ${tree}`,
       appendOutput({ ...usage, model, provider: devProvider });
       process.exit(0);
     }
-    execFileSync5("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT2 });
+    execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT2 });
     const branchPushed = true;
     summaryBranchPushed = branchName;
     try {
-      const diff = execFileSync5("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
+      const diff = execFileSync6("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
         cwd: REPO_ROOT2,
         encoding: "utf8"
       });
@@ -10231,148 +10571,6 @@ function gateCi(input) {
   };
 }
 
-// src/agents/reviewer/review-loop.ts
-var MAX_PATCH_CHARS = 2e4;
-var MAX_CONTENT_CHARS = 4e4;
-var MAX_ITERATIONS = 40;
-var REVIEW_TOOL_DEFS = [
-  {
-    name: "get_file_patch",
-    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "get_file_content",
-    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "finish_review",
-    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
-    input_schema: {
-      type: "object",
-      properties: {
-        approved: {
-          type: "boolean",
-          description: "true = ready to merge, false = changes required."
-        },
-        comment: {
-          type: "string",
-          description: "Full review comment in Markdown. Follow the required format from the system prompt."
-        }
-      },
-      required: ["approved", "comment"]
-    }
-  }
-];
-function detectMergeConflicts(files) {
-  const conflicted = [];
-  for (const f of files) {
-    if (f.patch && /^[+].*<{7}|^[+].*={7}|^[+].*>{7}/m.test(f.patch)) {
-      conflicted.push(f.filename);
-    }
-  }
-  return conflicted;
-}
-function buildFileList(files) {
-  return files.map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`).join("\n");
-}
-async function runReviewLoop(opts) {
-  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
-  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
-  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
-  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
-  const {
-    done: result,
-    usage,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  } = await loop.run({
-    system,
-    initialPrompt,
-    tools: REVIEW_TOOL_DEFS,
-    finishTool: "finish_review",
-    extractDone: (input) => ({
-      approved: input.approved,
-      comment: input.comment
-    }),
-    handlers: {
-      get_file_patch: (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_patch", file: filename });
-        const patch = fileMap.get(filename);
-        if (patch === void 0) return `(file not found in PR: ${filename})`;
-        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
-        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
-        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
-      },
-      get_file_content: async (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_content", file: filename });
-        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
-        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
-        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
-      }
-    },
-    maxIterations,
-    maxTokens,
-    logger
-  });
-  return {
-    result,
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  };
-}
-
-// src/agents/reviewer/rubric.ts
-var STRICT_DIRECTIVE = [
-  "## Rubric override \u2014 strict",
-  "",
-  "For this review, apply a STRICTER bar than usual:",
-  "",
-  "- Block on any missing test coverage for new/changed behaviour.",
-  "- Block on missing edge-case handling, error paths, or input validation.",
-  "- Block on weak naming, dead code, or unreachable branches.",
-  "- Block on incomplete documentation when public APIs change.",
-  "- Approve only when every acceptance criterion is fully satisfied with concrete evidence."
-].join("\n");
-var LENIENT_DIRECTIVE = [
-  "## Rubric override \u2014 lenient",
-  "",
-  "For this review, apply a MORE PERMISSIVE bar than usual:",
-  "",
-  "- Approve when the acceptance criteria are met, even if minor polish is missing.",
-  "- Treat naming nits, non-blocking style issues, and stylistic preferences as comments \u2014 not blockers.",
-  "- Block only on: failing tests, unimplemented ACs, merge conflicts, committed build artefacts, or security regressions.",
-  '- Prefer "approve with comments" over "request changes" when issues are non-blocking.'
-].join("\n");
-function applyRubricToPrompt(basePrompt, rubric) {
-  if (rubric === void 0) return basePrompt;
-  const directive = rubric === "strict" ? STRICT_DIRECTIVE : LENIENT_DIRECTIVE;
-  return `${basePrompt}
-
----
-
-${directive}`;
-}
-
 // src/agents/reviewer/changes-guard.ts
 function countPriorIterations(existingComments) {
   return existingComments.filter(
@@ -10459,7 +10657,6 @@ async function main3(envelope, logger) {
   const prNumber = prs[0].number;
   const pr = await runner.getPR({ owner, repo, prNumber });
   const headSha = pr.headSha;
-  const mergeable = pr.mergeable;
   const idempotencyMarker = byPrHeadSha("reviewer", headSha);
   const { skipped } = checkIdempotencyMarker(idempotencyMarker, existingComments);
   if (skipped) {
@@ -10526,40 +10723,21 @@ async function main3(envelope, logger) {
     return;
   }
   const files = await runner.listPRFiles({ owner, repo, prNumber });
-  const fileMap = new Map(files.map((f) => [f.filename, f.patch]));
-  const conflictedFiles = detectMergeConflicts(files);
-  const hasMergeConflicts = mergeable === false || conflictedFiles.length > 0;
   const commits = await runner.listPRCommits({ owner, repo, prNumber });
-  const commitLog = commits.map((c) => `${c.sha.slice(0, 7)} ${c.message.split("\n")[0]}`).join("\n");
-  const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    typeOverride
+  const prepared = prepareReviewer({
+    ticketKey,
+    issue,
+    pr,
+    files,
+    commits,
+    branchName,
+    typeOverride,
+    reviewRubric: reviewRubricOverride,
+    configLabels: effectiveCfg.labels,
+    repoRoot: REPO_ROOT3,
+    logger
   });
-  const mergeConflictWarning = hasMergeConflicts ? `
-\u26A0\uFE0F  MERGE CONFLICTS DETECTED \u2014 mergeable=${String(mergeable)}${conflictedFiles.length > 0 ? `, conflicted files: ${conflictedFiles.join(", ")}` : ""}` : "";
-  const initialPrompt = [
-    "## Jira Ticket",
-    delimitUntrusted(ticketBlock),
-    "",
-    "## PR Metadata",
-    `PR #${prNumber}: ${pr.title}`,
-    `Base: ${pr.baseRef} \u2190 Head: ${branchName} (${headSha.slice(0, 7)})`,
-    `Files changed: ${files.length}  Commits: ${commits.length}`,
-    mergeConflictWarning,
-    "",
-    "## Commits",
-    commitLog,
-    "",
-    "## Changed files (status  +additions  -deletions  path)",
-    buildFileList(files),
-    "",
-    "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
-    "When you have enough information, call finish_review."
-  ].filter((l) => l !== null).join("\n");
-  const baseSystem = buildSystem("review", REPO_ROOT3, {
-    extraParts: [loadOptionalPrompt("review-comment", REPO_ROOT3)],
-    separator: "\n\n---\n\n"
-  });
-  const system = applyRubricToPrompt(baseSystem, reviewRubricOverride);
+  const { system, initialPrompt, fileMap } = prepared;
   const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
   const {
     result: review,
@@ -10651,7 +10829,7 @@ async function main3(envelope, logger) {
 }
 
 // src/agents/iterator/iterate-action.ts
-import { execFileSync as execFileSync6 } from "node:child_process";
+import { execFileSync as execFileSync7 } from "node:child_process";
 
 // src/agents/iterator/outcome-guard.ts
 function assertIterOutputContract(outcome, outputs) {
@@ -10782,10 +10960,6 @@ async function main4(envelope, logger) {
   const reviewTransitionId = shouldAutoTransition ? requireEnv("FERRY_REVIEW_TRANSITION_ID") : "";
   const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
-  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
-  const hasLabelsConfig = effectiveCfg.labels !== void 0;
-  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
-  logCapabilities(logger, capabilities);
   const priorIterations = existingComments.filter(
     (c) => c.includes("[ferry:iterator:") && c.includes("complete. Pushed fixes to PR#")
   ).length;
@@ -10855,7 +11029,6 @@ async function main4(envelope, logger) {
     appendOutput({ input_tokens: 0, output_tokens: 0, model, provider: iterProvider });
     return;
   }
-  const system = buildSystem("iterate", REPO_ROOT4);
   configureFerryGitUser(REPO_ROOT4);
   if (checkoutExistingBranch(branchName, REPO_ROOT4) === "not-found") {
     await tracker.postComment(
@@ -10866,27 +11039,25 @@ async function main4(envelope, logger) {
     return;
   }
   const mergeConflicts = fetchAndMergeBase(baseBranch, REPO_ROOT4);
-  const existingLog = execFileSync6("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
+  const existingLog = execFileSync7("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
     cwd: REPO_ROOT4,
     encoding: "utf8"
   }).trim();
-  const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    typeOverride
+  const prepared = prepareIterator({
+    ticketKey,
+    issue,
+    headSha,
+    reviewComment,
+    mergeConflicts,
+    existingLog,
+    mcpPool,
+    configLabels: effectiveCfg.labels,
+    typeOverride,
+    repoRoot: REPO_ROOT4,
+    logger
   });
-  const initialPrompt = [
-    "## Jira Ticket",
-    delimitUntrusted(ticketBlock),
-    "",
-    "## Review Findings (fix only what is listed here)",
-    delimitUntrusted(reviewComment),
-    "",
-    mergeConflicts.length > 0 ? `## Merge Conflicts (resolve these first, before fixing review findings)
-${mergeConflicts.map((f) => `- ${f}`).join("\n")}` : "",
-    existingLog ? `## Existing commits on branch
-${existingLog}` : "",
-    "",
-    "When you have fixed all findings, call the `done` tool."
-  ].filter(Boolean).join("\n");
+  const { system, initialPrompt, mcpServers, capabilities } = prepared;
+  logCapabilities(logger, capabilities);
   const secretScan = makeSecretScan(REPO_ROOT4);
   const loop = createAgentLoop({
     provider: iterProvider,
@@ -10972,24 +11143,24 @@ ${existingLog}` : "",
     rule_ids: [],
     run_id: eventId
   });
-  execFileSync6("git", ["add", "-A"], { cwd: REPO_ROOT4 });
-  const finalStatus = execFileSync6("git", ["status", "--porcelain"], {
+  execFileSync7("git", ["add", "-A"], { cwd: REPO_ROOT4 });
+  const finalStatus = execFileSync7("git", ["status", "--porcelain"], {
     cwd: REPO_ROOT4,
     encoding: "utf8"
   }).trim();
   if (finalStatus) {
     await secretScan();
-    execFileSync6("git", ["commit", "-m", commitMessage], { cwd: REPO_ROOT4 });
+    execFileSync7("git", ["commit", "-m", commitMessage], { cwd: REPO_ROOT4 });
   }
   if (!dryRun) {
-    execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
+    execFileSync7("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
   } else {
     logger.info("DRY_RUN \u2014 skipped: git push origin branch");
   }
   const branchPushed = !dryRun;
   let iterFilesTouched = [];
   try {
-    const diff = execFileSync6("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
+    const diff = execFileSync7("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
       cwd: REPO_ROOT4,
       encoding: "utf8"
     });

--- a/.github/actions/ferry-run-iterator/agent.js
+++ b/.github/actions/ferry-run-iterator/agent.js
@@ -6610,7 +6610,7 @@ ${tree}`,
   };
 }
 
-// src/agents/reviewer/rubric.ts
+// src/lib/agent-runtime/reviewer-helpers.ts
 var STRICT_DIRECTIVE = [
   "## Rubric override \u2014 strict",
   "",
@@ -6641,53 +6641,6 @@ function applyRubricToPrompt(basePrompt, rubric) {
 
 ${directive}`;
 }
-
-// src/agents/reviewer/review-loop.ts
-var MAX_PATCH_CHARS = 2e4;
-var MAX_CONTENT_CHARS = 4e4;
-var MAX_ITERATIONS = 40;
-var REVIEW_TOOL_DEFS = [
-  {
-    name: "get_file_patch",
-    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "get_file_content",
-    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "finish_review",
-    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
-    input_schema: {
-      type: "object",
-      properties: {
-        approved: {
-          type: "boolean",
-          description: "true = ready to merge, false = changes required."
-        },
-        comment: {
-          type: "string",
-          description: "Full review comment in Markdown. Follow the required format from the system prompt."
-        }
-      },
-      required: ["approved", "comment"]
-    }
-  }
-];
 function detectMergeConflicts(files) {
   const conflicted = [];
   for (const f of files) {
@@ -6699,57 +6652,6 @@ function detectMergeConflicts(files) {
 }
 function buildFileList(files) {
   return files.map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`).join("\n");
-}
-async function runReviewLoop(opts) {
-  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
-  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
-  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
-  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
-  const {
-    done: result,
-    usage,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  } = await loop.run({
-    system,
-    initialPrompt,
-    tools: REVIEW_TOOL_DEFS,
-    finishTool: "finish_review",
-    extractDone: (input) => ({
-      approved: input.approved,
-      comment: input.comment
-    }),
-    handlers: {
-      get_file_patch: (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_patch", file: filename });
-        const patch = fileMap.get(filename);
-        if (patch === void 0) return `(file not found in PR: ${filename})`;
-        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
-        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
-        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
-      },
-      get_file_content: async (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_content", file: filename });
-        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
-        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
-        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
-      }
-    },
-    maxIterations,
-    maxTokens,
-    logger
-  });
-  return {
-    result,
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  };
 }
 
 // src/lib/agent-runtime/reviewer-prepare.ts
@@ -6763,9 +6665,9 @@ function prepareReviewer(input) {
     branchName,
     typeOverride,
     reviewRubric,
-    configLabels,
-    repoRoot,
-    logger
+    capabilities,
+    idempotencyMarker,
+    repoRoot
   } = input;
   const buildSystem2 = input._buildSystem ?? buildSystem;
   const loadOptionalPrompt2 = input._loadOptionalPrompt ?? loadOptionalPrompt;
@@ -6802,9 +6704,7 @@ function prepareReviewer(input) {
     separator: "\n\n---\n\n"
   });
   const system = applyRubricToPrompt(baseSystem, reviewRubric);
-  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
   const mcpServers = [];
-  const idempotencyMarker = byPrHeadSha("reviewer", headSha);
   return {
     system,
     initialPrompt,
@@ -6821,15 +6721,15 @@ function prepareIterator(input) {
   const {
     ticketKey,
     issue,
-    headSha,
     reviewComment,
     mergeConflicts,
     existingLog,
     mcpPool,
     configLabels,
+    capabilities,
+    idempotencyMarker,
     typeOverride,
-    repoRoot,
-    logger
+    repoRoot
   } = input;
   const buildSystem2 = input._buildSystem ?? buildSystem;
   const system = buildSystem2("iterate", repoRoot);
@@ -6848,10 +6748,8 @@ ${existingLog}` : "",
     "",
     "When you have fixed all findings, call the `done` tool."
   ].filter(Boolean).join("\n");
-  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
   const hasLabelsConfig = configLabels !== void 0;
   const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
-  const idempotencyMarker = byPrHeadSha("iterator", headSha);
   return {
     system,
     initialPrompt,
@@ -10571,6 +10469,104 @@ function gateCi(input) {
   };
 }
 
+// src/agents/reviewer/review-loop.ts
+var MAX_PATCH_CHARS = 2e4;
+var MAX_CONTENT_CHARS = 4e4;
+var MAX_ITERATIONS = 40;
+var REVIEW_TOOL_DEFS = [
+  {
+    name: "get_file_patch",
+    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "get_file_content",
+    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "finish_review",
+    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
+    input_schema: {
+      type: "object",
+      properties: {
+        approved: {
+          type: "boolean",
+          description: "true = ready to merge, false = changes required."
+        },
+        comment: {
+          type: "string",
+          description: "Full review comment in Markdown. Follow the required format from the system prompt."
+        }
+      },
+      required: ["approved", "comment"]
+    }
+  }
+];
+async function runReviewLoop(opts) {
+  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
+  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
+  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
+  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
+  const {
+    done: result,
+    usage,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  } = await loop.run({
+    system,
+    initialPrompt,
+    tools: REVIEW_TOOL_DEFS,
+    finishTool: "finish_review",
+    extractDone: (input) => ({
+      approved: input.approved,
+      comment: input.comment
+    }),
+    handlers: {
+      get_file_patch: (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_patch", file: filename });
+        const patch = fileMap.get(filename);
+        if (patch === void 0) return `(file not found in PR: ${filename})`;
+        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
+        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
+        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
+      },
+      get_file_content: async (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_content", file: filename });
+        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
+        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
+        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
+      }
+    },
+    maxIterations,
+    maxTokens,
+    logger
+  });
+  return {
+    result,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  };
+}
+
 // src/agents/reviewer/changes-guard.ts
 function countPriorIterations(existingComments) {
   return existingComments.filter(
@@ -10733,9 +10729,9 @@ async function main3(envelope, logger) {
     branchName,
     typeOverride,
     reviewRubric: reviewRubricOverride,
-    configLabels: effectiveCfg.labels,
-    repoRoot: REPO_ROOT3,
-    logger
+    capabilities,
+    idempotencyMarker,
+    repoRoot: REPO_ROOT3
   });
   const { system, initialPrompt, fileMap } = prepared;
   const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
@@ -10960,6 +10956,8 @@ async function main4(envelope, logger) {
   const reviewTransitionId = shouldAutoTransition ? requireEnv("FERRY_REVIEW_TRANSITION_ID") : "";
   const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels, logger);
+  logCapabilities(logger, capabilities);
   const priorIterations = existingComments.filter(
     (c) => c.includes("[ferry:iterator:") && c.includes("complete. Pushed fixes to PR#")
   ).length;
@@ -11052,12 +11050,12 @@ async function main4(envelope, logger) {
     existingLog,
     mcpPool,
     configLabels: effectiveCfg.labels,
+    capabilities,
+    idempotencyMarker,
     typeOverride,
-    repoRoot: REPO_ROOT4,
-    logger
+    repoRoot: REPO_ROOT4
   });
-  const { system, initialPrompt, mcpServers, capabilities } = prepared;
-  logCapabilities(logger, capabilities);
+  const { system, initialPrompt, mcpServers } = prepared;
   const secretScan = makeSecretScan(REPO_ROOT4);
   const loop = createAgentLoop({
     provider: iterProvider,

--- a/.github/actions/ferry-run-iterator/agent.js
+++ b/.github/actions/ferry-run-iterator/agent.js
@@ -6442,6 +6442,426 @@ function buildConflictComment(role, runId, err) {
   ].join("\n");
 }
 
+// src/lib/agent-runtime/refiner-prepare.ts
+var PRIOR_RUN_MARKER = /\[ferry:refiner:[^\]]+\]/;
+async function prepareRefiner(input) {
+  const { envelope, tracker } = input;
+  const { ticket_key: ticketKey, event_id: eventId } = envelope;
+  const issue = await tracker.getIssue(ticketKey);
+  const existingSubtasks = await tracker.getSubtaskDetails(ticketKey);
+  const priorRefinerRuns = issue.comments.filter((c) => PRIOR_RUN_MARKER.test(c));
+  const runLink = `https://github.com/${process.env.GITHUB_REPO ?? "unknown"}/actions/runs/${process.env.GITHUB_RUN_ID ?? "0"}`;
+  const idempotencyMarker = byEventId("refiner", eventId);
+  return {
+    issue,
+    existingSubtasks,
+    priorRefinerRuns,
+    runLink,
+    idempotencyMarker
+  };
+}
+
+// src/lib/agent-runtime/developer-prepare.ts
+import { execFileSync as execFileSync3 } from "node:child_process";
+
+// src/lib/llm/delimit-untrusted.ts
+var OPEN = "<<<UNTRUSTED>>>";
+var CLOSE = "<<<END UNTRUSTED>>>";
+var OPEN_ESCAPE = "<<<UNTRUSTED-LITERAL>>>";
+var CLOSE_ESCAPE = "<<<END UNTRUSTED-LITERAL>>>";
+function delimitUntrusted(value) {
+  const escaped = value.split(OPEN).join(OPEN_ESCAPE).split(CLOSE).join(CLOSE_ESCAPE);
+  return `${OPEN}
+${escaped}
+${CLOSE}`;
+}
+
+// src/lib/agent-runtime/developer-prepare.ts
+var checkoutOrCreateBranchDefault = (branchName, baseBranch, repoRoot, logger) => {
+  try {
+    execFileSync3("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
+      cwd: repoRoot,
+      stdio: "pipe"
+    });
+    execFileSync3("git", ["fetch", "origin", branchName], { cwd: repoRoot });
+    execFileSync3("git", ["checkout", branchName], { cwd: repoRoot });
+    const existingLog = execFileSync3("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
+      cwd: repoRoot,
+      encoding: "utf8"
+    }).trim();
+    if (existingLog) {
+      logger.info("resuming branch", {
+        branch: branchName,
+        prior_commits: existingLog.split("\n").length
+      });
+    }
+    const branchHeadSha = execFileSync3("git", ["rev-parse", "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf8"
+    }).trim();
+    return { branchHeadSha, existingLog };
+  } catch {
+    execFileSync3("git", ["checkout", "-B", branchName], { cwd: repoRoot });
+    logger.info("created branch", { branch: branchName });
+    return { branchHeadSha: "", existingLog: "" };
+  }
+};
+async function prepareDeveloper(input) {
+  const {
+    envelope,
+    issue,
+    effectiveCfg,
+    subtasks,
+    testRunner,
+    pkgManagerHint,
+    tree,
+    typeOverride,
+    owner,
+    repo,
+    baseBranch,
+    runner,
+    mcpPool,
+    repoRoot,
+    dryRun,
+    logger
+  } = input;
+  const buildSystem2 = input._buildSystem ?? buildSystem;
+  const checkoutOrCreateBranch = input._checkoutOrCreateBranch ?? checkoutOrCreateBranchDefault;
+  const configureGitUser = input._configureGitUser ?? configureFerryGitUser;
+  const ticketKey = envelope.ticket_key;
+  const eventId = envelope.event_id;
+  const labels = issue.labels.join(", ");
+  const comments = issue.comments.map((c) => `Comment: ${c}`).join("\n");
+  const ticketBlock = buildTicketBlock(ticketKey, issue, {
+    labels,
+    comments,
+    typeOverride
+  });
+  const system = buildSystem2("dev", repoRoot, {
+    extraParts: pkgManagerHint ? [`## Detected package manager
+
+${pkgManagerHint}`] : []
+  });
+  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
+  configureGitUser(repoRoot);
+  const { branchHeadSha, existingLog } = checkoutOrCreateBranch(
+    branchName,
+    baseBranch,
+    repoRoot,
+    logger
+  );
+  const resumeContext = existingLog ? `
+EXISTING WORK ON BRANCH (already committed \u2014 skip these, only do what remains):
+${existingLog}` : "";
+  let existingPrUrl = "";
+  let existingPrContext = "";
+  if (branchHeadSha && !dryRun) {
+    try {
+      const openPrs = await runner.listPRsForBranch(owner, repo, branchName);
+      if (openPrs.length > 0) {
+        const pr = openPrs[0];
+        existingPrUrl = `https://github.com/${owner}/${repo}/pull/${pr.number}`;
+        const prRef = { owner, repo, prNumber: pr.number };
+        const prFiles = await runner.listPRFiles(prRef);
+        const fileList = prFiles.map((f) => `${f.status}: ${f.filename}`).join("\n");
+        existingPrContext = [
+          `
+EXISTING_IMPLEMENTATION:`,
+          `Open PR: ${existingPrUrl} (head: ${branchHeadSha.slice(0, 7)})`,
+          `Changed files:
+${fileList}`,
+          `If the spec is already fully satisfied by the existing code, call \`done\` with outcome="already_satisfied".`
+        ].join("\n");
+        logger.info("existing PR found", { pr: existingPrUrl, files: prFiles.length });
+      }
+    } catch {
+    }
+  }
+  const idempotencyMarker = branchHeadSha ? byPrHeadSha("dev", branchHeadSha) : byEventId("dev", eventId);
+  const baseInitialPrompt = [
+    delimitUntrusted(ticketBlock),
+    "",
+    subtasks.length > 0 ? `SUBTASKS:
+${subtasks.join("\n")}` : "SUBTASKS: (none)",
+    "",
+    `TEST_RUNNER: ${testRunner}`,
+    "",
+    `REPO TREE (depth 2):
+${tree}`,
+    "",
+    "When you have finished implementing, call the `done` tool."
+  ].join("\n");
+  const initialPrompt = baseInitialPrompt + resumeContext + existingPrContext;
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
+  const hasLabelsConfig = effectiveCfg.labels !== void 0;
+  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  return {
+    system,
+    initialPrompt,
+    baseInitialPrompt,
+    mcpServers,
+    idempotencyMarker,
+    ticketBlock,
+    subtasks,
+    capabilities,
+    branchName,
+    branchHeadSha,
+    existingPrUrl
+  };
+}
+
+// src/agents/reviewer/rubric.ts
+var STRICT_DIRECTIVE = [
+  "## Rubric override \u2014 strict",
+  "",
+  "For this review, apply a STRICTER bar than usual:",
+  "",
+  "- Block on any missing test coverage for new/changed behaviour.",
+  "- Block on missing edge-case handling, error paths, or input validation.",
+  "- Block on weak naming, dead code, or unreachable branches.",
+  "- Block on incomplete documentation when public APIs change.",
+  "- Approve only when every acceptance criterion is fully satisfied with concrete evidence."
+].join("\n");
+var LENIENT_DIRECTIVE = [
+  "## Rubric override \u2014 lenient",
+  "",
+  "For this review, apply a MORE PERMISSIVE bar than usual:",
+  "",
+  "- Approve when the acceptance criteria are met, even if minor polish is missing.",
+  "- Treat naming nits, non-blocking style issues, and stylistic preferences as comments \u2014 not blockers.",
+  "- Block only on: failing tests, unimplemented ACs, merge conflicts, committed build artefacts, or security regressions.",
+  '- Prefer "approve with comments" over "request changes" when issues are non-blocking.'
+].join("\n");
+function applyRubricToPrompt(basePrompt, rubric) {
+  if (rubric === void 0) return basePrompt;
+  const directive = rubric === "strict" ? STRICT_DIRECTIVE : LENIENT_DIRECTIVE;
+  return `${basePrompt}
+
+---
+
+${directive}`;
+}
+
+// src/agents/reviewer/review-loop.ts
+var MAX_PATCH_CHARS = 2e4;
+var MAX_CONTENT_CHARS = 4e4;
+var MAX_ITERATIONS = 40;
+var REVIEW_TOOL_DEFS = [
+  {
+    name: "get_file_patch",
+    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "get_file_content",
+    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "finish_review",
+    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
+    input_schema: {
+      type: "object",
+      properties: {
+        approved: {
+          type: "boolean",
+          description: "true = ready to merge, false = changes required."
+        },
+        comment: {
+          type: "string",
+          description: "Full review comment in Markdown. Follow the required format from the system prompt."
+        }
+      },
+      required: ["approved", "comment"]
+    }
+  }
+];
+function detectMergeConflicts(files) {
+  const conflicted = [];
+  for (const f of files) {
+    if (f.patch && /^[+].*<{7}|^[+].*={7}|^[+].*>{7}/m.test(f.patch)) {
+      conflicted.push(f.filename);
+    }
+  }
+  return conflicted;
+}
+function buildFileList(files) {
+  return files.map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`).join("\n");
+}
+async function runReviewLoop(opts) {
+  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
+  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
+  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
+  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
+  const {
+    done: result,
+    usage,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  } = await loop.run({
+    system,
+    initialPrompt,
+    tools: REVIEW_TOOL_DEFS,
+    finishTool: "finish_review",
+    extractDone: (input) => ({
+      approved: input.approved,
+      comment: input.comment
+    }),
+    handlers: {
+      get_file_patch: (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_patch", file: filename });
+        const patch = fileMap.get(filename);
+        if (patch === void 0) return `(file not found in PR: ${filename})`;
+        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
+        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
+        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
+      },
+      get_file_content: async (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_content", file: filename });
+        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
+        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
+        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
+      }
+    },
+    maxIterations,
+    maxTokens,
+    logger
+  });
+  return {
+    result,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  };
+}
+
+// src/lib/agent-runtime/reviewer-prepare.ts
+function prepareReviewer(input) {
+  const {
+    ticketKey,
+    issue,
+    pr,
+    files,
+    commits,
+    branchName,
+    typeOverride,
+    reviewRubric,
+    configLabels,
+    repoRoot,
+    logger
+  } = input;
+  const buildSystem2 = input._buildSystem ?? buildSystem;
+  const loadOptionalPrompt2 = input._loadOptionalPrompt ?? loadOptionalPrompt;
+  const headSha = pr.headSha;
+  const prNumber = pr.number;
+  const fileMap = new Map(files.map((f) => [f.filename, f.patch]));
+  const conflictedFiles = detectMergeConflicts(files);
+  const hasMergeConflicts = pr.mergeable === false || conflictedFiles.length > 0;
+  const commitLog = commits.map((c) => `${c.sha.slice(0, 7)} ${c.message.split("\n")[0]}`).join("\n");
+  const ticketBlock = buildTicketBlock(ticketKey, issue, { typeOverride });
+  const mergeConflictWarning = hasMergeConflicts ? `
+\u26A0\uFE0F  MERGE CONFLICTS DETECTED \u2014 mergeable=${String(pr.mergeable)}${conflictedFiles.length > 0 ? `, conflicted files: ${conflictedFiles.join(", ")}` : ""}` : "";
+  const initialPrompt = [
+    "## Jira Ticket",
+    delimitUntrusted(ticketBlock),
+    "",
+    "## PR Metadata",
+    `PR #${prNumber}: ${pr.title}`,
+    `Base: ${pr.baseRef} \u2190 Head: ${branchName} (${headSha.slice(0, 7)})`,
+    `Files changed: ${files.length}  Commits: ${commits.length}`,
+    mergeConflictWarning,
+    "",
+    "## Commits",
+    commitLog,
+    "",
+    "## Changed files (status  +additions  -deletions  path)",
+    buildFileList(files),
+    "",
+    "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
+    "When you have enough information, call finish_review."
+  ].filter((l) => l !== null).join("\n");
+  const baseSystem = buildSystem2("review", repoRoot, {
+    extraParts: [loadOptionalPrompt2("review-comment", repoRoot)],
+    separator: "\n\n---\n\n"
+  });
+  const system = applyRubricToPrompt(baseSystem, reviewRubric);
+  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
+  const mcpServers = [];
+  const idempotencyMarker = byPrHeadSha("reviewer", headSha);
+  return {
+    system,
+    initialPrompt,
+    mcpServers,
+    idempotencyMarker,
+    ticketBlock,
+    capabilities,
+    fileMap
+  };
+}
+
+// src/lib/agent-runtime/iterator-prepare.ts
+function prepareIterator(input) {
+  const {
+    ticketKey,
+    issue,
+    headSha,
+    reviewComment,
+    mergeConflicts,
+    existingLog,
+    mcpPool,
+    configLabels,
+    typeOverride,
+    repoRoot,
+    logger
+  } = input;
+  const buildSystem2 = input._buildSystem ?? buildSystem;
+  const system = buildSystem2("iterate", repoRoot);
+  const ticketBlock = buildTicketBlock(ticketKey, issue, { typeOverride });
+  const initialPrompt = [
+    "## Jira Ticket",
+    delimitUntrusted(ticketBlock),
+    "",
+    "## Review Findings (fix only what is listed here)",
+    delimitUntrusted(reviewComment),
+    "",
+    mergeConflicts.length > 0 ? `## Merge Conflicts (resolve these first, before fixing review findings)
+${mergeConflicts.map((f) => `- ${f}`).join("\n")}` : "",
+    existingLog ? `## Existing commits on branch
+${existingLog}` : "",
+    "",
+    "When you have fixed all findings, call the `done` tool."
+  ].filter(Boolean).join("\n");
+  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
+  const hasLabelsConfig = configLabels !== void 0;
+  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  const idempotencyMarker = byPrHeadSha("iterator", headSha);
+  return {
+    system,
+    initialPrompt,
+    mcpServers,
+    idempotencyMarker,
+    ticketBlock,
+    capabilities
+  };
+}
+
 // src/lib/dry-run.ts
 function isDryRun() {
   return process.env.FERRY_DRY_RUN === "1" || process.env.FERRY_DRY_RUN === "true";
@@ -6640,18 +7060,6 @@ function createLlmCall(route) {
 
 // src/agents/refiner/refine.ts
 import { createRequire as createRequire3 } from "module";
-
-// src/lib/llm/delimit-untrusted.ts
-var OPEN = "<<<UNTRUSTED>>>";
-var CLOSE = "<<<END UNTRUSTED>>>";
-var OPEN_ESCAPE = "<<<UNTRUSTED-LITERAL>>>";
-var CLOSE_ESCAPE = "<<<END UNTRUSTED-LITERAL>>>";
-function delimitUntrusted(value) {
-  const escaped = value.split(OPEN).join(OPEN_ESCAPE).split(CLOSE).join(CLOSE_ESCAPE);
-  return `${OPEN}
-${escaped}
-${CLOSE}`;
-}
 
 // src/agents/refiner/parse.ts
 function extractFirstJsonObject(text) {
@@ -7028,15 +7436,12 @@ function estimateTicketCost(_plan, baseline) {
 
 // src/agents/refiner/refiner-action.ts
 var REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
-var PRIOR_RUN_MARKER = /\[ferry:refiner:[^\]]+\]/;
 async function run(envelope, deps) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const logger = deps.logger ?? createLogger(eventId, "ferry:refiner-action");
   const dryRun = isDryRun() || deps.dryRun === true;
-  const issue = await deps.tracker.getIssue(ticketKey);
-  const runLink = `https://github.com/${process.env.GITHUB_REPO ?? "unknown"}/actions/runs/${process.env.GITHUB_RUN_ID ?? "0"}`;
-  const existingSubtasks = await deps.tracker.getSubtaskDetails(ticketKey);
-  const priorRefinerRuns = issue.comments.filter((c) => PRIOR_RUN_MARKER.test(c));
+  const prepared = await prepareRefiner({ envelope, tracker: deps.tracker });
+  const { issue, existingSubtasks, priorRefinerRuns, runLink, idempotencyMarker } = prepared;
   const { plan, auditSummary } = await runRefiner({
     ticket: {
       key: issue.key,
@@ -7111,7 +7516,6 @@ async function run(envelope, deps) {
     existingSubtasks,
     tracker: deps.tracker
   });
-  const idempotencyMarker = `[ferry:refiner:${eventId}]`;
   if (result.noop) {
     logger.info("noop \u2014 existing sub-tasks still valid", { ticket: ticketKey });
     await deps.tracker.postComment(
@@ -7199,7 +7603,7 @@ async function main(envelope, logger) {
 }
 
 // src/agents/developer/dev-action.ts
-import { execFileSync as execFileSync5 } from "node:child_process";
+import { execFileSync as execFileSync6 } from "node:child_process";
 import * as fsp2 from "node:fs/promises";
 import * as path6 from "node:path";
 
@@ -9093,7 +9497,7 @@ function createAgentLoop(opts) {
 
 // src/agents/developer/workspace.ts
 import { readFileSync as readFileSync5, existsSync as existsSync4 } from "node:fs";
-import { execFileSync as execFileSync3 } from "node:child_process";
+import { execFileSync as execFileSync4 } from "node:child_process";
 import * as path5 from "node:path";
 function detectTestRunner(packageJsonPath2) {
   try {
@@ -9112,7 +9516,7 @@ function detectTestRunner(packageJsonPath2) {
 }
 function repoTree(repoRoot) {
   try {
-    return execFileSync3(
+    return execFileSync4(
       "find",
       [
         repoRoot,
@@ -9204,7 +9608,7 @@ function assertDevOutputContract(outcome, outputs) {
 }
 
 // src/agents/developer/wip-finalizer.ts
-import { execFileSync as execFileSync4 } from "node:child_process";
+import { execFileSync as execFileSync5 } from "node:child_process";
 function classifyError(err) {
   if (err instanceof FerryError) {
     const reason = err.context?.reason ?? "unknown";
@@ -9243,8 +9647,8 @@ async function runWipFinalizer(opts) {
   logger.info("wip_finalizer", { code, detail, branch: branchName });
   let committed = false;
   try {
-    execFileSync4("git", ["add", "-A"], { cwd: repoRoot });
-    const status = execFileSync4("git", ["status", "--porcelain"], {
+    execFileSync5("git", ["add", "-A"], { cwd: repoRoot });
+    const status = execFileSync5("git", ["status", "--porcelain"], {
       cwd: repoRoot,
       encoding: "utf8"
     });
@@ -9253,7 +9657,7 @@ async function runWipFinalizer(opts) {
       const wipMsg = `wip(${ticketKey}): interrupted \u2014 ${code}
 
 [ferry:dev:${eventId}]`;
-      execFileSync4("git", ["commit", "-m", wipMsg], { cwd: repoRoot });
+      execFileSync5("git", ["commit", "-m", wipMsg], { cwd: repoRoot });
       committed = true;
       logger.info("wip_committed", { branch: branchName });
     } else {
@@ -9265,14 +9669,14 @@ async function runWipFinalizer(opts) {
   let pushed = false;
   if (!dryRun) {
     try {
-      execFileSync4("git", ["push", "origin", branchName, "--force-with-lease"], {
+      execFileSync5("git", ["push", "origin", branchName, "--force-with-lease"], {
         cwd: repoRoot,
         stdio: "pipe"
       });
       pushed = true;
     } catch {
       try {
-        execFileSync4("git", ["push", "origin", branchName], { cwd: repoRoot, stdio: "pipe" });
+        execFileSync5("git", ["push", "origin", branchName], { cwd: repoRoot, stdio: "pipe" });
         pushed = true;
       } catch (pushErr) {
         logger.error("wip_push_failed", { error: pushErr.message });
@@ -9398,102 +9802,36 @@ async function main2(envelope, logger) {
   const reviewTransitionId = !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
   const jiraBaseUrl = requireEnv("FERRY_JIRA_BASE_URL");
   const { provider: devProvider } = effectiveCfg.models.dev;
-  const labels = issue.labels.join(", ");
-  const comments = issue.comments.map((c) => `Comment: ${c}`).join("\n");
-  const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    labels,
-    comments,
-    typeOverride
-  });
+  const model = effectiveCfg.models.dev.model;
   const subtasks = await tracker.getSubtasks(ticketKey);
   const testRunner = detectTestRunner(packageJsonPath(REPO_ROOT2));
   const pkgManagerHint = detectPackageManager(REPO_ROOT2);
   const tree = repoTree(REPO_ROOT2);
-  const system = buildSystem("dev", REPO_ROOT2, {
-    extraParts: pkgManagerHint ? [`## Detected package manager
-
-${pkgManagerHint}`] : []
-  });
-  const model = effectiveCfg.models.dev.model;
-  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
-  configureFerryGitUser(REPO_ROOT2);
-  let resumeContext = "";
-  let branchHeadSha = "";
-  try {
-    execFileSync5("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
-      cwd: REPO_ROOT2,
-      stdio: "pipe"
-    });
-    execFileSync5("git", ["fetch", "origin", branchName], { cwd: REPO_ROOT2 });
-    execFileSync5("git", ["checkout", branchName], { cwd: REPO_ROOT2 });
-    const existingLog = execFileSync5("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
-      cwd: REPO_ROOT2,
-      encoding: "utf8"
-    }).trim();
-    if (existingLog) {
-      resumeContext = `
-EXISTING WORK ON BRANCH (already committed \u2014 skip these, only do what remains):
-${existingLog}`;
-      logger.info("resuming branch", {
-        branch: branchName,
-        prior_commits: existingLog.split("\n").length
-      });
-    }
-    branchHeadSha = execFileSync5("git", ["rev-parse", "HEAD"], {
-      cwd: REPO_ROOT2,
-      encoding: "utf8"
-    }).trim();
-  } catch {
-    execFileSync5("git", ["checkout", "-B", branchName], { cwd: REPO_ROOT2 });
-    logger.info("created branch", { branch: branchName });
-  }
-  let existingPrUrl = "";
-  let existingPrContext = "";
-  if (branchHeadSha && !dryRun) {
-    try {
-      const openPrs = await runner.listPRsForBranch(owner, repo, branchName);
-      if (openPrs.length > 0) {
-        const pr = openPrs[0];
-        existingPrUrl = `https://github.com/${owner}/${repo}/pull/${pr.number}`;
-        const prRef = { owner, repo, prNumber: pr.number };
-        const prFiles = await runner.listPRFiles(prRef);
-        const fileList = prFiles.map((f) => `${f.status}: ${f.filename}`).join("\n");
-        existingPrContext = [
-          `
-EXISTING_IMPLEMENTATION:`,
-          `Open PR: ${existingPrUrl} (head: ${branchHeadSha.slice(0, 7)})`,
-          `Changed files:
-${fileList}`,
-          `If the spec is already fully satisfied by the existing code, call \`done\` with outcome="already_satisfied".`
-        ].join("\n");
-        logger.info("existing PR found", { pr: existingPrUrl, files: prFiles.length });
-      }
-    } catch {
-    }
-  }
-  const idempotencyMarker = branchHeadSha ? `[ferry:dev:${branchHeadSha.slice(0, 7)}]` : `[ferry:dev:${eventId}]`;
-  const initialPrompt = [
-    delimitUntrusted(ticketBlock),
-    "",
-    subtasks.length > 0 ? `SUBTASKS:
-${subtasks.join("\n")}` : "SUBTASKS: (none)",
-    "",
-    `TEST_RUNNER: ${testRunner}`,
-    "",
-    `REPO TREE (depth 2):
-${tree}`,
-    "",
-    "When you have finished implementing, call the `done` tool."
-  ].join("\n");
-  const secretScan = makeSecretScan(REPO_ROOT2);
   const mcpPool = loadMcpServers();
-  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
-  const hasLabelsConfig = effectiveCfg.labels !== void 0;
-  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  const prepared = await prepareDeveloper({
+    envelope,
+    issue,
+    effectiveCfg,
+    subtasks,
+    testRunner,
+    pkgManagerHint,
+    tree,
+    typeOverride,
+    owner,
+    repo,
+    baseBranch,
+    runner,
+    mcpPool,
+    repoRoot: REPO_ROOT2,
+    dryRun,
+    logger
+  });
+  const { system, initialPrompt, mcpServers, idempotencyMarker, branchName, capabilities } = prepared;
   logCapabilities(logger, capabilities);
   if (mcpServers.length > 0) {
     logger.info("MCP servers", { servers: mcpServers.map((s) => s.name) });
   }
+  const secretScan = makeSecretScan(REPO_ROOT2);
   const allToolSchemas = [...TOOL_SCHEMAS, COMMIT_PROGRESS_SCHEMA, SPAWN_SUBAGENT_SCHEMA];
   let loop;
   loop = createAgentLoop({
@@ -9521,7 +9859,9 @@ ${tree}`,
   try {
     loopResult = await loop.run({
       system,
-      initialPrompt: initialPrompt + resumeContext + existingPrContext,
+      // `initialPrompt` already includes the resume + existing-PR context
+      // (concatenated inside `prepareDeveloper`).
+      initialPrompt,
       tools: allToolSchemas,
       repoRoot: REPO_ROOT2,
       branchName,
@@ -9618,20 +9958,20 @@ ${tree}`,
       await fsp2.writeFile(verificationPath, verificationContent, "utf8");
       verificationNoteWritten = true;
     }
-    execFileSync5("git", ["add", "-A"], { cwd: REPO_ROOT2 });
-    const finalStatus = execFileSync5("git", ["status", "--porcelain"], {
+    execFileSync6("git", ["add", "-A"], { cwd: REPO_ROOT2 });
+    const finalStatus = execFileSync6("git", ["status", "--porcelain"], {
       cwd: REPO_ROOT2,
       encoding: "utf8"
     });
     if (finalStatus.trim()) {
       await secretScan();
       const msg = resolvedOutcome === "already_satisfied" ? `chore(${ticketKey}): add verification note \u2014 spec already satisfied` : done.commit_message ?? commitMessage;
-      execFileSync5("git", ["commit", "-m", msg], { cwd: REPO_ROOT2 });
+      execFileSync6("git", ["commit", "-m", msg], { cwd: REPO_ROOT2 });
     }
     if (dryRun) {
       let diffOutput = "(no local changes)";
       try {
-        diffOutput = execFileSync5(
+        diffOutput = execFileSync6(
           "sh",
           [
             "-c",
@@ -9660,11 +10000,11 @@ ${tree}`,
       appendOutput({ ...usage, model, provider: devProvider });
       process.exit(0);
     }
-    execFileSync5("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT2 });
+    execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT2 });
     const branchPushed = true;
     summaryBranchPushed = branchName;
     try {
-      const diff = execFileSync5("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
+      const diff = execFileSync6("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
         cwd: REPO_ROOT2,
         encoding: "utf8"
       });
@@ -10231,148 +10571,6 @@ function gateCi(input) {
   };
 }
 
-// src/agents/reviewer/review-loop.ts
-var MAX_PATCH_CHARS = 2e4;
-var MAX_CONTENT_CHARS = 4e4;
-var MAX_ITERATIONS = 40;
-var REVIEW_TOOL_DEFS = [
-  {
-    name: "get_file_patch",
-    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "get_file_content",
-    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "finish_review",
-    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
-    input_schema: {
-      type: "object",
-      properties: {
-        approved: {
-          type: "boolean",
-          description: "true = ready to merge, false = changes required."
-        },
-        comment: {
-          type: "string",
-          description: "Full review comment in Markdown. Follow the required format from the system prompt."
-        }
-      },
-      required: ["approved", "comment"]
-    }
-  }
-];
-function detectMergeConflicts(files) {
-  const conflicted = [];
-  for (const f of files) {
-    if (f.patch && /^[+].*<{7}|^[+].*={7}|^[+].*>{7}/m.test(f.patch)) {
-      conflicted.push(f.filename);
-    }
-  }
-  return conflicted;
-}
-function buildFileList(files) {
-  return files.map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`).join("\n");
-}
-async function runReviewLoop(opts) {
-  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
-  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
-  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
-  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
-  const {
-    done: result,
-    usage,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  } = await loop.run({
-    system,
-    initialPrompt,
-    tools: REVIEW_TOOL_DEFS,
-    finishTool: "finish_review",
-    extractDone: (input) => ({
-      approved: input.approved,
-      comment: input.comment
-    }),
-    handlers: {
-      get_file_patch: (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_patch", file: filename });
-        const patch = fileMap.get(filename);
-        if (patch === void 0) return `(file not found in PR: ${filename})`;
-        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
-        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
-        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
-      },
-      get_file_content: async (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_content", file: filename });
-        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
-        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
-        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
-      }
-    },
-    maxIterations,
-    maxTokens,
-    logger
-  });
-  return {
-    result,
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  };
-}
-
-// src/agents/reviewer/rubric.ts
-var STRICT_DIRECTIVE = [
-  "## Rubric override \u2014 strict",
-  "",
-  "For this review, apply a STRICTER bar than usual:",
-  "",
-  "- Block on any missing test coverage for new/changed behaviour.",
-  "- Block on missing edge-case handling, error paths, or input validation.",
-  "- Block on weak naming, dead code, or unreachable branches.",
-  "- Block on incomplete documentation when public APIs change.",
-  "- Approve only when every acceptance criterion is fully satisfied with concrete evidence."
-].join("\n");
-var LENIENT_DIRECTIVE = [
-  "## Rubric override \u2014 lenient",
-  "",
-  "For this review, apply a MORE PERMISSIVE bar than usual:",
-  "",
-  "- Approve when the acceptance criteria are met, even if minor polish is missing.",
-  "- Treat naming nits, non-blocking style issues, and stylistic preferences as comments \u2014 not blockers.",
-  "- Block only on: failing tests, unimplemented ACs, merge conflicts, committed build artefacts, or security regressions.",
-  '- Prefer "approve with comments" over "request changes" when issues are non-blocking.'
-].join("\n");
-function applyRubricToPrompt(basePrompt, rubric) {
-  if (rubric === void 0) return basePrompt;
-  const directive = rubric === "strict" ? STRICT_DIRECTIVE : LENIENT_DIRECTIVE;
-  return `${basePrompt}
-
----
-
-${directive}`;
-}
-
 // src/agents/reviewer/changes-guard.ts
 function countPriorIterations(existingComments) {
   return existingComments.filter(
@@ -10459,7 +10657,6 @@ async function main3(envelope, logger) {
   const prNumber = prs[0].number;
   const pr = await runner.getPR({ owner, repo, prNumber });
   const headSha = pr.headSha;
-  const mergeable = pr.mergeable;
   const idempotencyMarker = byPrHeadSha("reviewer", headSha);
   const { skipped } = checkIdempotencyMarker(idempotencyMarker, existingComments);
   if (skipped) {
@@ -10526,40 +10723,21 @@ async function main3(envelope, logger) {
     return;
   }
   const files = await runner.listPRFiles({ owner, repo, prNumber });
-  const fileMap = new Map(files.map((f) => [f.filename, f.patch]));
-  const conflictedFiles = detectMergeConflicts(files);
-  const hasMergeConflicts = mergeable === false || conflictedFiles.length > 0;
   const commits = await runner.listPRCommits({ owner, repo, prNumber });
-  const commitLog = commits.map((c) => `${c.sha.slice(0, 7)} ${c.message.split("\n")[0]}`).join("\n");
-  const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    typeOverride
+  const prepared = prepareReviewer({
+    ticketKey,
+    issue,
+    pr,
+    files,
+    commits,
+    branchName,
+    typeOverride,
+    reviewRubric: reviewRubricOverride,
+    configLabels: effectiveCfg.labels,
+    repoRoot: REPO_ROOT3,
+    logger
   });
-  const mergeConflictWarning = hasMergeConflicts ? `
-\u26A0\uFE0F  MERGE CONFLICTS DETECTED \u2014 mergeable=${String(mergeable)}${conflictedFiles.length > 0 ? `, conflicted files: ${conflictedFiles.join(", ")}` : ""}` : "";
-  const initialPrompt = [
-    "## Jira Ticket",
-    delimitUntrusted(ticketBlock),
-    "",
-    "## PR Metadata",
-    `PR #${prNumber}: ${pr.title}`,
-    `Base: ${pr.baseRef} \u2190 Head: ${branchName} (${headSha.slice(0, 7)})`,
-    `Files changed: ${files.length}  Commits: ${commits.length}`,
-    mergeConflictWarning,
-    "",
-    "## Commits",
-    commitLog,
-    "",
-    "## Changed files (status  +additions  -deletions  path)",
-    buildFileList(files),
-    "",
-    "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
-    "When you have enough information, call finish_review."
-  ].filter((l) => l !== null).join("\n");
-  const baseSystem = buildSystem("review", REPO_ROOT3, {
-    extraParts: [loadOptionalPrompt("review-comment", REPO_ROOT3)],
-    separator: "\n\n---\n\n"
-  });
-  const system = applyRubricToPrompt(baseSystem, reviewRubricOverride);
+  const { system, initialPrompt, fileMap } = prepared;
   const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
   const {
     result: review,
@@ -10651,7 +10829,7 @@ async function main3(envelope, logger) {
 }
 
 // src/agents/iterator/iterate-action.ts
-import { execFileSync as execFileSync6 } from "node:child_process";
+import { execFileSync as execFileSync7 } from "node:child_process";
 
 // src/agents/iterator/outcome-guard.ts
 function assertIterOutputContract(outcome, outputs) {
@@ -10782,10 +10960,6 @@ async function main4(envelope, logger) {
   const reviewTransitionId = shouldAutoTransition ? requireEnv("FERRY_REVIEW_TRANSITION_ID") : "";
   const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
-  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
-  const hasLabelsConfig = effectiveCfg.labels !== void 0;
-  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
-  logCapabilities(logger, capabilities);
   const priorIterations = existingComments.filter(
     (c) => c.includes("[ferry:iterator:") && c.includes("complete. Pushed fixes to PR#")
   ).length;
@@ -10855,7 +11029,6 @@ async function main4(envelope, logger) {
     appendOutput({ input_tokens: 0, output_tokens: 0, model, provider: iterProvider });
     return;
   }
-  const system = buildSystem("iterate", REPO_ROOT4);
   configureFerryGitUser(REPO_ROOT4);
   if (checkoutExistingBranch(branchName, REPO_ROOT4) === "not-found") {
     await tracker.postComment(
@@ -10866,27 +11039,25 @@ async function main4(envelope, logger) {
     return;
   }
   const mergeConflicts = fetchAndMergeBase(baseBranch, REPO_ROOT4);
-  const existingLog = execFileSync6("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
+  const existingLog = execFileSync7("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
     cwd: REPO_ROOT4,
     encoding: "utf8"
   }).trim();
-  const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    typeOverride
+  const prepared = prepareIterator({
+    ticketKey,
+    issue,
+    headSha,
+    reviewComment,
+    mergeConflicts,
+    existingLog,
+    mcpPool,
+    configLabels: effectiveCfg.labels,
+    typeOverride,
+    repoRoot: REPO_ROOT4,
+    logger
   });
-  const initialPrompt = [
-    "## Jira Ticket",
-    delimitUntrusted(ticketBlock),
-    "",
-    "## Review Findings (fix only what is listed here)",
-    delimitUntrusted(reviewComment),
-    "",
-    mergeConflicts.length > 0 ? `## Merge Conflicts (resolve these first, before fixing review findings)
-${mergeConflicts.map((f) => `- ${f}`).join("\n")}` : "",
-    existingLog ? `## Existing commits on branch
-${existingLog}` : "",
-    "",
-    "When you have fixed all findings, call the `done` tool."
-  ].filter(Boolean).join("\n");
+  const { system, initialPrompt, mcpServers, capabilities } = prepared;
+  logCapabilities(logger, capabilities);
   const secretScan = makeSecretScan(REPO_ROOT4);
   const loop = createAgentLoop({
     provider: iterProvider,
@@ -10972,24 +11143,24 @@ ${existingLog}` : "",
     rule_ids: [],
     run_id: eventId
   });
-  execFileSync6("git", ["add", "-A"], { cwd: REPO_ROOT4 });
-  const finalStatus = execFileSync6("git", ["status", "--porcelain"], {
+  execFileSync7("git", ["add", "-A"], { cwd: REPO_ROOT4 });
+  const finalStatus = execFileSync7("git", ["status", "--porcelain"], {
     cwd: REPO_ROOT4,
     encoding: "utf8"
   }).trim();
   if (finalStatus) {
     await secretScan();
-    execFileSync6("git", ["commit", "-m", commitMessage], { cwd: REPO_ROOT4 });
+    execFileSync7("git", ["commit", "-m", commitMessage], { cwd: REPO_ROOT4 });
   }
   if (!dryRun) {
-    execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
+    execFileSync7("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
   } else {
     logger.info("DRY_RUN \u2014 skipped: git push origin branch");
   }
   const branchPushed = !dryRun;
   let iterFilesTouched = [];
   try {
-    const diff = execFileSync6("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
+    const diff = execFileSync7("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
       cwd: REPO_ROOT4,
       encoding: "utf8"
     });

--- a/.github/actions/ferry-run-refiner/agent.js
+++ b/.github/actions/ferry-run-refiner/agent.js
@@ -6610,7 +6610,7 @@ ${tree}`,
   };
 }
 
-// src/agents/reviewer/rubric.ts
+// src/lib/agent-runtime/reviewer-helpers.ts
 var STRICT_DIRECTIVE = [
   "## Rubric override \u2014 strict",
   "",
@@ -6641,53 +6641,6 @@ function applyRubricToPrompt(basePrompt, rubric) {
 
 ${directive}`;
 }
-
-// src/agents/reviewer/review-loop.ts
-var MAX_PATCH_CHARS = 2e4;
-var MAX_CONTENT_CHARS = 4e4;
-var MAX_ITERATIONS = 40;
-var REVIEW_TOOL_DEFS = [
-  {
-    name: "get_file_patch",
-    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "get_file_content",
-    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "finish_review",
-    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
-    input_schema: {
-      type: "object",
-      properties: {
-        approved: {
-          type: "boolean",
-          description: "true = ready to merge, false = changes required."
-        },
-        comment: {
-          type: "string",
-          description: "Full review comment in Markdown. Follow the required format from the system prompt."
-        }
-      },
-      required: ["approved", "comment"]
-    }
-  }
-];
 function detectMergeConflicts(files) {
   const conflicted = [];
   for (const f of files) {
@@ -6699,57 +6652,6 @@ function detectMergeConflicts(files) {
 }
 function buildFileList(files) {
   return files.map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`).join("\n");
-}
-async function runReviewLoop(opts) {
-  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
-  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
-  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
-  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
-  const {
-    done: result,
-    usage,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  } = await loop.run({
-    system,
-    initialPrompt,
-    tools: REVIEW_TOOL_DEFS,
-    finishTool: "finish_review",
-    extractDone: (input) => ({
-      approved: input.approved,
-      comment: input.comment
-    }),
-    handlers: {
-      get_file_patch: (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_patch", file: filename });
-        const patch = fileMap.get(filename);
-        if (patch === void 0) return `(file not found in PR: ${filename})`;
-        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
-        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
-        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
-      },
-      get_file_content: async (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_content", file: filename });
-        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
-        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
-        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
-      }
-    },
-    maxIterations,
-    maxTokens,
-    logger
-  });
-  return {
-    result,
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  };
 }
 
 // src/lib/agent-runtime/reviewer-prepare.ts
@@ -6763,9 +6665,9 @@ function prepareReviewer(input) {
     branchName,
     typeOverride,
     reviewRubric,
-    configLabels,
-    repoRoot,
-    logger
+    capabilities,
+    idempotencyMarker,
+    repoRoot
   } = input;
   const buildSystem2 = input._buildSystem ?? buildSystem;
   const loadOptionalPrompt2 = input._loadOptionalPrompt ?? loadOptionalPrompt;
@@ -6802,9 +6704,7 @@ function prepareReviewer(input) {
     separator: "\n\n---\n\n"
   });
   const system = applyRubricToPrompt(baseSystem, reviewRubric);
-  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
   const mcpServers = [];
-  const idempotencyMarker = byPrHeadSha("reviewer", headSha);
   return {
     system,
     initialPrompt,
@@ -6821,15 +6721,15 @@ function prepareIterator(input) {
   const {
     ticketKey,
     issue,
-    headSha,
     reviewComment,
     mergeConflicts,
     existingLog,
     mcpPool,
     configLabels,
+    capabilities,
+    idempotencyMarker,
     typeOverride,
-    repoRoot,
-    logger
+    repoRoot
   } = input;
   const buildSystem2 = input._buildSystem ?? buildSystem;
   const system = buildSystem2("iterate", repoRoot);
@@ -6848,10 +6748,8 @@ ${existingLog}` : "",
     "",
     "When you have fixed all findings, call the `done` tool."
   ].filter(Boolean).join("\n");
-  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
   const hasLabelsConfig = configLabels !== void 0;
   const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
-  const idempotencyMarker = byPrHeadSha("iterator", headSha);
   return {
     system,
     initialPrompt,
@@ -10571,6 +10469,104 @@ function gateCi(input) {
   };
 }
 
+// src/agents/reviewer/review-loop.ts
+var MAX_PATCH_CHARS = 2e4;
+var MAX_CONTENT_CHARS = 4e4;
+var MAX_ITERATIONS = 40;
+var REVIEW_TOOL_DEFS = [
+  {
+    name: "get_file_patch",
+    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "get_file_content",
+    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "finish_review",
+    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
+    input_schema: {
+      type: "object",
+      properties: {
+        approved: {
+          type: "boolean",
+          description: "true = ready to merge, false = changes required."
+        },
+        comment: {
+          type: "string",
+          description: "Full review comment in Markdown. Follow the required format from the system prompt."
+        }
+      },
+      required: ["approved", "comment"]
+    }
+  }
+];
+async function runReviewLoop(opts) {
+  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
+  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
+  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
+  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
+  const {
+    done: result,
+    usage,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  } = await loop.run({
+    system,
+    initialPrompt,
+    tools: REVIEW_TOOL_DEFS,
+    finishTool: "finish_review",
+    extractDone: (input) => ({
+      approved: input.approved,
+      comment: input.comment
+    }),
+    handlers: {
+      get_file_patch: (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_patch", file: filename });
+        const patch = fileMap.get(filename);
+        if (patch === void 0) return `(file not found in PR: ${filename})`;
+        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
+        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
+        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
+      },
+      get_file_content: async (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_content", file: filename });
+        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
+        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
+        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
+      }
+    },
+    maxIterations,
+    maxTokens,
+    logger
+  });
+  return {
+    result,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  };
+}
+
 // src/agents/reviewer/changes-guard.ts
 function countPriorIterations(existingComments) {
   return existingComments.filter(
@@ -10733,9 +10729,9 @@ async function main3(envelope, logger) {
     branchName,
     typeOverride,
     reviewRubric: reviewRubricOverride,
-    configLabels: effectiveCfg.labels,
-    repoRoot: REPO_ROOT3,
-    logger
+    capabilities,
+    idempotencyMarker,
+    repoRoot: REPO_ROOT3
   });
   const { system, initialPrompt, fileMap } = prepared;
   const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
@@ -10960,6 +10956,8 @@ async function main4(envelope, logger) {
   const reviewTransitionId = shouldAutoTransition ? requireEnv("FERRY_REVIEW_TRANSITION_ID") : "";
   const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels, logger);
+  logCapabilities(logger, capabilities);
   const priorIterations = existingComments.filter(
     (c) => c.includes("[ferry:iterator:") && c.includes("complete. Pushed fixes to PR#")
   ).length;
@@ -11052,12 +11050,12 @@ async function main4(envelope, logger) {
     existingLog,
     mcpPool,
     configLabels: effectiveCfg.labels,
+    capabilities,
+    idempotencyMarker,
     typeOverride,
-    repoRoot: REPO_ROOT4,
-    logger
+    repoRoot: REPO_ROOT4
   });
-  const { system, initialPrompt, mcpServers, capabilities } = prepared;
-  logCapabilities(logger, capabilities);
+  const { system, initialPrompt, mcpServers } = prepared;
   const secretScan = makeSecretScan(REPO_ROOT4);
   const loop = createAgentLoop({
     provider: iterProvider,

--- a/.github/actions/ferry-run-refiner/agent.js
+++ b/.github/actions/ferry-run-refiner/agent.js
@@ -6442,6 +6442,426 @@ function buildConflictComment(role, runId, err) {
   ].join("\n");
 }
 
+// src/lib/agent-runtime/refiner-prepare.ts
+var PRIOR_RUN_MARKER = /\[ferry:refiner:[^\]]+\]/;
+async function prepareRefiner(input) {
+  const { envelope, tracker } = input;
+  const { ticket_key: ticketKey, event_id: eventId } = envelope;
+  const issue = await tracker.getIssue(ticketKey);
+  const existingSubtasks = await tracker.getSubtaskDetails(ticketKey);
+  const priorRefinerRuns = issue.comments.filter((c) => PRIOR_RUN_MARKER.test(c));
+  const runLink = `https://github.com/${process.env.GITHUB_REPO ?? "unknown"}/actions/runs/${process.env.GITHUB_RUN_ID ?? "0"}`;
+  const idempotencyMarker = byEventId("refiner", eventId);
+  return {
+    issue,
+    existingSubtasks,
+    priorRefinerRuns,
+    runLink,
+    idempotencyMarker
+  };
+}
+
+// src/lib/agent-runtime/developer-prepare.ts
+import { execFileSync as execFileSync3 } from "node:child_process";
+
+// src/lib/llm/delimit-untrusted.ts
+var OPEN = "<<<UNTRUSTED>>>";
+var CLOSE = "<<<END UNTRUSTED>>>";
+var OPEN_ESCAPE = "<<<UNTRUSTED-LITERAL>>>";
+var CLOSE_ESCAPE = "<<<END UNTRUSTED-LITERAL>>>";
+function delimitUntrusted(value) {
+  const escaped = value.split(OPEN).join(OPEN_ESCAPE).split(CLOSE).join(CLOSE_ESCAPE);
+  return `${OPEN}
+${escaped}
+${CLOSE}`;
+}
+
+// src/lib/agent-runtime/developer-prepare.ts
+var checkoutOrCreateBranchDefault = (branchName, baseBranch, repoRoot, logger) => {
+  try {
+    execFileSync3("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
+      cwd: repoRoot,
+      stdio: "pipe"
+    });
+    execFileSync3("git", ["fetch", "origin", branchName], { cwd: repoRoot });
+    execFileSync3("git", ["checkout", branchName], { cwd: repoRoot });
+    const existingLog = execFileSync3("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
+      cwd: repoRoot,
+      encoding: "utf8"
+    }).trim();
+    if (existingLog) {
+      logger.info("resuming branch", {
+        branch: branchName,
+        prior_commits: existingLog.split("\n").length
+      });
+    }
+    const branchHeadSha = execFileSync3("git", ["rev-parse", "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf8"
+    }).trim();
+    return { branchHeadSha, existingLog };
+  } catch {
+    execFileSync3("git", ["checkout", "-B", branchName], { cwd: repoRoot });
+    logger.info("created branch", { branch: branchName });
+    return { branchHeadSha: "", existingLog: "" };
+  }
+};
+async function prepareDeveloper(input) {
+  const {
+    envelope,
+    issue,
+    effectiveCfg,
+    subtasks,
+    testRunner,
+    pkgManagerHint,
+    tree,
+    typeOverride,
+    owner,
+    repo,
+    baseBranch,
+    runner,
+    mcpPool,
+    repoRoot,
+    dryRun,
+    logger
+  } = input;
+  const buildSystem2 = input._buildSystem ?? buildSystem;
+  const checkoutOrCreateBranch = input._checkoutOrCreateBranch ?? checkoutOrCreateBranchDefault;
+  const configureGitUser = input._configureGitUser ?? configureFerryGitUser;
+  const ticketKey = envelope.ticket_key;
+  const eventId = envelope.event_id;
+  const labels = issue.labels.join(", ");
+  const comments = issue.comments.map((c) => `Comment: ${c}`).join("\n");
+  const ticketBlock = buildTicketBlock(ticketKey, issue, {
+    labels,
+    comments,
+    typeOverride
+  });
+  const system = buildSystem2("dev", repoRoot, {
+    extraParts: pkgManagerHint ? [`## Detected package manager
+
+${pkgManagerHint}`] : []
+  });
+  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
+  configureGitUser(repoRoot);
+  const { branchHeadSha, existingLog } = checkoutOrCreateBranch(
+    branchName,
+    baseBranch,
+    repoRoot,
+    logger
+  );
+  const resumeContext = existingLog ? `
+EXISTING WORK ON BRANCH (already committed \u2014 skip these, only do what remains):
+${existingLog}` : "";
+  let existingPrUrl = "";
+  let existingPrContext = "";
+  if (branchHeadSha && !dryRun) {
+    try {
+      const openPrs = await runner.listPRsForBranch(owner, repo, branchName);
+      if (openPrs.length > 0) {
+        const pr = openPrs[0];
+        existingPrUrl = `https://github.com/${owner}/${repo}/pull/${pr.number}`;
+        const prRef = { owner, repo, prNumber: pr.number };
+        const prFiles = await runner.listPRFiles(prRef);
+        const fileList = prFiles.map((f) => `${f.status}: ${f.filename}`).join("\n");
+        existingPrContext = [
+          `
+EXISTING_IMPLEMENTATION:`,
+          `Open PR: ${existingPrUrl} (head: ${branchHeadSha.slice(0, 7)})`,
+          `Changed files:
+${fileList}`,
+          `If the spec is already fully satisfied by the existing code, call \`done\` with outcome="already_satisfied".`
+        ].join("\n");
+        logger.info("existing PR found", { pr: existingPrUrl, files: prFiles.length });
+      }
+    } catch {
+    }
+  }
+  const idempotencyMarker = branchHeadSha ? byPrHeadSha("dev", branchHeadSha) : byEventId("dev", eventId);
+  const baseInitialPrompt = [
+    delimitUntrusted(ticketBlock),
+    "",
+    subtasks.length > 0 ? `SUBTASKS:
+${subtasks.join("\n")}` : "SUBTASKS: (none)",
+    "",
+    `TEST_RUNNER: ${testRunner}`,
+    "",
+    `REPO TREE (depth 2):
+${tree}`,
+    "",
+    "When you have finished implementing, call the `done` tool."
+  ].join("\n");
+  const initialPrompt = baseInitialPrompt + resumeContext + existingPrContext;
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
+  const hasLabelsConfig = effectiveCfg.labels !== void 0;
+  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  return {
+    system,
+    initialPrompt,
+    baseInitialPrompt,
+    mcpServers,
+    idempotencyMarker,
+    ticketBlock,
+    subtasks,
+    capabilities,
+    branchName,
+    branchHeadSha,
+    existingPrUrl
+  };
+}
+
+// src/agents/reviewer/rubric.ts
+var STRICT_DIRECTIVE = [
+  "## Rubric override \u2014 strict",
+  "",
+  "For this review, apply a STRICTER bar than usual:",
+  "",
+  "- Block on any missing test coverage for new/changed behaviour.",
+  "- Block on missing edge-case handling, error paths, or input validation.",
+  "- Block on weak naming, dead code, or unreachable branches.",
+  "- Block on incomplete documentation when public APIs change.",
+  "- Approve only when every acceptance criterion is fully satisfied with concrete evidence."
+].join("\n");
+var LENIENT_DIRECTIVE = [
+  "## Rubric override \u2014 lenient",
+  "",
+  "For this review, apply a MORE PERMISSIVE bar than usual:",
+  "",
+  "- Approve when the acceptance criteria are met, even if minor polish is missing.",
+  "- Treat naming nits, non-blocking style issues, and stylistic preferences as comments \u2014 not blockers.",
+  "- Block only on: failing tests, unimplemented ACs, merge conflicts, committed build artefacts, or security regressions.",
+  '- Prefer "approve with comments" over "request changes" when issues are non-blocking.'
+].join("\n");
+function applyRubricToPrompt(basePrompt, rubric) {
+  if (rubric === void 0) return basePrompt;
+  const directive = rubric === "strict" ? STRICT_DIRECTIVE : LENIENT_DIRECTIVE;
+  return `${basePrompt}
+
+---
+
+${directive}`;
+}
+
+// src/agents/reviewer/review-loop.ts
+var MAX_PATCH_CHARS = 2e4;
+var MAX_CONTENT_CHARS = 4e4;
+var MAX_ITERATIONS = 40;
+var REVIEW_TOOL_DEFS = [
+  {
+    name: "get_file_patch",
+    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "get_file_content",
+    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "finish_review",
+    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
+    input_schema: {
+      type: "object",
+      properties: {
+        approved: {
+          type: "boolean",
+          description: "true = ready to merge, false = changes required."
+        },
+        comment: {
+          type: "string",
+          description: "Full review comment in Markdown. Follow the required format from the system prompt."
+        }
+      },
+      required: ["approved", "comment"]
+    }
+  }
+];
+function detectMergeConflicts(files) {
+  const conflicted = [];
+  for (const f of files) {
+    if (f.patch && /^[+].*<{7}|^[+].*={7}|^[+].*>{7}/m.test(f.patch)) {
+      conflicted.push(f.filename);
+    }
+  }
+  return conflicted;
+}
+function buildFileList(files) {
+  return files.map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`).join("\n");
+}
+async function runReviewLoop(opts) {
+  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
+  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
+  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
+  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
+  const {
+    done: result,
+    usage,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  } = await loop.run({
+    system,
+    initialPrompt,
+    tools: REVIEW_TOOL_DEFS,
+    finishTool: "finish_review",
+    extractDone: (input) => ({
+      approved: input.approved,
+      comment: input.comment
+    }),
+    handlers: {
+      get_file_patch: (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_patch", file: filename });
+        const patch = fileMap.get(filename);
+        if (patch === void 0) return `(file not found in PR: ${filename})`;
+        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
+        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
+        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
+      },
+      get_file_content: async (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_content", file: filename });
+        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
+        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
+        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
+      }
+    },
+    maxIterations,
+    maxTokens,
+    logger
+  });
+  return {
+    result,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  };
+}
+
+// src/lib/agent-runtime/reviewer-prepare.ts
+function prepareReviewer(input) {
+  const {
+    ticketKey,
+    issue,
+    pr,
+    files,
+    commits,
+    branchName,
+    typeOverride,
+    reviewRubric,
+    configLabels,
+    repoRoot,
+    logger
+  } = input;
+  const buildSystem2 = input._buildSystem ?? buildSystem;
+  const loadOptionalPrompt2 = input._loadOptionalPrompt ?? loadOptionalPrompt;
+  const headSha = pr.headSha;
+  const prNumber = pr.number;
+  const fileMap = new Map(files.map((f) => [f.filename, f.patch]));
+  const conflictedFiles = detectMergeConflicts(files);
+  const hasMergeConflicts = pr.mergeable === false || conflictedFiles.length > 0;
+  const commitLog = commits.map((c) => `${c.sha.slice(0, 7)} ${c.message.split("\n")[0]}`).join("\n");
+  const ticketBlock = buildTicketBlock(ticketKey, issue, { typeOverride });
+  const mergeConflictWarning = hasMergeConflicts ? `
+\u26A0\uFE0F  MERGE CONFLICTS DETECTED \u2014 mergeable=${String(pr.mergeable)}${conflictedFiles.length > 0 ? `, conflicted files: ${conflictedFiles.join(", ")}` : ""}` : "";
+  const initialPrompt = [
+    "## Jira Ticket",
+    delimitUntrusted(ticketBlock),
+    "",
+    "## PR Metadata",
+    `PR #${prNumber}: ${pr.title}`,
+    `Base: ${pr.baseRef} \u2190 Head: ${branchName} (${headSha.slice(0, 7)})`,
+    `Files changed: ${files.length}  Commits: ${commits.length}`,
+    mergeConflictWarning,
+    "",
+    "## Commits",
+    commitLog,
+    "",
+    "## Changed files (status  +additions  -deletions  path)",
+    buildFileList(files),
+    "",
+    "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
+    "When you have enough information, call finish_review."
+  ].filter((l) => l !== null).join("\n");
+  const baseSystem = buildSystem2("review", repoRoot, {
+    extraParts: [loadOptionalPrompt2("review-comment", repoRoot)],
+    separator: "\n\n---\n\n"
+  });
+  const system = applyRubricToPrompt(baseSystem, reviewRubric);
+  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
+  const mcpServers = [];
+  const idempotencyMarker = byPrHeadSha("reviewer", headSha);
+  return {
+    system,
+    initialPrompt,
+    mcpServers,
+    idempotencyMarker,
+    ticketBlock,
+    capabilities,
+    fileMap
+  };
+}
+
+// src/lib/agent-runtime/iterator-prepare.ts
+function prepareIterator(input) {
+  const {
+    ticketKey,
+    issue,
+    headSha,
+    reviewComment,
+    mergeConflicts,
+    existingLog,
+    mcpPool,
+    configLabels,
+    typeOverride,
+    repoRoot,
+    logger
+  } = input;
+  const buildSystem2 = input._buildSystem ?? buildSystem;
+  const system = buildSystem2("iterate", repoRoot);
+  const ticketBlock = buildTicketBlock(ticketKey, issue, { typeOverride });
+  const initialPrompt = [
+    "## Jira Ticket",
+    delimitUntrusted(ticketBlock),
+    "",
+    "## Review Findings (fix only what is listed here)",
+    delimitUntrusted(reviewComment),
+    "",
+    mergeConflicts.length > 0 ? `## Merge Conflicts (resolve these first, before fixing review findings)
+${mergeConflicts.map((f) => `- ${f}`).join("\n")}` : "",
+    existingLog ? `## Existing commits on branch
+${existingLog}` : "",
+    "",
+    "When you have fixed all findings, call the `done` tool."
+  ].filter(Boolean).join("\n");
+  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
+  const hasLabelsConfig = configLabels !== void 0;
+  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  const idempotencyMarker = byPrHeadSha("iterator", headSha);
+  return {
+    system,
+    initialPrompt,
+    mcpServers,
+    idempotencyMarker,
+    ticketBlock,
+    capabilities
+  };
+}
+
 // src/lib/dry-run.ts
 function isDryRun() {
   return process.env.FERRY_DRY_RUN === "1" || process.env.FERRY_DRY_RUN === "true";
@@ -6640,18 +7060,6 @@ function createLlmCall(route) {
 
 // src/agents/refiner/refine.ts
 import { createRequire as createRequire3 } from "module";
-
-// src/lib/llm/delimit-untrusted.ts
-var OPEN = "<<<UNTRUSTED>>>";
-var CLOSE = "<<<END UNTRUSTED>>>";
-var OPEN_ESCAPE = "<<<UNTRUSTED-LITERAL>>>";
-var CLOSE_ESCAPE = "<<<END UNTRUSTED-LITERAL>>>";
-function delimitUntrusted(value) {
-  const escaped = value.split(OPEN).join(OPEN_ESCAPE).split(CLOSE).join(CLOSE_ESCAPE);
-  return `${OPEN}
-${escaped}
-${CLOSE}`;
-}
 
 // src/agents/refiner/parse.ts
 function extractFirstJsonObject(text) {
@@ -7028,15 +7436,12 @@ function estimateTicketCost(_plan, baseline) {
 
 // src/agents/refiner/refiner-action.ts
 var REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
-var PRIOR_RUN_MARKER = /\[ferry:refiner:[^\]]+\]/;
 async function run(envelope, deps) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const logger = deps.logger ?? createLogger(eventId, "ferry:refiner-action");
   const dryRun = isDryRun() || deps.dryRun === true;
-  const issue = await deps.tracker.getIssue(ticketKey);
-  const runLink = `https://github.com/${process.env.GITHUB_REPO ?? "unknown"}/actions/runs/${process.env.GITHUB_RUN_ID ?? "0"}`;
-  const existingSubtasks = await deps.tracker.getSubtaskDetails(ticketKey);
-  const priorRefinerRuns = issue.comments.filter((c) => PRIOR_RUN_MARKER.test(c));
+  const prepared = await prepareRefiner({ envelope, tracker: deps.tracker });
+  const { issue, existingSubtasks, priorRefinerRuns, runLink, idempotencyMarker } = prepared;
   const { plan, auditSummary } = await runRefiner({
     ticket: {
       key: issue.key,
@@ -7111,7 +7516,6 @@ async function run(envelope, deps) {
     existingSubtasks,
     tracker: deps.tracker
   });
-  const idempotencyMarker = `[ferry:refiner:${eventId}]`;
   if (result.noop) {
     logger.info("noop \u2014 existing sub-tasks still valid", { ticket: ticketKey });
     await deps.tracker.postComment(
@@ -7199,7 +7603,7 @@ async function main(envelope, logger) {
 }
 
 // src/agents/developer/dev-action.ts
-import { execFileSync as execFileSync5 } from "node:child_process";
+import { execFileSync as execFileSync6 } from "node:child_process";
 import * as fsp2 from "node:fs/promises";
 import * as path6 from "node:path";
 
@@ -9093,7 +9497,7 @@ function createAgentLoop(opts) {
 
 // src/agents/developer/workspace.ts
 import { readFileSync as readFileSync5, existsSync as existsSync4 } from "node:fs";
-import { execFileSync as execFileSync3 } from "node:child_process";
+import { execFileSync as execFileSync4 } from "node:child_process";
 import * as path5 from "node:path";
 function detectTestRunner(packageJsonPath2) {
   try {
@@ -9112,7 +9516,7 @@ function detectTestRunner(packageJsonPath2) {
 }
 function repoTree(repoRoot) {
   try {
-    return execFileSync3(
+    return execFileSync4(
       "find",
       [
         repoRoot,
@@ -9204,7 +9608,7 @@ function assertDevOutputContract(outcome, outputs) {
 }
 
 // src/agents/developer/wip-finalizer.ts
-import { execFileSync as execFileSync4 } from "node:child_process";
+import { execFileSync as execFileSync5 } from "node:child_process";
 function classifyError(err) {
   if (err instanceof FerryError) {
     const reason = err.context?.reason ?? "unknown";
@@ -9243,8 +9647,8 @@ async function runWipFinalizer(opts) {
   logger.info("wip_finalizer", { code, detail, branch: branchName });
   let committed = false;
   try {
-    execFileSync4("git", ["add", "-A"], { cwd: repoRoot });
-    const status = execFileSync4("git", ["status", "--porcelain"], {
+    execFileSync5("git", ["add", "-A"], { cwd: repoRoot });
+    const status = execFileSync5("git", ["status", "--porcelain"], {
       cwd: repoRoot,
       encoding: "utf8"
     });
@@ -9253,7 +9657,7 @@ async function runWipFinalizer(opts) {
       const wipMsg = `wip(${ticketKey}): interrupted \u2014 ${code}
 
 [ferry:dev:${eventId}]`;
-      execFileSync4("git", ["commit", "-m", wipMsg], { cwd: repoRoot });
+      execFileSync5("git", ["commit", "-m", wipMsg], { cwd: repoRoot });
       committed = true;
       logger.info("wip_committed", { branch: branchName });
     } else {
@@ -9265,14 +9669,14 @@ async function runWipFinalizer(opts) {
   let pushed = false;
   if (!dryRun) {
     try {
-      execFileSync4("git", ["push", "origin", branchName, "--force-with-lease"], {
+      execFileSync5("git", ["push", "origin", branchName, "--force-with-lease"], {
         cwd: repoRoot,
         stdio: "pipe"
       });
       pushed = true;
     } catch {
       try {
-        execFileSync4("git", ["push", "origin", branchName], { cwd: repoRoot, stdio: "pipe" });
+        execFileSync5("git", ["push", "origin", branchName], { cwd: repoRoot, stdio: "pipe" });
         pushed = true;
       } catch (pushErr) {
         logger.error("wip_push_failed", { error: pushErr.message });
@@ -9398,102 +9802,36 @@ async function main2(envelope, logger) {
   const reviewTransitionId = !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
   const jiraBaseUrl = requireEnv("FERRY_JIRA_BASE_URL");
   const { provider: devProvider } = effectiveCfg.models.dev;
-  const labels = issue.labels.join(", ");
-  const comments = issue.comments.map((c) => `Comment: ${c}`).join("\n");
-  const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    labels,
-    comments,
-    typeOverride
-  });
+  const model = effectiveCfg.models.dev.model;
   const subtasks = await tracker.getSubtasks(ticketKey);
   const testRunner = detectTestRunner(packageJsonPath(REPO_ROOT2));
   const pkgManagerHint = detectPackageManager(REPO_ROOT2);
   const tree = repoTree(REPO_ROOT2);
-  const system = buildSystem("dev", REPO_ROOT2, {
-    extraParts: pkgManagerHint ? [`## Detected package manager
-
-${pkgManagerHint}`] : []
-  });
-  const model = effectiveCfg.models.dev.model;
-  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
-  configureFerryGitUser(REPO_ROOT2);
-  let resumeContext = "";
-  let branchHeadSha = "";
-  try {
-    execFileSync5("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
-      cwd: REPO_ROOT2,
-      stdio: "pipe"
-    });
-    execFileSync5("git", ["fetch", "origin", branchName], { cwd: REPO_ROOT2 });
-    execFileSync5("git", ["checkout", branchName], { cwd: REPO_ROOT2 });
-    const existingLog = execFileSync5("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
-      cwd: REPO_ROOT2,
-      encoding: "utf8"
-    }).trim();
-    if (existingLog) {
-      resumeContext = `
-EXISTING WORK ON BRANCH (already committed \u2014 skip these, only do what remains):
-${existingLog}`;
-      logger.info("resuming branch", {
-        branch: branchName,
-        prior_commits: existingLog.split("\n").length
-      });
-    }
-    branchHeadSha = execFileSync5("git", ["rev-parse", "HEAD"], {
-      cwd: REPO_ROOT2,
-      encoding: "utf8"
-    }).trim();
-  } catch {
-    execFileSync5("git", ["checkout", "-B", branchName], { cwd: REPO_ROOT2 });
-    logger.info("created branch", { branch: branchName });
-  }
-  let existingPrUrl = "";
-  let existingPrContext = "";
-  if (branchHeadSha && !dryRun) {
-    try {
-      const openPrs = await runner.listPRsForBranch(owner, repo, branchName);
-      if (openPrs.length > 0) {
-        const pr = openPrs[0];
-        existingPrUrl = `https://github.com/${owner}/${repo}/pull/${pr.number}`;
-        const prRef = { owner, repo, prNumber: pr.number };
-        const prFiles = await runner.listPRFiles(prRef);
-        const fileList = prFiles.map((f) => `${f.status}: ${f.filename}`).join("\n");
-        existingPrContext = [
-          `
-EXISTING_IMPLEMENTATION:`,
-          `Open PR: ${existingPrUrl} (head: ${branchHeadSha.slice(0, 7)})`,
-          `Changed files:
-${fileList}`,
-          `If the spec is already fully satisfied by the existing code, call \`done\` with outcome="already_satisfied".`
-        ].join("\n");
-        logger.info("existing PR found", { pr: existingPrUrl, files: prFiles.length });
-      }
-    } catch {
-    }
-  }
-  const idempotencyMarker = branchHeadSha ? `[ferry:dev:${branchHeadSha.slice(0, 7)}]` : `[ferry:dev:${eventId}]`;
-  const initialPrompt = [
-    delimitUntrusted(ticketBlock),
-    "",
-    subtasks.length > 0 ? `SUBTASKS:
-${subtasks.join("\n")}` : "SUBTASKS: (none)",
-    "",
-    `TEST_RUNNER: ${testRunner}`,
-    "",
-    `REPO TREE (depth 2):
-${tree}`,
-    "",
-    "When you have finished implementing, call the `done` tool."
-  ].join("\n");
-  const secretScan = makeSecretScan(REPO_ROOT2);
   const mcpPool = loadMcpServers();
-  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
-  const hasLabelsConfig = effectiveCfg.labels !== void 0;
-  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  const prepared = await prepareDeveloper({
+    envelope,
+    issue,
+    effectiveCfg,
+    subtasks,
+    testRunner,
+    pkgManagerHint,
+    tree,
+    typeOverride,
+    owner,
+    repo,
+    baseBranch,
+    runner,
+    mcpPool,
+    repoRoot: REPO_ROOT2,
+    dryRun,
+    logger
+  });
+  const { system, initialPrompt, mcpServers, idempotencyMarker, branchName, capabilities } = prepared;
   logCapabilities(logger, capabilities);
   if (mcpServers.length > 0) {
     logger.info("MCP servers", { servers: mcpServers.map((s) => s.name) });
   }
+  const secretScan = makeSecretScan(REPO_ROOT2);
   const allToolSchemas = [...TOOL_SCHEMAS, COMMIT_PROGRESS_SCHEMA, SPAWN_SUBAGENT_SCHEMA];
   let loop;
   loop = createAgentLoop({
@@ -9521,7 +9859,9 @@ ${tree}`,
   try {
     loopResult = await loop.run({
       system,
-      initialPrompt: initialPrompt + resumeContext + existingPrContext,
+      // `initialPrompt` already includes the resume + existing-PR context
+      // (concatenated inside `prepareDeveloper`).
+      initialPrompt,
       tools: allToolSchemas,
       repoRoot: REPO_ROOT2,
       branchName,
@@ -9618,20 +9958,20 @@ ${tree}`,
       await fsp2.writeFile(verificationPath, verificationContent, "utf8");
       verificationNoteWritten = true;
     }
-    execFileSync5("git", ["add", "-A"], { cwd: REPO_ROOT2 });
-    const finalStatus = execFileSync5("git", ["status", "--porcelain"], {
+    execFileSync6("git", ["add", "-A"], { cwd: REPO_ROOT2 });
+    const finalStatus = execFileSync6("git", ["status", "--porcelain"], {
       cwd: REPO_ROOT2,
       encoding: "utf8"
     });
     if (finalStatus.trim()) {
       await secretScan();
       const msg = resolvedOutcome === "already_satisfied" ? `chore(${ticketKey}): add verification note \u2014 spec already satisfied` : done.commit_message ?? commitMessage;
-      execFileSync5("git", ["commit", "-m", msg], { cwd: REPO_ROOT2 });
+      execFileSync6("git", ["commit", "-m", msg], { cwd: REPO_ROOT2 });
     }
     if (dryRun) {
       let diffOutput = "(no local changes)";
       try {
-        diffOutput = execFileSync5(
+        diffOutput = execFileSync6(
           "sh",
           [
             "-c",
@@ -9660,11 +10000,11 @@ ${tree}`,
       appendOutput({ ...usage, model, provider: devProvider });
       process.exit(0);
     }
-    execFileSync5("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT2 });
+    execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT2 });
     const branchPushed = true;
     summaryBranchPushed = branchName;
     try {
-      const diff = execFileSync5("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
+      const diff = execFileSync6("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
         cwd: REPO_ROOT2,
         encoding: "utf8"
       });
@@ -10231,148 +10571,6 @@ function gateCi(input) {
   };
 }
 
-// src/agents/reviewer/review-loop.ts
-var MAX_PATCH_CHARS = 2e4;
-var MAX_CONTENT_CHARS = 4e4;
-var MAX_ITERATIONS = 40;
-var REVIEW_TOOL_DEFS = [
-  {
-    name: "get_file_patch",
-    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "get_file_content",
-    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "finish_review",
-    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
-    input_schema: {
-      type: "object",
-      properties: {
-        approved: {
-          type: "boolean",
-          description: "true = ready to merge, false = changes required."
-        },
-        comment: {
-          type: "string",
-          description: "Full review comment in Markdown. Follow the required format from the system prompt."
-        }
-      },
-      required: ["approved", "comment"]
-    }
-  }
-];
-function detectMergeConflicts(files) {
-  const conflicted = [];
-  for (const f of files) {
-    if (f.patch && /^[+].*<{7}|^[+].*={7}|^[+].*>{7}/m.test(f.patch)) {
-      conflicted.push(f.filename);
-    }
-  }
-  return conflicted;
-}
-function buildFileList(files) {
-  return files.map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`).join("\n");
-}
-async function runReviewLoop(opts) {
-  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
-  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
-  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
-  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
-  const {
-    done: result,
-    usage,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  } = await loop.run({
-    system,
-    initialPrompt,
-    tools: REVIEW_TOOL_DEFS,
-    finishTool: "finish_review",
-    extractDone: (input) => ({
-      approved: input.approved,
-      comment: input.comment
-    }),
-    handlers: {
-      get_file_patch: (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_patch", file: filename });
-        const patch = fileMap.get(filename);
-        if (patch === void 0) return `(file not found in PR: ${filename})`;
-        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
-        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
-        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
-      },
-      get_file_content: async (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_content", file: filename });
-        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
-        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
-        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
-      }
-    },
-    maxIterations,
-    maxTokens,
-    logger
-  });
-  return {
-    result,
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  };
-}
-
-// src/agents/reviewer/rubric.ts
-var STRICT_DIRECTIVE = [
-  "## Rubric override \u2014 strict",
-  "",
-  "For this review, apply a STRICTER bar than usual:",
-  "",
-  "- Block on any missing test coverage for new/changed behaviour.",
-  "- Block on missing edge-case handling, error paths, or input validation.",
-  "- Block on weak naming, dead code, or unreachable branches.",
-  "- Block on incomplete documentation when public APIs change.",
-  "- Approve only when every acceptance criterion is fully satisfied with concrete evidence."
-].join("\n");
-var LENIENT_DIRECTIVE = [
-  "## Rubric override \u2014 lenient",
-  "",
-  "For this review, apply a MORE PERMISSIVE bar than usual:",
-  "",
-  "- Approve when the acceptance criteria are met, even if minor polish is missing.",
-  "- Treat naming nits, non-blocking style issues, and stylistic preferences as comments \u2014 not blockers.",
-  "- Block only on: failing tests, unimplemented ACs, merge conflicts, committed build artefacts, or security regressions.",
-  '- Prefer "approve with comments" over "request changes" when issues are non-blocking.'
-].join("\n");
-function applyRubricToPrompt(basePrompt, rubric) {
-  if (rubric === void 0) return basePrompt;
-  const directive = rubric === "strict" ? STRICT_DIRECTIVE : LENIENT_DIRECTIVE;
-  return `${basePrompt}
-
----
-
-${directive}`;
-}
-
 // src/agents/reviewer/changes-guard.ts
 function countPriorIterations(existingComments) {
   return existingComments.filter(
@@ -10459,7 +10657,6 @@ async function main3(envelope, logger) {
   const prNumber = prs[0].number;
   const pr = await runner.getPR({ owner, repo, prNumber });
   const headSha = pr.headSha;
-  const mergeable = pr.mergeable;
   const idempotencyMarker = byPrHeadSha("reviewer", headSha);
   const { skipped } = checkIdempotencyMarker(idempotencyMarker, existingComments);
   if (skipped) {
@@ -10526,40 +10723,21 @@ async function main3(envelope, logger) {
     return;
   }
   const files = await runner.listPRFiles({ owner, repo, prNumber });
-  const fileMap = new Map(files.map((f) => [f.filename, f.patch]));
-  const conflictedFiles = detectMergeConflicts(files);
-  const hasMergeConflicts = mergeable === false || conflictedFiles.length > 0;
   const commits = await runner.listPRCommits({ owner, repo, prNumber });
-  const commitLog = commits.map((c) => `${c.sha.slice(0, 7)} ${c.message.split("\n")[0]}`).join("\n");
-  const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    typeOverride
+  const prepared = prepareReviewer({
+    ticketKey,
+    issue,
+    pr,
+    files,
+    commits,
+    branchName,
+    typeOverride,
+    reviewRubric: reviewRubricOverride,
+    configLabels: effectiveCfg.labels,
+    repoRoot: REPO_ROOT3,
+    logger
   });
-  const mergeConflictWarning = hasMergeConflicts ? `
-\u26A0\uFE0F  MERGE CONFLICTS DETECTED \u2014 mergeable=${String(mergeable)}${conflictedFiles.length > 0 ? `, conflicted files: ${conflictedFiles.join(", ")}` : ""}` : "";
-  const initialPrompt = [
-    "## Jira Ticket",
-    delimitUntrusted(ticketBlock),
-    "",
-    "## PR Metadata",
-    `PR #${prNumber}: ${pr.title}`,
-    `Base: ${pr.baseRef} \u2190 Head: ${branchName} (${headSha.slice(0, 7)})`,
-    `Files changed: ${files.length}  Commits: ${commits.length}`,
-    mergeConflictWarning,
-    "",
-    "## Commits",
-    commitLog,
-    "",
-    "## Changed files (status  +additions  -deletions  path)",
-    buildFileList(files),
-    "",
-    "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
-    "When you have enough information, call finish_review."
-  ].filter((l) => l !== null).join("\n");
-  const baseSystem = buildSystem("review", REPO_ROOT3, {
-    extraParts: [loadOptionalPrompt("review-comment", REPO_ROOT3)],
-    separator: "\n\n---\n\n"
-  });
-  const system = applyRubricToPrompt(baseSystem, reviewRubricOverride);
+  const { system, initialPrompt, fileMap } = prepared;
   const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
   const {
     result: review,
@@ -10651,7 +10829,7 @@ async function main3(envelope, logger) {
 }
 
 // src/agents/iterator/iterate-action.ts
-import { execFileSync as execFileSync6 } from "node:child_process";
+import { execFileSync as execFileSync7 } from "node:child_process";
 
 // src/agents/iterator/outcome-guard.ts
 function assertIterOutputContract(outcome, outputs) {
@@ -10782,10 +10960,6 @@ async function main4(envelope, logger) {
   const reviewTransitionId = shouldAutoTransition ? requireEnv("FERRY_REVIEW_TRANSITION_ID") : "";
   const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
-  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
-  const hasLabelsConfig = effectiveCfg.labels !== void 0;
-  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
-  logCapabilities(logger, capabilities);
   const priorIterations = existingComments.filter(
     (c) => c.includes("[ferry:iterator:") && c.includes("complete. Pushed fixes to PR#")
   ).length;
@@ -10855,7 +11029,6 @@ async function main4(envelope, logger) {
     appendOutput({ input_tokens: 0, output_tokens: 0, model, provider: iterProvider });
     return;
   }
-  const system = buildSystem("iterate", REPO_ROOT4);
   configureFerryGitUser(REPO_ROOT4);
   if (checkoutExistingBranch(branchName, REPO_ROOT4) === "not-found") {
     await tracker.postComment(
@@ -10866,27 +11039,25 @@ async function main4(envelope, logger) {
     return;
   }
   const mergeConflicts = fetchAndMergeBase(baseBranch, REPO_ROOT4);
-  const existingLog = execFileSync6("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
+  const existingLog = execFileSync7("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
     cwd: REPO_ROOT4,
     encoding: "utf8"
   }).trim();
-  const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    typeOverride
+  const prepared = prepareIterator({
+    ticketKey,
+    issue,
+    headSha,
+    reviewComment,
+    mergeConflicts,
+    existingLog,
+    mcpPool,
+    configLabels: effectiveCfg.labels,
+    typeOverride,
+    repoRoot: REPO_ROOT4,
+    logger
   });
-  const initialPrompt = [
-    "## Jira Ticket",
-    delimitUntrusted(ticketBlock),
-    "",
-    "## Review Findings (fix only what is listed here)",
-    delimitUntrusted(reviewComment),
-    "",
-    mergeConflicts.length > 0 ? `## Merge Conflicts (resolve these first, before fixing review findings)
-${mergeConflicts.map((f) => `- ${f}`).join("\n")}` : "",
-    existingLog ? `## Existing commits on branch
-${existingLog}` : "",
-    "",
-    "When you have fixed all findings, call the `done` tool."
-  ].filter(Boolean).join("\n");
+  const { system, initialPrompt, mcpServers, capabilities } = prepared;
+  logCapabilities(logger, capabilities);
   const secretScan = makeSecretScan(REPO_ROOT4);
   const loop = createAgentLoop({
     provider: iterProvider,
@@ -10972,24 +11143,24 @@ ${existingLog}` : "",
     rule_ids: [],
     run_id: eventId
   });
-  execFileSync6("git", ["add", "-A"], { cwd: REPO_ROOT4 });
-  const finalStatus = execFileSync6("git", ["status", "--porcelain"], {
+  execFileSync7("git", ["add", "-A"], { cwd: REPO_ROOT4 });
+  const finalStatus = execFileSync7("git", ["status", "--porcelain"], {
     cwd: REPO_ROOT4,
     encoding: "utf8"
   }).trim();
   if (finalStatus) {
     await secretScan();
-    execFileSync6("git", ["commit", "-m", commitMessage], { cwd: REPO_ROOT4 });
+    execFileSync7("git", ["commit", "-m", commitMessage], { cwd: REPO_ROOT4 });
   }
   if (!dryRun) {
-    execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
+    execFileSync7("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
   } else {
     logger.info("DRY_RUN \u2014 skipped: git push origin branch");
   }
   const branchPushed = !dryRun;
   let iterFilesTouched = [];
   try {
-    const diff = execFileSync6("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
+    const diff = execFileSync7("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
       cwd: REPO_ROOT4,
       encoding: "utf8"
     });

--- a/.github/actions/ferry-run-reviewer/agent.js
+++ b/.github/actions/ferry-run-reviewer/agent.js
@@ -6610,7 +6610,7 @@ ${tree}`,
   };
 }
 
-// src/agents/reviewer/rubric.ts
+// src/lib/agent-runtime/reviewer-helpers.ts
 var STRICT_DIRECTIVE = [
   "## Rubric override \u2014 strict",
   "",
@@ -6641,53 +6641,6 @@ function applyRubricToPrompt(basePrompt, rubric) {
 
 ${directive}`;
 }
-
-// src/agents/reviewer/review-loop.ts
-var MAX_PATCH_CHARS = 2e4;
-var MAX_CONTENT_CHARS = 4e4;
-var MAX_ITERATIONS = 40;
-var REVIEW_TOOL_DEFS = [
-  {
-    name: "get_file_patch",
-    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "get_file_content",
-    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "finish_review",
-    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
-    input_schema: {
-      type: "object",
-      properties: {
-        approved: {
-          type: "boolean",
-          description: "true = ready to merge, false = changes required."
-        },
-        comment: {
-          type: "string",
-          description: "Full review comment in Markdown. Follow the required format from the system prompt."
-        }
-      },
-      required: ["approved", "comment"]
-    }
-  }
-];
 function detectMergeConflicts(files) {
   const conflicted = [];
   for (const f of files) {
@@ -6699,57 +6652,6 @@ function detectMergeConflicts(files) {
 }
 function buildFileList(files) {
   return files.map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`).join("\n");
-}
-async function runReviewLoop(opts) {
-  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
-  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
-  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
-  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
-  const {
-    done: result,
-    usage,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  } = await loop.run({
-    system,
-    initialPrompt,
-    tools: REVIEW_TOOL_DEFS,
-    finishTool: "finish_review",
-    extractDone: (input) => ({
-      approved: input.approved,
-      comment: input.comment
-    }),
-    handlers: {
-      get_file_patch: (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_patch", file: filename });
-        const patch = fileMap.get(filename);
-        if (patch === void 0) return `(file not found in PR: ${filename})`;
-        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
-        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
-        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
-      },
-      get_file_content: async (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_content", file: filename });
-        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
-        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
-        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
-      }
-    },
-    maxIterations,
-    maxTokens,
-    logger
-  });
-  return {
-    result,
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  };
 }
 
 // src/lib/agent-runtime/reviewer-prepare.ts
@@ -6763,9 +6665,9 @@ function prepareReviewer(input) {
     branchName,
     typeOverride,
     reviewRubric,
-    configLabels,
-    repoRoot,
-    logger
+    capabilities,
+    idempotencyMarker,
+    repoRoot
   } = input;
   const buildSystem2 = input._buildSystem ?? buildSystem;
   const loadOptionalPrompt2 = input._loadOptionalPrompt ?? loadOptionalPrompt;
@@ -6802,9 +6704,7 @@ function prepareReviewer(input) {
     separator: "\n\n---\n\n"
   });
   const system = applyRubricToPrompt(baseSystem, reviewRubric);
-  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
   const mcpServers = [];
-  const idempotencyMarker = byPrHeadSha("reviewer", headSha);
   return {
     system,
     initialPrompt,
@@ -6821,15 +6721,15 @@ function prepareIterator(input) {
   const {
     ticketKey,
     issue,
-    headSha,
     reviewComment,
     mergeConflicts,
     existingLog,
     mcpPool,
     configLabels,
+    capabilities,
+    idempotencyMarker,
     typeOverride,
-    repoRoot,
-    logger
+    repoRoot
   } = input;
   const buildSystem2 = input._buildSystem ?? buildSystem;
   const system = buildSystem2("iterate", repoRoot);
@@ -6848,10 +6748,8 @@ ${existingLog}` : "",
     "",
     "When you have fixed all findings, call the `done` tool."
   ].filter(Boolean).join("\n");
-  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
   const hasLabelsConfig = configLabels !== void 0;
   const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
-  const idempotencyMarker = byPrHeadSha("iterator", headSha);
   return {
     system,
     initialPrompt,
@@ -10571,6 +10469,104 @@ function gateCi(input) {
   };
 }
 
+// src/agents/reviewer/review-loop.ts
+var MAX_PATCH_CHARS = 2e4;
+var MAX_CONTENT_CHARS = 4e4;
+var MAX_ITERATIONS = 40;
+var REVIEW_TOOL_DEFS = [
+  {
+    name: "get_file_patch",
+    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "get_file_content",
+    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "finish_review",
+    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
+    input_schema: {
+      type: "object",
+      properties: {
+        approved: {
+          type: "boolean",
+          description: "true = ready to merge, false = changes required."
+        },
+        comment: {
+          type: "string",
+          description: "Full review comment in Markdown. Follow the required format from the system prompt."
+        }
+      },
+      required: ["approved", "comment"]
+    }
+  }
+];
+async function runReviewLoop(opts) {
+  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
+  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
+  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
+  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
+  const {
+    done: result,
+    usage,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  } = await loop.run({
+    system,
+    initialPrompt,
+    tools: REVIEW_TOOL_DEFS,
+    finishTool: "finish_review",
+    extractDone: (input) => ({
+      approved: input.approved,
+      comment: input.comment
+    }),
+    handlers: {
+      get_file_patch: (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_patch", file: filename });
+        const patch = fileMap.get(filename);
+        if (patch === void 0) return `(file not found in PR: ${filename})`;
+        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
+        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
+        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
+      },
+      get_file_content: async (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_content", file: filename });
+        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
+        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
+        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
+      }
+    },
+    maxIterations,
+    maxTokens,
+    logger
+  });
+  return {
+    result,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  };
+}
+
 // src/agents/reviewer/changes-guard.ts
 function countPriorIterations(existingComments) {
   return existingComments.filter(
@@ -10733,9 +10729,9 @@ async function main3(envelope, logger) {
     branchName,
     typeOverride,
     reviewRubric: reviewRubricOverride,
-    configLabels: effectiveCfg.labels,
-    repoRoot: REPO_ROOT3,
-    logger
+    capabilities,
+    idempotencyMarker,
+    repoRoot: REPO_ROOT3
   });
   const { system, initialPrompt, fileMap } = prepared;
   const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
@@ -10960,6 +10956,8 @@ async function main4(envelope, logger) {
   const reviewTransitionId = shouldAutoTransition ? requireEnv("FERRY_REVIEW_TRANSITION_ID") : "";
   const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels, logger);
+  logCapabilities(logger, capabilities);
   const priorIterations = existingComments.filter(
     (c) => c.includes("[ferry:iterator:") && c.includes("complete. Pushed fixes to PR#")
   ).length;
@@ -11052,12 +11050,12 @@ async function main4(envelope, logger) {
     existingLog,
     mcpPool,
     configLabels: effectiveCfg.labels,
+    capabilities,
+    idempotencyMarker,
     typeOverride,
-    repoRoot: REPO_ROOT4,
-    logger
+    repoRoot: REPO_ROOT4
   });
-  const { system, initialPrompt, mcpServers, capabilities } = prepared;
-  logCapabilities(logger, capabilities);
+  const { system, initialPrompt, mcpServers } = prepared;
   const secretScan = makeSecretScan(REPO_ROOT4);
   const loop = createAgentLoop({
     provider: iterProvider,

--- a/.github/actions/ferry-run-reviewer/agent.js
+++ b/.github/actions/ferry-run-reviewer/agent.js
@@ -6442,6 +6442,426 @@ function buildConflictComment(role, runId, err) {
   ].join("\n");
 }
 
+// src/lib/agent-runtime/refiner-prepare.ts
+var PRIOR_RUN_MARKER = /\[ferry:refiner:[^\]]+\]/;
+async function prepareRefiner(input) {
+  const { envelope, tracker } = input;
+  const { ticket_key: ticketKey, event_id: eventId } = envelope;
+  const issue = await tracker.getIssue(ticketKey);
+  const existingSubtasks = await tracker.getSubtaskDetails(ticketKey);
+  const priorRefinerRuns = issue.comments.filter((c) => PRIOR_RUN_MARKER.test(c));
+  const runLink = `https://github.com/${process.env.GITHUB_REPO ?? "unknown"}/actions/runs/${process.env.GITHUB_RUN_ID ?? "0"}`;
+  const idempotencyMarker = byEventId("refiner", eventId);
+  return {
+    issue,
+    existingSubtasks,
+    priorRefinerRuns,
+    runLink,
+    idempotencyMarker
+  };
+}
+
+// src/lib/agent-runtime/developer-prepare.ts
+import { execFileSync as execFileSync3 } from "node:child_process";
+
+// src/lib/llm/delimit-untrusted.ts
+var OPEN = "<<<UNTRUSTED>>>";
+var CLOSE = "<<<END UNTRUSTED>>>";
+var OPEN_ESCAPE = "<<<UNTRUSTED-LITERAL>>>";
+var CLOSE_ESCAPE = "<<<END UNTRUSTED-LITERAL>>>";
+function delimitUntrusted(value) {
+  const escaped = value.split(OPEN).join(OPEN_ESCAPE).split(CLOSE).join(CLOSE_ESCAPE);
+  return `${OPEN}
+${escaped}
+${CLOSE}`;
+}
+
+// src/lib/agent-runtime/developer-prepare.ts
+var checkoutOrCreateBranchDefault = (branchName, baseBranch, repoRoot, logger) => {
+  try {
+    execFileSync3("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
+      cwd: repoRoot,
+      stdio: "pipe"
+    });
+    execFileSync3("git", ["fetch", "origin", branchName], { cwd: repoRoot });
+    execFileSync3("git", ["checkout", branchName], { cwd: repoRoot });
+    const existingLog = execFileSync3("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
+      cwd: repoRoot,
+      encoding: "utf8"
+    }).trim();
+    if (existingLog) {
+      logger.info("resuming branch", {
+        branch: branchName,
+        prior_commits: existingLog.split("\n").length
+      });
+    }
+    const branchHeadSha = execFileSync3("git", ["rev-parse", "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf8"
+    }).trim();
+    return { branchHeadSha, existingLog };
+  } catch {
+    execFileSync3("git", ["checkout", "-B", branchName], { cwd: repoRoot });
+    logger.info("created branch", { branch: branchName });
+    return { branchHeadSha: "", existingLog: "" };
+  }
+};
+async function prepareDeveloper(input) {
+  const {
+    envelope,
+    issue,
+    effectiveCfg,
+    subtasks,
+    testRunner,
+    pkgManagerHint,
+    tree,
+    typeOverride,
+    owner,
+    repo,
+    baseBranch,
+    runner,
+    mcpPool,
+    repoRoot,
+    dryRun,
+    logger
+  } = input;
+  const buildSystem2 = input._buildSystem ?? buildSystem;
+  const checkoutOrCreateBranch = input._checkoutOrCreateBranch ?? checkoutOrCreateBranchDefault;
+  const configureGitUser = input._configureGitUser ?? configureFerryGitUser;
+  const ticketKey = envelope.ticket_key;
+  const eventId = envelope.event_id;
+  const labels = issue.labels.join(", ");
+  const comments = issue.comments.map((c) => `Comment: ${c}`).join("\n");
+  const ticketBlock = buildTicketBlock(ticketKey, issue, {
+    labels,
+    comments,
+    typeOverride
+  });
+  const system = buildSystem2("dev", repoRoot, {
+    extraParts: pkgManagerHint ? [`## Detected package manager
+
+${pkgManagerHint}`] : []
+  });
+  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
+  configureGitUser(repoRoot);
+  const { branchHeadSha, existingLog } = checkoutOrCreateBranch(
+    branchName,
+    baseBranch,
+    repoRoot,
+    logger
+  );
+  const resumeContext = existingLog ? `
+EXISTING WORK ON BRANCH (already committed \u2014 skip these, only do what remains):
+${existingLog}` : "";
+  let existingPrUrl = "";
+  let existingPrContext = "";
+  if (branchHeadSha && !dryRun) {
+    try {
+      const openPrs = await runner.listPRsForBranch(owner, repo, branchName);
+      if (openPrs.length > 0) {
+        const pr = openPrs[0];
+        existingPrUrl = `https://github.com/${owner}/${repo}/pull/${pr.number}`;
+        const prRef = { owner, repo, prNumber: pr.number };
+        const prFiles = await runner.listPRFiles(prRef);
+        const fileList = prFiles.map((f) => `${f.status}: ${f.filename}`).join("\n");
+        existingPrContext = [
+          `
+EXISTING_IMPLEMENTATION:`,
+          `Open PR: ${existingPrUrl} (head: ${branchHeadSha.slice(0, 7)})`,
+          `Changed files:
+${fileList}`,
+          `If the spec is already fully satisfied by the existing code, call \`done\` with outcome="already_satisfied".`
+        ].join("\n");
+        logger.info("existing PR found", { pr: existingPrUrl, files: prFiles.length });
+      }
+    } catch {
+    }
+  }
+  const idempotencyMarker = branchHeadSha ? byPrHeadSha("dev", branchHeadSha) : byEventId("dev", eventId);
+  const baseInitialPrompt = [
+    delimitUntrusted(ticketBlock),
+    "",
+    subtasks.length > 0 ? `SUBTASKS:
+${subtasks.join("\n")}` : "SUBTASKS: (none)",
+    "",
+    `TEST_RUNNER: ${testRunner}`,
+    "",
+    `REPO TREE (depth 2):
+${tree}`,
+    "",
+    "When you have finished implementing, call the `done` tool."
+  ].join("\n");
+  const initialPrompt = baseInitialPrompt + resumeContext + existingPrContext;
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
+  const hasLabelsConfig = effectiveCfg.labels !== void 0;
+  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  return {
+    system,
+    initialPrompt,
+    baseInitialPrompt,
+    mcpServers,
+    idempotencyMarker,
+    ticketBlock,
+    subtasks,
+    capabilities,
+    branchName,
+    branchHeadSha,
+    existingPrUrl
+  };
+}
+
+// src/agents/reviewer/rubric.ts
+var STRICT_DIRECTIVE = [
+  "## Rubric override \u2014 strict",
+  "",
+  "For this review, apply a STRICTER bar than usual:",
+  "",
+  "- Block on any missing test coverage for new/changed behaviour.",
+  "- Block on missing edge-case handling, error paths, or input validation.",
+  "- Block on weak naming, dead code, or unreachable branches.",
+  "- Block on incomplete documentation when public APIs change.",
+  "- Approve only when every acceptance criterion is fully satisfied with concrete evidence."
+].join("\n");
+var LENIENT_DIRECTIVE = [
+  "## Rubric override \u2014 lenient",
+  "",
+  "For this review, apply a MORE PERMISSIVE bar than usual:",
+  "",
+  "- Approve when the acceptance criteria are met, even if minor polish is missing.",
+  "- Treat naming nits, non-blocking style issues, and stylistic preferences as comments \u2014 not blockers.",
+  "- Block only on: failing tests, unimplemented ACs, merge conflicts, committed build artefacts, or security regressions.",
+  '- Prefer "approve with comments" over "request changes" when issues are non-blocking.'
+].join("\n");
+function applyRubricToPrompt(basePrompt, rubric) {
+  if (rubric === void 0) return basePrompt;
+  const directive = rubric === "strict" ? STRICT_DIRECTIVE : LENIENT_DIRECTIVE;
+  return `${basePrompt}
+
+---
+
+${directive}`;
+}
+
+// src/agents/reviewer/review-loop.ts
+var MAX_PATCH_CHARS = 2e4;
+var MAX_CONTENT_CHARS = 4e4;
+var MAX_ITERATIONS = 40;
+var REVIEW_TOOL_DEFS = [
+  {
+    name: "get_file_patch",
+    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "get_file_content",
+    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
+    input_schema: {
+      type: "object",
+      properties: {
+        filename: { type: "string", description: "Exact file path." }
+      },
+      required: ["filename"]
+    }
+  },
+  {
+    name: "finish_review",
+    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
+    input_schema: {
+      type: "object",
+      properties: {
+        approved: {
+          type: "boolean",
+          description: "true = ready to merge, false = changes required."
+        },
+        comment: {
+          type: "string",
+          description: "Full review comment in Markdown. Follow the required format from the system prompt."
+        }
+      },
+      required: ["approved", "comment"]
+    }
+  }
+];
+function detectMergeConflicts(files) {
+  const conflicted = [];
+  for (const f of files) {
+    if (f.patch && /^[+].*<{7}|^[+].*={7}|^[+].*>{7}/m.test(f.patch)) {
+      conflicted.push(f.filename);
+    }
+  }
+  return conflicted;
+}
+function buildFileList(files) {
+  return files.map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`).join("\n");
+}
+async function runReviewLoop(opts) {
+  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
+  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
+  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
+  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
+  const {
+    done: result,
+    usage,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  } = await loop.run({
+    system,
+    initialPrompt,
+    tools: REVIEW_TOOL_DEFS,
+    finishTool: "finish_review",
+    extractDone: (input) => ({
+      approved: input.approved,
+      comment: input.comment
+    }),
+    handlers: {
+      get_file_patch: (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_patch", file: filename });
+        const patch = fileMap.get(filename);
+        if (patch === void 0) return `(file not found in PR: ${filename})`;
+        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
+        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
+        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
+      },
+      get_file_content: async (input) => {
+        const filename = input.filename;
+        logger.info("tool", { tool: "get_file_content", file: filename });
+        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
+        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
+        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
+      }
+    },
+    maxIterations,
+    maxTokens,
+    logger
+  });
+  return {
+    result,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    iterations,
+    toolCounts,
+    toolCallRecords
+  };
+}
+
+// src/lib/agent-runtime/reviewer-prepare.ts
+function prepareReviewer(input) {
+  const {
+    ticketKey,
+    issue,
+    pr,
+    files,
+    commits,
+    branchName,
+    typeOverride,
+    reviewRubric,
+    configLabels,
+    repoRoot,
+    logger
+  } = input;
+  const buildSystem2 = input._buildSystem ?? buildSystem;
+  const loadOptionalPrompt2 = input._loadOptionalPrompt ?? loadOptionalPrompt;
+  const headSha = pr.headSha;
+  const prNumber = pr.number;
+  const fileMap = new Map(files.map((f) => [f.filename, f.patch]));
+  const conflictedFiles = detectMergeConflicts(files);
+  const hasMergeConflicts = pr.mergeable === false || conflictedFiles.length > 0;
+  const commitLog = commits.map((c) => `${c.sha.slice(0, 7)} ${c.message.split("\n")[0]}`).join("\n");
+  const ticketBlock = buildTicketBlock(ticketKey, issue, { typeOverride });
+  const mergeConflictWarning = hasMergeConflicts ? `
+\u26A0\uFE0F  MERGE CONFLICTS DETECTED \u2014 mergeable=${String(pr.mergeable)}${conflictedFiles.length > 0 ? `, conflicted files: ${conflictedFiles.join(", ")}` : ""}` : "";
+  const initialPrompt = [
+    "## Jira Ticket",
+    delimitUntrusted(ticketBlock),
+    "",
+    "## PR Metadata",
+    `PR #${prNumber}: ${pr.title}`,
+    `Base: ${pr.baseRef} \u2190 Head: ${branchName} (${headSha.slice(0, 7)})`,
+    `Files changed: ${files.length}  Commits: ${commits.length}`,
+    mergeConflictWarning,
+    "",
+    "## Commits",
+    commitLog,
+    "",
+    "## Changed files (status  +additions  -deletions  path)",
+    buildFileList(files),
+    "",
+    "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
+    "When you have enough information, call finish_review."
+  ].filter((l) => l !== null).join("\n");
+  const baseSystem = buildSystem2("review", repoRoot, {
+    extraParts: [loadOptionalPrompt2("review-comment", repoRoot)],
+    separator: "\n\n---\n\n"
+  });
+  const system = applyRubricToPrompt(baseSystem, reviewRubric);
+  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
+  const mcpServers = [];
+  const idempotencyMarker = byPrHeadSha("reviewer", headSha);
+  return {
+    system,
+    initialPrompt,
+    mcpServers,
+    idempotencyMarker,
+    ticketBlock,
+    capabilities,
+    fileMap
+  };
+}
+
+// src/lib/agent-runtime/iterator-prepare.ts
+function prepareIterator(input) {
+  const {
+    ticketKey,
+    issue,
+    headSha,
+    reviewComment,
+    mergeConflicts,
+    existingLog,
+    mcpPool,
+    configLabels,
+    typeOverride,
+    repoRoot,
+    logger
+  } = input;
+  const buildSystem2 = input._buildSystem ?? buildSystem;
+  const system = buildSystem2("iterate", repoRoot);
+  const ticketBlock = buildTicketBlock(ticketKey, issue, { typeOverride });
+  const initialPrompt = [
+    "## Jira Ticket",
+    delimitUntrusted(ticketBlock),
+    "",
+    "## Review Findings (fix only what is listed here)",
+    delimitUntrusted(reviewComment),
+    "",
+    mergeConflicts.length > 0 ? `## Merge Conflicts (resolve these first, before fixing review findings)
+${mergeConflicts.map((f) => `- ${f}`).join("\n")}` : "",
+    existingLog ? `## Existing commits on branch
+${existingLog}` : "",
+    "",
+    "When you have fixed all findings, call the `done` tool."
+  ].filter(Boolean).join("\n");
+  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
+  const hasLabelsConfig = configLabels !== void 0;
+  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  const idempotencyMarker = byPrHeadSha("iterator", headSha);
+  return {
+    system,
+    initialPrompt,
+    mcpServers,
+    idempotencyMarker,
+    ticketBlock,
+    capabilities
+  };
+}
+
 // src/lib/dry-run.ts
 function isDryRun() {
   return process.env.FERRY_DRY_RUN === "1" || process.env.FERRY_DRY_RUN === "true";
@@ -6640,18 +7060,6 @@ function createLlmCall(route) {
 
 // src/agents/refiner/refine.ts
 import { createRequire as createRequire3 } from "module";
-
-// src/lib/llm/delimit-untrusted.ts
-var OPEN = "<<<UNTRUSTED>>>";
-var CLOSE = "<<<END UNTRUSTED>>>";
-var OPEN_ESCAPE = "<<<UNTRUSTED-LITERAL>>>";
-var CLOSE_ESCAPE = "<<<END UNTRUSTED-LITERAL>>>";
-function delimitUntrusted(value) {
-  const escaped = value.split(OPEN).join(OPEN_ESCAPE).split(CLOSE).join(CLOSE_ESCAPE);
-  return `${OPEN}
-${escaped}
-${CLOSE}`;
-}
 
 // src/agents/refiner/parse.ts
 function extractFirstJsonObject(text) {
@@ -7028,15 +7436,12 @@ function estimateTicketCost(_plan, baseline) {
 
 // src/agents/refiner/refiner-action.ts
 var REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
-var PRIOR_RUN_MARKER = /\[ferry:refiner:[^\]]+\]/;
 async function run(envelope, deps) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const logger = deps.logger ?? createLogger(eventId, "ferry:refiner-action");
   const dryRun = isDryRun() || deps.dryRun === true;
-  const issue = await deps.tracker.getIssue(ticketKey);
-  const runLink = `https://github.com/${process.env.GITHUB_REPO ?? "unknown"}/actions/runs/${process.env.GITHUB_RUN_ID ?? "0"}`;
-  const existingSubtasks = await deps.tracker.getSubtaskDetails(ticketKey);
-  const priorRefinerRuns = issue.comments.filter((c) => PRIOR_RUN_MARKER.test(c));
+  const prepared = await prepareRefiner({ envelope, tracker: deps.tracker });
+  const { issue, existingSubtasks, priorRefinerRuns, runLink, idempotencyMarker } = prepared;
   const { plan, auditSummary } = await runRefiner({
     ticket: {
       key: issue.key,
@@ -7111,7 +7516,6 @@ async function run(envelope, deps) {
     existingSubtasks,
     tracker: deps.tracker
   });
-  const idempotencyMarker = `[ferry:refiner:${eventId}]`;
   if (result.noop) {
     logger.info("noop \u2014 existing sub-tasks still valid", { ticket: ticketKey });
     await deps.tracker.postComment(
@@ -7199,7 +7603,7 @@ async function main(envelope, logger) {
 }
 
 // src/agents/developer/dev-action.ts
-import { execFileSync as execFileSync5 } from "node:child_process";
+import { execFileSync as execFileSync6 } from "node:child_process";
 import * as fsp2 from "node:fs/promises";
 import * as path6 from "node:path";
 
@@ -9093,7 +9497,7 @@ function createAgentLoop(opts) {
 
 // src/agents/developer/workspace.ts
 import { readFileSync as readFileSync5, existsSync as existsSync4 } from "node:fs";
-import { execFileSync as execFileSync3 } from "node:child_process";
+import { execFileSync as execFileSync4 } from "node:child_process";
 import * as path5 from "node:path";
 function detectTestRunner(packageJsonPath2) {
   try {
@@ -9112,7 +9516,7 @@ function detectTestRunner(packageJsonPath2) {
 }
 function repoTree(repoRoot) {
   try {
-    return execFileSync3(
+    return execFileSync4(
       "find",
       [
         repoRoot,
@@ -9204,7 +9608,7 @@ function assertDevOutputContract(outcome, outputs) {
 }
 
 // src/agents/developer/wip-finalizer.ts
-import { execFileSync as execFileSync4 } from "node:child_process";
+import { execFileSync as execFileSync5 } from "node:child_process";
 function classifyError(err) {
   if (err instanceof FerryError) {
     const reason = err.context?.reason ?? "unknown";
@@ -9243,8 +9647,8 @@ async function runWipFinalizer(opts) {
   logger.info("wip_finalizer", { code, detail, branch: branchName });
   let committed = false;
   try {
-    execFileSync4("git", ["add", "-A"], { cwd: repoRoot });
-    const status = execFileSync4("git", ["status", "--porcelain"], {
+    execFileSync5("git", ["add", "-A"], { cwd: repoRoot });
+    const status = execFileSync5("git", ["status", "--porcelain"], {
       cwd: repoRoot,
       encoding: "utf8"
     });
@@ -9253,7 +9657,7 @@ async function runWipFinalizer(opts) {
       const wipMsg = `wip(${ticketKey}): interrupted \u2014 ${code}
 
 [ferry:dev:${eventId}]`;
-      execFileSync4("git", ["commit", "-m", wipMsg], { cwd: repoRoot });
+      execFileSync5("git", ["commit", "-m", wipMsg], { cwd: repoRoot });
       committed = true;
       logger.info("wip_committed", { branch: branchName });
     } else {
@@ -9265,14 +9669,14 @@ async function runWipFinalizer(opts) {
   let pushed = false;
   if (!dryRun) {
     try {
-      execFileSync4("git", ["push", "origin", branchName, "--force-with-lease"], {
+      execFileSync5("git", ["push", "origin", branchName, "--force-with-lease"], {
         cwd: repoRoot,
         stdio: "pipe"
       });
       pushed = true;
     } catch {
       try {
-        execFileSync4("git", ["push", "origin", branchName], { cwd: repoRoot, stdio: "pipe" });
+        execFileSync5("git", ["push", "origin", branchName], { cwd: repoRoot, stdio: "pipe" });
         pushed = true;
       } catch (pushErr) {
         logger.error("wip_push_failed", { error: pushErr.message });
@@ -9398,102 +9802,36 @@ async function main2(envelope, logger) {
   const reviewTransitionId = !shouldAutoTransition ? "" : requireEnv("FERRY_REVIEW_TRANSITION_ID");
   const jiraBaseUrl = requireEnv("FERRY_JIRA_BASE_URL");
   const { provider: devProvider } = effectiveCfg.models.dev;
-  const labels = issue.labels.join(", ");
-  const comments = issue.comments.map((c) => `Comment: ${c}`).join("\n");
-  const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    labels,
-    comments,
-    typeOverride
-  });
+  const model = effectiveCfg.models.dev.model;
   const subtasks = await tracker.getSubtasks(ticketKey);
   const testRunner = detectTestRunner(packageJsonPath(REPO_ROOT2));
   const pkgManagerHint = detectPackageManager(REPO_ROOT2);
   const tree = repoTree(REPO_ROOT2);
-  const system = buildSystem("dev", REPO_ROOT2, {
-    extraParts: pkgManagerHint ? [`## Detected package manager
-
-${pkgManagerHint}`] : []
-  });
-  const model = effectiveCfg.models.dev.model;
-  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
-  configureFerryGitUser(REPO_ROOT2);
-  let resumeContext = "";
-  let branchHeadSha = "";
-  try {
-    execFileSync5("git", ["ls-remote", "--exit-code", "--heads", "origin", branchName], {
-      cwd: REPO_ROOT2,
-      stdio: "pipe"
-    });
-    execFileSync5("git", ["fetch", "origin", branchName], { cwd: REPO_ROOT2 });
-    execFileSync5("git", ["checkout", branchName], { cwd: REPO_ROOT2 });
-    const existingLog = execFileSync5("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
-      cwd: REPO_ROOT2,
-      encoding: "utf8"
-    }).trim();
-    if (existingLog) {
-      resumeContext = `
-EXISTING WORK ON BRANCH (already committed \u2014 skip these, only do what remains):
-${existingLog}`;
-      logger.info("resuming branch", {
-        branch: branchName,
-        prior_commits: existingLog.split("\n").length
-      });
-    }
-    branchHeadSha = execFileSync5("git", ["rev-parse", "HEAD"], {
-      cwd: REPO_ROOT2,
-      encoding: "utf8"
-    }).trim();
-  } catch {
-    execFileSync5("git", ["checkout", "-B", branchName], { cwd: REPO_ROOT2 });
-    logger.info("created branch", { branch: branchName });
-  }
-  let existingPrUrl = "";
-  let existingPrContext = "";
-  if (branchHeadSha && !dryRun) {
-    try {
-      const openPrs = await runner.listPRsForBranch(owner, repo, branchName);
-      if (openPrs.length > 0) {
-        const pr = openPrs[0];
-        existingPrUrl = `https://github.com/${owner}/${repo}/pull/${pr.number}`;
-        const prRef = { owner, repo, prNumber: pr.number };
-        const prFiles = await runner.listPRFiles(prRef);
-        const fileList = prFiles.map((f) => `${f.status}: ${f.filename}`).join("\n");
-        existingPrContext = [
-          `
-EXISTING_IMPLEMENTATION:`,
-          `Open PR: ${existingPrUrl} (head: ${branchHeadSha.slice(0, 7)})`,
-          `Changed files:
-${fileList}`,
-          `If the spec is already fully satisfied by the existing code, call \`done\` with outcome="already_satisfied".`
-        ].join("\n");
-        logger.info("existing PR found", { pr: existingPrUrl, files: prFiles.length });
-      }
-    } catch {
-    }
-  }
-  const idempotencyMarker = branchHeadSha ? `[ferry:dev:${branchHeadSha.slice(0, 7)}]` : `[ferry:dev:${eventId}]`;
-  const initialPrompt = [
-    delimitUntrusted(ticketBlock),
-    "",
-    subtasks.length > 0 ? `SUBTASKS:
-${subtasks.join("\n")}` : "SUBTASKS: (none)",
-    "",
-    `TEST_RUNNER: ${testRunner}`,
-    "",
-    `REPO TREE (depth 2):
-${tree}`,
-    "",
-    "When you have finished implementing, call the `done` tool."
-  ].join("\n");
-  const secretScan = makeSecretScan(REPO_ROOT2);
   const mcpPool = loadMcpServers();
-  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
-  const hasLabelsConfig = effectiveCfg.labels !== void 0;
-  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  const prepared = await prepareDeveloper({
+    envelope,
+    issue,
+    effectiveCfg,
+    subtasks,
+    testRunner,
+    pkgManagerHint,
+    tree,
+    typeOverride,
+    owner,
+    repo,
+    baseBranch,
+    runner,
+    mcpPool,
+    repoRoot: REPO_ROOT2,
+    dryRun,
+    logger
+  });
+  const { system, initialPrompt, mcpServers, idempotencyMarker, branchName, capabilities } = prepared;
   logCapabilities(logger, capabilities);
   if (mcpServers.length > 0) {
     logger.info("MCP servers", { servers: mcpServers.map((s) => s.name) });
   }
+  const secretScan = makeSecretScan(REPO_ROOT2);
   const allToolSchemas = [...TOOL_SCHEMAS, COMMIT_PROGRESS_SCHEMA, SPAWN_SUBAGENT_SCHEMA];
   let loop;
   loop = createAgentLoop({
@@ -9521,7 +9859,9 @@ ${tree}`,
   try {
     loopResult = await loop.run({
       system,
-      initialPrompt: initialPrompt + resumeContext + existingPrContext,
+      // `initialPrompt` already includes the resume + existing-PR context
+      // (concatenated inside `prepareDeveloper`).
+      initialPrompt,
       tools: allToolSchemas,
       repoRoot: REPO_ROOT2,
       branchName,
@@ -9618,20 +9958,20 @@ ${tree}`,
       await fsp2.writeFile(verificationPath, verificationContent, "utf8");
       verificationNoteWritten = true;
     }
-    execFileSync5("git", ["add", "-A"], { cwd: REPO_ROOT2 });
-    const finalStatus = execFileSync5("git", ["status", "--porcelain"], {
+    execFileSync6("git", ["add", "-A"], { cwd: REPO_ROOT2 });
+    const finalStatus = execFileSync6("git", ["status", "--porcelain"], {
       cwd: REPO_ROOT2,
       encoding: "utf8"
     });
     if (finalStatus.trim()) {
       await secretScan();
       const msg = resolvedOutcome === "already_satisfied" ? `chore(${ticketKey}): add verification note \u2014 spec already satisfied` : done.commit_message ?? commitMessage;
-      execFileSync5("git", ["commit", "-m", msg], { cwd: REPO_ROOT2 });
+      execFileSync6("git", ["commit", "-m", msg], { cwd: REPO_ROOT2 });
     }
     if (dryRun) {
       let diffOutput = "(no local changes)";
       try {
-        diffOutput = execFileSync5(
+        diffOutput = execFileSync6(
           "sh",
           [
             "-c",
@@ -9660,11 +10000,11 @@ ${tree}`,
       appendOutput({ ...usage, model, provider: devProvider });
       process.exit(0);
     }
-    execFileSync5("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT2 });
+    execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT2 });
     const branchPushed = true;
     summaryBranchPushed = branchName;
     try {
-      const diff = execFileSync5("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
+      const diff = execFileSync6("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
         cwd: REPO_ROOT2,
         encoding: "utf8"
       });
@@ -10231,148 +10571,6 @@ function gateCi(input) {
   };
 }
 
-// src/agents/reviewer/review-loop.ts
-var MAX_PATCH_CHARS = 2e4;
-var MAX_CONTENT_CHARS = 4e4;
-var MAX_ITERATIONS = 40;
-var REVIEW_TOOL_DEFS = [
-  {
-    name: "get_file_patch",
-    description: "Get the unified diff patch for a specific file in this PR. Use this to inspect what changed in a file before making a finding.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path as listed in the PR file list." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "get_file_content",
-    description: "Get the full content of a file from the PR head branch. Use when the patch is truncated or you need context outside the changed lines.",
-    input_schema: {
-      type: "object",
-      properties: {
-        filename: { type: "string", description: "Exact file path." }
-      },
-      required: ["filename"]
-    }
-  },
-  {
-    name: "finish_review",
-    description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
-    input_schema: {
-      type: "object",
-      properties: {
-        approved: {
-          type: "boolean",
-          description: "true = ready to merge, false = changes required."
-        },
-        comment: {
-          type: "string",
-          description: "Full review comment in Markdown. Follow the required format from the system prompt."
-        }
-      },
-      required: ["approved", "comment"]
-    }
-  }
-];
-function detectMergeConflicts(files) {
-  const conflicted = [];
-  for (const f of files) {
-    if (f.patch && /^[+].*<{7}|^[+].*={7}|^[+].*>{7}/m.test(f.patch)) {
-      conflicted.push(f.filename);
-    }
-  }
-  return conflicted;
-}
-function buildFileList(files) {
-  return files.map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`).join("\n");
-}
-async function runReviewLoop(opts) {
-  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
-  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
-  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
-  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
-  const {
-    done: result,
-    usage,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  } = await loop.run({
-    system,
-    initialPrompt,
-    tools: REVIEW_TOOL_DEFS,
-    finishTool: "finish_review",
-    extractDone: (input) => ({
-      approved: input.approved,
-      comment: input.comment
-    }),
-    handlers: {
-      get_file_patch: (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_patch", file: filename });
-        const patch = fileMap.get(filename);
-        if (patch === void 0) return `(file not found in PR: ${filename})`;
-        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
-        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
-        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
-      },
-      get_file_content: async (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_content", file: filename });
-        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
-        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
-        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
-      }
-    },
-    maxIterations,
-    maxTokens,
-    logger
-  });
-  return {
-    result,
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  };
-}
-
-// src/agents/reviewer/rubric.ts
-var STRICT_DIRECTIVE = [
-  "## Rubric override \u2014 strict",
-  "",
-  "For this review, apply a STRICTER bar than usual:",
-  "",
-  "- Block on any missing test coverage for new/changed behaviour.",
-  "- Block on missing edge-case handling, error paths, or input validation.",
-  "- Block on weak naming, dead code, or unreachable branches.",
-  "- Block on incomplete documentation when public APIs change.",
-  "- Approve only when every acceptance criterion is fully satisfied with concrete evidence."
-].join("\n");
-var LENIENT_DIRECTIVE = [
-  "## Rubric override \u2014 lenient",
-  "",
-  "For this review, apply a MORE PERMISSIVE bar than usual:",
-  "",
-  "- Approve when the acceptance criteria are met, even if minor polish is missing.",
-  "- Treat naming nits, non-blocking style issues, and stylistic preferences as comments \u2014 not blockers.",
-  "- Block only on: failing tests, unimplemented ACs, merge conflicts, committed build artefacts, or security regressions.",
-  '- Prefer "approve with comments" over "request changes" when issues are non-blocking.'
-].join("\n");
-function applyRubricToPrompt(basePrompt, rubric) {
-  if (rubric === void 0) return basePrompt;
-  const directive = rubric === "strict" ? STRICT_DIRECTIVE : LENIENT_DIRECTIVE;
-  return `${basePrompt}
-
----
-
-${directive}`;
-}
-
 // src/agents/reviewer/changes-guard.ts
 function countPriorIterations(existingComments) {
   return existingComments.filter(
@@ -10459,7 +10657,6 @@ async function main3(envelope, logger) {
   const prNumber = prs[0].number;
   const pr = await runner.getPR({ owner, repo, prNumber });
   const headSha = pr.headSha;
-  const mergeable = pr.mergeable;
   const idempotencyMarker = byPrHeadSha("reviewer", headSha);
   const { skipped } = checkIdempotencyMarker(idempotencyMarker, existingComments);
   if (skipped) {
@@ -10526,40 +10723,21 @@ async function main3(envelope, logger) {
     return;
   }
   const files = await runner.listPRFiles({ owner, repo, prNumber });
-  const fileMap = new Map(files.map((f) => [f.filename, f.patch]));
-  const conflictedFiles = detectMergeConflicts(files);
-  const hasMergeConflicts = mergeable === false || conflictedFiles.length > 0;
   const commits = await runner.listPRCommits({ owner, repo, prNumber });
-  const commitLog = commits.map((c) => `${c.sha.slice(0, 7)} ${c.message.split("\n")[0]}`).join("\n");
-  const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    typeOverride
+  const prepared = prepareReviewer({
+    ticketKey,
+    issue,
+    pr,
+    files,
+    commits,
+    branchName,
+    typeOverride,
+    reviewRubric: reviewRubricOverride,
+    configLabels: effectiveCfg.labels,
+    repoRoot: REPO_ROOT3,
+    logger
   });
-  const mergeConflictWarning = hasMergeConflicts ? `
-\u26A0\uFE0F  MERGE CONFLICTS DETECTED \u2014 mergeable=${String(mergeable)}${conflictedFiles.length > 0 ? `, conflicted files: ${conflictedFiles.join(", ")}` : ""}` : "";
-  const initialPrompt = [
-    "## Jira Ticket",
-    delimitUntrusted(ticketBlock),
-    "",
-    "## PR Metadata",
-    `PR #${prNumber}: ${pr.title}`,
-    `Base: ${pr.baseRef} \u2190 Head: ${branchName} (${headSha.slice(0, 7)})`,
-    `Files changed: ${files.length}  Commits: ${commits.length}`,
-    mergeConflictWarning,
-    "",
-    "## Commits",
-    commitLog,
-    "",
-    "## Changed files (status  +additions  -deletions  path)",
-    buildFileList(files),
-    "",
-    "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
-    "When you have enough information, call finish_review."
-  ].filter((l) => l !== null).join("\n");
-  const baseSystem = buildSystem("review", REPO_ROOT3, {
-    extraParts: [loadOptionalPrompt("review-comment", REPO_ROOT3)],
-    separator: "\n\n---\n\n"
-  });
-  const system = applyRubricToPrompt(baseSystem, reviewRubricOverride);
+  const { system, initialPrompt, fileMap } = prepared;
   const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
   const {
     result: review,
@@ -10651,7 +10829,7 @@ async function main3(envelope, logger) {
 }
 
 // src/agents/iterator/iterate-action.ts
-import { execFileSync as execFileSync6 } from "node:child_process";
+import { execFileSync as execFileSync7 } from "node:child_process";
 
 // src/agents/iterator/outcome-guard.ts
 function assertIterOutputContract(outcome, outputs) {
@@ -10782,10 +10960,6 @@ async function main4(envelope, logger) {
   const reviewTransitionId = shouldAutoTransition ? requireEnv("FERRY_REVIEW_TRANSITION_ID") : "";
   const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
-  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
-  const hasLabelsConfig = effectiveCfg.labels !== void 0;
-  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
-  logCapabilities(logger, capabilities);
   const priorIterations = existingComments.filter(
     (c) => c.includes("[ferry:iterator:") && c.includes("complete. Pushed fixes to PR#")
   ).length;
@@ -10855,7 +11029,6 @@ async function main4(envelope, logger) {
     appendOutput({ input_tokens: 0, output_tokens: 0, model, provider: iterProvider });
     return;
   }
-  const system = buildSystem("iterate", REPO_ROOT4);
   configureFerryGitUser(REPO_ROOT4);
   if (checkoutExistingBranch(branchName, REPO_ROOT4) === "not-found") {
     await tracker.postComment(
@@ -10866,27 +11039,25 @@ async function main4(envelope, logger) {
     return;
   }
   const mergeConflicts = fetchAndMergeBase(baseBranch, REPO_ROOT4);
-  const existingLog = execFileSync6("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
+  const existingLog = execFileSync7("git", ["log", `origin/${baseBranch}..HEAD`, "--oneline"], {
     cwd: REPO_ROOT4,
     encoding: "utf8"
   }).trim();
-  const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    typeOverride
+  const prepared = prepareIterator({
+    ticketKey,
+    issue,
+    headSha,
+    reviewComment,
+    mergeConflicts,
+    existingLog,
+    mcpPool,
+    configLabels: effectiveCfg.labels,
+    typeOverride,
+    repoRoot: REPO_ROOT4,
+    logger
   });
-  const initialPrompt = [
-    "## Jira Ticket",
-    delimitUntrusted(ticketBlock),
-    "",
-    "## Review Findings (fix only what is listed here)",
-    delimitUntrusted(reviewComment),
-    "",
-    mergeConflicts.length > 0 ? `## Merge Conflicts (resolve these first, before fixing review findings)
-${mergeConflicts.map((f) => `- ${f}`).join("\n")}` : "",
-    existingLog ? `## Existing commits on branch
-${existingLog}` : "",
-    "",
-    "When you have fixed all findings, call the `done` tool."
-  ].filter(Boolean).join("\n");
+  const { system, initialPrompt, mcpServers, capabilities } = prepared;
+  logCapabilities(logger, capabilities);
   const secretScan = makeSecretScan(REPO_ROOT4);
   const loop = createAgentLoop({
     provider: iterProvider,
@@ -10972,24 +11143,24 @@ ${existingLog}` : "",
     rule_ids: [],
     run_id: eventId
   });
-  execFileSync6("git", ["add", "-A"], { cwd: REPO_ROOT4 });
-  const finalStatus = execFileSync6("git", ["status", "--porcelain"], {
+  execFileSync7("git", ["add", "-A"], { cwd: REPO_ROOT4 });
+  const finalStatus = execFileSync7("git", ["status", "--porcelain"], {
     cwd: REPO_ROOT4,
     encoding: "utf8"
   }).trim();
   if (finalStatus) {
     await secretScan();
-    execFileSync6("git", ["commit", "-m", commitMessage], { cwd: REPO_ROOT4 });
+    execFileSync7("git", ["commit", "-m", commitMessage], { cwd: REPO_ROOT4 });
   }
   if (!dryRun) {
-    execFileSync6("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
+    execFileSync7("git", ["push", "origin", branchName, "--force-with-lease"], { cwd: REPO_ROOT4 });
   } else {
     logger.info("DRY_RUN \u2014 skipped: git push origin branch");
   }
   const branchPushed = !dryRun;
   let iterFilesTouched = [];
   try {
-    const diff = execFileSync6("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
+    const diff = execFileSync7("git", ["diff", "--name-only", `origin/${baseBranch}...HEAD`], {
       cwd: REPO_ROOT4,
       encoding: "utf8"
     });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,29 @@ export default [
       'no-console': 'error',
     },
   },
+  // Layering invariant: `src/lib/agent-runtime/**` is the lower shared layer
+  // and must never reach into `src/agents/**` (agents consume the lib layer,
+  // not the other way around). See issue #330 / PR #345 for the rationale.
+  {
+    files: ['src/lib/agent-runtime/**/*.ts'],
+    languageOptions: {
+      parserOptions: { project: null },
+    },
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['**/agents/**', '../../agents/**', '../agents/**'],
+              message:
+                'src/lib/agent-runtime/** must not import from src/agents/** — that inverts the lib/agents layering. Move shared helpers into src/lib/agent-runtime/ instead.',
+            },
+          ],
+        },
+      ],
+    },
+  },
   // Agent code must never import Octokit or Jira modules directly
   {
     files: ['src/agents/**/*.ts'],

--- a/src/agents/developer/dev-action.ts
+++ b/src/agents/developer/dev-action.ts
@@ -1,23 +1,19 @@
 import { execFileSync } from 'node:child_process';
 import * as fsp from 'node:fs/promises';
 import * as path from 'node:path';
-import { delimitUntrusted } from '../../lib/llm/delimit-untrusted.js';
 import {
   requireEnv,
   loadMcpServers,
-  buildSystem,
-  buildTicketBlock,
   appendOutput,
   writeStepSummary,
-  configureFerryGitUser,
   makeCommitProgress,
   makeSecretScan,
   logCapabilities,
   logTicketOverrides,
   createGitHubContext,
   resolveGitConfig,
-  resolveBranchPrefix,
   loadFerryConfigFromBaseBranch,
+  prepareDeveloper,
 } from '../../lib/agent-runtime/index.js';
 import type { EventEnvelopeV1 } from '../../lib/envelope/types.js';
 import type { Logger } from '../../lib/agent-runtime/index.js';
@@ -34,8 +30,6 @@ import {
 import { createAgentLoop } from '../../lib/llm/agent-loop/index.js';
 import type { AgentLoop } from '../../lib/llm/agent-loop/types.js';
 import {
-  resolveCapabilities,
-  filterMcpServers,
   resolveTicketOverrides,
   applyTicketOverrides,
   hasNonDefaultOverrides,
@@ -172,110 +166,46 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
   const jiraBaseUrl = requireEnv('FERRY_JIRA_BASE_URL');
 
   const { provider: devProvider } = effectiveCfg.models.dev;
-  const labels = issue.labels.join(', ');
-  const comments = issue.comments.map((c) => `Comment: ${c}`).join('\n');
-  const ticketBlock = buildTicketBlock(ticketKey, issue, {
-    labels,
-    comments,
-    typeOverride,
-  });
+  const model = effectiveCfg.models.dev.model;
 
   const subtasks = await tracker.getSubtasks(ticketKey);
   const testRunner = detectTestRunner(packageJsonPath(REPO_ROOT));
   const pkgManagerHint = detectPackageManager(REPO_ROOT);
   const tree = repoTree(REPO_ROOT);
-
-  const system = buildSystem('dev', REPO_ROOT, {
-    extraParts: pkgManagerHint ? [`## Detected package manager\n\n${pkgManagerHint}`] : [],
-  });
-  const model = effectiveCfg.models.dev.model;
-
-  // Branch is determined upfront from the ticket key so restarts resume the same branch.
-  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
-
-  configureFerryGitUser(REPO_ROOT);
-
-  let resumeContext = '';
-  let branchHeadSha = '';
-  try {
-    execFileSync('git', ['ls-remote', '--exit-code', '--heads', 'origin', branchName], {
-      cwd: REPO_ROOT,
-      stdio: 'pipe',
-    });
-    execFileSync('git', ['fetch', 'origin', branchName], { cwd: REPO_ROOT });
-    execFileSync('git', ['checkout', branchName], { cwd: REPO_ROOT });
-    const existingLog = execFileSync('git', ['log', `origin/${baseBranch}..HEAD`, '--oneline'], {
-      cwd: REPO_ROOT,
-      encoding: 'utf8',
-    }).trim();
-    if (existingLog) {
-      resumeContext = `\nEXISTING WORK ON BRANCH (already committed — skip these, only do what remains):\n${existingLog}`;
-      logger.info('resuming branch', {
-        branch: branchName,
-        prior_commits: existingLog.split('\n').length,
-      });
-    }
-    branchHeadSha = execFileSync('git', ['rev-parse', 'HEAD'], {
-      cwd: REPO_ROOT,
-      encoding: 'utf8',
-    }).trim();
-  } catch {
-    execFileSync('git', ['checkout', '-B', branchName], { cwd: REPO_ROOT });
-    logger.info('created branch', { branch: branchName });
-  }
-
-  // Pre-flight: check for an open Ferry PR on this branch and inject context.
-  let existingPrUrl = '';
-  let existingPrContext = '';
-  if (branchHeadSha && !dryRun) {
-    try {
-      const openPrs = await runner.listPRsForBranch(owner, repo, branchName);
-      if (openPrs.length > 0) {
-        const pr = openPrs[0];
-        existingPrUrl = `https://github.com/${owner}/${repo}/pull/${pr.number}`;
-        const prRef = { owner, repo, prNumber: pr.number };
-        const prFiles = await runner.listPRFiles(prRef);
-        const fileList = prFiles.map((f) => `${f.status}: ${f.filename}`).join('\n');
-        existingPrContext = [
-          `\nEXISTING_IMPLEMENTATION:`,
-          `Open PR: ${existingPrUrl} (head: ${branchHeadSha.slice(0, 7)})`,
-          `Changed files:\n${fileList}`,
-          `If the spec is already fully satisfied by the existing code, call \`done\` with outcome="already_satisfied".`,
-        ].join('\n');
-        logger.info('existing PR found', { pr: existingPrUrl, files: prFiles.length });
-      }
-    } catch {
-      // best-effort: if PR check fails, proceed without context
-    }
-  }
-
-  // Idempotency marker: keyed on branch head SHA so re-runs on the same state collapse.
-  const idempotencyMarker = branchHeadSha
-    ? `[ferry:dev:${branchHeadSha.slice(0, 7)}]`
-    : `[ferry:dev:${eventId}]`;
-
-  const initialPrompt = [
-    delimitUntrusted(ticketBlock),
-    '',
-    subtasks.length > 0 ? `SUBTASKS:\n${subtasks.join('\n')}` : 'SUBTASKS: (none)',
-    '',
-    `TEST_RUNNER: ${testRunner}`,
-    '',
-    `REPO TREE (depth 2):\n${tree}`,
-    '',
-    'When you have finished implementing, call the `done` tool.',
-  ].join('\n');
-
-  const secretScan = makeSecretScan(REPO_ROOT);
   const mcpPool = loadMcpServers();
-  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
-  const hasLabelsConfig = effectiveCfg.labels !== undefined;
-  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+
+  // Pre-loop setup: builds system prompt, ticket block, initial prompt (with
+  // resume + existing-PR context), capability-filtered MCP pool, idempotency
+  // marker, and the branch name. Performs the branch checkout + best-effort
+  // PR-existence probe. Extracted into a reusable prepare function (#330) so
+  // the future cc-prepare composite (#331) consumes the same source.
+  const prepared = await prepareDeveloper({
+    envelope,
+    issue,
+    effectiveCfg,
+    subtasks,
+    testRunner,
+    pkgManagerHint,
+    tree,
+    typeOverride,
+    owner,
+    repo,
+    baseBranch,
+    runner,
+    mcpPool,
+    repoRoot: REPO_ROOT,
+    dryRun,
+    logger,
+  });
+  const { system, initialPrompt, mcpServers, idempotencyMarker, branchName, capabilities } =
+    prepared;
 
   logCapabilities(logger, capabilities);
   if (mcpServers.length > 0) {
     logger.info('MCP servers', { servers: mcpServers.map((s) => s.name) });
   }
+
+  const secretScan = makeSecretScan(REPO_ROOT);
 
   const allToolSchemas = [...TOOL_SCHEMAS, COMMIT_PROGRESS_SCHEMA, SPAWN_SUBAGENT_SCHEMA];
 
@@ -307,7 +237,9 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
   try {
     loopResult = await loop.run({
       system,
-      initialPrompt: initialPrompt + resumeContext + existingPrContext,
+      // `initialPrompt` already includes the resume + existing-PR context
+      // (concatenated inside `prepareDeveloper`).
+      initialPrompt,
       tools: allToolSchemas,
       repoRoot: REPO_ROOT,
       branchName,

--- a/src/agents/iterator/iterate-action.ts
+++ b/src/agents/iterator/iterate-action.ts
@@ -7,6 +7,7 @@ import { checkIterationCap } from './cap.js';
 import { decideIteratorTransition } from './transition.js';
 import { formatCommitMessage } from './prompt.js';
 import {
+  resolveCapabilities,
   resolveTicketOverrides,
   applyTicketOverrides,
   hasNonDefaultOverrides,
@@ -143,6 +144,13 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
   const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
 
+  // Resolve capabilities once, BEFORE every early-return gate below, so the
+  // capability telemetry is emitted on every invocation — not only when we
+  // reach the loop. The resolved value is threaded into `prepareIterator`
+  // (single source of truth per `RolePreparedContextBase`).
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels, logger);
+  logCapabilities(logger, capabilities);
+
   const priorIterations = existingComments.filter(
     (c) => c.includes('[ferry:iterator:') && c.includes('complete. Pushed fixes to PR#'),
   ).length;
@@ -247,7 +255,8 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
   // Pre-loop setup: builds system prompt, ticket block, initial prompt, and
   // the capability-filtered MCP pool. Extracted into a reusable prepare
   // function (#330) so the future cc-prepare composite (#331) consumes the
-  // same source.
+  // same source. `capabilities` and `idempotencyMarker` are threaded in
+  // from the action (single source of truth — see `RolePreparedContextBase`).
   const prepared = prepareIterator({
     ticketKey,
     issue,
@@ -257,13 +266,12 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     existingLog,
     mcpPool,
     configLabels: effectiveCfg.labels,
+    capabilities,
+    idempotencyMarker,
     typeOverride,
     repoRoot: REPO_ROOT,
-    logger,
   });
-  const { system, initialPrompt, mcpServers, capabilities } = prepared;
-
-  logCapabilities(logger, capabilities);
+  const { system, initialPrompt, mcpServers } = prepared;
 
   const secretScan = makeSecretScan(REPO_ROOT);
 

--- a/src/agents/iterator/iterate-action.ts
+++ b/src/agents/iterator/iterate-action.ts
@@ -1,5 +1,4 @@
 import { execFileSync } from 'node:child_process';
-import { delimitUntrusted } from '../../lib/llm/delimit-untrusted.js';
 import { checkIdempotencyMarker } from '../../lib/io/idempotency.js';
 import { TOOL_SCHEMAS, COMMIT_PROGRESS_SCHEMA, executeTool } from '../developer/tools.js';
 import { createAgentLoop } from '../../lib/llm/agent-loop/index.js';
@@ -8,8 +7,6 @@ import { checkIterationCap } from './cap.js';
 import { decideIteratorTransition } from './transition.js';
 import { formatCommitMessage } from './prompt.js';
 import {
-  resolveCapabilities,
-  filterMcpServers,
   resolveTicketOverrides,
   applyTicketOverrides,
   hasNonDefaultOverrides,
@@ -22,8 +19,6 @@ import {
 import {
   requireEnv,
   loadMcpServers,
-  buildSystem,
-  buildTicketBlock,
   appendOutput,
   writeStepSummary,
   configureFerryGitUser,
@@ -39,6 +34,7 @@ import {
   loadFerryConfigFromBaseBranch,
   byEventId,
   byPrHeadSha,
+  prepareIterator,
 } from '../../lib/agent-runtime/index.js';
 import type { EventEnvelopeV1 } from '../../lib/envelope/types.js';
 import type { Logger } from '../../lib/agent-runtime/index.js';
@@ -146,11 +142,6 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
 
   const { provider: iterProvider, model } = effectiveCfg.models.iterate;
   const mcpPool = loadMcpServers();
-  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
-  const hasLabelsConfig = effectiveCfg.labels !== undefined;
-  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
-
-  logCapabilities(logger, capabilities);
 
   const priorIterations = existingComments.filter(
     (c) => c.includes('[ferry:iterator:') && c.includes('complete. Pushed fixes to PR#'),
@@ -235,8 +226,6 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     return;
   }
 
-  const system = buildSystem('iterate', REPO_ROOT);
-
   configureFerryGitUser(REPO_ROOT);
 
   if (checkoutExistingBranch(branchName, REPO_ROOT) === 'not-found') {
@@ -255,26 +244,26 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     encoding: 'utf8',
   }).trim();
 
-  const ticketBlock = buildTicketBlock(ticketKey, issue, {
+  // Pre-loop setup: builds system prompt, ticket block, initial prompt, and
+  // the capability-filtered MCP pool. Extracted into a reusable prepare
+  // function (#330) so the future cc-prepare composite (#331) consumes the
+  // same source.
+  const prepared = prepareIterator({
+    ticketKey,
+    issue,
+    headSha,
+    reviewComment,
+    mergeConflicts,
+    existingLog,
+    mcpPool,
+    configLabels: effectiveCfg.labels,
     typeOverride,
+    repoRoot: REPO_ROOT,
+    logger,
   });
+  const { system, initialPrompt, mcpServers, capabilities } = prepared;
 
-  const initialPrompt = [
-    '## Jira Ticket',
-    delimitUntrusted(ticketBlock),
-    '',
-    '## Review Findings (fix only what is listed here)',
-    delimitUntrusted(reviewComment),
-    '',
-    mergeConflicts.length > 0
-      ? `## Merge Conflicts (resolve these first, before fixing review findings)\n${mergeConflicts.map((f) => `- ${f}`).join('\n')}`
-      : '',
-    existingLog ? `## Existing commits on branch\n${existingLog}` : '',
-    '',
-    'When you have fixed all findings, call the `done` tool.',
-  ]
-    .filter(Boolean)
-    .join('\n');
+  logCapabilities(logger, capabilities);
 
   const secretScan = makeSecretScan(REPO_ROOT);
 

--- a/src/agents/refiner/refiner-action.ts
+++ b/src/agents/refiner/refiner-action.ts
@@ -14,6 +14,7 @@ import {
   applyDryRunMarker,
   LabelConflictError,
   logTicketOverrides,
+  prepareRefiner,
 } from '../../lib/agent-runtime/index.js';
 import type { Logger } from '../../lib/agent-runtime/index.js';
 import { runRefiner } from './refine.js';
@@ -24,8 +25,6 @@ import type { LlmCall } from './refine.js';
 import type { EventEnvelopeV1 } from '../../lib/envelope/types.js';
 
 const REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
-
-const PRIOR_RUN_MARKER = /\[ferry:refiner:[^\]]+\]/;
 
 export interface RefinerActionDeps {
   tracker: IssueTracker;
@@ -44,11 +43,12 @@ export async function run(envelope: EventEnvelopeV1, deps: RefinerActionDeps): P
   const logger = deps.logger ?? createLogger(eventId, 'ferry:refiner-action');
   const dryRun = isDryRun() || deps.dryRun === true;
 
-  const issue = await deps.tracker.getIssue(ticketKey);
-  const runLink = `https://github.com/${process.env.GITHUB_REPO ?? 'unknown'}/actions/runs/${process.env.GITHUB_RUN_ID ?? '0'}`;
-
-  const existingSubtasks = await deps.tracker.getSubtaskDetails(ticketKey);
-  const priorRefinerRuns = issue.comments.filter((c) => PRIOR_RUN_MARKER.test(c));
+  // Pre-loop setup: fetches the Jira issue, existing subtasks, prior refiner
+  // runs, and computes the runLink + idempotency marker. Extracted into a
+  // reusable prepare function (#330) so the future cc-prepare composite (#331)
+  // consumes the same source.
+  const prepared = await prepareRefiner({ envelope, tracker: deps.tracker });
+  const { issue, existingSubtasks, priorRefinerRuns, runLink, idempotencyMarker } = prepared;
 
   const { plan, auditSummary } = await runRefiner({
     ticket: {
@@ -134,8 +134,6 @@ export async function run(envelope: EventEnvelopeV1, deps: RefinerActionDeps): P
     existingSubtasks,
     tracker: deps.tracker,
   });
-
-  const idempotencyMarker = `[ferry:refiner:${eventId}]`;
 
   if (result.noop) {
     logger.info('noop — existing sub-tasks still valid', { ticket: ticketKey });

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -213,7 +213,8 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
   // overlay + rubric override), the initial prompt, the filename→patch map,
   // and the capability-filtered MCP pool. Extracted into a reusable prepare
   // function (#330) so the future cc-prepare composite (#331) consumes the
-  // same source.
+  // same source. `capabilities` and `idempotencyMarker` are threaded in
+  // from the action (single source of truth — see `RolePreparedContextBase`).
   const prepared = prepareReviewer({
     ticketKey,
     issue,
@@ -223,9 +224,9 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     branchName,
     typeOverride,
     reviewRubric: reviewRubricOverride,
-    configLabels: effectiveCfg.labels,
+    capabilities,
+    idempotencyMarker,
     repoRoot: REPO_ROOT,
-    logger,
   });
   const { system, initialPrompt, fileMap } = prepared;
 

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -1,9 +1,7 @@
 import { createToolCallLoop } from '../../lib/llm/tool-loop/index.js';
-import { delimitUntrusted } from '../../lib/llm/delimit-untrusted.js';
 import { checkIdempotencyMarker } from '../../lib/io/idempotency.js';
 import { gateCi } from './ci-gate.js';
-import { detectMergeConflicts, buildFileList, runReviewLoop } from './review-loop.js';
-import { applyRubricToPrompt } from './rubric.js';
+import { runReviewLoop } from './review-loop.js';
 import {
   resolveCapabilities,
   resolveTicketOverrides,
@@ -18,9 +16,6 @@ import {
   requireEnv,
   appendOutput,
   writeStepSummary,
-  buildSystem,
-  loadOptionalPrompt,
-  buildTicketBlock,
   createGitHubContext,
   resolveGitConfig,
   resolveBranchPrefix,
@@ -29,6 +24,7 @@ import {
   logTicketOverrides,
   byEventId,
   byPrHeadSha,
+  prepareReviewer,
 } from '../../lib/agent-runtime/index.js';
 import { countPriorIterations } from './changes-guard.js';
 import type { EventEnvelopeV1 } from '../../lib/envelope/types.js';
@@ -131,7 +127,6 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
   // Fetch the full PR to get the `mergeable` field (not available in list response)
   const pr = await runner.getPR({ owner, repo, prNumber });
   const headSha = pr.headSha;
-  const mergeable = pr.mergeable;
 
   // Idempotency keyed on head SHA — a new push always produces a new SHA,
   // so the review runs fresh after each iteration regardless of event_id.
@@ -210,55 +205,30 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     return;
   }
 
-  // Fetch ALL PR files (paginated)
+  // Fetch ALL PR files (paginated) + commits for context.
   const files = await runner.listPRFiles({ owner, repo, prNumber });
-  const fileMap = new Map<string, string | undefined>(files.map((f) => [f.filename, f.patch]));
-
-  // Detect merge conflicts in patches
-  const conflictedFiles = detectMergeConflicts(files);
-  const hasMergeConflicts = mergeable === false || conflictedFiles.length > 0;
-
-  // Fetch commits for context
   const commits = await runner.listPRCommits({ owner, repo, prNumber });
-  const commitLog = commits
-    .map((c) => `${c.sha.slice(0, 7)} ${c.message.split('\n')[0]}`)
-    .join('\n');
 
-  const ticketBlock = buildTicketBlock(ticketKey, issue, {
+  // Pre-loop setup: builds the reviewer system prompt (with review-comment
+  // overlay + rubric override), the initial prompt, the filename→patch map,
+  // and the capability-filtered MCP pool. Extracted into a reusable prepare
+  // function (#330) so the future cc-prepare composite (#331) consumes the
+  // same source.
+  const prepared = prepareReviewer({
+    ticketKey,
+    issue,
+    pr,
+    files,
+    commits,
+    branchName,
     typeOverride,
+    reviewRubric: reviewRubricOverride,
+    configLabels: effectiveCfg.labels,
+    repoRoot: REPO_ROOT,
+    logger,
   });
+  const { system, initialPrompt, fileMap } = prepared;
 
-  const mergeConflictWarning = hasMergeConflicts
-    ? `\n⚠️  MERGE CONFLICTS DETECTED — mergeable=${String(mergeable)}${conflictedFiles.length > 0 ? `, conflicted files: ${conflictedFiles.join(', ')}` : ''}`
-    : '';
-
-  const initialPrompt = [
-    '## Jira Ticket',
-    delimitUntrusted(ticketBlock),
-    '',
-    '## PR Metadata',
-    `PR #${prNumber}: ${pr.title}`,
-    `Base: ${pr.baseRef} ← Head: ${branchName} (${headSha.slice(0, 7)})`,
-    `Files changed: ${files.length}  Commits: ${commits.length}`,
-    mergeConflictWarning,
-    '',
-    '## Commits',
-    commitLog,
-    '',
-    '## Changed files (status  +additions  -deletions  path)',
-    buildFileList(files),
-    '',
-    'Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.',
-    'When you have enough information, call finish_review.',
-  ]
-    .filter((l) => l !== null)
-    .join('\n');
-
-  const baseSystem = buildSystem('review', REPO_ROOT, {
-    extraParts: [loadOptionalPrompt('review-comment', REPO_ROOT)],
-    separator: '\n\n---\n\n',
-  });
-  const system = applyRubricToPrompt(baseSystem, reviewRubricOverride);
   const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
 
   const {

--- a/src/agents/reviewer/review-loop.ts
+++ b/src/agents/reviewer/review-loop.ts
@@ -64,21 +64,12 @@ export interface ReviewResult {
   comment: string;
 }
 
-export function detectMergeConflicts(files: PRFile[]): string[] {
-  const conflicted: string[] = [];
-  for (const f of files) {
-    if (f.patch && /^[+].*<{7}|^[+].*={7}|^[+].*>{7}/m.test(f.patch)) {
-      conflicted.push(f.filename);
-    }
-  }
-  return conflicted;
-}
-
-export function buildFileList(files: PRFile[]): string {
-  return files
-    .map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`)
-    .join('\n');
-}
+// The implementations of detectMergeConflicts and buildFileList live in
+// `src/lib/agent-runtime/reviewer-helpers.ts` so the lib layer's
+// reviewer-prepare can depend on them without inverting the
+// agents/** → lib/** layering. Re-exported here so existing import paths
+// under src/agents/reviewer/** stay valid.
+export { detectMergeConflicts, buildFileList } from '../../lib/agent-runtime/reviewer-helpers.js';
 
 export async function runReviewLoop(opts: {
   loop: ToolCallLoop;

--- a/src/agents/reviewer/rubric.ts
+++ b/src/agents/reviewer/rubric.ts
@@ -2,53 +2,10 @@
  * Reviewer rubric overlay — appended to the base reviewer system prompt when
  * `ferry:strict-review` or `ferry:lenient-review` is on the ticket.
  *
- * Kept short and append-only (not a base-prompt swap) so the rubric overlay
- * composes with the existing `prompts/review.md` and any optional
- * `prompts/review-comment.md` overlay. The directive is the LAST section of the
- * system prompt — it overrides earlier instructions about review strictness.
+ * The implementation lives in `src/lib/agent-runtime/reviewer-helpers.ts`
+ * (the lib layer cannot depend on agents/**, so the canonical location of
+ * the helper moved there in #330). This file is kept as a re-export so the
+ * reviewer agent's existing import paths stay valid.
  */
 
-import type { TicketOverrides } from '../../lib/agent-runtime/index.js';
-
-const STRICT_DIRECTIVE = [
-  '## Rubric override — strict',
-  '',
-  'For this review, apply a STRICTER bar than usual:',
-  '',
-  '- Block on any missing test coverage for new/changed behaviour.',
-  '- Block on missing edge-case handling, error paths, or input validation.',
-  '- Block on weak naming, dead code, or unreachable branches.',
-  '- Block on incomplete documentation when public APIs change.',
-  '- Approve only when every acceptance criterion is fully satisfied with concrete evidence.',
-].join('\n');
-
-const LENIENT_DIRECTIVE = [
-  '## Rubric override — lenient',
-  '',
-  'For this review, apply a MORE PERMISSIVE bar than usual:',
-  '',
-  '- Approve when the acceptance criteria are met, even if minor polish is missing.',
-  '- Treat naming nits, non-blocking style issues, and stylistic preferences as comments — not blockers.',
-  '- Block only on: failing tests, unimplemented ACs, merge conflicts, committed build artefacts, or security regressions.',
-  '- Prefer "approve with comments" over "request changes" when issues are non-blocking.',
-].join('\n');
-
-/**
- * Appends a rubric-override directive to the reviewer system prompt.
- *
- * - `rubric === 'strict'`  → appends the strict directive.
- * - `rubric === 'lenient'` → appends the lenient directive.
- * - `rubric === undefined` → returns `basePrompt` unchanged.
- *
- * The directive is appended (not substituted) so it composes with the base
- * prompt and any optional overlay. It is placed last, so it wins when it
- * disagrees with earlier sections.
- */
-export function applyRubricToPrompt(
-  basePrompt: string,
-  rubric: TicketOverrides['reviewRubric'],
-): string {
-  if (rubric === undefined) return basePrompt;
-  const directive = rubric === 'strict' ? STRICT_DIRECTIVE : LENIENT_DIRECTIVE;
-  return `${basePrompt}\n\n---\n\n${directive}`;
-}
+export { applyRubricToPrompt } from '../../lib/agent-runtime/reviewer-helpers.js';

--- a/src/lib/agent-runtime/developer-prepare.test.ts
+++ b/src/lib/agent-runtime/developer-prepare.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { prepareDeveloper, type BranchCheckoutResult } from './developer-prepare.js';
+import { createLogger } from '../logger/index.js';
+import type { TrackerIssue } from '../io/tracker/types.js';
+import type { CIRunner } from '../dispatch/runner/types.js';
+import type { FerryConfig } from '../config.js';
+import type { EventEnvelopeV1 } from '../envelope/types.js';
+import type { McpServerConfig } from '../llm/agent-loop/types.js';
+
+const REPO_ROOT = '/workspace/repo';
+
+const envelope: EventEnvelopeV1 = {
+  version: 'v1',
+  event_id: 'evt-dev-001',
+  ticket_key: 'PROJ-400',
+  phase: 'dev',
+  source: 'jira-column',
+  ts: '2026-01-01T00:00:00Z',
+};
+
+const issue: TrackerIssue = {
+  key: 'PROJ-400',
+  summary: 'Implement signup',
+  description: 'AC: signup endpoint',
+  comments: ['First comment', 'Second comment'],
+  labels: ['ferry:dev'],
+  issueType: 'Story',
+  issueTypeRaw: 'Story',
+};
+
+const effectiveCfg = {
+  models: { dev: { provider: 'anthropic', model: 'claude-opus-4-7' } },
+  git: { working_branch_prefix: 'ferry/feat/' },
+  labels: undefined,
+} as unknown as FerryConfig;
+
+const mcpPool: McpServerConfig[] = [{ name: 'context7', url: 'https://example.com' }];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeRunner(overrides: Partial<CIRunner> = {}): CIRunner {
+  return {
+    listPRsForBranch: vi.fn().mockResolvedValue([]),
+    listPRFiles: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  } as unknown as CIRunner;
+}
+
+function buildSystemStub(name: string, _root: string, opts?: { extraParts?: unknown[] }) {
+  return `SYSTEM(${name}, parts=${(opts?.extraParts ?? []).length})`;
+}
+
+describe('prepareDeveloper', () => {
+  it('builds system, ticket block, initial prompt, idempotency marker and capability-filtered MCP pool', async () => {
+    const checkoutOrCreateBranch = vi.fn(
+      (): BranchCheckoutResult => ({ branchHeadSha: '', existingLog: '' }),
+    );
+    const ctx = await prepareDeveloper({
+      envelope,
+      issue,
+      effectiveCfg,
+      subtasks: ['Step one', 'Step two'],
+      testRunner: 'vitest',
+      pkgManagerHint: 'npm',
+      tree: 'src/\n  index.ts',
+      typeOverride: undefined,
+      owner: 'big-emotion',
+      repo: 'ferry',
+      baseBranch: 'main',
+      runner: makeRunner(),
+      mcpPool,
+      repoRoot: REPO_ROOT,
+      dryRun: false,
+      logger: createLogger('evt-dev-001', 'test'),
+      _buildSystem: buildSystemStub,
+      _checkoutOrCreateBranch: checkoutOrCreateBranch,
+      _configureGitUser: () => {},
+    });
+
+    expect(ctx.system).toBe('SYSTEM(dev, parts=1)');
+    expect(ctx.branchName).toBe('ferry/feat/PROJ-400');
+    expect(ctx.branchHeadSha).toBe('');
+    // No existing branch → idempotency falls back to event_id
+    expect(ctx.idempotencyMarker).toBe('[ferry:dev:evt-dev-001]');
+    expect(ctx.existingPrUrl).toBe('');
+    expect(ctx.ticketBlock).toContain('TICKET: PROJ-400');
+    expect(ctx.ticketBlock).toContain('LABELS: ferry:dev');
+    expect(ctx.initialPrompt).toContain('TICKET: PROJ-400');
+    expect(ctx.initialPrompt).toContain('SUBTASKS:\nStep one\nStep two');
+    expect(ctx.initialPrompt).toContain('TEST_RUNNER: vitest');
+    expect(ctx.initialPrompt).toContain('REPO TREE (depth 2):\nsrc/\n  index.ts');
+    expect(ctx.initialPrompt).toContain(
+      'When you have finished implementing, call the `done` tool.',
+    );
+    expect(checkoutOrCreateBranch).toHaveBeenCalledWith(
+      'ferry/feat/PROJ-400',
+      'main',
+      REPO_ROOT,
+      expect.any(Object),
+    );
+  });
+
+  it('uses "SUBTASKS: (none)" when there are no subtasks', async () => {
+    const ctx = await prepareDeveloper({
+      envelope,
+      issue,
+      effectiveCfg,
+      subtasks: [],
+      testRunner: 'vitest',
+      pkgManagerHint: undefined,
+      tree: '(unavailable)',
+      typeOverride: undefined,
+      owner: 'o',
+      repo: 'r',
+      baseBranch: 'main',
+      runner: makeRunner(),
+      mcpPool,
+      repoRoot: REPO_ROOT,
+      dryRun: false,
+      logger: createLogger('evt', 'test'),
+      _buildSystem: buildSystemStub,
+      _checkoutOrCreateBranch: () => ({ branchHeadSha: '', existingLog: '' }),
+      _configureGitUser: () => {},
+    });
+
+    expect(ctx.initialPrompt).toContain('SUBTASKS: (none)');
+    // No pkgManagerHint → no extra part
+    expect(ctx.system).toBe('SYSTEM(dev, parts=0)');
+  });
+
+  it('keys the idempotency marker on the branch head SHA when the branch already exists', async () => {
+    const ctx = await prepareDeveloper({
+      envelope,
+      issue,
+      effectiveCfg,
+      subtasks: [],
+      testRunner: 'vitest',
+      pkgManagerHint: 'npm',
+      tree: '',
+      typeOverride: undefined,
+      owner: 'o',
+      repo: 'r',
+      baseBranch: 'main',
+      runner: makeRunner(),
+      mcpPool,
+      repoRoot: REPO_ROOT,
+      dryRun: false,
+      logger: createLogger('evt', 'test'),
+      _buildSystem: buildSystemStub,
+      _checkoutOrCreateBranch: () => ({
+        branchHeadSha: 'abcdef1234567890',
+        existingLog: 'aaa1111 prior work',
+      }),
+      _configureGitUser: () => {},
+    });
+
+    expect(ctx.branchHeadSha).toBe('abcdef1234567890');
+    expect(ctx.idempotencyMarker).toBe('[ferry:dev:abcdef1]');
+    expect(ctx.initialPrompt).toContain(
+      'EXISTING WORK ON BRANCH (already committed — skip these, only do what remains):\naaa1111 prior work',
+    );
+  });
+
+  it('injects an existing-PR context section when an open Ferry PR is found on the branch', async () => {
+    const listPRsForBranch = vi.fn().mockResolvedValue([{ number: 99 }]);
+    const listPRFiles = vi.fn().mockResolvedValue([
+      { filename: 'src/foo.ts', status: 'modified' },
+      { filename: 'src/bar.ts', status: 'added' },
+    ]);
+    const runner = makeRunner({ listPRsForBranch, listPRFiles });
+
+    const ctx = await prepareDeveloper({
+      envelope,
+      issue,
+      effectiveCfg,
+      subtasks: [],
+      testRunner: 'vitest',
+      pkgManagerHint: 'npm',
+      tree: '',
+      typeOverride: undefined,
+      owner: 'big-emotion',
+      repo: 'ferry',
+      baseBranch: 'main',
+      runner,
+      mcpPool,
+      repoRoot: REPO_ROOT,
+      dryRun: false,
+      logger: createLogger('evt', 'test'),
+      _buildSystem: buildSystemStub,
+      _checkoutOrCreateBranch: () => ({ branchHeadSha: 'abcdef1234567890', existingLog: '' }),
+      _configureGitUser: () => {},
+    });
+
+    expect(ctx.existingPrUrl).toBe('https://github.com/big-emotion/ferry/pull/99');
+    expect(ctx.initialPrompt).toContain('EXISTING_IMPLEMENTATION:');
+    expect(ctx.initialPrompt).toContain('Open PR: https://github.com/big-emotion/ferry/pull/99');
+    expect(ctx.initialPrompt).toContain('Changed files:\nmodified: src/foo.ts\nadded: src/bar.ts');
+    expect(listPRsForBranch).toHaveBeenCalledWith('big-emotion', 'ferry', 'ferry/feat/PROJ-400');
+  });
+
+  it('skips the PR probe under dryRun, even when a branch head SHA is known', async () => {
+    const listPRsForBranch = vi.fn().mockResolvedValue([{ number: 99 }]);
+    const runner = makeRunner({ listPRsForBranch });
+
+    const ctx = await prepareDeveloper({
+      envelope,
+      issue,
+      effectiveCfg,
+      subtasks: [],
+      testRunner: 'vitest',
+      pkgManagerHint: undefined,
+      tree: '',
+      typeOverride: undefined,
+      owner: 'o',
+      repo: 'r',
+      baseBranch: 'main',
+      runner,
+      mcpPool,
+      repoRoot: REPO_ROOT,
+      dryRun: true,
+      logger: createLogger('evt', 'test'),
+      _buildSystem: buildSystemStub,
+      _checkoutOrCreateBranch: () => ({ branchHeadSha: 'sha1234567890', existingLog: '' }),
+      _configureGitUser: () => {},
+    });
+
+    expect(listPRsForBranch).not.toHaveBeenCalled();
+    expect(ctx.existingPrUrl).toBe('');
+    expect(ctx.initialPrompt).not.toContain('EXISTING_IMPLEMENTATION:');
+  });
+
+  it('treats PR-probe failures as best-effort and continues with empty existingPrContext', async () => {
+    const listPRsForBranch = vi.fn().mockRejectedValue(new Error('GitHub 5xx'));
+    const runner = makeRunner({ listPRsForBranch });
+
+    const ctx = await prepareDeveloper({
+      envelope,
+      issue,
+      effectiveCfg,
+      subtasks: [],
+      testRunner: 'vitest',
+      pkgManagerHint: undefined,
+      tree: '',
+      typeOverride: undefined,
+      owner: 'o',
+      repo: 'r',
+      baseBranch: 'main',
+      runner,
+      mcpPool,
+      repoRoot: REPO_ROOT,
+      dryRun: false,
+      logger: createLogger('evt', 'test'),
+      _buildSystem: buildSystemStub,
+      _checkoutOrCreateBranch: () => ({ branchHeadSha: 'sha1234567890', existingLog: '' }),
+      _configureGitUser: () => {},
+    });
+
+    expect(ctx.existingPrUrl).toBe('');
+    expect(ctx.initialPrompt).not.toContain('EXISTING_IMPLEMENTATION:');
+  });
+
+  it('invokes _configureGitUser exactly once', async () => {
+    const configureSpy = vi.fn();
+    await prepareDeveloper({
+      envelope,
+      issue,
+      effectiveCfg,
+      subtasks: [],
+      testRunner: 'vitest',
+      pkgManagerHint: undefined,
+      tree: '',
+      typeOverride: undefined,
+      owner: 'o',
+      repo: 'r',
+      baseBranch: 'main',
+      runner: makeRunner(),
+      mcpPool,
+      repoRoot: REPO_ROOT,
+      dryRun: false,
+      logger: createLogger('evt', 'test'),
+      _buildSystem: buildSystemStub,
+      _checkoutOrCreateBranch: () => ({ branchHeadSha: '', existingLog: '' }),
+      _configureGitUser: configureSpy,
+    });
+
+    expect(configureSpy).toHaveBeenCalledTimes(1);
+    expect(configureSpy).toHaveBeenCalledWith(REPO_ROOT);
+  });
+});

--- a/src/lib/agent-runtime/developer-prepare.test.ts
+++ b/src/lib/agent-runtime/developer-prepare.test.ts
@@ -261,6 +261,48 @@ describe('prepareDeveloper', () => {
     expect(ctx.initialPrompt).not.toContain('EXISTING_IMPLEMENTATION:');
   });
 
+  it('filters the MCP pool down to capability-triggered servers when labels config is provided', async () => {
+    const cfgWithLabels = {
+      ...effectiveCfg,
+      labels: {
+        'ferry:docs': { mcp_servers: ['context7'] },
+      },
+    } as unknown as FerryConfig;
+    const issueWithLabel: TrackerIssue = {
+      ...issue,
+      labels: ['ferry:docs'],
+    };
+    const richMcpPool: McpServerConfig[] = [
+      { name: 'context7', url: 'https://example.com/c7' },
+      { name: 'jira', url: 'https://example.com/jira' },
+    ];
+
+    const ctx = await prepareDeveloper({
+      envelope,
+      issue: issueWithLabel,
+      effectiveCfg: cfgWithLabels,
+      subtasks: [],
+      testRunner: 'vitest',
+      pkgManagerHint: undefined,
+      tree: '',
+      typeOverride: undefined,
+      owner: 'o',
+      repo: 'r',
+      baseBranch: 'main',
+      runner: makeRunner(),
+      mcpPool: richMcpPool,
+      repoRoot: REPO_ROOT,
+      dryRun: false,
+      logger: createLogger('evt', 'test'),
+      _buildSystem: buildSystemStub,
+      _checkoutOrCreateBranch: () => ({ branchHeadSha: '', existingLog: '' }),
+      _configureGitUser: () => {},
+    });
+
+    // Only context7 should remain — jira is not enabled by the ferry:docs label.
+    expect(ctx.mcpServers.map((s) => s.name)).toEqual(['context7']);
+  });
+
   it('invokes _configureGitUser exactly once', async () => {
     const configureSpy = vi.fn();
     await prepareDeveloper({

--- a/src/lib/agent-runtime/developer-prepare.ts
+++ b/src/lib/agent-runtime/developer-prepare.ts
@@ -1,0 +1,249 @@
+/**
+ * Developer role pre-loop setup (issue #330).
+ *
+ * Extracted from `src/agents/developer/dev-action.ts`. Builds the developer
+ * system prompt, ticket block, initial prompt, capability-filtered MCP pool,
+ * idempotency marker, and (best-effort) existing-PR context. Performs the
+ * branch checkout / create via an injectable helper so the function stays
+ * testable without spinning up git.
+ *
+ * The action calls this AFTER label-override resolution, base/target branch
+ * validation, and any `process.exit` short-circuits — the prepare function
+ * has no Jira side effects, no `process.exit`, and only the git/GitHub reads
+ * the dev workflow has always performed.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { delimitUntrusted } from '../llm/delimit-untrusted.js';
+import { configureFerryGitUser as defaultConfigureFerryGitUser } from './git.js';
+import { byEventId, byPrHeadSha } from './idempotency.js';
+import { buildSystem as defaultBuildSystem, buildTicketBlock } from './prompt.js';
+import { resolveBranchPrefix } from './resolve-git-config.js';
+import {
+  resolveCapabilities,
+  filterMcpServers,
+  type ResolvedCapabilities,
+} from '../labels/capabilities.js';
+import type { McpServerConfig } from '../llm/agent-loop/types.js';
+import type { CIRunner } from '../dispatch/runner/types.js';
+import type { TrackerIssue } from '../io/tracker/types.js';
+import type { FerryConfig } from '../config.js';
+import type { EventEnvelopeV1 } from '../envelope/types.js';
+import type { Logger } from '../logger/index.js';
+import type { RolePreparedContextBase } from './prepare.js';
+
+export interface BranchCheckoutResult {
+  /** HEAD SHA after checkout, or "" when a fresh branch was just created. */
+  branchHeadSha: string;
+  /** Trimmed `git log origin/<base>..HEAD --oneline` — empty if no prior commits. */
+  existingLog: string;
+}
+
+export type CheckoutOrCreateBranchFn = (
+  branchName: string,
+  baseBranch: string,
+  repoRoot: string,
+  logger: Logger,
+) => BranchCheckoutResult;
+
+/**
+ * Default branch checkout: try to fetch/checkout the existing branch on
+ * origin; on any failure create a fresh local branch from the current HEAD.
+ * Mirrors the original inline logic in `dev-action.ts` verbatim.
+ */
+export const checkoutOrCreateBranchDefault: CheckoutOrCreateBranchFn = (
+  branchName,
+  baseBranch,
+  repoRoot,
+  logger,
+) => {
+  try {
+    execFileSync('git', ['ls-remote', '--exit-code', '--heads', 'origin', branchName], {
+      cwd: repoRoot,
+      stdio: 'pipe',
+    });
+    execFileSync('git', ['fetch', 'origin', branchName], { cwd: repoRoot });
+    execFileSync('git', ['checkout', branchName], { cwd: repoRoot });
+    const existingLog = execFileSync('git', ['log', `origin/${baseBranch}..HEAD`, '--oneline'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    }).trim();
+    if (existingLog) {
+      logger.info('resuming branch', {
+        branch: branchName,
+        prior_commits: existingLog.split('\n').length,
+      });
+    }
+    const branchHeadSha = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    }).trim();
+    return { branchHeadSha, existingLog };
+  } catch {
+    execFileSync('git', ['checkout', '-B', branchName], { cwd: repoRoot });
+    logger.info('created branch', { branch: branchName });
+    return { branchHeadSha: '', existingLog: '' };
+  }
+};
+
+export interface PrepareDeveloperInput {
+  envelope: EventEnvelopeV1;
+  issue: TrackerIssue;
+  effectiveCfg: FerryConfig;
+  /** From `tracker.getSubtasks(ticketKey)` — already fetched by the action. */
+  subtasks: string[];
+  /** From `detectTestRunner(packageJsonPath(...))`. */
+  testRunner: string;
+  /** From `detectPackageManager(...)`; null/undefined hide the extra system-prompt part. */
+  pkgManagerHint: string | null | undefined;
+  /** From `repoTree(...)`. */
+  tree: string;
+  typeOverride: string | undefined;
+  owner: string;
+  repo: string;
+  baseBranch: string;
+  runner: CIRunner;
+  mcpPool: McpServerConfig[];
+  repoRoot: string;
+  dryRun: boolean;
+  logger: Logger;
+  /** Test seam — defaults to the real `buildSystem`. */
+  _buildSystem?: typeof defaultBuildSystem;
+  /** Test seam — defaults to executing git commands. */
+  _checkoutOrCreateBranch?: CheckoutOrCreateBranchFn;
+  /** Test seam — defaults to `configureFerryGitUser`. */
+  _configureGitUser?: (repoRoot: string) => void;
+}
+
+export interface DeveloperPreparedContext extends RolePreparedContextBase {
+  capabilities: ResolvedCapabilities;
+  /** Working branch name derived from `working_branch_prefix` + ticket key. */
+  branchName: string;
+  /** Empty when a fresh branch was just created; otherwise the HEAD SHA. */
+  branchHeadSha: string;
+  /** Empty when no open Ferry PR exists on the branch (or dry-run skipped the probe). */
+  existingPrUrl: string;
+  /** Original (pre-concatenation) initial prompt — exposed for the cc-prepare composite. */
+  baseInitialPrompt: string;
+  /** Subtasks list — forwarded for downstream PR-body construction. */
+  subtasks: string[];
+}
+
+export async function prepareDeveloper(
+  input: PrepareDeveloperInput,
+): Promise<DeveloperPreparedContext> {
+  const {
+    envelope,
+    issue,
+    effectiveCfg,
+    subtasks,
+    testRunner,
+    pkgManagerHint,
+    tree,
+    typeOverride,
+    owner,
+    repo,
+    baseBranch,
+    runner,
+    mcpPool,
+    repoRoot,
+    dryRun,
+    logger,
+  } = input;
+  const buildSystem = input._buildSystem ?? defaultBuildSystem;
+  const checkoutOrCreateBranch = input._checkoutOrCreateBranch ?? checkoutOrCreateBranchDefault;
+  const configureGitUser = input._configureGitUser ?? defaultConfigureFerryGitUser;
+
+  const ticketKey = envelope.ticket_key;
+  const eventId = envelope.event_id;
+
+  const labels = issue.labels.join(', ');
+  const comments = issue.comments.map((c) => `Comment: ${c}`).join('\n');
+  const ticketBlock = buildTicketBlock(ticketKey, issue, {
+    labels,
+    comments,
+    typeOverride,
+  });
+
+  const system = buildSystem('dev', repoRoot, {
+    extraParts: pkgManagerHint ? [`## Detected package manager\n\n${pkgManagerHint}`] : [],
+  });
+
+  // Branch is determined upfront from the ticket key so restarts resume the same branch.
+  const branchName = `${resolveBranchPrefix(effectiveCfg.git.working_branch_prefix, issue)}${ticketKey}`;
+
+  configureGitUser(repoRoot);
+
+  const { branchHeadSha, existingLog } = checkoutOrCreateBranch(
+    branchName,
+    baseBranch,
+    repoRoot,
+    logger,
+  );
+
+  const resumeContext = existingLog
+    ? `\nEXISTING WORK ON BRANCH (already committed — skip these, only do what remains):\n${existingLog}`
+    : '';
+
+  // Pre-flight: check for an open Ferry PR on this branch and inject context.
+  let existingPrUrl = '';
+  let existingPrContext = '';
+  if (branchHeadSha && !dryRun) {
+    try {
+      const openPrs = await runner.listPRsForBranch(owner, repo, branchName);
+      if (openPrs.length > 0) {
+        const pr = openPrs[0];
+        existingPrUrl = `https://github.com/${owner}/${repo}/pull/${pr.number}`;
+        const prRef = { owner, repo, prNumber: pr.number };
+        const prFiles = await runner.listPRFiles(prRef);
+        const fileList = prFiles.map((f) => `${f.status}: ${f.filename}`).join('\n');
+        existingPrContext = [
+          `\nEXISTING_IMPLEMENTATION:`,
+          `Open PR: ${existingPrUrl} (head: ${branchHeadSha.slice(0, 7)})`,
+          `Changed files:\n${fileList}`,
+          `If the spec is already fully satisfied by the existing code, call \`done\` with outcome="already_satisfied".`,
+        ].join('\n');
+        logger.info('existing PR found', { pr: existingPrUrl, files: prFiles.length });
+      }
+    } catch {
+      // best-effort: if PR check fails, proceed without context
+    }
+  }
+
+  // Idempotency marker: keyed on branch head SHA so re-runs on the same state collapse.
+  const idempotencyMarker = branchHeadSha
+    ? byPrHeadSha('dev', branchHeadSha)
+    : byEventId('dev', eventId);
+
+  const baseInitialPrompt = [
+    delimitUntrusted(ticketBlock),
+    '',
+    subtasks.length > 0 ? `SUBTASKS:\n${subtasks.join('\n')}` : 'SUBTASKS: (none)',
+    '',
+    `TEST_RUNNER: ${testRunner}`,
+    '',
+    `REPO TREE (depth 2):\n${tree}`,
+    '',
+    'When you have finished implementing, call the `done` tool.',
+  ].join('\n');
+
+  const initialPrompt = baseInitialPrompt + resumeContext + existingPrContext;
+
+  const capabilities = resolveCapabilities(issue.labels, effectiveCfg.labels);
+  const hasLabelsConfig = effectiveCfg.labels !== undefined;
+  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+
+  return {
+    system,
+    initialPrompt,
+    baseInitialPrompt,
+    mcpServers,
+    idempotencyMarker,
+    ticketBlock,
+    subtasks,
+    capabilities,
+    branchName,
+    branchHeadSha,
+    existingPrUrl,
+  };
+}

--- a/src/lib/agent-runtime/index.ts
+++ b/src/lib/agent-runtime/index.ts
@@ -46,3 +46,23 @@ export {
   buildConflictComment,
   applyDryRunMarker,
 } from '../labels/overrides.js';
+
+// Per-role pre-loop setup (issue #330). Each agent's *-action.ts delegates the
+// stateful, side-effect-light setup chunk (system + initialPrompt + MCP filter
+// + idempotency marker + branch/PR probe) to these prepare functions, so the
+// future cc-prepare composite can feed `buildClaudeCodeJob` from the same
+// source. The shared base type lives in ./prepare.
+export type { RolePreparedContextBase } from './prepare.js';
+export { prepareRefiner } from './refiner-prepare.js';
+export type { PrepareRefinerInput, RefinerPreparedContext } from './refiner-prepare.js';
+export { prepareDeveloper, checkoutOrCreateBranchDefault } from './developer-prepare.js';
+export type {
+  PrepareDeveloperInput,
+  DeveloperPreparedContext,
+  BranchCheckoutResult,
+  CheckoutOrCreateBranchFn,
+} from './developer-prepare.js';
+export { prepareReviewer } from './reviewer-prepare.js';
+export type { PrepareReviewerInput, ReviewerPreparedContext } from './reviewer-prepare.js';
+export { prepareIterator } from './iterator-prepare.js';
+export type { PrepareIteratorInput, IteratorPreparedContext } from './iterator-prepare.js';

--- a/src/lib/agent-runtime/iterator-prepare.test.ts
+++ b/src/lib/agent-runtime/iterator-prepare.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { prepareIterator } from './iterator-prepare.js';
+import type { TrackerIssue } from '../io/tracker/types.js';
+import type { McpServerConfig } from '../llm/agent-loop/types.js';
+
+const REPO_ROOT = '/workspace/repo';
+
+const issue: TrackerIssue = {
+  key: 'PROJ-200',
+  summary: 'Fix the regression',
+  description: 'Steps to reproduce…',
+  comments: [],
+  labels: [],
+  issueType: 'Bug',
+  issueTypeRaw: 'Bug',
+};
+
+const mcpPool: McpServerConfig[] = [
+  { name: 'context7', url: 'https://mcp.context7.com/mcp' },
+  { name: 'jira', url: 'https://example.com/jira' },
+];
+
+const buildSystemStub = (name: string) => `SYSTEM(${name})`;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('prepareIterator', () => {
+  it('builds the iterator system prompt, ticket block, initial prompt and idempotency marker', () => {
+    const ctx = prepareIterator({
+      ticketKey: 'PROJ-200',
+      issue,
+      headSha: 'abcdef1234567890abcdef1234567890abcdef12',
+      reviewComment: 'CHANGES_REQUESTED: please fix the off-by-one in foo.ts.',
+      mergeConflicts: [],
+      existingLog: 'a1b2c3d feat: initial work',
+      mcpPool,
+      configLabels: undefined,
+      typeOverride: undefined,
+      repoRoot: REPO_ROOT,
+      _buildSystem: buildSystemStub,
+    });
+
+    expect(ctx.system).toBe('SYSTEM(iterate)');
+    expect(ctx.idempotencyMarker).toBe('[ferry:iterator:abcdef1]');
+    expect(ctx.ticketBlock).toContain('TICKET: PROJ-200');
+    expect(ctx.ticketBlock).toContain('TITLE: Fix the regression');
+    expect(ctx.initialPrompt).toContain('## Jira Ticket');
+    expect(ctx.initialPrompt).toContain('TICKET: PROJ-200');
+    expect(ctx.initialPrompt).toContain('## Review Findings (fix only what is listed here)');
+    expect(ctx.initialPrompt).toContain('CHANGES_REQUESTED: please fix the off-by-one in foo.ts.');
+    expect(ctx.initialPrompt).toContain(
+      '## Existing commits on branch\na1b2c3d feat: initial work',
+    );
+    expect(ctx.initialPrompt).toContain('When you have fixed all findings, call the `done` tool.');
+    expect(ctx.initialPrompt).not.toContain('## Merge Conflicts');
+  });
+
+  it('inserts a merge-conflict section when conflicts are present', () => {
+    const ctx = prepareIterator({
+      ticketKey: 'PROJ-200',
+      issue,
+      headSha: '1234567abcd',
+      reviewComment: 'CHANGES_REQUESTED',
+      mergeConflicts: ['src/a.ts', 'src/b.ts'],
+      existingLog: '',
+      mcpPool,
+      configLabels: undefined,
+      typeOverride: undefined,
+      repoRoot: REPO_ROOT,
+      _buildSystem: buildSystemStub,
+    });
+
+    expect(ctx.initialPrompt).toContain(
+      '## Merge Conflicts (resolve these first, before fixing review findings)\n- src/a.ts\n- src/b.ts',
+    );
+    expect(ctx.initialPrompt).not.toContain('## Existing commits on branch');
+  });
+
+  it('keeps the empty MCP pool when no labels config is provided (capabilities are empty)', () => {
+    const ctx = prepareIterator({
+      ticketKey: 'PROJ-200',
+      issue,
+      headSha: 'abcdef1',
+      reviewComment: '',
+      mergeConflicts: [],
+      existingLog: '',
+      mcpPool,
+      configLabels: undefined,
+      typeOverride: undefined,
+      repoRoot: REPO_ROOT,
+      _buildSystem: buildSystemStub,
+    });
+
+    // No labels config → hasLabelsConfig=false → filterMcpServers returns the pool unfiltered
+    expect(ctx.mcpServers).toEqual(mcpPool);
+    expect(ctx.capabilities.mcpServerNames).toEqual([]);
+  });
+
+  it('forwards the typeOverride into the ticket block', () => {
+    const ctx = prepareIterator({
+      ticketKey: 'PROJ-200',
+      issue,
+      headSha: 'abcdef1',
+      reviewComment: '',
+      mergeConflicts: [],
+      existingLog: '',
+      mcpPool,
+      configLabels: undefined,
+      typeOverride: 'Spike',
+      repoRoot: REPO_ROOT,
+      _buildSystem: buildSystemStub,
+    });
+
+    expect(ctx.ticketBlock).toContain('TYPE: Spike');
+  });
+});

--- a/src/lib/agent-runtime/iterator-prepare.test.ts
+++ b/src/lib/agent-runtime/iterator-prepare.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { prepareIterator } from './iterator-prepare.js';
 import type { TrackerIssue } from '../io/tracker/types.js';
 import type { McpServerConfig } from '../llm/agent-loop/types.js';
+import type { ResolvedCapabilities } from '../labels/capabilities.js';
+import type { LabelCapability } from '../config.js';
 
 const REPO_ROOT = '/workspace/repo';
 
@@ -20,6 +22,13 @@ const mcpPool: McpServerConfig[] = [
   { name: 'jira', url: 'https://example.com/jira' },
 ];
 
+const emptyCapabilities: ResolvedCapabilities = {
+  mcpServerNames: [],
+  serverAllowedTools: {},
+  triggeredLabels: [],
+  unknownFerryLabels: [],
+};
+
 const buildSystemStub = (name: string) => `SYSTEM(${name})`;
 
 afterEach(() => {
@@ -27,7 +36,7 @@ afterEach(() => {
 });
 
 describe('prepareIterator', () => {
-  it('builds the iterator system prompt, ticket block, initial prompt and idempotency marker', () => {
+  it('builds the iterator system prompt, ticket block, initial prompt and threads the idempotency marker', () => {
     const ctx = prepareIterator({
       ticketKey: 'PROJ-200',
       issue,
@@ -37,6 +46,8 @@ describe('prepareIterator', () => {
       existingLog: 'a1b2c3d feat: initial work',
       mcpPool,
       configLabels: undefined,
+      capabilities: emptyCapabilities,
+      idempotencyMarker: '[ferry:iterator:abcdef1]',
       typeOverride: undefined,
       repoRoot: REPO_ROOT,
       _buildSystem: buildSystemStub,
@@ -67,6 +78,8 @@ describe('prepareIterator', () => {
       existingLog: '',
       mcpPool,
       configLabels: undefined,
+      capabilities: emptyCapabilities,
+      idempotencyMarker: '[ferry:iterator:1234567]',
       typeOverride: undefined,
       repoRoot: REPO_ROOT,
       _buildSystem: buildSystemStub,
@@ -78,7 +91,7 @@ describe('prepareIterator', () => {
     expect(ctx.initialPrompt).not.toContain('## Existing commits on branch');
   });
 
-  it('keeps the empty MCP pool when no labels config is provided (capabilities are empty)', () => {
+  it('keeps the full MCP pool when no labels config is provided (filter is a no-op)', () => {
     const ctx = prepareIterator({
       ticketKey: 'PROJ-200',
       issue,
@@ -88,6 +101,8 @@ describe('prepareIterator', () => {
       existingLog: '',
       mcpPool,
       configLabels: undefined,
+      capabilities: emptyCapabilities,
+      idempotencyMarker: '[ferry:iterator:abcdef1]',
       typeOverride: undefined,
       repoRoot: REPO_ROOT,
       _buildSystem: buildSystemStub,
@@ -96,6 +111,37 @@ describe('prepareIterator', () => {
     // No labels config → hasLabelsConfig=false → filterMcpServers returns the pool unfiltered
     expect(ctx.mcpServers).toEqual(mcpPool);
     expect(ctx.capabilities.mcpServerNames).toEqual([]);
+  });
+
+  it('filters the MCP pool down to capability-triggered servers when labels config is provided', () => {
+    const configLabels: Record<string, LabelCapability> = {
+      'ferry:docs': { mcp_servers: ['context7'] },
+    };
+    const triggeredCapabilities: ResolvedCapabilities = {
+      mcpServerNames: ['context7'],
+      serverAllowedTools: { context7: [] },
+      triggeredLabels: ['ferry:docs'],
+      unknownFerryLabels: [],
+    };
+
+    const ctx = prepareIterator({
+      ticketKey: 'PROJ-200',
+      issue: { ...issue, labels: ['ferry:docs'] },
+      headSha: 'abcdef1',
+      reviewComment: '',
+      mergeConflicts: [],
+      existingLog: '',
+      mcpPool,
+      configLabels,
+      capabilities: triggeredCapabilities,
+      idempotencyMarker: '[ferry:iterator:abcdef1]',
+      typeOverride: undefined,
+      repoRoot: REPO_ROOT,
+      _buildSystem: buildSystemStub,
+    });
+
+    // Only context7 should remain — the unfiltered pool also has 'jira'.
+    expect(ctx.mcpServers.map((s) => s.name)).toEqual(['context7']);
   });
 
   it('forwards the typeOverride into the ticket block', () => {
@@ -108,6 +154,8 @@ describe('prepareIterator', () => {
       existingLog: '',
       mcpPool,
       configLabels: undefined,
+      capabilities: emptyCapabilities,
+      idempotencyMarker: '[ferry:iterator:abcdef1]',
       typeOverride: 'Spike',
       repoRoot: REPO_ROOT,
       _buildSystem: buildSystemStub,

--- a/src/lib/agent-runtime/iterator-prepare.ts
+++ b/src/lib/agent-runtime/iterator-prepare.ts
@@ -14,23 +14,17 @@
  */
 
 import { delimitUntrusted } from '../llm/delimit-untrusted.js';
-import { byPrHeadSha } from './idempotency.js';
 import { buildSystem as defaultBuildSystem, buildTicketBlock } from './prompt.js';
-import {
-  resolveCapabilities,
-  filterMcpServers,
-  type ResolvedCapabilities,
-} from '../labels/capabilities.js';
+import { filterMcpServers, type ResolvedCapabilities } from '../labels/capabilities.js';
 import type { LabelCapability } from '../config.js';
 import type { McpServerConfig } from '../llm/agent-loop/types.js';
 import type { TrackerIssue } from '../io/tracker/types.js';
-import type { Logger } from '../logger/index.js';
 import type { RolePreparedContextBase } from './prepare.js';
 
 export interface PrepareIteratorInput {
   ticketKey: string;
   issue: TrackerIssue;
-  /** Full PR head SHA — first 7 chars become the idempotency anchor. */
+  /** Full PR head SHA — first 7 chars are the idempotency anchor. */
   headSha: string;
   /** Latest reviewer findings body (already verified non-empty, non-approved by the caller). */
   reviewComment: string;
@@ -40,30 +34,40 @@ export interface PrepareIteratorInput {
   existingLog: string;
   mcpPool: McpServerConfig[];
   configLabels: Record<string, LabelCapability> | undefined;
+  /**
+   * Resolved capabilities — computed once by the caller before any early-return
+   * gate so capability telemetry is emitted on every invocation, not only when
+   * we reach the loop. The single source of `capabilities` lives in the action.
+   */
+  capabilities: ResolvedCapabilities;
+  /**
+   * `[ferry:iterator:<sha7>]` marker computed once by the caller (it must be
+   * computed BEFORE the action's idempotency-skip gate, so we just thread the
+   * same value into prepare to keep a single source of truth — per
+   * `RolePreparedContextBase`).
+   */
+  idempotencyMarker: string;
   typeOverride: string | undefined;
   repoRoot: string;
-  logger?: Logger;
   /** Test seam — defaults to the real `buildSystem`. */
   _buildSystem?: typeof defaultBuildSystem;
 }
 
-export interface IteratorPreparedContext extends RolePreparedContextBase {
-  capabilities: ResolvedCapabilities;
-}
+export type IteratorPreparedContext = RolePreparedContextBase;
 
 export function prepareIterator(input: PrepareIteratorInput): IteratorPreparedContext {
   const {
     ticketKey,
     issue,
-    headSha,
     reviewComment,
     mergeConflicts,
     existingLog,
     mcpPool,
     configLabels,
+    capabilities,
+    idempotencyMarker,
     typeOverride,
     repoRoot,
-    logger,
   } = input;
   const buildSystem = input._buildSystem ?? defaultBuildSystem;
 
@@ -88,11 +92,8 @@ export function prepareIterator(input: PrepareIteratorInput): IteratorPreparedCo
     .filter(Boolean)
     .join('\n');
 
-  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
   const hasLabelsConfig = configLabels !== undefined;
   const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
-
-  const idempotencyMarker = byPrHeadSha('iterator', headSha);
 
   return {
     system,

--- a/src/lib/agent-runtime/iterator-prepare.ts
+++ b/src/lib/agent-runtime/iterator-prepare.ts
@@ -1,0 +1,105 @@
+/**
+ * Iterator role pre-loop setup (issue #330).
+ *
+ * Extracted from `src/agents/iterator/iterate-action.ts`. Builds the iterator's
+ * system prompt, initial prompt, ticket block, idempotency marker, and the
+ * capability-filtered MCP pool from the already-resolved state the action
+ * computed (head SHA, latest review comment, merge conflicts from
+ * `fetchAndMergeBase`, existing-log output).
+ *
+ * The action keeps the side-effecting branch checkout (`checkoutExistingBranch`
+ * + `fetchAndMergeBase`) inline because they short-circuit the action with a
+ * Jira comment when the branch is absent — that exit semantic is intentionally
+ * kept where it lives.
+ */
+
+import { delimitUntrusted } from '../llm/delimit-untrusted.js';
+import { byPrHeadSha } from './idempotency.js';
+import { buildSystem as defaultBuildSystem, buildTicketBlock } from './prompt.js';
+import {
+  resolveCapabilities,
+  filterMcpServers,
+  type ResolvedCapabilities,
+} from '../labels/capabilities.js';
+import type { LabelCapability } from '../config.js';
+import type { McpServerConfig } from '../llm/agent-loop/types.js';
+import type { TrackerIssue } from '../io/tracker/types.js';
+import type { Logger } from '../logger/index.js';
+import type { RolePreparedContextBase } from './prepare.js';
+
+export interface PrepareIteratorInput {
+  ticketKey: string;
+  issue: TrackerIssue;
+  /** Full PR head SHA — first 7 chars become the idempotency anchor. */
+  headSha: string;
+  /** Latest reviewer findings body (already verified non-empty, non-approved by the caller). */
+  reviewComment: string;
+  /** Conflicted files returned by `fetchAndMergeBase`. Empty array = no conflicts. */
+  mergeConflicts: string[];
+  /** Trimmed `git log origin/<base>..HEAD --oneline` output. Empty = no prior commits. */
+  existingLog: string;
+  mcpPool: McpServerConfig[];
+  configLabels: Record<string, LabelCapability> | undefined;
+  typeOverride: string | undefined;
+  repoRoot: string;
+  logger?: Logger;
+  /** Test seam — defaults to the real `buildSystem`. */
+  _buildSystem?: typeof defaultBuildSystem;
+}
+
+export interface IteratorPreparedContext extends RolePreparedContextBase {
+  capabilities: ResolvedCapabilities;
+}
+
+export function prepareIterator(input: PrepareIteratorInput): IteratorPreparedContext {
+  const {
+    ticketKey,
+    issue,
+    headSha,
+    reviewComment,
+    mergeConflicts,
+    existingLog,
+    mcpPool,
+    configLabels,
+    typeOverride,
+    repoRoot,
+    logger,
+  } = input;
+  const buildSystem = input._buildSystem ?? defaultBuildSystem;
+
+  const system = buildSystem('iterate', repoRoot);
+
+  const ticketBlock = buildTicketBlock(ticketKey, issue, { typeOverride });
+
+  const initialPrompt = [
+    '## Jira Ticket',
+    delimitUntrusted(ticketBlock),
+    '',
+    '## Review Findings (fix only what is listed here)',
+    delimitUntrusted(reviewComment),
+    '',
+    mergeConflicts.length > 0
+      ? `## Merge Conflicts (resolve these first, before fixing review findings)\n${mergeConflicts.map((f) => `- ${f}`).join('\n')}`
+      : '',
+    existingLog ? `## Existing commits on branch\n${existingLog}` : '',
+    '',
+    'When you have fixed all findings, call the `done` tool.',
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
+  const hasLabelsConfig = configLabels !== undefined;
+  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+
+  const idempotencyMarker = byPrHeadSha('iterator', headSha);
+
+  return {
+    system,
+    initialPrompt,
+    mcpServers,
+    idempotencyMarker,
+    ticketBlock,
+    capabilities,
+  };
+}

--- a/src/lib/agent-runtime/prepare.ts
+++ b/src/lib/agent-runtime/prepare.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared "prepared context" base type for the four agent roles
+ * (refiner / developer / reviewer / iterator).
+ *
+ * Each role's `*-prepare.ts` module builds the `RolePreparedContextBase`
+ * fields PLUS any role-specific extras, returning a typed extension of this
+ * interface. The agent action then invokes its loop with the returned context.
+ *
+ * The single source of `system` / `initialPrompt` / `mcpServers` is the goal
+ * of this refactor (issue #330) — it structurally enforces the ADR-0006 §2
+ * "prompts reused verbatim" promise, so the future cc-prepare composite
+ * (sister issue #331) consumes the same prepare function and feeds
+ * `buildClaudeCodeJob` with identical inputs.
+ *
+ * Note: the refiner does not currently use `createAgentLoop`/`runReviewLoop`
+ * on the script path — its `system` and `initialPrompt` are constructed
+ * inside `runRefiner`. The refiner's prepared context therefore omits those
+ * three loop-only fields; this stays compatible with the cc-prepare path,
+ * which will call `buildSystem('refiner')` itself.
+ */
+
+import type { McpServerConfig } from '../llm/agent-loop/types.js';
+import type { ResolvedCapabilities } from '../labels/capabilities.js';
+
+export interface RolePreparedContextBase {
+  /** Resolved `buildSystem(<role>)` output — forwarded verbatim to the loop. */
+  system: string;
+  /** Final initial prompt for the loop (delimited ticket block, etc.). */
+  initialPrompt: string;
+  /** Capability-filtered MCP pool. Never carries unfiltered defaults. */
+  mcpServers: McpServerConfig[];
+  /** `[ferry:<role>:<key>]` marker used by audit comments. */
+  idempotencyMarker: string;
+  /** The delimited ticket block — exposed so the cc-prepare composite can re-use it. */
+  ticketBlock: string;
+  /** Resolved capabilities (mcp server names, triggered labels, etc.). */
+  capabilities: ResolvedCapabilities;
+}

--- a/src/lib/agent-runtime/refiner-prepare.test.ts
+++ b/src/lib/agent-runtime/refiner-prepare.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { prepareRefiner } from './refiner-prepare.js';
+import { InMemoryTracker } from '../io/tracker/in-memory.js';
+import type { EventEnvelopeV1 } from '../envelope/types.js';
+
+const envelope: EventEnvelopeV1 = {
+  version: 'v1',
+  event_id: 'evt-prep-001',
+  ticket_key: 'PROJ-100',
+  phase: 'refine',
+  source: 'jira-column',
+  ts: '2026-01-01T00:00:00Z',
+};
+
+function makeTracker(): InMemoryTracker {
+  const tracker = new InMemoryTracker();
+  tracker.seed({
+    key: 'PROJ-100',
+    summary: 'Refine setup',
+    description: 'Body text',
+    comments: [
+      'random comment',
+      '[ferry:refiner:evt-old-1] Refined. Created 2…',
+      'another comment',
+      '[ferry:refiner:evt-old-2] Refined. Kept 1…',
+    ],
+    labels: [],
+    issueType: 'Story',
+    issueTypeRaw: 'Story',
+  });
+  tracker.seedSubtaskDetails('PROJ-100', [
+    { key: 'PROJ-101', title: 'Existing one', description: 'desc', status: 'To Do' },
+  ]);
+  return tracker;
+}
+
+describe('prepareRefiner', () => {
+  beforeEach(() => {
+    process.env.GITHUB_REPO = 'big-emotion/ferry';
+    process.env.GITHUB_RUN_ID = '12345';
+  });
+
+  afterEach(() => {
+    delete process.env.GITHUB_REPO;
+    delete process.env.GITHUB_RUN_ID;
+    vi.restoreAllMocks();
+  });
+
+  it('returns the issue, existing subtasks, prior refiner runs, runLink and idempotency marker', async () => {
+    const tracker = makeTracker();
+    const ctx = await prepareRefiner({ envelope, tracker });
+
+    expect(ctx.issue.key).toBe('PROJ-100');
+    expect(ctx.existingSubtasks).toHaveLength(1);
+    expect(ctx.existingSubtasks[0].key).toBe('PROJ-101');
+    expect(ctx.priorRefinerRuns).toEqual([
+      '[ferry:refiner:evt-old-1] Refined. Created 2…',
+      '[ferry:refiner:evt-old-2] Refined. Kept 1…',
+    ]);
+    expect(ctx.runLink).toBe('https://github.com/big-emotion/ferry/actions/runs/12345');
+    expect(ctx.idempotencyMarker).toBe('[ferry:refiner:evt-prep-001]');
+  });
+
+  it('falls back to "unknown" repo and "0" run id when env vars are missing', async () => {
+    delete process.env.GITHUB_REPO;
+    delete process.env.GITHUB_RUN_ID;
+    const tracker = makeTracker();
+    const ctx = await prepareRefiner({ envelope, tracker });
+
+    expect(ctx.runLink).toBe('https://github.com/unknown/actions/runs/0');
+  });
+
+  it('returns an empty priorRefinerRuns list when the issue has no refiner markers', async () => {
+    const tracker = new InMemoryTracker();
+    tracker.seed({
+      key: 'PROJ-100',
+      summary: 'Fresh ticket',
+      description: 'No prior runs',
+      comments: ['just a user comment'],
+      labels: [],
+      issueType: 'Story',
+      issueTypeRaw: 'Story',
+    });
+    const ctx = await prepareRefiner({ envelope, tracker });
+
+    expect(ctx.priorRefinerRuns).toEqual([]);
+    expect(ctx.existingSubtasks).toEqual([]);
+  });
+
+  it('only invokes the tracker once for issue + once for subtask details', async () => {
+    const tracker = makeTracker();
+    const getIssueSpy = vi.spyOn(tracker, 'getIssue');
+    const getSubtaskDetailsSpy = vi.spyOn(tracker, 'getSubtaskDetails');
+
+    await prepareRefiner({ envelope, tracker });
+
+    expect(getIssueSpy).toHaveBeenCalledTimes(1);
+    expect(getIssueSpy).toHaveBeenCalledWith('PROJ-100');
+    expect(getSubtaskDetailsSpy).toHaveBeenCalledTimes(1);
+    expect(getSubtaskDetailsSpy).toHaveBeenCalledWith('PROJ-100');
+  });
+});

--- a/src/lib/agent-runtime/refiner-prepare.ts
+++ b/src/lib/agent-runtime/refiner-prepare.ts
@@ -1,0 +1,51 @@
+/**
+ * Refiner role pre-loop setup (issue #330).
+ *
+ * Extracted from `src/agents/refiner/refiner-action.ts` so the same setup feeds
+ * both the script path and the future cc-prepare composite (sister issue #331).
+ *
+ * Unlike the developer / iterator / reviewer roles, the refiner does not invoke
+ * `createAgentLoop` — it runs a single LLM JSON-mode call via `runRefiner`. The
+ * prepared context here therefore exposes the *inputs* to `runRefiner` (issue,
+ * existingSubtasks, priorRefinerRuns, runLink) plus the idempotency marker,
+ * rather than the `system` / `initialPrompt` / `mcpServers` triple used by the
+ * agent-loop roles.
+ */
+
+import type { EventEnvelopeV1 } from '../envelope/types.js';
+import type { IssueTracker, TrackerIssue, TrackerSubtask } from '../io/tracker/types.js';
+import { byEventId } from './idempotency.js';
+
+const PRIOR_RUN_MARKER = /\[ferry:refiner:[^\]]+\]/;
+
+export interface PrepareRefinerInput {
+  envelope: EventEnvelopeV1;
+  tracker: IssueTracker;
+}
+
+export interface RefinerPreparedContext {
+  issue: TrackerIssue;
+  existingSubtasks: TrackerSubtask[];
+  priorRefinerRuns: string[];
+  runLink: string;
+  idempotencyMarker: string;
+}
+
+export async function prepareRefiner(input: PrepareRefinerInput): Promise<RefinerPreparedContext> {
+  const { envelope, tracker } = input;
+  const { ticket_key: ticketKey, event_id: eventId } = envelope;
+
+  const issue = await tracker.getIssue(ticketKey);
+  const existingSubtasks = await tracker.getSubtaskDetails(ticketKey);
+  const priorRefinerRuns = issue.comments.filter((c) => PRIOR_RUN_MARKER.test(c));
+  const runLink = `https://github.com/${process.env.GITHUB_REPO ?? 'unknown'}/actions/runs/${process.env.GITHUB_RUN_ID ?? '0'}`;
+  const idempotencyMarker = byEventId('refiner', eventId);
+
+  return {
+    issue,
+    existingSubtasks,
+    priorRefinerRuns,
+    runLink,
+    idempotencyMarker,
+  };
+}

--- a/src/lib/agent-runtime/reviewer-helpers.ts
+++ b/src/lib/agent-runtime/reviewer-helpers.ts
@@ -1,0 +1,73 @@
+/**
+ * Reviewer helper utilities shared between the reviewer agent's in-loop code
+ * (`src/agents/reviewer/review-loop.ts`, `src/agents/reviewer/rubric.ts`) and
+ * the pre-loop setup (`src/lib/agent-runtime/reviewer-prepare.ts`).
+ *
+ * Moved into `src/lib/agent-runtime/**` to preserve the project's layering
+ * invariant: `src/lib/**` is the shared lower layer and `src/agents/**` is
+ * its consumer — the lib layer must never reach into agent modules.
+ *
+ * The original locations re-export from here so existing call sites under
+ * `src/agents/reviewer/**` keep importing them with no diff churn.
+ */
+import type { PRFile } from '../dispatch/runner/types.js';
+import type { TicketOverrides } from '../labels/capabilities.js';
+
+const STRICT_DIRECTIVE = [
+  '## Rubric override — strict',
+  '',
+  'For this review, apply a STRICTER bar than usual:',
+  '',
+  '- Block on any missing test coverage for new/changed behaviour.',
+  '- Block on missing edge-case handling, error paths, or input validation.',
+  '- Block on weak naming, dead code, or unreachable branches.',
+  '- Block on incomplete documentation when public APIs change.',
+  '- Approve only when every acceptance criterion is fully satisfied with concrete evidence.',
+].join('\n');
+
+const LENIENT_DIRECTIVE = [
+  '## Rubric override — lenient',
+  '',
+  'For this review, apply a MORE PERMISSIVE bar than usual:',
+  '',
+  '- Approve when the acceptance criteria are met, even if minor polish is missing.',
+  '- Treat naming nits, non-blocking style issues, and stylistic preferences as comments — not blockers.',
+  '- Block only on: failing tests, unimplemented ACs, merge conflicts, committed build artefacts, or security regressions.',
+  '- Prefer "approve with comments" over "request changes" when issues are non-blocking.',
+].join('\n');
+
+/**
+ * Appends a rubric-override directive to the reviewer system prompt.
+ *
+ * - `rubric === 'strict'`  → appends the strict directive.
+ * - `rubric === 'lenient'` → appends the lenient directive.
+ * - `rubric === undefined` → returns `basePrompt` unchanged.
+ *
+ * The directive is appended (not substituted) so it composes with the base
+ * prompt and any optional overlay. It is placed last, so it wins when it
+ * disagrees with earlier sections.
+ */
+export function applyRubricToPrompt(
+  basePrompt: string,
+  rubric: TicketOverrides['reviewRubric'],
+): string {
+  if (rubric === undefined) return basePrompt;
+  const directive = rubric === 'strict' ? STRICT_DIRECTIVE : LENIENT_DIRECTIVE;
+  return `${basePrompt}\n\n---\n\n${directive}`;
+}
+
+export function detectMergeConflicts(files: PRFile[]): string[] {
+  const conflicted: string[] = [];
+  for (const f of files) {
+    if (f.patch && /^[+].*<{7}|^[+].*={7}|^[+].*>{7}/m.test(f.patch)) {
+      conflicted.push(f.filename);
+    }
+  }
+  return conflicted;
+}
+
+export function buildFileList(files: PRFile[]): string {
+  return files
+    .map((f) => `${f.status.padEnd(8)} +${f.additions} -${f.deletions}  ${f.filename}`)
+    .join('\n');
+}

--- a/src/lib/agent-runtime/reviewer-prepare.test.ts
+++ b/src/lib/agent-runtime/reviewer-prepare.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { prepareReviewer } from './reviewer-prepare.js';
 import type { TrackerIssue } from '../io/tracker/types.js';
 import type { PR, PRFile } from '../dispatch/runner/types.js';
+import type { ResolvedCapabilities } from '../labels/capabilities.js';
 
 const REPO_ROOT = '/workspace/repo';
 
@@ -34,6 +35,13 @@ const commits = [
   { sha: 'def5678baadf00d', message: 'fix: b' },
 ];
 
+const emptyCapabilities: ResolvedCapabilities = {
+  mcpServerNames: [],
+  serverAllowedTools: {},
+  triggeredLabels: [],
+  unknownFerryLabels: [],
+};
+
 const buildSystemStub = (name: string, _root: string, opts?: { extraParts?: unknown[] }) =>
   `SYSTEM(${name}, parts=${(opts?.extraParts ?? []).length})`;
 
@@ -50,7 +58,8 @@ describe('prepareReviewer', () => {
       branchName: 'ferry/feat/PROJ-300',
       typeOverride: undefined,
       reviewRubric: undefined,
-      configLabels: undefined,
+      capabilities: emptyCapabilities,
+      idempotencyMarker: '[ferry:reviewer:feedbee]',
       repoRoot: REPO_ROOT,
       _buildSystem: buildSystemStub,
       _loadOptionalPrompt: loadOptionalPromptStub,
@@ -71,7 +80,8 @@ describe('prepareReviewer', () => {
       branchName: 'ferry/feat/PROJ-300',
       typeOverride: undefined,
       reviewRubric: 'strict',
-      configLabels: undefined,
+      capabilities: emptyCapabilities,
+      idempotencyMarker: '[ferry:reviewer:feedbee]',
       repoRoot: REPO_ROOT,
       _buildSystem: buildSystemStub,
       _loadOptionalPrompt: loadOptionalPromptStub,
@@ -90,7 +100,8 @@ describe('prepareReviewer', () => {
       branchName: 'ferry/feat/PROJ-300',
       typeOverride: undefined,
       reviewRubric: 'lenient',
-      configLabels: undefined,
+      capabilities: emptyCapabilities,
+      idempotencyMarker: '[ferry:reviewer:feedbee]',
       repoRoot: REPO_ROOT,
       _buildSystem: buildSystemStub,
       _loadOptionalPrompt: loadOptionalPromptStub,
@@ -109,7 +120,8 @@ describe('prepareReviewer', () => {
       branchName: 'ferry/feat/PROJ-300',
       typeOverride: undefined,
       reviewRubric: undefined,
-      configLabels: undefined,
+      capabilities: emptyCapabilities,
+      idempotencyMarker: '[ferry:reviewer:feedbee]',
       repoRoot: REPO_ROOT,
       _buildSystem: buildSystemStub,
       _loadOptionalPrompt: loadOptionalPromptStub,
@@ -149,7 +161,8 @@ describe('prepareReviewer', () => {
       branchName: 'ferry/feat/PROJ-300',
       typeOverride: undefined,
       reviewRubric: undefined,
-      configLabels: undefined,
+      capabilities: emptyCapabilities,
+      idempotencyMarker: '[ferry:reviewer:feedbee]',
       repoRoot: REPO_ROOT,
       _buildSystem: buildSystemStub,
       _loadOptionalPrompt: loadOptionalPromptStub,
@@ -160,7 +173,7 @@ describe('prepareReviewer', () => {
     expect(ctx.initialPrompt).toContain('conflicted files: src/c.ts');
   });
 
-  it('uses the PR head SHA to anchor the idempotency marker', () => {
+  it('threads the idempotency marker through unchanged', () => {
     const ctx = prepareReviewer({
       ticketKey: 'PROJ-300',
       issue,
@@ -170,7 +183,8 @@ describe('prepareReviewer', () => {
       branchName: 'ferry/feat/PROJ-300',
       typeOverride: undefined,
       reviewRubric: undefined,
-      configLabels: undefined,
+      capabilities: emptyCapabilities,
+      idempotencyMarker: '[ferry:reviewer:feedbee]',
       repoRoot: REPO_ROOT,
       _buildSystem: buildSystemStub,
       _loadOptionalPrompt: loadOptionalPromptStub,
@@ -189,7 +203,8 @@ describe('prepareReviewer', () => {
       branchName: 'ferry/feat/PROJ-300',
       typeOverride: undefined,
       reviewRubric: undefined,
-      configLabels: undefined,
+      capabilities: emptyCapabilities,
+      idempotencyMarker: '[ferry:reviewer:feedbee]',
       repoRoot: REPO_ROOT,
       _buildSystem: buildSystemStub,
       _loadOptionalPrompt: loadOptionalPromptStub,

--- a/src/lib/agent-runtime/reviewer-prepare.test.ts
+++ b/src/lib/agent-runtime/reviewer-prepare.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import { prepareReviewer } from './reviewer-prepare.js';
+import type { TrackerIssue } from '../io/tracker/types.js';
+import type { PR, PRFile } from '../dispatch/runner/types.js';
+
+const REPO_ROOT = '/workspace/repo';
+
+const issue: TrackerIssue = {
+  key: 'PROJ-300',
+  summary: 'Add feature X',
+  description: 'Spec for X',
+  comments: [],
+  labels: [],
+  issueType: 'Story',
+  issueTypeRaw: 'Story',
+};
+
+const pr: PR = {
+  number: 42,
+  title: 'feat: add X',
+  baseRef: 'main',
+  headRef: 'ferry/feat/PROJ-300',
+  headSha: 'feedbeefcafebabe1234567890abcdef12345678',
+  mergeable: true,
+};
+
+const files: PRFile[] = [
+  { filename: 'src/a.ts', status: 'modified', additions: 4, deletions: 2, patch: '@@ patch' },
+  { filename: 'src/b.ts', status: 'added', additions: 10, deletions: 0, patch: '@@ patch b' },
+];
+
+const commits = [
+  { sha: 'abc1234deadbeef', message: 'feat: a\n\ndetails' },
+  { sha: 'def5678baadf00d', message: 'fix: b' },
+];
+
+const buildSystemStub = (name: string, _root: string, opts?: { extraParts?: unknown[] }) =>
+  `SYSTEM(${name}, parts=${(opts?.extraParts ?? []).length})`;
+
+const loadOptionalPromptStub = () => 'OPTIONAL_REVIEW_COMMENT_OVERLAY';
+
+describe('prepareReviewer', () => {
+  it('builds the reviewer system prompt with review-comment overlay, no rubric override by default', () => {
+    const ctx = prepareReviewer({
+      ticketKey: 'PROJ-300',
+      issue,
+      pr,
+      files,
+      commits,
+      branchName: 'ferry/feat/PROJ-300',
+      typeOverride: undefined,
+      reviewRubric: undefined,
+      configLabels: undefined,
+      repoRoot: REPO_ROOT,
+      _buildSystem: buildSystemStub,
+      _loadOptionalPrompt: loadOptionalPromptStub,
+    });
+
+    expect(ctx.system).toBe('SYSTEM(review, parts=1)');
+    // No rubric override → system is the base verbatim
+    expect(ctx.system).not.toContain('## Rubric override');
+  });
+
+  it('applies the strict rubric override when reviewRubric=strict', () => {
+    const ctx = prepareReviewer({
+      ticketKey: 'PROJ-300',
+      issue,
+      pr,
+      files,
+      commits,
+      branchName: 'ferry/feat/PROJ-300',
+      typeOverride: undefined,
+      reviewRubric: 'strict',
+      configLabels: undefined,
+      repoRoot: REPO_ROOT,
+      _buildSystem: buildSystemStub,
+      _loadOptionalPrompt: loadOptionalPromptStub,
+    });
+
+    expect(ctx.system).toContain('## Rubric override — strict');
+  });
+
+  it('applies the lenient rubric override when reviewRubric=lenient', () => {
+    const ctx = prepareReviewer({
+      ticketKey: 'PROJ-300',
+      issue,
+      pr,
+      files,
+      commits,
+      branchName: 'ferry/feat/PROJ-300',
+      typeOverride: undefined,
+      reviewRubric: 'lenient',
+      configLabels: undefined,
+      repoRoot: REPO_ROOT,
+      _buildSystem: buildSystemStub,
+      _loadOptionalPrompt: loadOptionalPromptStub,
+    });
+
+    expect(ctx.system).toContain('## Rubric override — lenient');
+  });
+
+  it('produces an initial prompt with the ticket, PR metadata, commits and changed file list', () => {
+    const ctx = prepareReviewer({
+      ticketKey: 'PROJ-300',
+      issue,
+      pr,
+      files,
+      commits,
+      branchName: 'ferry/feat/PROJ-300',
+      typeOverride: undefined,
+      reviewRubric: undefined,
+      configLabels: undefined,
+      repoRoot: REPO_ROOT,
+      _buildSystem: buildSystemStub,
+      _loadOptionalPrompt: loadOptionalPromptStub,
+    });
+
+    expect(ctx.initialPrompt).toContain('## Jira Ticket');
+    expect(ctx.initialPrompt).toContain('TICKET: PROJ-300');
+    expect(ctx.initialPrompt).toContain('PR #42: feat: add X');
+    expect(ctx.initialPrompt).toContain('Base: main ← Head: ferry/feat/PROJ-300 (feedbee)');
+    expect(ctx.initialPrompt).toContain('Files changed: 2  Commits: 2');
+    expect(ctx.initialPrompt).toContain('abc1234 feat: a');
+    expect(ctx.initialPrompt).toContain('def5678 fix: b');
+    // status is padEnd(8): "modified" stays as-is, "added" becomes "added   "
+    expect(ctx.initialPrompt).toContain('modified +4 -2  src/a.ts');
+    expect(ctx.initialPrompt).toContain('added    +10 -0  src/b.ts');
+    expect(ctx.initialPrompt).toContain('Use get_file_patch to inspect');
+    expect(ctx.initialPrompt).not.toContain('MERGE CONFLICTS DETECTED');
+  });
+
+  it('emits a merge-conflict warning when pr.mergeable=false or patches contain conflict markers', () => {
+    const conflictedFiles: PRFile[] = [
+      ...files,
+      {
+        filename: 'src/c.ts',
+        status: 'modified',
+        additions: 1,
+        deletions: 0,
+        patch: '@@\n+<<<<<<< HEAD\n+ours\n+=======\n+theirs\n+>>>>>>> branch',
+      },
+    ];
+    const ctx = prepareReviewer({
+      ticketKey: 'PROJ-300',
+      issue,
+      pr: { ...pr, mergeable: false },
+      files: conflictedFiles,
+      commits,
+      branchName: 'ferry/feat/PROJ-300',
+      typeOverride: undefined,
+      reviewRubric: undefined,
+      configLabels: undefined,
+      repoRoot: REPO_ROOT,
+      _buildSystem: buildSystemStub,
+      _loadOptionalPrompt: loadOptionalPromptStub,
+    });
+
+    expect(ctx.initialPrompt).toContain('⚠️  MERGE CONFLICTS DETECTED');
+    expect(ctx.initialPrompt).toContain('mergeable=false');
+    expect(ctx.initialPrompt).toContain('conflicted files: src/c.ts');
+  });
+
+  it('uses the PR head SHA to anchor the idempotency marker', () => {
+    const ctx = prepareReviewer({
+      ticketKey: 'PROJ-300',
+      issue,
+      pr,
+      files,
+      commits,
+      branchName: 'ferry/feat/PROJ-300',
+      typeOverride: undefined,
+      reviewRubric: undefined,
+      configLabels: undefined,
+      repoRoot: REPO_ROOT,
+      _buildSystem: buildSystemStub,
+      _loadOptionalPrompt: loadOptionalPromptStub,
+    });
+
+    expect(ctx.idempotencyMarker).toBe('[ferry:reviewer:feedbee]');
+  });
+
+  it('exposes the fileMap of filename → patch for the review loop', () => {
+    const ctx = prepareReviewer({
+      ticketKey: 'PROJ-300',
+      issue,
+      pr,
+      files,
+      commits,
+      branchName: 'ferry/feat/PROJ-300',
+      typeOverride: undefined,
+      reviewRubric: undefined,
+      configLabels: undefined,
+      repoRoot: REPO_ROOT,
+      _buildSystem: buildSystemStub,
+      _loadOptionalPrompt: loadOptionalPromptStub,
+    });
+
+    expect(ctx.fileMap.get('src/a.ts')).toBe('@@ patch');
+    expect(ctx.fileMap.get('src/b.ts')).toBe('@@ patch b');
+    expect(ctx.fileMap.size).toBe(2);
+  });
+});

--- a/src/lib/agent-runtime/reviewer-prepare.ts
+++ b/src/lib/agent-runtime/reviewer-prepare.ts
@@ -1,0 +1,139 @@
+/**
+ * Reviewer role pre-loop setup (issue #330).
+ *
+ * Extracted from `src/agents/reviewer/review-action.ts`. Builds the reviewer's
+ * system prompt (with optional review-comment overlay and rubric override),
+ * the initial prompt with PR metadata + commits + changed files, the
+ * idempotency marker keyed on PR head SHA, and the filename→patch map the
+ * review loop consumes.
+ *
+ * The action keeps PR resolution + CI gating + idempotency-skip checks inline
+ * because they short-circuit with Jira/PR comments and have role-specific exit
+ * semantics. This prepare function runs *after* those gates have been passed.
+ */
+
+import { delimitUntrusted } from '../llm/delimit-untrusted.js';
+import { byPrHeadSha } from './idempotency.js';
+import {
+  buildSystem as defaultBuildSystem,
+  buildTicketBlock,
+  loadOptionalPrompt as defaultLoadOptionalPrompt,
+} from './prompt.js';
+import {
+  resolveCapabilities,
+  type ResolvedCapabilities,
+  type TicketOverrides,
+} from '../labels/capabilities.js';
+import { applyRubricToPrompt } from '../../agents/reviewer/rubric.js';
+import { detectMergeConflicts, buildFileList } from '../../agents/reviewer/review-loop.js';
+import type { LabelCapability } from '../config.js';
+import type { TrackerIssue } from '../io/tracker/types.js';
+import type { PR, PRFile } from '../dispatch/runner/types.js';
+import type { Logger } from '../logger/index.js';
+import type { McpServerConfig } from '../llm/agent-loop/types.js';
+import type { RolePreparedContextBase } from './prepare.js';
+
+export interface PrepareReviewerInput {
+  ticketKey: string;
+  issue: TrackerIssue;
+  pr: PR;
+  files: PRFile[];
+  commits: Array<{ sha: string; message: string }>;
+  branchName: string;
+  typeOverride: string | undefined;
+  reviewRubric: TicketOverrides['reviewRubric'];
+  configLabels: Record<string, LabelCapability> | undefined;
+  repoRoot: string;
+  logger?: Logger;
+  /** Test seam — defaults to the real `buildSystem`. */
+  _buildSystem?: typeof defaultBuildSystem;
+  /** Test seam — defaults to the real `loadOptionalPrompt`. */
+  _loadOptionalPrompt?: typeof defaultLoadOptionalPrompt;
+}
+
+export interface ReviewerPreparedContext extends RolePreparedContextBase {
+  capabilities: ResolvedCapabilities;
+  /** filename → patch map consumed by the review loop's `get_file_patch` handler. */
+  fileMap: Map<string, string | undefined>;
+}
+
+export function prepareReviewer(input: PrepareReviewerInput): ReviewerPreparedContext {
+  const {
+    ticketKey,
+    issue,
+    pr,
+    files,
+    commits,
+    branchName,
+    typeOverride,
+    reviewRubric,
+    configLabels,
+    repoRoot,
+    logger,
+  } = input;
+  const buildSystem = input._buildSystem ?? defaultBuildSystem;
+  const loadOptionalPrompt = input._loadOptionalPrompt ?? defaultLoadOptionalPrompt;
+
+  const headSha = pr.headSha;
+  const prNumber = pr.number;
+
+  // file map + merge-conflict detection mirror the original review-action exactly
+  const fileMap = new Map<string, string | undefined>(files.map((f) => [f.filename, f.patch]));
+  const conflictedFiles = detectMergeConflicts(files);
+  const hasMergeConflicts = pr.mergeable === false || conflictedFiles.length > 0;
+
+  const commitLog = commits
+    .map((c) => `${c.sha.slice(0, 7)} ${c.message.split('\n')[0]}`)
+    .join('\n');
+
+  const ticketBlock = buildTicketBlock(ticketKey, issue, { typeOverride });
+
+  const mergeConflictWarning = hasMergeConflicts
+    ? `\n⚠️  MERGE CONFLICTS DETECTED — mergeable=${String(pr.mergeable)}${conflictedFiles.length > 0 ? `, conflicted files: ${conflictedFiles.join(', ')}` : ''}`
+    : '';
+
+  const initialPrompt = [
+    '## Jira Ticket',
+    delimitUntrusted(ticketBlock),
+    '',
+    '## PR Metadata',
+    `PR #${prNumber}: ${pr.title}`,
+    `Base: ${pr.baseRef} ← Head: ${branchName} (${headSha.slice(0, 7)})`,
+    `Files changed: ${files.length}  Commits: ${commits.length}`,
+    mergeConflictWarning,
+    '',
+    '## Commits',
+    commitLog,
+    '',
+    '## Changed files (status  +additions  -deletions  path)',
+    buildFileList(files),
+    '',
+    'Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.',
+    'When you have enough information, call finish_review.',
+  ]
+    .filter((l) => l !== null)
+    .join('\n');
+
+  const baseSystem = buildSystem('review', repoRoot, {
+    extraParts: [loadOptionalPrompt('review-comment', repoRoot)],
+    separator: '\n\n---\n\n',
+  });
+  const system = applyRubricToPrompt(baseSystem, reviewRubric);
+
+  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
+  // The reviewer agent has never used MCP servers; we expose an empty list to
+  // satisfy the shared `RolePreparedContextBase` shape.
+  const mcpServers: McpServerConfig[] = [];
+
+  const idempotencyMarker = byPrHeadSha('reviewer', headSha);
+
+  return {
+    system,
+    initialPrompt,
+    mcpServers,
+    idempotencyMarker,
+    ticketBlock,
+    capabilities,
+    fileMap,
+  };
+}

--- a/src/lib/agent-runtime/reviewer-prepare.ts
+++ b/src/lib/agent-runtime/reviewer-prepare.ts
@@ -13,23 +13,15 @@
  */
 
 import { delimitUntrusted } from '../llm/delimit-untrusted.js';
-import { byPrHeadSha } from './idempotency.js';
 import {
   buildSystem as defaultBuildSystem,
   buildTicketBlock,
   loadOptionalPrompt as defaultLoadOptionalPrompt,
 } from './prompt.js';
-import {
-  resolveCapabilities,
-  type ResolvedCapabilities,
-  type TicketOverrides,
-} from '../labels/capabilities.js';
-import { applyRubricToPrompt } from '../../agents/reviewer/rubric.js';
-import { detectMergeConflicts, buildFileList } from '../../agents/reviewer/review-loop.js';
-import type { LabelCapability } from '../config.js';
+import { type ResolvedCapabilities, type TicketOverrides } from '../labels/capabilities.js';
+import { applyRubricToPrompt, detectMergeConflicts, buildFileList } from './reviewer-helpers.js';
 import type { TrackerIssue } from '../io/tracker/types.js';
 import type { PR, PRFile } from '../dispatch/runner/types.js';
-import type { Logger } from '../logger/index.js';
 import type { McpServerConfig } from '../llm/agent-loop/types.js';
 import type { RolePreparedContextBase } from './prepare.js';
 
@@ -42,9 +34,20 @@ export interface PrepareReviewerInput {
   branchName: string;
   typeOverride: string | undefined;
   reviewRubric: TicketOverrides['reviewRubric'];
-  configLabels: Record<string, LabelCapability> | undefined;
+  /**
+   * Resolved capabilities — computed once by the caller before any early-return
+   * gate so capability telemetry is emitted on every invocation. The single
+   * source of `capabilities` lives in the action.
+   */
+  capabilities: ResolvedCapabilities;
+  /**
+   * `[ferry:reviewer:<sha7>]` marker computed once by the caller (it must be
+   * computed BEFORE the action's idempotency-skip gate; we just thread the
+   * same value into prepare to keep a single source of truth — per
+   * `RolePreparedContextBase`).
+   */
+  idempotencyMarker: string;
   repoRoot: string;
-  logger?: Logger;
   /** Test seam — defaults to the real `buildSystem`. */
   _buildSystem?: typeof defaultBuildSystem;
   /** Test seam — defaults to the real `loadOptionalPrompt`. */
@@ -52,7 +55,6 @@ export interface PrepareReviewerInput {
 }
 
 export interface ReviewerPreparedContext extends RolePreparedContextBase {
-  capabilities: ResolvedCapabilities;
   /** filename → patch map consumed by the review loop's `get_file_patch` handler. */
   fileMap: Map<string, string | undefined>;
 }
@@ -67,9 +69,9 @@ export function prepareReviewer(input: PrepareReviewerInput): ReviewerPreparedCo
     branchName,
     typeOverride,
     reviewRubric,
-    configLabels,
+    capabilities,
+    idempotencyMarker,
     repoRoot,
-    logger,
   } = input;
   const buildSystem = input._buildSystem ?? defaultBuildSystem;
   const loadOptionalPrompt = input._loadOptionalPrompt ?? defaultLoadOptionalPrompt;
@@ -120,12 +122,9 @@ export function prepareReviewer(input: PrepareReviewerInput): ReviewerPreparedCo
   });
   const system = applyRubricToPrompt(baseSystem, reviewRubric);
 
-  const capabilities = resolveCapabilities(issue.labels, configLabels, logger);
   // The reviewer agent has never used MCP servers; we expose an empty list to
   // satisfy the shared `RolePreparedContextBase` shape.
   const mcpServers: McpServerConfig[] = [];
-
-  const idempotencyMarker = byPrHeadSha('reviewer', headSha);
 
   return {
     system,


### PR DESCRIPTION
**Closes #330. Part of #339.** Prerequisite refactor for the `ferry-cc-prepare` composite (sister issue #331).

## What

Each agent today executes 60-100+ lines of stateful setup before `createAgentLoop` / `runReviewLoop`: Jira fetch, `buildSystem(<role>)`, `initialPrompt` builder, MCP capability filter, branch checkout, PR-existence probe, idempotency-marker computation. Until now that setup only lived inline at the top of each `<role>-action.ts`, so `buildClaudeCodeJob`'s docstring promise — that `system` / `initialPrompt` / `mcpServers` are forwarded verbatim — was true at the leaf and false in practice, because reaching them required duplicating the same setup.

This PR extracts the setup into four reusable prepare functions under `src/lib/agent-runtime/`:

- **`refiner-prepare.ts`** → `prepareRefiner` returns the inputs to `runRefiner` (issue, existingSubtasks, priorRefinerRuns, runLink) plus the idempotency marker. The refiner does not use an agent loop on the script path, so `system` / `initialPrompt` are not populated here; the cc-prepare composite will compute them from `buildSystem('refiner')` + `buildPrompt(refinerInput)`.
- **`developer-prepare.ts`** → `prepareDeveloper` (async) builds system, ticket block, initial prompt (with resume + existing-PR context concatenated), capability-filtered MCP pool, idempotency marker, branchName, branchHeadSha, existingPrUrl. Branch checkout is factored into an injectable `CheckoutOrCreateBranchFn` so the function tests cleanly without spinning up git. The PR-existence probe is best-effort and skipped under `dryRun`.
- **`reviewer-prepare.ts`** → `prepareReviewer` builds system (with the optional review-comment overlay and rubric override applied), initial prompt with PR metadata + commits + changed files, idempotency marker, and the filename→patch map the review loop consumes.
- **`iterator-prepare.ts`** → `prepareIterator` builds system, ticket block, initial prompt with review findings + merge conflicts + existing-branch log, capability-filtered MCP pool, and the idempotency marker.

A shared `RolePreparedContextBase` interface in `prepare.ts` documents the four invariant fields (`system`, `initialPrompt`, `mcpServers`, `idempotencyMarker`) plus `ticketBlock` + `capabilities`; each role's context type extends it with role-specific extras (`branchName`, `branchHeadSha`, `existingPrUrl`, `fileMap`, etc.).

The four `*-action.ts` files now delegate their setup chunks to the new functions, preserving every side effect verbatim. Label-override resolution, branch validation, and short-circuit exits (read-only, skip-phase, PR-not-found, idempotency-skip, etc.) stay inline in the actions because they have role-specific exit semantics; the prepare functions run after those gates have passed.

## Why

This structurally enforces the **ADR-0006 §2 "prompts reused verbatim" promise** — the `ferry-cc-prepare` composite (sister issue #331) will consume the same prepare functions and feed `buildClaudeCodeJob` with identical inputs. No more "true at the leaf, false in practice".

It also strictly reduces the inline footprint in every `*-action.ts`: ~64 lines out of `dev-action.ts`, ~30 lines out of each of the three others.

## Acceptance criteria (from #330)

- [x] **Zero behaviour change on the script path** — 2088 baseline tests still pass.
- [x] **New unit tests on the extracted prepare functions, one fixture per role** — 22 new tests added (2110 total).
- [x] **`npm run check:bundle` clean** — bundles rebuilt in this PR.
- [x] **ADR-0006 §2 "prompts reused verbatim" promise is now structurally enforced** — `system` / `initialPrompt` flow through a single source per role.

## CI gates passing locally

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm test` ✅ (149 files / 2110 tests)
- `npm run check:bundle` ✅
- `npm run smoke:bundle` ✅ (4 roles)
- `npm run check:fr-drift` ✅

## Diff shape

```
src/agents/developer/dev-action.ts    | 128 ++++++++--------------------------
src/agents/iterator/iterate-action.ts |  47 +++++--------
src/agents/refiner/refiner-action.ts  |  16 ++---
src/agents/reviewer/review-action.ts  |  72 ++++++-------------
src/lib/agent-runtime/index.ts        |  20 ++++++
5 files changed, 94 insertions(+), 189 deletions(-)
```

Plus 5 new source files (4 prepare modules + 1 base type) and 4 new test files.

## Refs

- ADR-0006 §2 ("prompts reused verbatim")
- `decisions/0002-claude-code-path-parity-analysis.md` §C
- Sister issue #331 (`ferry-cc-prepare` composite — consumer of these functions)
- Parent epic #339 (claude-code path runtime activation)