### PR TITLE
fix: add narrow Write(.ferry/cc-output.json) grant for read-only roles on claude-code path

### DIFF
--- a/.ferry/cc-prepare-action.js
+++ b/.ferry/cc-prepare-action.js
@@ -6658,35 +6658,6 @@ function assertToolPolicyEnforcesNoAutoMerge(policy) {
   }
 }
 
-// src/lib/claude-code/claude-args.ts
-function buildClaudeArgs(input) {
-  const servers = input.mcpServers ?? [];
-  const allowedTools = [...nativeToolsForRole(input.role), ...mcpToolAllowlist(servers)];
-  const disallowedTools = [...NO_AUTO_MERGE_DENY];
-  assertToolPolicyEnforcesNoAutoMerge({ allowedTools, disallowedTools });
-  const args = [
-    "--append-system-prompt",
-    input.system,
-    "--allowedTools",
-    allowedTools.join(","),
-    "--disallowedTools",
-    disallowedTools.join(",")
-  ];
-  if (servers.length > 0) {
-    args.push("--mcp-config", JSON.stringify(toClaudeCodeMcpConfig(servers)));
-  }
-  if (input.maxTurns !== void 0) {
-    if (!Number.isInteger(input.maxTurns) || input.maxTurns <= 0) {
-      throw new Error(`max-turns must be a positive integer, got ${input.maxTurns}`);
-    }
-    args.push("--max-turns", String(input.maxTurns));
-  }
-  if (input.model !== void 0 && input.model.trim().length > 0) {
-    args.push("--model", input.model);
-  }
-  return args;
-}
-
 // src/lib/claude-code/output-artifact.ts
 var CC_OUTPUT_ARTIFACT_PATH = ".ferry/cc-output.json";
 var DONE_OUTCOMES = ["implemented", "already_satisfied", "blocked"];
@@ -6842,6 +6813,39 @@ FINAL OUTPUT (claude-code path): the \`done\`/\`finish_review\` tools are not av
   }
   const access = ROLE_ACCESS[role];
   return `${header} Commit and push your work with \`git\` first (there is no \`commit_progress\` tool on this path; access=${access}). Then write: ${DEV_ITER_SHAPE}`;
+}
+
+// src/lib/claude-code/claude-args.ts
+function buildClaudeArgs(input) {
+  const servers = input.mcpServers ?? [];
+  const allowedTools = [
+    ...nativeToolsForRole(input.role),
+    `Write(${CC_OUTPUT_ARTIFACT_PATH})`,
+    ...mcpToolAllowlist(servers)
+  ];
+  const disallowedTools = [...NO_AUTO_MERGE_DENY];
+  assertToolPolicyEnforcesNoAutoMerge({ allowedTools, disallowedTools });
+  const args = [
+    "--append-system-prompt",
+    input.system,
+    "--allowedTools",
+    allowedTools.join(","),
+    "--disallowedTools",
+    disallowedTools.join(",")
+  ];
+  if (servers.length > 0) {
+    args.push("--mcp-config", JSON.stringify(toClaudeCodeMcpConfig(servers)));
+  }
+  if (input.maxTurns !== void 0) {
+    if (!Number.isInteger(input.maxTurns) || input.maxTurns <= 0) {
+      throw new Error(`max-turns must be a positive integer, got ${input.maxTurns}`);
+    }
+    args.push("--max-turns", String(input.maxTurns));
+  }
+  if (input.model !== void 0 && input.model.trim().length > 0) {
+    args.push("--model", input.model);
+  }
+  return args;
 }
 
 // src/lib/claude-code/job.ts

--- a/.github/actions/ferry-cc-prepare/cc-prepare-action.js
+++ b/.github/actions/ferry-cc-prepare/cc-prepare-action.js
@@ -6658,35 +6658,6 @@ function assertToolPolicyEnforcesNoAutoMerge(policy) {
   }
 }
 
