### PR TITLE
fix: add id-token: write to claude-code workflow templates (#353)

### DIFF
--- a/.ferry/cc-prepare-action.js
+++ b/.ferry/cc-prepare-action.js
@@ -6872,11 +6872,12 @@ function buildClaudeCodeJob(input) {
 }
 
 // src/lib/claude-code/job-permissions.ts
-var REQUIRED_WRITE_SCOPES = ["contents", "pull-requests", "issues"];
+var REQUIRED_WRITE_SCOPES = ["contents", "pull-requests", "issues", "id-token"];
 var CLAUDE_CODE_JOB_PERMISSIONS = {
   contents: "write",
   "pull-requests": "write",
-  issues: "write"
+  issues: "write",
+  "id-token": "write"
 };
 function assertLeastPrivilege(permissions) {
   const fail2 = (reason) => {

--- a/.github/actions/ferry-cc-prepare/cc-prepare-action.js
+++ b/.github/actions/ferry-cc-prepare/cc-prepare-action.js
@@ -6872,11 +6872,12 @@ function buildClaudeCodeJob(input) {
 }
 
 // src/lib/claude-code/job-permissions.ts
-var REQUIRED_WRITE_SCOPES = ["contents", "pull-requests", "issues"];
+var REQUIRED_WRITE_SCOPES = ["contents", "pull-requests", "issues", "id-token"];
 var CLAUDE_CODE_JOB_PERMISSIONS = {
   contents: "write",
   "pull-requests": "write",
-  issues: "write"
+  issues: "write",
+  "id-token": "write"
 };
 function assertLeastPrivilege(permissions) {
   const fail2 = (reason) => {

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -53,6 +53,12 @@ If there are no consumer-visible changes, omit the section (or note `(none — i
 
 ---
 
+## v0.13.x → v0.14.0
+
+- **(action)** Add `id-token: write` to the `run-agent-claude-code` job's `permissions:` block in each of your four agent workflows (`ferry-refine.yml`, `ferry-dev.yml`, `ferry-review.yml`, `ferry-iterate.yml`). `anthropics/claude-code-action@v1` unconditionally calls `core.getIDToken()` during `setupGitHubToken`; when a job has an explicit `permissions:` block that omits `id-token`, GitHub Actions denies the OIDC fetch and every consumer dispatch fails with "Could not fetch an OIDC token" (#353). Run `npx -p @big-emotion/ferry@v0.14.0 ferry-update` to apply the updated stubs automatically, or add the line by hand alongside the existing permission entries.
+
+---
+
 ## v0.12.x → v0.13.0
 
 requires-secrets: CLAUDE_CODE_OAUTH_TOKEN

--- a/examples/consumer-setup/workflows/ferry-dev.yml
+++ b/examples/consumer-setup/workflows/ferry-dev.yml
@@ -130,6 +130,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
     outputs:
       input_tokens: ${{ steps.cc-apply.outputs.input_tokens }}
       output_tokens: ${{ steps.cc-apply.outputs.output_tokens }}

--- a/examples/consumer-setup/workflows/ferry-iterate.yml
+++ b/examples/consumer-setup/workflows/ferry-iterate.yml
@@ -133,6 +133,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
     outputs:
       input_tokens: ${{ steps.cc-apply.outputs.input_tokens }}
       output_tokens: ${{ steps.cc-apply.outputs.output_tokens }}

--- a/examples/consumer-setup/workflows/ferry-refine.yml
+++ b/examples/consumer-setup/workflows/ferry-refine.yml
@@ -111,6 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
     outputs:
       input_tokens: ${{ steps.cc-apply.outputs.input_tokens }}
       output_tokens: ${{ steps.cc-apply.outputs.output_tokens }}

--- a/examples/consumer-setup/workflows/ferry-review.yml
+++ b/examples/consumer-setup/workflows/ferry-review.yml
@@ -129,6 +129,7 @@ jobs:
       pull-requests: write
       issues: write
       checks: read
+      id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
     outputs:
       input_tokens: ${{ steps.cc-apply.outputs.input_tokens }}
       output_tokens: ${{ steps.cc-apply.outputs.output_tokens }}

--- a/src/cli/init/templates.test.ts
+++ b/src/cli/init/templates.test.ts
@@ -280,6 +280,31 @@ describe('workflowTemplates — cc-path role coverage is complete', () => {
   });
 });
 
+describe('workflowTemplates — run-agent-claude-code permissions include id-token: write (#353)', () => {
+  // anthropics/claude-code-action@v1 unconditionally calls core.getIDToken() during
+  // setupGitHubToken. When a job has an explicit permissions: block that omits
+  // id-token, GitHub Actions denies the OIDC fetch and every consumer dispatch fails
+  // with "Could not fetch an OIDC token". This regression guard ensures the missing
+  // scope cannot be reintroduced by a future template edit.
+  const roles = [
+    { filename: 'ferry-refine.yml', role: 'refiner' },
+    { filename: 'ferry-dev.yml', role: 'developer' },
+    { filename: 'ferry-review.yml', role: 'reviewer' },
+    { filename: 'ferry-iterate.yml', role: 'iterator' },
+  ] as const;
+
+  for (const { filename, role } of roles) {
+    it(`${filename} (${role}): run-agent-claude-code permissions block contains id-token: write`, () => {
+      const tmpl = workflowTemplates('v1').find((t) => t.filename === filename);
+      expect(tmpl, `${filename} not found`).toBeDefined();
+      expect(
+        tmpl!.content,
+        `${filename}: run-agent-claude-code job is missing id-token: write (fixes #353)`,
+      ).toContain('id-token: write');
+    });
+  }
+});
+
 describe('workflowTemplates — execution path variants', () => {
   it('script path is byte-identical whether implicit or explicit', () => {
     expect(workflowTemplates('v1', 'script')).toEqual(workflowTemplates('v1'));

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -124,6 +124,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write # required for claude-code-action OIDC auth
     outputs:
       input_tokens: \${{ steps.cc-apply.outputs.input_tokens }}
       output_tokens: \${{ steps.cc-apply.outputs.output_tokens }}
@@ -304,6 +305,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write # required for claude-code-action OIDC auth
     outputs:
       input_tokens: \${{ steps.cc-apply.outputs.input_tokens }}
       output_tokens: \${{ steps.cc-apply.outputs.output_tokens }}
@@ -488,6 +490,7 @@ jobs:
       pull-requests: write
       issues: write
       checks: read
+      id-token: write # required for claude-code-action OIDC auth
     outputs:
       input_tokens: \${{ steps.cc-apply.outputs.input_tokens }}
       output_tokens: \${{ steps.cc-apply.outputs.output_tokens }}
@@ -676,6 +679,7 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write # required for claude-code-action OIDC auth
     outputs:
       input_tokens: \${{ steps.cc-apply.outputs.input_tokens }}
       output_tokens: \${{ steps.cc-apply.outputs.output_tokens }}

--- a/src/lib/claude-code/job-permissions.test.ts
+++ b/src/lib/claude-code/job-permissions.test.ts
@@ -7,16 +7,20 @@ import {
 } from './job-permissions.js';
 
 describe('CLAUDE_CODE_JOB_PERMISSIONS', () => {
-  it('grants exactly the three scopes the agents need, all write', () => {
+  it('grants exactly the four scopes the agents need, all write', () => {
     expect(CLAUDE_CODE_JOB_PERMISSIONS).toEqual({
       contents: 'write',
       'pull-requests': 'write',
       issues: 'write',
+      'id-token': 'write',
     });
   });
 
-  it('never grants id-token / actions / packages / workflows', () => {
-    expect(CLAUDE_CODE_JOB_PERMISSIONS).not.toHaveProperty('id-token');
+  it('grants id-token: write (required by claude-code-action@v1 OIDC auth)', () => {
+    expect(CLAUDE_CODE_JOB_PERMISSIONS).toHaveProperty('id-token', 'write');
+  });
+
+  it('never grants actions / packages / workflows', () => {
     expect(CLAUDE_CODE_JOB_PERMISSIONS).not.toHaveProperty('actions');
     expect(CLAUDE_CODE_JOB_PERMISSIONS).not.toHaveProperty('packages');
     expect(CLAUDE_CODE_JOB_PERMISSIONS).not.toHaveProperty('workflows');
@@ -44,13 +48,13 @@ describe('assertLeastPrivilege', () => {
     ).toThrow(/least-privilege/i);
   });
 
-  it('throws on id-token: write (OIDC escalation)', () => {
+  it('passes when id-token: write is present (required by claude-code-action@v1 OIDC)', () => {
     expect(() =>
       assertLeastPrivilege({
         ...CLAUDE_CODE_JOB_PERMISSIONS,
         'id-token': 'write',
       }),
-    ).toThrow(/least-privilege/i);
+    ).not.toThrow();
   });
 
   it('throws on any extra write scope (actions:write)', () => {
@@ -79,6 +83,7 @@ describe('renderPermissionsYaml', () => {
     expect(yaml).toContain('  contents: write');
     expect(yaml).toContain('  pull-requests: write');
     expect(yaml).toContain('  issues: write');
+    expect(yaml).toContain('  id-token: write');
   });
 
   it('omits scopes explicitly set to none', () => {

--- a/src/lib/claude-code/job-permissions.ts
+++ b/src/lib/claude-code/job-permissions.ts
@@ -9,9 +9,12 @@
  * merge` and a feature-branch push both ride on `contents: write`. The deny is
  * therefore enforced by the tool policy; this module's job is narrower but
  * still load-bearing: guarantee the action token is scoped to *exactly* the
- * three permissions the agents need and nothing that would broaden blast radius
- * (no `id-token` OIDC, no `actions`/`workflows`/`packages` write, no
- * `write-all`).
+ * permissions the agents need and nothing that would broaden blast radius
+ * (no `actions`/`workflows`/`packages` write, no `write-all`).
+ *
+ * Note: `id-token: write` is required because `anthropics/claude-code-action@v1`
+ * unconditionally calls `core.getIDToken()` during `setupGitHubToken`; omitting
+ * it causes every dispatch to fail at OIDC fetch (issue #353).
  *
  * `#302` generates the claude-code workflow; it consumes `renderPermissionsYaml`
  * and must `assertLeastPrivilege` before emitting the job.
@@ -22,19 +25,20 @@ export type PermissionScope = 'read' | 'write' | 'none';
 export type JobPermissions = Record<string, PermissionScope>;
 
 /** The only scopes the four agents need on the claude-code path. */
-const REQUIRED_WRITE_SCOPES = ['contents', 'pull-requests', 'issues'] as const;
+const REQUIRED_WRITE_SCOPES = ['contents', 'pull-requests', 'issues', 'id-token'] as const;
 
 /** Canonical least-privilege descriptor for the claude-code-action job. */
 export const CLAUDE_CODE_JOB_PERMISSIONS: JobPermissions = {
   contents: 'write',
   'pull-requests': 'write',
   issues: 'write',
+  'id-token': 'write',
 };
 
 /**
  * Fail-closed check that a permissions map is least-privilege for this path:
  *
- * - the three required scopes are present and set to `write`;
+ * - the four required scopes are present and set to `write`;
  * - no other scope is granted `read` or `write` (only an explicit `none` is
  *   tolerated — it is equivalent to omission and keeps generated workflows
  *   self-documenting);

--- a/src/lib/dispatch/cc-prepare-action.test.ts
+++ b/src/lib/dispatch/cc-prepare-action.test.ts
@@ -567,8 +567,9 @@ describe('prepareCcJob — tool-policy and job-permissions hardening (#303)', ()
       for (const [scope, level] of Object.entries(CLAUDE_CODE_JOB_PERMISSIONS)) {
         expect(out.permissionsYaml).toContain(`${scope}: ${level}`);
       }
-      // Must not grant dangerous extra scopes.
-      expect(out.permissionsYaml).not.toContain('id-token');
+      // id-token: write is required for claude-code-action@v1 OIDC auth (#353).
+      expect(out.permissionsYaml).toContain('id-token: write');
+      // Must not grant dangerous extra scopes beyond the canonical set.
       expect(out.permissionsYaml).not.toContain('actions: write');
     }
   });

--- a/src/lib/dispatch/cc-prepare-action.test.ts
+++ b/src/lib/dispatch/cc-prepare-action.test.ts
@@ -518,9 +518,11 @@ describe('runCcPrepareAction — non-refiner roles are wired into the entrypoint
       // Explicitly clear GITHUB_TOKEN because the CI environment sets it, which
       // would otherwise cause requireEnv('GITHUB_TOKEN') to succeed and reach
       // runner.getRepoDefaultBranch before the expected throw.
+      // We must stub it to '' rather than omitting it because GHA always injects
+      // GITHUB_TOKEN, so relying on absence isn't portable across environments.
       vi.stubEnv('GITHUB_TOKEN', '');
       for (const [k, v] of Object.entries(
-        baseEnv({ GITHUB_OUTPUT: tmp.outputFile, FERRY_AGENT_ROLE: role }),
+        baseEnv({ GITHUB_OUTPUT: tmp.outputFile, FERRY_AGENT_ROLE: role, GITHUB_TOKEN: '' }),
       )) {
         vi.stubEnv(k, v);
       }


### PR DESCRIPTION
Fixes #353

## Summary

`anthropics/claude-code-action@v1` unconditionally calls `core.getIDToken()` during `setupGitHubToken`. When a job has an explicit `permissions:` block that omits `id-token`, GitHub Actions denies the OIDC fetch and every consumer dispatch fails with "Could not fetch an OIDC token".

## Changes

- Add `id-token: write` to `run-agent-claude-code` jobs in all four consumer workflow templates
- Add `id-token: write` to `CLAUDE_CODE_JOB_PERMISSIONS` and `REQUIRED_WRITE_SCOPES` in `job-permissions.ts` so `renderPermissionsYaml` and `assertLeastPrivilege` stay in sync
- Update tests to reflect that `id-token: write` is now required
- Fix pre-existing test failure where `GITHUB_TOKEN` was always present in the GHA environment
- Rebuild `.ferry/` action bundles

Generated with [Claude Code](https://claude.ai/code)