### PR TITLE
feat(cc-wiring): wire claude-code-action chain — refiner end-to-end, dev/review/iterate fail-loud scaffold (refs #333)

### DIFF
--- a/examples/consumer-setup/workflows/ferry-dev.yml
+++ b/examples/consumer-setup/workflows/ferry-dev.yml
@@ -152,7 +152,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
       - name: Run claude-code-action
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.cc-prepare.outputs.prompt }}
@@ -190,7 +190,7 @@ jobs:
           phase: dev
           run_id: ${{ github.event.client_payload.event_id }}
           model: ${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-4-6' }}
-          outcome: ${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          outcome: ${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
           input_tokens: ${{ needs.run-agent.outputs.input_tokens || needs.run-agent-claude-code.outputs.input_tokens || '0' }}
           output_tokens: ${{ needs.run-agent.outputs.output_tokens || needs.run-agent-claude-code.outputs.output_tokens || '0' }}
           cost_eur: ${{ needs.run-agent.outputs.cost_eur || needs.run-agent-claude-code.outputs.cost_eur || '0' }}

--- a/examples/consumer-setup/workflows/ferry-dev.yml
+++ b/examples/consumer-setup/workflows/ferry-dev.yml
@@ -135,6 +135,19 @@ jobs:
       output_tokens: ${{ steps.cc-apply.outputs.output_tokens }}
       cost_eur: ${{ steps.cc-apply.outputs.cost_eur }}
     steps:
+      # Fail-loud guard: ferry-cc-prepare's composite entrypoint currently only handles
+      # role 'refiner' end-to-end. Runtime support for developer/reviewer/iterator lands
+      # in a follow-up to #333. Until then, this job must hard-fail before cc-prepare so
+      # consumers get a clear actionable error instead of a late-stage throw.
+      - name: Guard — cc-path not yet wired for developer
+        shell: bash
+        run: |
+          echo "::error::Ferry: the claude-code execution path is not yet wired for role 'developer'."
+          echo "::error::ferry-cc-prepare's composite entrypoint currently only handles role 'refiner' end-to-end."
+          echo "::error::Runtime support for developer / reviewer / iterator arrives in a follow-up to #333."
+          echo "::error::Workaround: route this ticket via the script path (do not set FERRY_EXECUTION_PATH=claude-code)."
+          exit 1
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/examples/consumer-setup/workflows/ferry-dev.yml
+++ b/examples/consumer-setup/workflows/ferry-dev.yml
@@ -175,7 +175,7 @@ jobs:
   emit-audit:
     name: Emit audit line
     needs: [run-agent, run-agent-claude-code]
-    if: always() && (needs.run-agent.result == 'success' || needs.run-agent-claude-code.result == 'success')
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/examples/consumer-setup/workflows/ferry-dev.yml
+++ b/examples/consumer-setup/workflows/ferry-dev.yml
@@ -130,21 +130,47 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+    outputs:
+      input_tokens: ${{ steps.cc-apply.outputs.input_tokens }}
+      output_tokens: ${{ steps.cc-apply.outputs.output_tokens }}
+      cost_eur: ${{ steps.cc-apply.outputs.cost_eur }}
     steps:
-      # Placeholder: the claude-code-action wiring lands in a follow-up PR. The
-      # routing decision is fully implemented (this branch will be selected for
-      # `ferry:claude-code` / `execution_path: claude-code`), but the action
-      # invocation itself + the front-half loader (envelope/config/Jira/MCP)
-      # are out of scope for this change. Failing loud avoids silent skips.
-      - name: claude-code execution path not yet wired
-        shell: bash
-        run: |
-          echo "::error::Ferry routing resolved this run to the claude-code-action path," \
-            "but the claude-code execution branch is not yet wired in this Ferry release." \
-            "Set execution_path: script in ferry.config.yaml (or remove the ferry:claude-code" \
-            "label on the ticket) to use the bundled-script path. Tracked as a follow-up to" \
-            "the routing-only PR."
-          exit 1
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Prepare claude-code job
+        id: cc-prepare
+        uses: big-emotion/ferry/.github/actions/ferry-cc-prepare@v0.12.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          role: developer
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+          github_token: ${{ github.token }}
+          github_repo: ${{ github.repository }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+      - name: Run claude-code-action
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.cc-prepare.outputs.prompt }}
+          claude_args: ${{ steps.cc-prepare.outputs.claude_args }}
+
+      - name: Apply claude-code output
+        id: cc-apply
+        uses: big-emotion/ferry/.github/actions/ferry-cc-apply@v0.12.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          role: developer
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+          idempotency_marker: ${{ steps.cc-prepare.outputs.idempotency_marker }}
+          ferry_review_transition_id: ${{ secrets.FERRY_REVIEW_TRANSITION_ID }}
+          github_token: ${{ github.token }}
+          github_repo: ${{ github.repository }}
 
   emit-audit:
     name: Emit audit line
@@ -165,9 +191,9 @@ jobs:
           run_id: ${{ github.event.client_payload.event_id }}
           model: ${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-4-6' }}
           outcome: ${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
-          input_tokens: ${{ needs.run-agent.outputs.input_tokens || '0' }}
-          output_tokens: ${{ needs.run-agent.outputs.output_tokens || '0' }}
-          cost_eur: ${{ needs.run-agent.outputs.cost_eur || '0' }}
+          input_tokens: ${{ needs.run-agent.outputs.input_tokens || needs.run-agent-claude-code.outputs.input_tokens || '0' }}
+          output_tokens: ${{ needs.run-agent.outputs.output_tokens || needs.run-agent-claude-code.outputs.output_tokens || '0' }}
+          cost_eur: ${{ needs.run-agent.outputs.cost_eur || needs.run-agent-claude-code.outputs.cost_eur || '0' }}
           start_ms: ${{ github.run_id }}
           audit_issue: ${{ vars.FERRY_AUDIT_ISSUE }}
           github_token: ${{ github.token }}

--- a/examples/consumer-setup/workflows/ferry-iterate.yml
+++ b/examples/consumer-setup/workflows/ferry-iterate.yml
@@ -138,6 +138,19 @@ jobs:
       output_tokens: ${{ steps.cc-apply.outputs.output_tokens }}
       cost_eur: ${{ steps.cc-apply.outputs.cost_eur }}
     steps:
+      # Fail-loud guard: ferry-cc-prepare's composite entrypoint currently only handles
+      # role 'refiner' end-to-end. Runtime support for developer/reviewer/iterator lands
+      # in a follow-up to #333. Until then, this job must hard-fail before cc-prepare so
+      # consumers get a clear actionable error instead of a late-stage throw.
+      - name: Guard — cc-path not yet wired for iterator
+        shell: bash
+        run: |
+          echo "::error::Ferry: the claude-code execution path is not yet wired for role 'iterator'."
+          echo "::error::ferry-cc-prepare's composite entrypoint currently only handles role 'refiner' end-to-end."
+          echo "::error::Runtime support for developer / reviewer / iterator arrives in a follow-up to #333."
+          echo "::error::Workaround: route this ticket via the script path (do not set FERRY_EXECUTION_PATH=claude-code)."
+          exit 1
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/examples/consumer-setup/workflows/ferry-iterate.yml
+++ b/examples/consumer-setup/workflows/ferry-iterate.yml
@@ -180,7 +180,7 @@ jobs:
   emit-audit:
     name: Emit audit line
     needs: [run-agent, run-agent-claude-code]
-    if: always() && (needs.run-agent.result == 'success' || needs.run-agent-claude-code.result == 'success')
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/examples/consumer-setup/workflows/ferry-iterate.yml
+++ b/examples/consumer-setup/workflows/ferry-iterate.yml
@@ -133,16 +133,49 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+    outputs:
+      input_tokens: ${{ steps.cc-apply.outputs.input_tokens }}
+      output_tokens: ${{ steps.cc-apply.outputs.output_tokens }}
+      cost_eur: ${{ steps.cc-apply.outputs.cost_eur }}
     steps:
-      # Placeholder: the claude-code-action wiring lands in a follow-up PR.
-      - name: claude-code execution path not yet wired
-        shell: bash
-        run: |
-          echo "::error::Ferry routing resolved this run to the claude-code-action path," \
-            "but the claude-code execution branch is not yet wired in this Ferry release." \
-            "Set execution_path: script in ferry.config.yaml (or remove the ferry:claude-code" \
-            "label on the ticket) to use the bundled-script path."
-          exit 1
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Prepare claude-code job
+        id: cc-prepare
+        uses: big-emotion/ferry/.github/actions/ferry-cc-prepare@v0.12.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          role: iterator
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+          github_token: ${{ github.token }}
+          github_repo: ${{ github.repository }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+      - name: Run claude-code-action
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.cc-prepare.outputs.prompt }}
+          claude_args: ${{ steps.cc-prepare.outputs.claude_args }}
+
+      - name: Apply claude-code output
+        id: cc-apply
+        uses: big-emotion/ferry/.github/actions/ferry-cc-apply@v0.12.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          role: iterator
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+          idempotency_marker: ${{ steps.cc-prepare.outputs.idempotency_marker }}
+          ferry_review_transition_id: ${{ secrets.FERRY_REVIEW_TRANSITION_ID }}
+          github_token: ${{ github.token }}
+          github_repo: ${{ github.repository }}
 
   emit-audit:
     name: Emit audit line
@@ -163,9 +196,9 @@ jobs:
           run_id: ${{ github.event.client_payload.event_id }}
           model: ${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
           outcome: ${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
-          input_tokens: ${{ needs.run-agent.outputs.input_tokens || '0' }}
-          output_tokens: ${{ needs.run-agent.outputs.output_tokens || '0' }}
-          cost_eur: ${{ needs.run-agent.outputs.cost_eur || '0' }}
+          input_tokens: ${{ needs.run-agent.outputs.input_tokens || needs.run-agent-claude-code.outputs.input_tokens || '0' }}
+          output_tokens: ${{ needs.run-agent.outputs.output_tokens || needs.run-agent-claude-code.outputs.output_tokens || '0' }}
+          cost_eur: ${{ needs.run-agent.outputs.cost_eur || needs.run-agent-claude-code.outputs.cost_eur || '0' }}
           start_ms: ${{ github.run_id }}
           audit_issue: ${{ vars.FERRY_AUDIT_ISSUE }}
           github_token: ${{ github.token }}

--- a/examples/consumer-setup/workflows/ferry-iterate.yml
+++ b/examples/consumer-setup/workflows/ferry-iterate.yml
@@ -157,7 +157,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
       - name: Run claude-code-action
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.cc-prepare.outputs.prompt }}
@@ -195,7 +195,7 @@ jobs:
           phase: iterate
           run_id: ${{ github.event.client_payload.event_id }}
           model: ${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
-          outcome: ${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          outcome: ${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
           input_tokens: ${{ needs.run-agent.outputs.input_tokens || needs.run-agent-claude-code.outputs.input_tokens || '0' }}
           output_tokens: ${{ needs.run-agent.outputs.output_tokens || needs.run-agent-claude-code.outputs.output_tokens || '0' }}
           cost_eur: ${{ needs.run-agent.outputs.cost_eur || needs.run-agent-claude-code.outputs.cost_eur || '0' }}

--- a/examples/consumer-setup/workflows/ferry-refine.yml
+++ b/examples/consumer-setup/workflows/ferry-refine.yml
@@ -155,7 +155,7 @@ jobs:
   emit-audit:
     name: Emit audit line
     needs: [run-agent, run-agent-claude-code]
-    if: always() && (needs.run-agent.result == 'success' || needs.run-agent-claude-code.result == 'success')
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/examples/consumer-setup/workflows/ferry-refine.yml
+++ b/examples/consumer-setup/workflows/ferry-refine.yml
@@ -133,7 +133,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
       - name: Run claude-code-action
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.cc-prepare.outputs.prompt }}
@@ -170,7 +170,7 @@ jobs:
           phase: refine
           run_id: ${{ github.event.client_payload.event_id }}
           model: ${{ vars.FERRY_REFINER_MODEL || 'claude-sonnet-4-6' }}
-          outcome: ${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          outcome: ${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
           input_tokens: ${{ needs.run-agent-claude-code.outputs.input_tokens || '0' }}
           output_tokens: ${{ needs.run-agent-claude-code.outputs.output_tokens || '0' }}
           cost_eur: ${{ needs.run-agent-claude-code.outputs.cost_eur || '0' }}

--- a/examples/consumer-setup/workflows/ferry-refine.yml
+++ b/examples/consumer-setup/workflows/ferry-refine.yml
@@ -111,18 +111,46 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      input_tokens: ${{ steps.cc-apply.outputs.input_tokens }}
+      output_tokens: ${{ steps.cc-apply.outputs.output_tokens }}
+      cost_eur: ${{ steps.cc-apply.outputs.cost_eur }}
     steps:
-      # Placeholder: the claude-code-action wiring lands in a follow-up PR.
-      # The routing decision is fully implemented; only the action invocation
-      # and front-half loader (envelope/config/Jira/MCP) are out of scope here.
-      - name: claude-code execution path not yet wired
-        shell: bash
-        run: |
-          echo "::error::Ferry routing resolved this run to the claude-code-action path," \
-            "but the claude-code execution branch is not yet wired in this Ferry release." \
-            "Set execution_path: script in ferry.config.yaml (or remove the ferry:claude-code" \
-            "label on the ticket) to use the bundled-script path."
-          exit 1
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Prepare claude-code job
+        id: cc-prepare
+        uses: big-emotion/ferry/.github/actions/ferry-cc-prepare@v0.12.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          role: refiner
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+          github_token: ${{ github.token }}
+          github_repo: ${{ github.repository }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+      - name: Run claude-code-action
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.cc-prepare.outputs.prompt }}
+          claude_args: ${{ steps.cc-prepare.outputs.claude_args }}
+
+      - name: Apply claude-code output
+        id: cc-apply
+        uses: big-emotion/ferry/.github/actions/ferry-cc-apply@v0.12.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          role: refiner
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+          idempotency_marker: ${{ steps.cc-prepare.outputs.idempotency_marker }}
+          github_token: ${{ github.token }}
+          github_repo: ${{ github.repository }}
 
   emit-audit:
     name: Emit audit line
@@ -143,6 +171,9 @@ jobs:
           run_id: ${{ github.event.client_payload.event_id }}
           model: ${{ vars.FERRY_REFINER_MODEL || 'claude-sonnet-4-6' }}
           outcome: ${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          input_tokens: ${{ needs.run-agent-claude-code.outputs.input_tokens || '0' }}
+          output_tokens: ${{ needs.run-agent-claude-code.outputs.output_tokens || '0' }}
+          cost_eur: ${{ needs.run-agent-claude-code.outputs.cost_eur || '0' }}
           start_ms: ${{ github.run_id }}
           audit_issue: ${{ vars.FERRY_AUDIT_ISSUE }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/consumer-setup/workflows/ferry-review.yml
+++ b/examples/consumer-setup/workflows/ferry-review.yml
@@ -134,6 +134,19 @@ jobs:
       output_tokens: ${{ steps.cc-apply.outputs.output_tokens }}
       cost_eur: ${{ steps.cc-apply.outputs.cost_eur }}
     steps:
+      # Fail-loud guard: ferry-cc-prepare's composite entrypoint currently only handles
+      # role 'refiner' end-to-end. Runtime support for developer/reviewer/iterator lands
+      # in a follow-up to #333. Until then, this job must hard-fail before cc-prepare so
+      # consumers get a clear actionable error instead of a late-stage throw.
+      - name: Guard — cc-path not yet wired for reviewer
+        shell: bash
+        run: |
+          echo "::error::Ferry: the claude-code execution path is not yet wired for role 'reviewer'."
+          echo "::error::ferry-cc-prepare's composite entrypoint currently only handles role 'refiner' end-to-end."
+          echo "::error::Runtime support for developer / reviewer / iterator arrives in a follow-up to #333."
+          echo "::error::Workaround: route this ticket via the script path (do not set FERRY_EXECUTION_PATH=claude-code)."
+          exit 1
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/examples/consumer-setup/workflows/ferry-review.yml
+++ b/examples/consumer-setup/workflows/ferry-review.yml
@@ -129,16 +129,47 @@ jobs:
       pull-requests: write
       issues: write
       checks: read
+    outputs:
+      input_tokens: ${{ steps.cc-apply.outputs.input_tokens }}
+      output_tokens: ${{ steps.cc-apply.outputs.output_tokens }}
+      cost_eur: ${{ steps.cc-apply.outputs.cost_eur }}
     steps:
-      # Placeholder: the claude-code-action wiring lands in a follow-up PR.
-      - name: claude-code execution path not yet wired
-        shell: bash
-        run: |
-          echo "::error::Ferry routing resolved this run to the claude-code-action path," \
-            "but the claude-code execution branch is not yet wired in this Ferry release." \
-            "Set execution_path: script in ferry.config.yaml (or remove the ferry:claude-code" \
-            "label on the ticket) to use the bundled-script path."
-          exit 1
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Prepare claude-code job
+        id: cc-prepare
+        uses: big-emotion/ferry/.github/actions/ferry-cc-prepare@v0.12.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          role: reviewer
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+          github_token: ${{ github.token }}
+          github_repo: ${{ github.repository }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+      - name: Run claude-code-action
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.cc-prepare.outputs.prompt }}
+          claude_args: ${{ steps.cc-prepare.outputs.claude_args }}
+
+      - name: Apply claude-code output
+        id: cc-apply
+        uses: big-emotion/ferry/.github/actions/ferry-cc-apply@v0.12.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          role: reviewer
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+          idempotency_marker: ${{ steps.cc-prepare.outputs.idempotency_marker }}
+          ferry_iter_transition_id: ${{ secrets.FERRY_ITER_TRANSITION_ID }}
+          github_token: ${{ github.token }}
+          github_repo: ${{ github.repository }}
 
   emit-audit:
     name: Emit audit line
@@ -159,9 +190,9 @@ jobs:
           run_id: ${{ github.event.client_payload.event_id }}
           model: ${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
           outcome: ${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
-          input_tokens: ${{ needs.run-agent.outputs.input_tokens || '0' }}
-          output_tokens: ${{ needs.run-agent.outputs.output_tokens || '0' }}
-          cost_eur: ${{ needs.run-agent.outputs.cost_eur || '0' }}
+          input_tokens: ${{ needs.run-agent.outputs.input_tokens || needs.run-agent-claude-code.outputs.input_tokens || '0' }}
+          output_tokens: ${{ needs.run-agent.outputs.output_tokens || needs.run-agent-claude-code.outputs.output_tokens || '0' }}
+          cost_eur: ${{ needs.run-agent.outputs.cost_eur || needs.run-agent-claude-code.outputs.cost_eur || '0' }}
           start_ms: ${{ github.run_id }}
           audit_issue: ${{ vars.FERRY_AUDIT_ISSUE }}
           github_token: ${{ github.token }}

--- a/examples/consumer-setup/workflows/ferry-review.yml
+++ b/examples/consumer-setup/workflows/ferry-review.yml
@@ -168,13 +168,14 @@ jobs:
           jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
           idempotency_marker: ${{ steps.cc-prepare.outputs.idempotency_marker }}
           ferry_iter_transition_id: ${{ secrets.FERRY_ITER_TRANSITION_ID }}
+          ferry_approve_transition_id: ${{ secrets.FERRY_APPROVE_TRANSITION_ID }}
           github_token: ${{ github.token }}
           github_repo: ${{ github.repository }}
 
   emit-audit:
     name: Emit audit line
     needs: [run-agent, run-agent-claude-code]
-    if: always() && (needs.run-agent.result == 'success' || needs.run-agent-claude-code.result == 'success')
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/examples/consumer-setup/workflows/ferry-review.yml
+++ b/examples/consumer-setup/workflows/ferry-review.yml
@@ -151,7 +151,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
       - name: Run claude-code-action
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.cc-prepare.outputs.prompt }}
@@ -190,7 +190,7 @@ jobs:
           phase: review
           run_id: ${{ github.event.client_payload.event_id }}
           model: ${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
-          outcome: ${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          outcome: ${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
           input_tokens: ${{ needs.run-agent.outputs.input_tokens || needs.run-agent-claude-code.outputs.input_tokens || '0' }}
           output_tokens: ${{ needs.run-agent.outputs.output_tokens || needs.run-agent-claude-code.outputs.output_tokens || '0' }}
           cost_eur: ${{ needs.run-agent.outputs.cost_eur || needs.run-agent-claude-code.outputs.cost_eur || '0' }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,8 @@
         "prettier": "^3.0.0",
         "tsx": "^4.0.0",
         "typescript": "^6.0.3",
-        "vitest": "^4.1.5"
+        "vitest": "^4.1.5",
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -4190,7 +4191,6 @@
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "prettier": "^3.0.0",
     "tsx": "^4.0.0",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.5"
+    "vitest": "^4.1.5",
+    "yaml": "^2.9.0"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.97.0",

--- a/src/cli/init/init.test.ts
+++ b/src/cli/init/init.test.ts
@@ -204,33 +204,33 @@ describe('workflowTemplates', () => {
     expect(workflowTemplates('v1', 'script')).toEqual(workflowTemplates('v1'));
   });
 
-  it('script path contains no claude-code guard or header', () => {
+  it('script path contains no claude-code header', () => {
     for (const tmpl of workflowTemplates('v1')) {
-      expect(tmpl.content).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
       expect(tmpl.content).not.toContain('Execution path: claude-code');
     }
   });
 
-  it('claude-code path materializes a fail-fast CLAUDE_CODE_OAUTH_TOKEN guard in every agent workflow', () => {
+  it('claude-code path wires the four-step chain in every agent workflow', () => {
     for (const tmpl of workflowTemplates('v1', 'claude-code')) {
       expect(tmpl.content).toContain('# Execution path: claude-code');
-      expect(tmpl.content).toContain('Require CLAUDE_CODE_OAUTH_TOKEN');
+      expect(tmpl.content).toContain('ferry-cc-prepare');
+      expect(tmpl.content).toContain('anthropics/claude-code-action@v1');
+      expect(tmpl.content).toContain('ferry-cc-apply');
       expect(tmpl.content).toContain(
-        'CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}',
+        'claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}',
       );
-      expect(tmpl.content).toContain('exit 1');
-      // The guard goes in the agent job only — exactly one occurrence per file.
-      const occurrences = tmpl.content.split('Require CLAUDE_CODE_OAUTH_TOKEN').length - 1;
-      expect(occurrences).toBe(1);
     }
   });
 
-  it('claude-code guard runs before the agent action', () => {
+  it('claude-code path runs cc-prepare before claude-code-action before cc-apply', () => {
     const dev = workflowTemplates('v1', 'claude-code').find((t) => t.filename === 'ferry-dev.yml');
-    const guardIdx = dev?.content.indexOf('Require CLAUDE_CODE_OAUTH_TOKEN') ?? -1;
-    const agentIdx = dev?.content.indexOf('ferry-run-developer') ?? -1;
-    expect(guardIdx).toBeGreaterThan(-1);
-    expect(agentIdx).toBeGreaterThan(-1);
-    expect(guardIdx).toBeLessThan(agentIdx);
+    const prepareIdx = dev?.content.indexOf('ferry-cc-prepare') ?? -1;
+    const actionIdx = dev?.content.indexOf('anthropics/claude-code-action@v1') ?? -1;
+    const applyIdx = dev?.content.indexOf('ferry-cc-apply') ?? -1;
+    expect(prepareIdx).toBeGreaterThan(-1);
+    expect(actionIdx).toBeGreaterThan(-1);
+    expect(applyIdx).toBeGreaterThan(-1);
+    expect(prepareIdx).toBeLessThan(actionIdx);
+    expect(actionIdx).toBeLessThan(applyIdx);
   });
 });

--- a/src/cli/init/init.test.ts
+++ b/src/cli/init/init.test.ts
@@ -214,7 +214,10 @@ describe('workflowTemplates', () => {
     for (const tmpl of workflowTemplates('v1', 'claude-code')) {
       expect(tmpl.content).toContain('# Execution path: claude-code');
       expect(tmpl.content).toContain('ferry-cc-prepare');
-      expect(tmpl.content).toContain('anthropics/claude-code-action@v1');
+      // Match by action ref only (not the version pin) so SHA-pinning the action
+      // doesn't require touching this presence check. The pin shape itself is
+      // asserted in templates.test.ts.
+      expect(tmpl.content).toContain('anthropics/claude-code-action@');
       expect(tmpl.content).toContain('ferry-cc-apply');
       expect(tmpl.content).toContain(
         'claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}',
@@ -225,7 +228,7 @@ describe('workflowTemplates', () => {
   it('claude-code path runs cc-prepare before claude-code-action before cc-apply', () => {
     const dev = workflowTemplates('v1', 'claude-code').find((t) => t.filename === 'ferry-dev.yml');
     const prepareIdx = dev?.content.indexOf('ferry-cc-prepare') ?? -1;
-    const actionIdx = dev?.content.indexOf('anthropics/claude-code-action@v1') ?? -1;
+    const actionIdx = dev?.content.indexOf('anthropics/claude-code-action@') ?? -1;
     const applyIdx = dev?.content.indexOf('ferry-cc-apply') ?? -1;
     expect(prepareIdx).toBeGreaterThan(-1);
     expect(actionIdx).toBeGreaterThan(-1);

--- a/src/cli/init/templates.test.ts
+++ b/src/cli/init/templates.test.ts
@@ -176,10 +176,17 @@ describe('workflowTemplates — role-specific wiring', () => {
     );
   });
 
-  it('ferry-review.yml wires FERRY_ITER_TRANSITION_ID into cc-apply (FR24)', () => {
+  it('ferry-review.yml wires FERRY_ITER_TRANSITION_ID into cc-apply (FR24 changes)', () => {
     const review = workflowTemplates('v1').find((t) => t.filename === 'ferry-review.yml');
     expect(review?.content).toContain(
       'ferry_iter_transition_id: ${{ secrets.FERRY_ITER_TRANSITION_ID }}',
+    );
+  });
+
+  it('ferry-review.yml wires FERRY_APPROVE_TRANSITION_ID into cc-apply (FR24 approve)', () => {
+    const review = workflowTemplates('v1').find((t) => t.filename === 'ferry-review.yml');
+    expect(review?.content).toContain(
+      'ferry_approve_transition_id: ${{ secrets.FERRY_APPROVE_TRANSITION_ID }}',
     );
   });
 

--- a/src/cli/init/templates.test.ts
+++ b/src/cli/init/templates.test.ts
@@ -259,6 +259,61 @@ describe('workflowTemplates — supply-chain action pinning', () => {
   });
 });
 
+describe('workflowTemplates — cc-path role-coverage guard', () => {
+  // ferry-cc-prepare's composite entrypoint currently only handles role 'refiner'
+  // end-to-end. The dev / review / iterate templates ship a fail-loud guard step
+  // at the top of run-agent-claude-code so consumers see a clear actionable error
+  // instead of a late-stage throw from cc-prepare. Refiner has NO such guard —
+  // its cc-path is wired and meant to run.
+  const NON_REFINER_ROLES: ReadonlyArray<{ filename: string; role: string }> = [
+    { filename: 'ferry-dev.yml', role: 'developer' },
+    { filename: 'ferry-review.yml', role: 'reviewer' },
+    { filename: 'ferry-iterate.yml', role: 'iterator' },
+  ];
+
+  for (const { filename, role } of NON_REFINER_ROLES) {
+    it(`${filename}: ships a fail-loud guard for role '${role}' cc-path`, () => {
+      const tmpl = workflowTemplates('v1').find((t) => t.filename === filename);
+      expect(tmpl, `${filename}: template not found`).toBeDefined();
+      expect(tmpl!.content, `${filename}: missing guard step name`).toContain(
+        `Guard — cc-path not yet wired for ${role}`,
+      );
+      expect(tmpl!.content, `${filename}: missing role-specific error message`).toContain(
+        `::error::Ferry: the claude-code execution path is not yet wired for role '${role}'.`,
+      );
+      expect(tmpl!.content, `${filename}: guard does not exit 1`).toMatch(
+        /Guard — cc-path not yet wired[\s\S]*?exit 1/,
+      );
+    });
+  }
+
+  it("ferry-refine.yml has NO 'cc-path not yet wired' guard (refiner cc-path is live)", () => {
+    const refine = workflowTemplates('v1').find((t) => t.filename === 'ferry-refine.yml');
+    expect(refine, 'ferry-refine.yml not found').toBeDefined();
+    expect(
+      refine!.content,
+      'ferry-refine.yml unexpectedly contains the cc-path guard step',
+    ).not.toContain('Guard — cc-path not yet wired');
+  });
+
+  it('guard runs before cc-prepare in every non-refiner template', () => {
+    for (const { filename } of NON_REFINER_ROLES) {
+      const tmpl = workflowTemplates('v1').find((t) => t.filename === filename);
+      const guardIdx = tmpl!.content.indexOf('Guard — cc-path not yet wired');
+      // Anchor on the step NAME (unique in the cc-path job) rather than the
+      // bare 'ferry-cc-prepare' substring, which also appears earlier in the
+      // guard's own explanatory comment.
+      const prepareStepIdx = tmpl!.content.indexOf('Prepare claude-code job');
+      expect(guardIdx, `${filename}: guard missing`).toBeGreaterThan(-1);
+      expect(prepareStepIdx, `${filename}: cc-prepare step missing`).toBeGreaterThan(-1);
+      expect(
+        guardIdx,
+        `${filename}: guard must precede cc-prepare to fail fast before any composite work`,
+      ).toBeLessThan(prepareStepIdx);
+    }
+  });
+});
+
 describe('workflowTemplates — execution path variants', () => {
   it('script path is byte-identical whether implicit or explicit', () => {
     expect(workflowTemplates('v1', 'script')).toEqual(workflowTemplates('v1'));

--- a/src/cli/init/templates.test.ts
+++ b/src/cli/init/templates.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from 'vitest';
+import { workflowTemplates } from './templates.js';
+
+const AGENT_FILES = ['ferry-refine.yml', 'ferry-dev.yml', 'ferry-review.yml', 'ferry-iterate.yml'];
+
+// Validates that a rendered template is structurally sound YAML for GitHub Actions:
+// - Uses only spaces, no tabs (YAML is space-sensitive)
+// - All ${{ expressions are closed with }}
+// - No bare TypeScript-style ${...} interpolation escaped as single-brace
+// - Top-level keys (name, on, jobs) are present and unindented
+function assertValidWorkflowYaml(content: string, filename: string): void {
+  // No tabs — YAML indentation must use spaces
+  expect(content, `${filename}: tabs found (YAML must use spaces)`).not.toMatch(/\t/);
+
+  // All GitHub Actions ${{ expressions must be closed
+  const openCount = (content.match(/\$\{\{/g) ?? []).length;
+  const closeCount = (content.match(/\}\}/g) ?? []).length;
+  expect(openCount, `${filename}: unmatched \${{ expressions`).toBeGreaterThan(0);
+  expect(closeCount, `${filename}: unmatched }} closers`).toBeGreaterThan(0);
+  // Allow for }} used in jinja-style contexts; just ensure we have at least as many closes
+  expect(closeCount, `${filename}: more opens than closes`).toBeGreaterThanOrEqual(openCount);
+
+  // No bare TypeScript-style ${...} (single-brace) that would indicate escaping mistakes
+  // GitHub Actions uses ${{ }}, never ${ }
+  expect(content, `${filename}: bare single-brace \${...} found — escaping error`).not.toMatch(
+    /\$\{[^{]/,
+  );
+
+  // Required GitHub Actions YAML top-level keys must be unindented
+  expect(content, `${filename}: missing top-level 'name:'`).toMatch(/^name:/m);
+  expect(content, `${filename}: missing top-level 'on:'`).toMatch(/^on:/m);
+  expect(content, `${filename}: missing top-level 'jobs:'`).toMatch(/^jobs:/m);
+}
+
+describe('workflowTemplates — count and filenames', () => {
+  it('returns exactly 4 workflow templates', () => {
+    expect(workflowTemplates('v1')).toHaveLength(4);
+  });
+
+  it('includes all four agent workflow filenames', () => {
+    const names = workflowTemplates('v1').map((t) => t.filename);
+    for (const f of AGENT_FILES) {
+      expect(names).toContain(f);
+    }
+  });
+});
+
+describe('workflowTemplates — YAML validity', () => {
+  it('each template renders as structurally valid GitHub Actions YAML (script path)', () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      assertValidWorkflowYaml(tmpl.content, tmpl.filename);
+    }
+  });
+
+  it('each template renders as structurally valid GitHub Actions YAML (claude-code path)', () => {
+    for (const tmpl of workflowTemplates('v1', 'claude-code')) {
+      assertValidWorkflowYaml(tmpl.content, tmpl.filename);
+    }
+  });
+
+  it('embeds the ferry version tag in each agent workflow', () => {
+    for (const tmpl of workflowTemplates('v0.12.0')) {
+      expect(tmpl.content).toContain('@v0.12.0');
+    }
+  });
+});
+
+describe('workflowTemplates — routing structure', () => {
+  it('every template has a route job that resolves execution path', () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      expect(tmpl.content, `${tmpl.filename}: missing route job`).toContain('ferry-route@v1');
+      expect(tmpl.content, `${tmpl.filename}: missing path output`).toContain(
+        'path: ${{ steps.route.outputs.path }}',
+      );
+    }
+  });
+
+  it('run-agent (script path) is gated on route output', () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      expect(tmpl.content, `${tmpl.filename}: script path missing if gate`).toContain(
+        "if: needs.route.outputs.path == 'script'",
+      );
+    }
+  });
+
+  it('run-agent-claude-code is gated on route output', () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      expect(tmpl.content, `${tmpl.filename}: cc path missing if gate`).toContain(
+        "if: needs.route.outputs.path == 'claude-code'",
+      );
+    }
+  });
+
+  it('emit-audit depends on both run-agent and run-agent-claude-code', () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      expect(tmpl.content, `${tmpl.filename}: emit-audit missing dual dependency`).toContain(
+        'needs: [run-agent, run-agent-claude-code]',
+      );
+      // emit-audit must run even when one path is skipped
+      expect(tmpl.content, `${tmpl.filename}: emit-audit missing always() guard`).toContain(
+        'if: always() &&',
+      );
+    }
+  });
+});
+
+describe('workflowTemplates — claude-code path four-step chain', () => {
+  it('run-agent-claude-code contains all four steps in order', () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      const content = tmpl.content;
+      const prepareIdx = content.indexOf('ferry-cc-prepare');
+      const actionIdx = content.indexOf('anthropics/claude-code-action@v1');
+      const applyIdx = content.indexOf('ferry-cc-apply');
+
+      expect(prepareIdx, `${tmpl.filename}: missing ferry-cc-prepare`).toBeGreaterThan(-1);
+      expect(actionIdx, `${tmpl.filename}: missing claude-code-action@v1`).toBeGreaterThan(-1);
+      expect(applyIdx, `${tmpl.filename}: missing ferry-cc-apply`).toBeGreaterThan(-1);
+      expect(
+        prepareIdx,
+        `${tmpl.filename}: cc-prepare must precede claude-code-action`,
+      ).toBeLessThan(actionIdx);
+      expect(actionIdx, `${tmpl.filename}: claude-code-action must precede cc-apply`).toBeLessThan(
+        applyIdx,
+      );
+    }
+  });
+
+  it('cc-prepare receives the CLAUDE_CODE_OAUTH_TOKEN input', () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      expect(
+        tmpl.content,
+        `${tmpl.filename}: missing claude_code_oauth_token in cc-prepare`,
+      ).toContain('claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}');
+    }
+  });
+
+  it('claude-code-action receives prompt and claude_args from cc-prepare outputs', () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      expect(tmpl.content, `${tmpl.filename}: missing prompt wiring`).toContain(
+        'prompt: ${{ steps.cc-prepare.outputs.prompt }}',
+      );
+      expect(tmpl.content, `${tmpl.filename}: missing claude_args wiring`).toContain(
+        'claude_args: ${{ steps.cc-prepare.outputs.claude_args }}',
+      );
+    }
+  });
+
+  it('cc-apply receives idempotency_marker from cc-prepare output', () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      expect(tmpl.content, `${tmpl.filename}: missing idempotency_marker wiring`).toContain(
+        'idempotency_marker: ${{ steps.cc-prepare.outputs.idempotency_marker }}',
+      );
+    }
+  });
+
+  it('run-agent-claude-code exposes cost outputs for emit-audit', () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      expect(tmpl.content, `${tmpl.filename}: missing input_tokens output`).toContain(
+        'input_tokens: ${{ steps.cc-apply.outputs.input_tokens }}',
+      );
+      expect(tmpl.content, `${tmpl.filename}: missing output_tokens output`).toContain(
+        'output_tokens: ${{ steps.cc-apply.outputs.output_tokens }}',
+      );
+      expect(tmpl.content, `${tmpl.filename}: missing cost_eur output`).toContain(
+        'cost_eur: ${{ steps.cc-apply.outputs.cost_eur }}',
+      );
+    }
+  });
+});
+
+describe('workflowTemplates — role-specific wiring', () => {
+  it('ferry-dev.yml wires FERRY_REVIEW_TRANSITION_ID into cc-apply (FR18)', () => {
+    const dev = workflowTemplates('v1').find((t) => t.filename === 'ferry-dev.yml');
+    expect(dev?.content).toContain(
+      'ferry_review_transition_id: ${{ secrets.FERRY_REVIEW_TRANSITION_ID }}',
+    );
+  });
+
+  it('ferry-review.yml wires FERRY_ITER_TRANSITION_ID into cc-apply (FR24)', () => {
+    const review = workflowTemplates('v1').find((t) => t.filename === 'ferry-review.yml');
+    expect(review?.content).toContain(
+      'ferry_iter_transition_id: ${{ secrets.FERRY_ITER_TRANSITION_ID }}',
+    );
+  });
+
+  it('ferry-iterate.yml wires FERRY_REVIEW_TRANSITION_ID into cc-apply (FR28)', () => {
+    const iterate = workflowTemplates('v1').find((t) => t.filename === 'ferry-iterate.yml');
+    expect(iterate?.content).toContain(
+      'ferry_review_transition_id: ${{ secrets.FERRY_REVIEW_TRANSITION_ID }}',
+    );
+  });
+
+  it('ferry-iterate.yml uses fetch-depth: 0 for both script and cc path checkouts', () => {
+    const iterate = workflowTemplates('v1').find((t) => t.filename === 'ferry-iterate.yml');
+    const fetchDepthCount = (iterate?.content.match(/fetch-depth: 0/g) ?? []).length;
+    expect(fetchDepthCount).toBe(2);
+  });
+
+  it('ferry-review.yml declares checks: read permission on both run-agent jobs', () => {
+    const review = workflowTemplates('v1').find((t) => t.filename === 'ferry-review.yml');
+    const checksCount = (review?.content.match(/checks: read/g) ?? []).length;
+    expect(checksCount).toBe(2);
+  });
+});
+
+describe('workflowTemplates — execution path variants', () => {
+  it('script path is byte-identical whether implicit or explicit', () => {
+    expect(workflowTemplates('v1', 'script')).toEqual(workflowTemplates('v1'));
+  });
+
+  it('script path contains no claude-code activation header', () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      expect(tmpl.content).not.toContain('Execution path: claude-code');
+    }
+  });
+
+  it('claude-code path adds the activation header to every template', () => {
+    for (const tmpl of workflowTemplates('v1', 'claude-code')) {
+      expect(tmpl.content).toContain('# Execution path: claude-code');
+    }
+  });
+});

--- a/src/cli/init/templates.test.ts
+++ b/src/cli/init/templates.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { parse as parseYaml } from 'yaml';
 import { workflowTemplates } from './templates.js';
 
 const AGENT_FILES = ['ferry-refine.yml', 'ferry-dev.yml', 'ferry-review.yml', 'ferry-iterate.yml'];
@@ -21,15 +22,22 @@ function assertValidWorkflowYaml(content: string, filename: string): void {
   expect(closeCount, `${filename}: more opens than closes`).toBeGreaterThanOrEqual(openCount);
 
   // No bare TypeScript-style ${...} (single-brace) that would indicate escaping mistakes
-  // GitHub Actions uses ${{ }}, never ${ }
+  // GitHub Actions uses ${{ }}, never ${ }. Negative lookahead reads as "dollar-brace not
+  // followed by another brace" — same intent as the previous /\$\{[^{]/ but no false-positive
+  // on a literal `${ }` that could appear inside a comment.
   expect(content, `${filename}: bare single-brace \${...} found — escaping error`).not.toMatch(
-    /\$\{[^{]/,
+    /\$\{(?!\{)/,
   );
 
   // Required GitHub Actions YAML top-level keys must be unindented
   expect(content, `${filename}: missing top-level 'name:'`).toMatch(/^name:/m);
   expect(content, `${filename}: missing top-level 'on:'`).toMatch(/^on:/m);
   expect(content, `${filename}: missing top-level 'jobs:'`).toMatch(/^jobs:/m);
+
+  // The string-shape checks above catch the common escaping bugs, but they miss
+  // indentation mistakes that a regex can't see (e.g. a step block indented one level
+  // too deep). A real YAML parse round-trip catches those for free.
+  expect(() => parseYaml(content), `${filename}: yaml.parse threw`).not.toThrow();
 }
 
 describe('workflowTemplates — count and filenames', () => {
@@ -109,11 +117,15 @@ describe('workflowTemplates — claude-code path four-step chain', () => {
     for (const tmpl of workflowTemplates('v1')) {
       const content = tmpl.content;
       const prepareIdx = content.indexOf('ferry-cc-prepare');
-      const actionIdx = content.indexOf('anthropics/claude-code-action@v1');
+      // Match by action ref (not the version pin) so SHA-pinning the action doesn't
+      // require touching this ordering test.
+      const actionIdx = content.indexOf('anthropics/claude-code-action@');
       const applyIdx = content.indexOf('ferry-cc-apply');
 
       expect(prepareIdx, `${tmpl.filename}: missing ferry-cc-prepare`).toBeGreaterThan(-1);
-      expect(actionIdx, `${tmpl.filename}: missing claude-code-action@v1`).toBeGreaterThan(-1);
+      expect(actionIdx, `${tmpl.filename}: missing anthropics/claude-code-action`).toBeGreaterThan(
+        -1,
+      );
       expect(applyIdx, `${tmpl.filename}: missing ferry-cc-apply`).toBeGreaterThan(-1);
       expect(
         prepareIdx,
@@ -207,6 +219,43 @@ describe('workflowTemplates — role-specific wiring', () => {
     const review = workflowTemplates('v1').find((t) => t.filename === 'ferry-review.yml');
     const checksCount = (review?.content.match(/checks: read/g) ?? []).length;
     expect(checksCount).toBe(2);
+  });
+});
+
+describe('workflowTemplates — emit-audit outcome shape', () => {
+  // Locks in the `!= 'skipped'` shape of the outcome ternary. The earlier shape
+  // (`== 'success' && ...`) silently reported `skipped` for genuine script-path
+  // failures once the audit gate was widened to `!= 'skipped'`. Regressing this
+  // would poison cost-governance's view of failed runs.
+  it("outcome ternary uses != 'skipped' (script path branch), not == 'success'", () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      expect(
+        tmpl.content,
+        `${tmpl.filename}: outcome ternary still uses the regressed == 'success' shape`,
+      ).not.toContain("needs.run-agent.result == 'success' && needs.run-agent.result");
+      expect(
+        tmpl.content,
+        `${tmpl.filename}: outcome ternary missing != 'skipped' shape`,
+      ).toContain(
+        "outcome: ${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}",
+      );
+    }
+  });
+});
+
+describe('workflowTemplates — supply-chain action pinning', () => {
+  // anthropics/claude-code-action is a token-scoped action — tag refs like @v1 are
+  // mutable, so we require a 40-char commit SHA with a trailing version comment.
+  it('claude-code-action is SHA-pinned (not tag-pinned)', () => {
+    const SHA_PIN = /anthropics\/claude-code-action@[0-9a-f]{40}\s*#\s*v\d+/;
+    const TAG_PIN = /anthropics\/claude-code-action@v\d+\s*$/m;
+    for (const tmpl of workflowTemplates('v1')) {
+      expect(tmpl.content, `${tmpl.filename}: claude-code-action not SHA-pinned`).toMatch(SHA_PIN);
+      expect(
+        tmpl.content,
+        `${tmpl.filename}: claude-code-action still uses a mutable tag`,
+      ).not.toMatch(TAG_PIN);
+    }
   });
 });
 

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -168,7 +168,7 @@ jobs:
   emit-audit:
     name: Emit audit line
     needs: [run-agent, run-agent-claude-code]
-    if: always() && (needs.run-agent.result == 'success' || needs.run-agent-claude-code.result == 'success')
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -349,7 +349,7 @@ jobs:
   emit-audit:
     name: Emit audit line
     needs: [run-agent, run-agent-claude-code]
-    if: always() && (needs.run-agent.result == 'success' || needs.run-agent-claude-code.result == 'success')
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -527,13 +527,14 @@ jobs:
           jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
           idempotency_marker: \${{ steps.cc-prepare.outputs.idempotency_marker }}
           ferry_iter_transition_id: \${{ secrets.FERRY_ITER_TRANSITION_ID }}
+          ferry_approve_transition_id: \${{ secrets.FERRY_APPROVE_TRANSITION_ID }}
           github_token: \${{ github.token }}
           github_repo: \${{ github.repository }}
 
   emit-audit:
     name: Emit audit line
     needs: [run-agent, run-agent-claude-code]
-    if: always() && (needs.run-agent.result == 'success' || needs.run-agent-claude-code.result == 'success')
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -721,7 +722,7 @@ jobs:
   emit-audit:
     name: Emit audit line
     needs: [run-agent, run-agent-claude-code]
-    if: always() && (needs.run-agent.result == 'success' || needs.run-agent-claude-code.result == 'success')
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -146,7 +146,7 @@ jobs:
           claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
       - name: Run claude-code-action
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
         with:
           claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: \${{ steps.cc-prepare.outputs.prompt }}
@@ -183,7 +183,7 @@ jobs:
           phase: refine
           run_id: \${{ github.event.client_payload.event_id }}
           model: claude-sonnet-4-6
-          outcome: \${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          outcome: \${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
           input_tokens: \${{ needs.run-agent-claude-code.outputs.input_tokens || '0' }}
           output_tokens: \${{ needs.run-agent-claude-code.outputs.output_tokens || '0' }}
           cost_eur: \${{ needs.run-agent-claude-code.outputs.cost_eur || '0' }}
@@ -326,7 +326,7 @@ jobs:
           claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
       - name: Run claude-code-action
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
         with:
           claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: \${{ steps.cc-prepare.outputs.prompt }}
@@ -364,7 +364,7 @@ jobs:
           phase: dev
           run_id: \${{ github.event.client_payload.event_id }}
           model: claude-sonnet-4-6
-          outcome: \${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          outcome: \${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
           input_tokens: \${{ needs.run-agent.outputs.input_tokens || needs.run-agent-claude-code.outputs.input_tokens || '0' }}
           output_tokens: \${{ needs.run-agent.outputs.output_tokens || needs.run-agent-claude-code.outputs.output_tokens || '0' }}
           cost_eur: \${{ needs.run-agent.outputs.cost_eur || needs.run-agent-claude-code.outputs.cost_eur || '0' }}
@@ -510,7 +510,7 @@ jobs:
           claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
       - name: Run claude-code-action
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
         with:
           claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: \${{ steps.cc-prepare.outputs.prompt }}
@@ -549,7 +549,7 @@ jobs:
           phase: review
           run_id: \${{ github.event.client_payload.event_id }}
           model: \${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
-          outcome: \${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          outcome: \${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
           input_tokens: \${{ needs.run-agent.outputs.input_tokens || needs.run-agent-claude-code.outputs.input_tokens || '0' }}
           output_tokens: \${{ needs.run-agent.outputs.output_tokens || needs.run-agent-claude-code.outputs.output_tokens || '0' }}
           cost_eur: \${{ needs.run-agent.outputs.cost_eur || needs.run-agent-claude-code.outputs.cost_eur || '0' }}
@@ -699,7 +699,7 @@ jobs:
           claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
       - name: Run claude-code-action
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
         with:
           claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: \${{ steps.cc-prepare.outputs.prompt }}
@@ -737,7 +737,7 @@ jobs:
           phase: iterate
           run_id: \${{ github.event.client_payload.event_id }}
           model: \${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
-          outcome: \${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          outcome: \${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
           input_tokens: \${{ needs.run-agent.outputs.input_tokens || needs.run-agent-claude-code.outputs.input_tokens || '0' }}
           output_tokens: \${{ needs.run-agent.outputs.output_tokens || needs.run-agent-claude-code.outputs.output_tokens || '0' }}
           cost_eur: \${{ needs.run-agent.outputs.cost_eur || needs.run-agent-claude-code.outputs.cost_eur || '0' }}

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -9,22 +9,6 @@ const CLAUDE_CODE_HEADER =
   '# Required secret: CLAUDE_CODE_OAUTH_TOKEN (run `claude setup-token`; Claude Pro/Max subscription).\n' +
   '# Set execution_path: script in ferry.config.yaml to revert to the bundled multi-provider path.\n';
 
-// Deterministic fail-fast guard (ADR-0006 §6): the claude-code path must abort
-// before the agent runs if the OAuth token secret is absent. Anchored before the
-// gitleaks install, which exists only in the agent job (not gate-envelope /
-// emit-audit), so the guard is injected exactly once per workflow.
-const INSTALL_GITLEAKS_ANCHOR = '      - name: Install gitleaks\n';
-const CLAUDE_CODE_GUARD_STEP = `      - name: Require CLAUDE_CODE_OAUTH_TOKEN (claude-code execution path)
-        env:
-          CLAUDE_CODE_OAUTH_TOKEN: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-        shell: bash
-        run: |
-          if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
-            echo "::error::CLAUDE_CODE_OAUTH_TOKEN is required for the claude-code execution path. Run 'claude setup-token' (needs a Claude Pro/Max subscription) and add it as a repo secret, or set execution_path: script in ferry.config.yaml."
-            exit 1
-          fi
-${INSTALL_GITLEAKS_ANCHOR}`;
-
 function applyExecutionPath(
   templates: WorkflowEntry[],
   executionPath: ExecutionPath,
@@ -32,9 +16,7 @@ function applyExecutionPath(
   if (executionPath !== 'claude-code') return templates;
   return templates.map((t) => ({
     filename: t.filename,
-    content: t.content
-      .replace(MANAGED_BY_LINE, MANAGED_BY_LINE + CLAUDE_CODE_HEADER)
-      .replace(INSTALL_GITLEAKS_ANCHOR, CLAUDE_CODE_GUARD_STEP),
+    content: t.content.replace(MANAGED_BY_LINE, MANAGED_BY_LINE + CLAUDE_CODE_HEADER),
   }));
 }
 
@@ -50,6 +32,8 @@ export function workflowTemplates(
 #                   ANTHROPIC_API_KEY  — required when FERRY_REFINER_PROVIDER=anthropic (default)
 #                   OPENAI_API_KEY     — required when FERRY_REFINER_PROVIDER=openai
 #                   GOOGLE_API_KEY     — required when FERRY_REFINER_PROVIDER=google
+#                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
+#                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path)
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_REFINER_PROVIDER (default: anthropic; also: openai, google)
 #                     FERRY_REFINER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
@@ -80,9 +64,32 @@ jobs:
         with:
           payload: \${{ toJson(github.event.client_payload) }}
 
-  run-agent:
-    name: Run Refiner agent
+  route:
+    name: Resolve execution path
     needs: [gate-envelope]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      path: \${{ steps.route.outputs.path }}
+      reason: \${{ steps.route.outputs.reason }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve execution path
+        id: route
+        uses: big-emotion/ferry/.github/actions/ferry-route@${version}
+        with:
+          payload: \${{ toJson(github.event.client_payload) }}
+          role: refiner
+          jira_base_url: \${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: \${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
+
+  run-agent:
+    name: Run Refiner agent (script path)
+    needs: [route]
+    if: needs.route.outputs.path == 'script'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -110,10 +117,58 @@ jobs:
           github_repo: \${{ github.repository }}
           ferry_refiner_model: claude-sonnet-4-6
 
+  run-agent-claude-code:
+    name: Run Refiner agent (claude-code path)
+    needs: [route]
+    if: needs.route.outputs.path == 'claude-code'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      input_tokens: \${{ steps.cc-apply.outputs.input_tokens }}
+      output_tokens: \${{ steps.cc-apply.outputs.output_tokens }}
+      cost_eur: \${{ steps.cc-apply.outputs.cost_eur }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Prepare claude-code job
+        id: cc-prepare
+        uses: big-emotion/ferry/.github/actions/ferry-cc-prepare@${version}
+        with:
+          payload: \${{ toJson(github.event.client_payload) }}
+          role: refiner
+          jira_base_url: \${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: \${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
+          github_token: \${{ github.token }}
+          github_repo: \${{ github.repository }}
+          claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+      - name: Run claude-code-action
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: \${{ steps.cc-prepare.outputs.prompt }}
+          claude_args: \${{ steps.cc-prepare.outputs.claude_args }}
+
+      - name: Apply claude-code output
+        id: cc-apply
+        uses: big-emotion/ferry/.github/actions/ferry-cc-apply@${version}
+        with:
+          payload: \${{ toJson(github.event.client_payload) }}
+          role: refiner
+          jira_base_url: \${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: \${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
+          idempotency_marker: \${{ steps.cc-prepare.outputs.idempotency_marker }}
+          github_token: \${{ github.token }}
+          github_repo: \${{ github.repository }}
+
   emit-audit:
     name: Emit audit line
-    needs: [run-agent]
-    if: needs.run-agent.result != 'skipped'
+    needs: [run-agent, run-agent-claude-code]
+    if: always() && (needs.run-agent.result == 'success' || needs.run-agent-claude-code.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -128,7 +183,10 @@ jobs:
           phase: refine
           run_id: \${{ github.event.client_payload.event_id }}
           model: claude-sonnet-4-6
-          outcome: \${{ needs.run-agent.result }}
+          outcome: \${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          input_tokens: \${{ needs.run-agent-claude-code.outputs.input_tokens || '0' }}
+          output_tokens: \${{ needs.run-agent-claude-code.outputs.output_tokens || '0' }}
+          cost_eur: \${{ needs.run-agent-claude-code.outputs.cost_eur || '0' }}
           start_ms: \${{ github.run_id }}
           audit_issue: \${{ vars.FERRY_AUDIT_ISSUE }}
           github_token: \${{ secrets.GITHUB_TOKEN }}
@@ -142,6 +200,8 @@ jobs:
 #                   ANTHROPIC_API_KEY  — required when FERRY_DEV_PROVIDER=anthropic (default)
 #                   OPENAI_API_KEY     — required when FERRY_DEV_PROVIDER=openai
 #                   GOOGLE_API_KEY     — required when FERRY_DEV_PROVIDER=google
+#                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
+#                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path)
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_DEV_PROVIDER (default: anthropic; also: openai, google)
 #                     FERRY_DEV_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
@@ -174,9 +234,32 @@ jobs:
         with:
           payload: \${{ toJson(github.event.client_payload) }}
 
-  run-agent:
-    name: Run Developer agent
+  route:
+    name: Resolve execution path
     needs: [gate-envelope]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      path: \${{ steps.route.outputs.path }}
+      reason: \${{ steps.route.outputs.reason }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve execution path
+        id: route
+        uses: big-emotion/ferry/.github/actions/ferry-route@${version}
+        with:
+          payload: \${{ toJson(github.event.client_payload) }}
+          role: developer
+          jira_base_url: \${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: \${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
+
+  run-agent:
+    name: Run Developer agent (script path)
+    needs: [route]
+    if: needs.route.outputs.path == 'script'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -185,6 +268,7 @@ jobs:
     outputs:
       input_tokens: \${{ steps.run-developer.outputs.input_tokens }}
       output_tokens: \${{ steps.run-developer.outputs.output_tokens }}
+      cost_eur: \${{ steps.run-developer.outputs.cost_eur }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -211,10 +295,61 @@ jobs:
           github_repo: \${{ github.repository }}
           ferry_dev_model: claude-sonnet-4-6
 
+  run-agent-claude-code:
+    name: Run Developer agent (claude-code path)
+    needs: [route]
+    if: needs.route.outputs.path == 'claude-code'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    outputs:
+      input_tokens: \${{ steps.cc-apply.outputs.input_tokens }}
+      output_tokens: \${{ steps.cc-apply.outputs.output_tokens }}
+      cost_eur: \${{ steps.cc-apply.outputs.cost_eur }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Prepare claude-code job
+        id: cc-prepare
+        uses: big-emotion/ferry/.github/actions/ferry-cc-prepare@${version}
+        with:
+          payload: \${{ toJson(github.event.client_payload) }}
+          role: developer
+          jira_base_url: \${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: \${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
+          github_token: \${{ github.token }}
+          github_repo: \${{ github.repository }}
+          claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+      - name: Run claude-code-action
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: \${{ steps.cc-prepare.outputs.prompt }}
+          claude_args: \${{ steps.cc-prepare.outputs.claude_args }}
+
+      - name: Apply claude-code output
+        id: cc-apply
+        uses: big-emotion/ferry/.github/actions/ferry-cc-apply@${version}
+        with:
+          payload: \${{ toJson(github.event.client_payload) }}
+          role: developer
+          jira_base_url: \${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: \${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
+          idempotency_marker: \${{ steps.cc-prepare.outputs.idempotency_marker }}
+          ferry_review_transition_id: \${{ secrets.FERRY_REVIEW_TRANSITION_ID }}
+          github_token: \${{ github.token }}
+          github_repo: \${{ github.repository }}
+
   emit-audit:
     name: Emit audit line
-    needs: [run-agent]
-    if: needs.run-agent.result != 'skipped'
+    needs: [run-agent, run-agent-claude-code]
+    if: always() && (needs.run-agent.result == 'success' || needs.run-agent-claude-code.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -229,9 +364,10 @@ jobs:
           phase: dev
           run_id: \${{ github.event.client_payload.event_id }}
           model: claude-sonnet-4-6
-          outcome: \${{ needs.run-agent.result }}
-          input_tokens: \${{ needs.run-agent.outputs.input_tokens || '0' }}
-          output_tokens: \${{ needs.run-agent.outputs.output_tokens || '0' }}
+          outcome: \${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          input_tokens: \${{ needs.run-agent.outputs.input_tokens || needs.run-agent-claude-code.outputs.input_tokens || '0' }}
+          output_tokens: \${{ needs.run-agent.outputs.output_tokens || needs.run-agent-claude-code.outputs.output_tokens || '0' }}
+          cost_eur: \${{ needs.run-agent.outputs.cost_eur || needs.run-agent-claude-code.outputs.cost_eur || '0' }}
           start_ms: \${{ github.run_id }}
           audit_issue: \${{ vars.FERRY_AUDIT_ISSUE }}
           github_token: \${{ github.token }}
@@ -245,6 +381,8 @@ jobs:
 #                   ANTHROPIC_API_KEY  — required when FERRY_REVIEW_PROVIDER=anthropic (default)
 #                   OPENAI_API_KEY     — required when FERRY_REVIEW_PROVIDER=openai
 #                   GOOGLE_API_KEY     — required when FERRY_REVIEW_PROVIDER=google
+#                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
+#                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path)
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_REVIEW_PROVIDER (default: anthropic; also: openai, google)
 #                     FERRY_REVIEW_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
@@ -277,9 +415,32 @@ jobs:
         with:
           payload: \${{ toJson(github.event.client_payload) }}
 
-  run-agent:
-    name: Run Reviewer agent
+  route:
+    name: Resolve execution path
     needs: [gate-envelope]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      path: \${{ steps.route.outputs.path }}
+      reason: \${{ steps.route.outputs.reason }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve execution path
+        id: route
+        uses: big-emotion/ferry/.github/actions/ferry-route@${version}
+        with:
+          payload: \${{ toJson(github.event.client_payload) }}
+          role: reviewer
+          jira_base_url: \${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: \${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
+
+  run-agent:
+    name: Run Reviewer agent (script path)
+    needs: [route]
+    if: needs.route.outputs.path == 'script'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -289,6 +450,7 @@ jobs:
     outputs:
       input_tokens: \${{ steps.run-reviewer.outputs.input_tokens }}
       output_tokens: \${{ steps.run-reviewer.outputs.output_tokens }}
+      cost_eur: \${{ steps.run-reviewer.outputs.cost_eur }}
       model: \${{ steps.run-reviewer.outputs.model }}
     steps:
       - name: Checkout repository
@@ -316,10 +478,62 @@ jobs:
           github_repo: \${{ github.repository }}
           ferry_review_model: \${{ vars.FERRY_REVIEW_MODEL || 'claude-sonnet-4-6' }}
 
+  run-agent-claude-code:
+    name: Run Reviewer agent (claude-code path)
+    needs: [route]
+    if: needs.route.outputs.path == 'claude-code'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      checks: read
+    outputs:
+      input_tokens: \${{ steps.cc-apply.outputs.input_tokens }}
+      output_tokens: \${{ steps.cc-apply.outputs.output_tokens }}
+      cost_eur: \${{ steps.cc-apply.outputs.cost_eur }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Prepare claude-code job
+        id: cc-prepare
+        uses: big-emotion/ferry/.github/actions/ferry-cc-prepare@${version}
+        with:
+          payload: \${{ toJson(github.event.client_payload) }}
+          role: reviewer
+          jira_base_url: \${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: \${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
+          github_token: \${{ github.token }}
+          github_repo: \${{ github.repository }}
+          claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+      - name: Run claude-code-action
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: \${{ steps.cc-prepare.outputs.prompt }}
+          claude_args: \${{ steps.cc-prepare.outputs.claude_args }}
+
+      - name: Apply claude-code output
+        id: cc-apply
+        uses: big-emotion/ferry/.github/actions/ferry-cc-apply@${version}
+        with:
+          payload: \${{ toJson(github.event.client_payload) }}
+          role: reviewer
+          jira_base_url: \${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: \${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
+          idempotency_marker: \${{ steps.cc-prepare.outputs.idempotency_marker }}
+          ferry_iter_transition_id: \${{ secrets.FERRY_ITER_TRANSITION_ID }}
+          github_token: \${{ github.token }}
+          github_repo: \${{ github.repository }}
+
   emit-audit:
     name: Emit audit line
-    needs: [run-agent]
-    if: needs.run-agent.result != 'skipped'
+    needs: [run-agent, run-agent-claude-code]
+    if: always() && (needs.run-agent.result == 'success' || needs.run-agent-claude-code.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -334,9 +548,10 @@ jobs:
           phase: review
           run_id: \${{ github.event.client_payload.event_id }}
           model: \${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
-          outcome: \${{ needs.run-agent.result }}
-          input_tokens: \${{ needs.run-agent.outputs.input_tokens || '0' }}
-          output_tokens: \${{ needs.run-agent.outputs.output_tokens || '0' }}
+          outcome: \${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          input_tokens: \${{ needs.run-agent.outputs.input_tokens || needs.run-agent-claude-code.outputs.input_tokens || '0' }}
+          output_tokens: \${{ needs.run-agent.outputs.output_tokens || needs.run-agent-claude-code.outputs.output_tokens || '0' }}
+          cost_eur: \${{ needs.run-agent.outputs.cost_eur || needs.run-agent-claude-code.outputs.cost_eur || '0' }}
           start_ms: \${{ github.run_id }}
           audit_issue: \${{ vars.FERRY_AUDIT_ISSUE }}
           github_token: \${{ github.token }}
@@ -350,6 +565,8 @@ jobs:
 #                   ANTHROPIC_API_KEY  — required when FERRY_ITER_PROVIDER=anthropic (default)
 #                   OPENAI_API_KEY     — required when FERRY_ITER_PROVIDER=openai
 #                   GOOGLE_API_KEY     — required when FERRY_ITER_PROVIDER=google
+#                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
+#                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path)
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_ITER_PROVIDER (default: anthropic; also: openai, google)
 #                     FERRY_ITER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
@@ -383,9 +600,32 @@ jobs:
         with:
           payload: \${{ toJson(github.event.client_payload) }}
 
-  run-agent:
-    name: Run Iterator agent
+  route:
+    name: Resolve execution path
     needs: [gate-envelope]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      path: \${{ steps.route.outputs.path }}
+      reason: \${{ steps.route.outputs.reason }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve execution path
+        id: route
+        uses: big-emotion/ferry/.github/actions/ferry-route@${version}
+        with:
+          payload: \${{ toJson(github.event.client_payload) }}
+          role: iterator
+          jira_base_url: \${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: \${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
+
+  run-agent:
+    name: Run Iterator agent (script path)
+    needs: [route]
+    if: needs.route.outputs.path == 'script'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -394,6 +634,7 @@ jobs:
     outputs:
       input_tokens: \${{ steps.run-iterator.outputs.input_tokens }}
       output_tokens: \${{ steps.run-iterator.outputs.output_tokens }}
+      cost_eur: \${{ steps.run-iterator.outputs.cost_eur }}
       model: \${{ steps.run-iterator.outputs.model }}
     steps:
       - name: Checkout repository
@@ -424,10 +665,63 @@ jobs:
           ferry_iter_model: \${{ vars.FERRY_ITER_MODEL || 'claude-sonnet-4-6' }}
           ferry_iter_max_input_tokens: \${{ vars.FERRY_ITER_MAX_INPUT_TOKENS || '500000' }}
 
+  run-agent-claude-code:
+    name: Run Iterator agent (claude-code path)
+    needs: [route]
+    if: needs.route.outputs.path == 'claude-code'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    outputs:
+      input_tokens: \${{ steps.cc-apply.outputs.input_tokens }}
+      output_tokens: \${{ steps.cc-apply.outputs.output_tokens }}
+      cost_eur: \${{ steps.cc-apply.outputs.cost_eur }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Prepare claude-code job
+        id: cc-prepare
+        uses: big-emotion/ferry/.github/actions/ferry-cc-prepare@${version}
+        with:
+          payload: \${{ toJson(github.event.client_payload) }}
+          role: iterator
+          jira_base_url: \${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: \${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
+          github_token: \${{ github.token }}
+          github_repo: \${{ github.repository }}
+          claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+      - name: Run claude-code-action
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: \${{ steps.cc-prepare.outputs.prompt }}
+          claude_args: \${{ steps.cc-prepare.outputs.claude_args }}
+
+      - name: Apply claude-code output
+        id: cc-apply
+        uses: big-emotion/ferry/.github/actions/ferry-cc-apply@${version}
+        with:
+          payload: \${{ toJson(github.event.client_payload) }}
+          role: iterator
+          jira_base_url: \${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: \${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
+          idempotency_marker: \${{ steps.cc-prepare.outputs.idempotency_marker }}
+          ferry_review_transition_id: \${{ secrets.FERRY_REVIEW_TRANSITION_ID }}
+          github_token: \${{ github.token }}
+          github_repo: \${{ github.repository }}
+
   emit-audit:
     name: Emit audit line
-    needs: [run-agent]
-    if: needs.run-agent.result != 'skipped'
+    needs: [run-agent, run-agent-claude-code]
+    if: always() && (needs.run-agent.result == 'success' || needs.run-agent-claude-code.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -442,9 +736,10 @@ jobs:
           phase: iterate
           run_id: \${{ github.event.client_payload.event_id }}
           model: \${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
-          outcome: \${{ needs.run-agent.result }}
-          input_tokens: \${{ needs.run-agent.outputs.input_tokens || '0' }}
-          output_tokens: \${{ needs.run-agent.outputs.output_tokens || '0' }}
+          outcome: \${{ needs.run-agent.result == 'success' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          input_tokens: \${{ needs.run-agent.outputs.input_tokens || needs.run-agent-claude-code.outputs.input_tokens || '0' }}
+          output_tokens: \${{ needs.run-agent.outputs.output_tokens || needs.run-agent-claude-code.outputs.output_tokens || '0' }}
+          cost_eur: \${{ needs.run-agent.outputs.cost_eur || needs.run-agent-claude-code.outputs.cost_eur || '0' }}
           start_ms: \${{ github.run_id }}
           audit_issue: \${{ vars.FERRY_AUDIT_ISSUE }}
           github_token: \${{ github.token }}

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -309,6 +309,19 @@ jobs:
       output_tokens: \${{ steps.cc-apply.outputs.output_tokens }}
       cost_eur: \${{ steps.cc-apply.outputs.cost_eur }}
     steps:
+      # Fail-loud guard: ferry-cc-prepare's composite entrypoint currently only handles
+      # role 'refiner' end-to-end. Runtime support for developer/reviewer/iterator lands
+      # in a follow-up to #333. Until then, this job must hard-fail before cc-prepare so
+      # consumers get a clear actionable error instead of a late-stage throw.
+      - name: Guard — cc-path not yet wired for developer
+        shell: bash
+        run: |
+          echo "::error::Ferry: the claude-code execution path is not yet wired for role 'developer'."
+          echo "::error::ferry-cc-prepare's composite entrypoint currently only handles role 'refiner' end-to-end."
+          echo "::error::Runtime support for developer / reviewer / iterator arrives in a follow-up to #333."
+          echo "::error::Workaround: route this ticket via the script path (do not set FERRY_EXECUTION_PATH=claude-code)."
+          exit 1
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -493,6 +506,19 @@ jobs:
       output_tokens: \${{ steps.cc-apply.outputs.output_tokens }}
       cost_eur: \${{ steps.cc-apply.outputs.cost_eur }}
     steps:
+      # Fail-loud guard: ferry-cc-prepare's composite entrypoint currently only handles
+      # role 'refiner' end-to-end. Runtime support for developer/reviewer/iterator lands
+      # in a follow-up to #333. Until then, this job must hard-fail before cc-prepare so
+      # consumers get a clear actionable error instead of a late-stage throw.
+      - name: Guard — cc-path not yet wired for reviewer
+        shell: bash
+        run: |
+          echo "::error::Ferry: the claude-code execution path is not yet wired for role 'reviewer'."
+          echo "::error::ferry-cc-prepare's composite entrypoint currently only handles role 'refiner' end-to-end."
+          echo "::error::Runtime support for developer / reviewer / iterator arrives in a follow-up to #333."
+          echo "::error::Workaround: route this ticket via the script path (do not set FERRY_EXECUTION_PATH=claude-code)."
+          exit 1
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -680,6 +706,19 @@ jobs:
       output_tokens: \${{ steps.cc-apply.outputs.output_tokens }}
       cost_eur: \${{ steps.cc-apply.outputs.cost_eur }}
     steps:
+      # Fail-loud guard: ferry-cc-prepare's composite entrypoint currently only handles
+      # role 'refiner' end-to-end. Runtime support for developer/reviewer/iterator lands
+      # in a follow-up to #333. Until then, this job must hard-fail before cc-prepare so
+      # consumers get a clear actionable error instead of a late-stage throw.
+      - name: Guard — cc-path not yet wired for iterator
+        shell: bash
+        run: |
+          echo "::error::Ferry: the claude-code execution path is not yet wired for role 'iterator'."
+          echo "::error::ferry-cc-prepare's composite entrypoint currently only handles role 'refiner' end-to-end."
+          echo "::error::Runtime support for developer / reviewer / iterator arrives in a follow-up to #333."
+          echo "::error::Workaround: route this ticket via the script path (do not set FERRY_EXECUTION_PATH=claude-code)."
+          exit 1
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Refs #333. Part of #339. Cc-prepare role-coverage follow-up: #350.

## Summary

Wires the four-step `claude-code` execution chain (checkout → `ferry-cc-prepare` → `anthropics/claude-code-action` → `ferry-cc-apply`) into all four agent workflow templates (`src/cli/init/templates.ts`) and the matching `examples/consumer-setup/workflows/` files.

**Scope of runtime coverage:**

- **Refiner cc-path is live end-to-end.** `ferry-cc-prepare` handles `role: 'refiner'` in its composite entrypoint.
- **Developer / reviewer / iterator cc-paths ship as scaffolded templates with a fail-loud guard.** `ferry-cc-prepare`'s composite entrypoint currently throws (`cc-prepare-action.ts:560–564`) for any role other than refiner. To prevent silent late-stage failure, the **first step** of `run-agent-claude-code` in `ferry-dev.yml`, `ferry-review.yml`, `ferry-iterate.yml` is a guard that emits role-scoped `::error::` lines and exits 1 — so a misrouted ticket fails immediately, with zero LLM token spend, and audits as `failure`. Runtime support for these three roles lands via **#350** (the `ferry-cc-prepare` role-completion follow-up).

This is why the title says `refs #333` rather than `closes #333`: templates land for all four roles, but the runtime cc-path lands only for refiner.

## What changed

- **Templates** (`src/cli/init/templates.ts`) — wire the four-step chain into the `run-agent-claude-code` job of all four agent workflows; emit-audit consumes cc-apply token outputs via `run-agent-claude-code.outputs.*`.
- **Example consumer workflows** (`examples/consumer-setup/workflows/ferry-*.yml`) — mirrored.
- **Role-scoped fail-loud guard** — first step of `run-agent-claude-code` in dev/review/iterate (templates + examples). Refiner has **no guard** — its cc-path runs.
- **emit-audit gate** widened from `result == 'success'` to `result != 'skipped'`, so genuine `failure` results (including from the new guards) reach the audit log instead of being silently dropped.
- **`outcome:` ternary** corrected from `== 'success' &&` to `!= 'skipped' &&` so the script-path-failure case audits as `failure`, not `skipped`.
- **OAuth secret guard step removed** — `ferry-cc-prepare` already fails fast on missing `CLAUDE_CODE_OAUTH_TOKEN`, so the bespoke shell guard step (and `INSTALL_GITLEAKS_ANCHOR`) are redundant.
- **Supply-chain hardening** — `anthropics/claude-code-action` SHA-pinned to `1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127` (was the mutable `@v1` tag).
- **Test coverage** — new `src/cli/init/templates.test.ts` (a) parses the rendered YAML round-trip via `yaml.parse`, (b) asserts the four-step chain ordering, (c) locks in the role-specific guards and the refiner-cleanliness asymmetry, (d) locks in the `!= 'skipped'` outcome shape, (e) locks in the SHA-pin shape of `claude-code-action`. `yaml` promoted from transitive to explicit `devDependency`.

## Out of scope (deliberately deferred)

- **`ferry-cc-prepare` role coverage for developer / reviewer / iterator** — tracked in #350. Includes the reviewer `ferry_pr_number` wiring (originally Item 2 of the review) and removing the fail-loud guards once the runtime lands.
- **Refine workflow script-path token-output emit** — pre-existing on `main`; reviewer marked "Out of scope to fix here, but worth a follow-up issue."
- **Template ↔ example drift detection `npm` script** — reviewer marked "Not blocking"; broader refactor.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm test` — **2219 / 2219** passing across 152 test files
- [x] `templates.test.ts` covers YAML validity (regex + `yaml.parse` round-trip), four-step chain ordering, emit-audit outcome shape (`!= 'skipped'`), supply-chain SHA-pin shape, and cc-path role-coverage guard asymmetry
- [x] `init.test.ts` widened to match `anthropics/claude-code-action@` by ref (not pin version) so future SHA-pin bumps don't ripple

Generated with [Claude Code](https://claude.ai/code)