-// src/lib/claude-code/claude-args.ts
-function buildClaudeArgs(input) {
-  const servers = input.mcpServers ?? [];
-  const allowedTools = [...nativeToolsForRole(input.role), ...mcpToolAllowlist(servers)];
-  const disallowedTools = [...NO_AUTO_MERGE_DENY];
-  assertToolPolicyEnforcesNoAutoMerge({ allowedTools, disallowedTools });
-  const args = [
-    "--append-system-prompt",
-    input.system,
-    "--allowedTools",
-    allowedTools.join(","),
-    "--disallowedTools",
-    disallowedTools.join(",")
-  ];
-  if (servers.length > 0) {
-    args.push("--mcp-config", JSON.stringify(toClaudeCodeMcpConfig(servers)));
-  }
-  if (input.maxTurns !== void 0) {
-    if (!Number.isInteger(input.maxTurns) || input.maxTurns <= 0) {
-      throw new Error(`max-turns must be a positive integer, got ${input.maxTurns}`);
-    }
-    args.push("--max-turns", String(input.maxTurns));
-  }
-  if (input.model !== void 0 && input.model.trim().length > 0) {
-    args.push("--model", input.model);
-  }
-  return args;
-}
-
 // src/lib/claude-code/output-artifact.ts
 var CC_OUTPUT_ARTIFACT_PATH = ".ferry/cc-output.json";
 var DONE_OUTCOMES = ["implemented", "already_satisfied", "blocked"];
@@ -6842,6 +6813,39 @@ FINAL OUTPUT (claude-code path): the \`done\`/\`finish_review\` tools are not av
   }
   const access = ROLE_ACCESS[role];
   return `${header} Commit and push your work with \`git\` first (there is no \`commit_progress\` tool on this path; access=${access}). Then write: ${DEV_ITER_SHAPE}`;
+}
+
+// src/lib/claude-code/claude-args.ts
+function buildClaudeArgs(input) {
+  const servers = input.mcpServers ?? [];
+  const allowedTools = [
+    ...nativeToolsForRole(input.role),
+    `Write(${CC_OUTPUT_ARTIFACT_PATH})`,
+    ...mcpToolAllowlist(servers)
+  ];
+  const disallowedTools = [...NO_AUTO_MERGE_DENY];
+  assertToolPolicyEnforcesNoAutoMerge({ allowedTools, disallowedTools });
+  const args = [
+    "--append-system-prompt",
+    input.system,
+    "--allowedTools",
+    allowedTools.join(","),
+    "--disallowedTools",
+    disallowedTools.join(",")
+  ];
+  if (servers.length > 0) {
+    args.push("--mcp-config", JSON.stringify(toClaudeCodeMcpConfig(servers)));
+  }
+  if (input.maxTurns !== void 0) {
+    if (!Number.isInteger(input.maxTurns) || input.maxTurns <= 0) {
+      throw new Error(`max-turns must be a positive integer, got ${input.maxTurns}`);
+    }
+    args.push("--max-turns", String(input.maxTurns));
+  }
+  if (input.model !== void 0 && input.model.trim().length > 0) {
+    args.push("--model", input.model);
+  }
+  return args;
 }
 
 // src/lib/claude-code/job.ts

--- a/src/lib/claude-code/claude-args.test.ts
+++ b/src/lib/claude-code/claude-args.test.ts
@@ -18,14 +18,24 @@ describe('buildClaudeArgs', () => {
 
   it('builds --allowedTools from the role native set (read-write for developer)', () => {
     const args = buildClaudeArgs({ role: 'developer', system: 's' });
-    expect(flagValue(args, '--allowedTools')).toBe('Bash,Read,Write,Edit,Glob,Grep');
+    expect(flagValue(args, '--allowedTools')).toBe(
+      'Bash,Read,Write,Edit,Glob,Grep,Write(.ferry/cc-output.json)',
+    );
   });
 
-  it('builds the read-only native set for reviewer and refiner', () => {
+  it('builds the read-only native set for reviewer and refiner with narrow artifact Write grant', () => {
     for (const role of ['reviewer', 'refiner'] as const) {
       expect(flagValue(buildClaudeArgs({ role, system: 's' }), '--allowedTools')).toBe(
-        'Read,Glob,Grep',
+        'Read,Glob,Grep,Write(.ferry/cc-output.json)',
       );
+    }
+  });
+
+  it('narrow Write(.ferry/cc-output.json) grant is present for every role', () => {
+    const ROLES: FerryRole[] = ['refiner', 'developer', 'reviewer', 'iterator'];
+    for (const role of ROLES) {
+      const allowed = flagValue(buildClaudeArgs({ role, system: 's' }), '--allowedTools') ?? '';
+      expect(allowed).toContain('Write(.ferry/cc-output.json)');
     }
   });
 
@@ -36,7 +46,7 @@ describe('buildClaudeArgs', () => {
     ];
     const args = buildClaudeArgs({ role: 'reviewer', system: 's', mcpServers: servers });
     expect(flagValue(args, '--allowedTools')).toBe(
-      'Read,Glob,Grep,mcp__jira__get_issue,mcp__context7',
+      'Read,Glob,Grep,Write(.ferry/cc-output.json),mcp__jira__get_issue,mcp__context7',
     );
   });
 

--- a/src/lib/claude-code/claude-args.ts
+++ b/src/lib/claude-code/claude-args.ts
@@ -18,6 +18,7 @@ import type { FerryRole } from './tool-profiles.js';
 import { nativeToolsForRole } from './tool-profiles.js';
 import { toClaudeCodeMcpConfig, mcpToolAllowlist } from './mcp-config.js';
 import { assertToolPolicyEnforcesNoAutoMerge, NO_AUTO_MERGE_DENY } from './tool-policy.js';
+import { CC_OUTPUT_ARTIFACT_PATH } from './output-artifact.js';
 
 export interface BuildClaudeArgsInput {
   role: FerryRole;
@@ -32,7 +33,14 @@ export interface BuildClaudeArgsInput {
 
 export function buildClaudeArgs(input: BuildClaudeArgsInput): string[] {
   const servers = input.mcpServers ?? [];
-  const allowedTools = [...nativeToolsForRole(input.role), ...mcpToolAllowlist(servers)];
+  // All roles need a narrow Write grant for the output artifact (.ferry/cc-output.json).
+  // Read-only roles (refiner/reviewer) have no broad Write in their native tool set,
+  // so without this grant the agent cannot write its result and cc-apply fails with ENOENT.
+  const allowedTools = [
+    ...nativeToolsForRole(input.role),
+    `Write(${CC_OUTPUT_ARTIFACT_PATH})`,
+    ...mcpToolAllowlist(servers),
+  ];
 
   // Fail-closed: assert the no-auto-merge invariant before emitting args.
   // Throws if the allow set re-grants a denied rule (ADR-0002 §D, #303).

--- a/src/lib/dispatch/cc-prepare-action.test.ts
+++ b/src/lib/dispatch/cc-prepare-action.test.ts
@@ -515,6 +515,10 @@ describe('runCcPrepareAction — non-refiner roles are wired into the entrypoint
       process.chdir(tmp.cwd);
       // GITHUB_TOKEN intentionally omitted — the role branch demands it via
       // `resolveRoleRuntimeContext`, which proves we reached the new code path.
+      // Explicitly clear GITHUB_TOKEN because the CI environment sets it, which
+      // would otherwise cause requireEnv('GITHUB_TOKEN') to succeed and reach
+      // runner.getRepoDefaultBranch before the expected throw.
+      vi.stubEnv('GITHUB_TOKEN', '');
       for (const [k, v] of Object.entries(
         baseEnv({ GITHUB_OUTPUT: tmp.outputFile, FERRY_AGENT_ROLE: role }),
       )) {


### PR DESCRIPTION
Fixes #354.

## Changes

**Root cause:** Refiner and reviewer agents on the claude-code path have `ROLE_ACCESS = 'read-only'`, which restricted `--allowedTools` to `Read,Glob,Grep`. The `outcomePromptSuffix()` function instructs all roles to write their result to `.ferry/cc-output.json`, but `Write` was absent from read-only role allowlists. Every refiner/reviewer run ended with permission denials and cc-apply failing with ENOENT.

**Fix:** Added `Write(.ferry/cc-output.json)` as a path-scoped narrow grant in `buildClaudeArgs` for all roles (Option 1 from the issue). Read-only roles remain blocked from arbitrary writes.

**Bonus:** Fixed 3 pre-existing test failures in the `#350` role-dispatch tests that failed in CI because `GITHUB_TOKEN` is always set in GitHub Actions.

Generated with [Claude Code](https://claude.ai/code)