### PR TITLE
fix(cc-refiner): make the claude-code-path refiner create Jira sub-tasks

### DIFF
--- a/.ferry/cc-apply-action.js
+++ b/.ferry/cc-apply-action.js
@@ -188,28 +188,6 @@ function decideContract(output, ctx) {
         exitCode: 0
       };
     }
-    case "refiner": {
-      if (output.result === "noop") {
-        const subtaskCount = ctx.subtaskCount ?? 0;
-        const reason = output.noop_reason ?? "";
-        return {
-          comment: `${m} No changes needed \u2014 existing ${subtaskCount} sub-task(s) still valid. ${reason}`.trimEnd(),
-          labels: [],
-          transitions: [],
-          exitCode: 0
-        };
-      }
-      const runLink = requireCtx(ctx.runLink, "runLink", "refiner", output.result);
-      const created = output.created ?? 0;
-      const kept = output.kept ?? 0;
-      const staled = output.staled ?? 0;
-      return {
-        comment: `${m} Refined. Created ${created}, kept ${kept}, staled ${staled} sub-task(s). See run: ${runLink}`,
-        labels: [],
-        transitions: [],
-        exitCode: 0
-      };
-    }
   }
 }
 
@@ -1661,6 +1639,197 @@ function countPriorIterations(existingComments) {
 
 // src/lib/claude-code/output-artifact.ts
 var CC_OUTPUT_ARTIFACT_PATH = ".ferry/cc-output.json";
+function fail(detail) {
+  throw new Error(`Invalid ${CC_OUTPUT_ARTIFACT_PATH}: ${detail}`);
+}
+function asObject(raw) {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    fail("expected a JSON object");
+  }
+  return raw;
+}
+function nonEmptyString(v) {
+  return typeof v === "string" && v.trim().length > 0;
+}
+function isStringArray(v) {
+  return Array.isArray(v) && v.every((e) => typeof e === "string");
+}
+function parseRefinerAction(a, idx) {
+  const o = asObject(a);
+  switch (o.type) {
+    case "create":
+      if (!nonEmptyString(o.title) || !nonEmptyString(o.description)) {
+        fail(`actions[${idx}] create requires title and description`);
+      }
+      return { type: "create", title: o.title, description: o.description };
+    case "keep":
+    case "mark_stale":
+      if (!nonEmptyString(o.existing_key) || !nonEmptyString(o.reason)) {
+        fail(`actions[${idx}] ${o.type} requires existing_key and reason`);
+      }
+      return {
+        type: o.type,
+        existing_key: o.existing_key,
+        reason: o.reason
+      };
+    case "noop":
+      if (!nonEmptyString(o.reason)) fail(`actions[${idx}] noop requires reason`);
+      return { type: "noop", reason: o.reason };
+    default:
+      return fail(`actions[${idx}] has unknown type ${String(o.type)}`);
+  }
+}
+function parseRefinerCostEstimate(raw) {
+  const o = asObject(raw);
+  if (typeof o.loUsd !== "number" || !Number.isFinite(o.loUsd) || o.loUsd < 0) {
+    fail("cost_estimate.loUsd must be a non-negative number");
+  }
+  if (typeof o.hiUsd !== "number" || !Number.isFinite(o.hiUsd) || o.hiUsd < 0) {
+    fail("cost_estimate.hiUsd must be a non-negative number");
+  }
+  if (o.confidence !== "low" && o.confidence !== "medium" && o.confidence !== "high") {
+    fail("cost_estimate.confidence must be 'low', 'medium', or 'high'");
+  }
+  if (typeof o.baselineRuns !== "number" || !Number.isInteger(o.baselineRuns) || o.baselineRuns < 0) {
+    fail("cost_estimate.baselineRuns must be a non-negative integer");
+  }
+  return {
+    loUsd: o.loUsd,
+    hiUsd: o.hiUsd,
+    confidence: o.confidence,
+    baselineRuns: o.baselineRuns
+  };
+}
+function parseRefinerArtifact(raw) {
+  const o = asObject(raw);
+  if (!Array.isArray(o.actions) || o.actions.length === 0) {
+    fail("actions must be a non-empty array");
+  }
+  if (!isStringArray(o.touch_paths)) fail("touch_paths must be an array of strings");
+  if (o.output_locale !== "en" && o.output_locale !== "fr") {
+    fail("output_locale must be 'en' or 'fr'");
+  }
+  if (!nonEmptyString(o.audit_summary)) fail("audit_summary is required");
+  if (o.attachments !== void 0 && !isStringArray(o.attachments)) {
+    fail("attachments must be an array of strings");
+  }
+  const out = {
+    actions: o.actions.map(parseRefinerAction),
+    touch_paths: o.touch_paths,
+    output_locale: o.output_locale,
+    audit_summary: o.audit_summary
+  };
+  if (o.attachments !== void 0) out.attachments = o.attachments;
+  if (o.cost_estimate !== void 0) {
+    out.cost_estimate = parseRefinerCostEstimate(o.cost_estimate);
+  }
+  return out;
+}
+
+// src/agents/refiner/batch.ts
+import { createHash } from "node:crypto";
+var SUBTASK_CAP = 12;
+function subtaskContentHash(title, description) {
+  return createHash("sha256").update(`${title}
+${description}`).digest("hex").slice(0, 12);
+}
+function prepareBatch(createActions, cap) {
+  const subtaskCap = cap ?? (parseInt(process.env.FERRY_REFINER_SUBTASK_CAP ?? "", 10) || SUBTASK_CAP);
+  const truncated = createActions.length > subtaskCap;
+  const slice = truncated ? createActions.slice(0, subtaskCap) : createActions;
+  const subtasks = slice.map((s) => ({
+    title: s.title,
+    description: `${s.description}
+
+[ferry:refiner-subtask:${subtaskContentHash(s.title, s.description)}]`
+  }));
+  return {
+    subtasks,
+    truncated,
+    originalCount: createActions.length
+  };
+}
+async function applyBatch(prepared, create) {
+  try {
+    const refs = await create(prepared.subtasks);
+    return { createdCount: refs.length, ids: refs.map((r) => r.id) };
+  } catch (e) {
+    throw new FerryError("transient", {
+      reason: "batch-create-failed",
+      cause: e instanceof Error ? e.message : String(e)
+    });
+  }
+}
+
+// src/agents/refiner/idempotency.ts
+var MARKER_REGEX = /\[ferry:refiner-subtask:[^\]]+\]/;
+function extractSubtaskMarker(description) {
+  const match = description.match(MARKER_REGEX);
+  return match ? match[0] : null;
+}
+function filterExistingSubtasks(prepared, existingDescriptions) {
+  const existingMarkers = new Set(
+    existingDescriptions.map(extractSubtaskMarker).filter((m) => m !== null)
+  );
+  const subtasks = prepared.subtasks.filter((s) => {
+    const m = extractSubtaskMarker(s.description);
+    return m === null || !existingMarkers.has(m);
+  });
+  return { ...prepared, subtasks };
+}
+
+// src/agents/refiner/reconcile.ts
+var LOCKED_STATUSES = /* @__PURE__ */ new Set(["In Progress", "Done"]);
+async function applyActions(actions, ctx) {
+  const noopAction = actions.find((a) => a.type === "noop");
+  if (noopAction) {
+    return {
+      createdCount: 0,
+      keptCount: 0,
+      staledCount: 0,
+      noop: true,
+      noopReason: noopAction.reason
+    };
+  }
+  const existingByKey = new Map(ctx.existingSubtasks.map((s) => [s.key, s]));
+  const existingDescriptions = ctx.existingSubtasks.map((s) => s.description);
+  const staleMarkerPrefix = `[ferry:refiner-stale:${ctx.eventId}]`;
+  let keptCount = 0;
+  let staledCount = 0;
+  for (const action of actions) {
+    if (action.type === "keep") {
+      keptCount++;
+      continue;
+    }
+    if (action.type === "mark_stale") {
+      const existing = existingByKey.get(action.existing_key);
+      if (existing && LOCKED_STATUSES.has(existing.status)) {
+        await ctx.tracker.postComment(
+          ctx.ticketKey,
+          `${staleMarkerPrefix} Would mark ${action.existing_key} stale but it is ${existing.status} \u2014 ${action.reason}`
+        );
+      } else {
+        await ctx.tracker.postComment(action.existing_key, `${staleMarkerPrefix} ${action.reason}`);
+      }
+      staledCount++;
+    }
+  }
+  const createActions = actions.filter(
+    (a) => a.type === "create"
+  );
+  let createdCount = 0;
+  if (createActions.length > 0) {
+    const batch = filterExistingSubtasks(prepareBatch(createActions), existingDescriptions);
+    const applied = await applyBatch(
+      batch,
+      (items) => Promise.all(
+        items.map((item) => ctx.tracker.createSubtask(ctx.ticketKey, item.title, item.description))
+      )
+    );
+    createdCount = applied.createdCount;
+  }
+  return { createdCount, keptCount, staledCount, noop: false };
+}
 
 // src/lib/dispatch/cc-apply-action.ts
 var VALID_ROLES = ["refiner", "developer", "reviewer", "iterator"];
@@ -1694,8 +1863,6 @@ async function applyCcArtifact(params) {
     prNumber,
     priorIterations,
     cap,
-    runLink,
-    subtaskCount,
     tracker,
     ticketKey,
     dryRun,
@@ -1711,12 +1878,38 @@ async function applyCcArtifact(params) {
     ...prUrl !== void 0 ? { prUrl } : {},
     ...prNumber !== void 0 ? { prNumber } : {},
     ...priorIterations !== void 0 ? { priorIterations } : {},
-    ...cap !== void 0 ? { cap } : {},
-    ...runLink !== void 0 ? { runLink } : {},
-    ...subtaskCount !== void 0 ? { subtaskCount } : {}
+    ...cap !== void 0 ? { cap } : {}
   };
   const decision = decideContract(output, ctx);
   return applyContract({ tracker, ticketKey, marker, existingComments, decision, dryRun, getEnv });
+}
+async function applyRefinerCcArtifact(params) {
+  const { rawArtifact, marker, existingComments, eventId, ticketKey, runLink, tracker, dryRun } = params;
+  let plan;
+  try {
+    plan = parseRefinerArtifact(rawArtifact);
+  } catch (err) {
+    throw new FerryError("state-invariant", {
+      reason: "agent-output-invalid",
+      paths: [err instanceof Error ? err.message : String(err)]
+    });
+  }
+  if (checkIdempotencyMarker(marker, existingComments).skipped) {
+    return { skipped: true, emitted: false, exitCode: 0 };
+  }
+  if (dryRun === true) {
+    return { skipped: false, emitted: false, exitCode: 0 };
+  }
+  const existingSubtasks = await tracker.getSubtaskDetails(ticketKey);
+  const result = await applyActions(plan.actions, {
+    ticketKey,
+    eventId,
+    existingSubtasks,
+    tracker
+  });
+  const comment = result.noop ? `${marker} No changes needed \u2014 existing ${existingSubtasks.length} sub-task(s) still valid. ${result.noopReason ?? ""}`.trimEnd() : `${marker} Refined. Created ${result.createdCount}, kept ${result.keptCount}, staled ${result.staledCount} sub-task(s). See run: ${runLink}`;
+  await tracker.postComment(ticketKey, comment);
+  return { skipped: false, emitted: true, exitCode: 0 };
 }
 async function runCcApplyAction() {
   const rawPayload = process.env.FERRY_ENVELOPE_PAYLOAD;
@@ -1767,8 +1960,6 @@ async function runCcApplyAction() {
   const cap = role === "reviewer" ? config.limits.max_iterations : void 0;
   const githubRepo = process.env.GITHUB_REPO ?? "unknown";
   const githubRunId = process.env.GITHUB_RUN_ID ?? "0";
-  const runLink = role === "refiner" ? `https://github.com/${githubRepo}/actions/runs/${githubRunId}` : void 0;
-  const subtaskCount = role === "refiner" ? parseInt(process.env.FERRY_SUBTASK_COUNT ?? "0", 10) || 0 : void 0;
   const prNumber = role === "reviewer" || role === "iterator" ? parseInt(process.env.FERRY_PR_NUMBER ?? "", 10) || void 0 : void 0;
   const artifactPath = join2(process.cwd(), CC_OUTPUT_ARTIFACT_PATH);
   let rawArtifact;
@@ -1782,7 +1973,16 @@ async function runCcApplyAction() {
   }
   let result;
   try {
-    result = await applyCcArtifact({
+    result = role === "refiner" ? await applyRefinerCcArtifact({
+      rawArtifact,
+      marker,
+      existingComments,
+      eventId: envelope.event_id,
+      ticketKey: envelope.ticket_key,
+      runLink: `https://github.com/${githubRepo}/actions/runs/${githubRunId}`,
+      tracker,
+      dryRun
+    }) : await applyCcArtifact({
       rawArtifact,
       role,
       marker,
@@ -1791,8 +1991,6 @@ async function runCcApplyAction() {
       prNumber,
       priorIterations,
       cap,
-      runLink,
-      subtaskCount,
       tracker,
       ticketKey: envelope.ticket_key,
       dryRun
@@ -1826,5 +2024,6 @@ if (invokedDirectly) {
 }
 export {
   applyCcArtifact,
+  applyRefinerCcArtifact,
   runCcApplyAction
 };

--- a/.ferry/cc-prepare-action.js
+++ b/.ferry/cc-prepare-action.js
@@ -121,7 +121,8 @@ var require_fast_content_type_parse = __commonJS({
 });
 
 // src/lib/dispatch/cc-prepare-action.ts
-import { appendFileSync } from "node:fs";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join as join4 } from "node:path";
 import { randomBytes } from "node:crypto";
 import { execFileSync as execFileSync5 } from "node:child_process";
 
@@ -2439,13 +2440,13 @@ function packageJsonPath(repoRoot) {
   return path3.join(repoRoot, "package.json");
 }
 function detectPackageManager(repoRoot, _checkExists = existsSync4, _readFile = (p, enc) => readFileSync4(p, enc)) {
-  const join4 = (file) => path3.join(repoRoot, file);
-  if (_checkExists(join4("pnpm-lock.yaml"))) {
+  const join5 = (file) => path3.join(repoRoot, file);
+  if (_checkExists(join5("pnpm-lock.yaml"))) {
     return "pnpm lockfile detected (`pnpm-lock.yaml`). Use pnpm for all install and script commands.";
   }
-  if (_checkExists(join4("package.json"))) {
+  if (_checkExists(join5("package.json"))) {
     try {
-      const pkg = JSON.parse(_readFile(join4("package.json"), "utf8"));
+      const pkg = JSON.parse(_readFile(join5("package.json"), "utf8"));
       const pm = typeof pkg.packageManager === "string" ? pkg.packageManager : "";
       if (pm.startsWith("pnpm")) {
         return "pnpm declared in `package.json` (`packageManager` field). Use pnpm for all install and script commands.";
@@ -2462,25 +2463,25 @@ function detectPackageManager(repoRoot, _checkExists = existsSync4, _readFile = 
     } catch {
     }
   }
-  if (_checkExists(join4("yarn.lock"))) {
+  if (_checkExists(join5("yarn.lock"))) {
     return "yarn lockfile detected (`yarn.lock`). Use yarn for all install and script commands.";
   }
-  if (_checkExists(join4("bun.lockb"))) {
+  if (_checkExists(join5("bun.lockb"))) {
     return "bun lockfile detected (`bun.lockb`). Use bun for all install and script commands.";
   }
-  if (_checkExists(join4("package-lock.json"))) {
+  if (_checkExists(join5("package-lock.json"))) {
     return "npm lockfile detected (`package-lock.json`). Use npm for all install and script commands.";
   }
-  const hasPyproject = _checkExists(join4("pyproject.toml"));
-  const hasRequirements = _checkExists(join4("requirements.txt"));
+  const hasPyproject = _checkExists(join5("pyproject.toml"));
+  const hasRequirements = _checkExists(join5("requirements.txt"));
   if (hasPyproject || hasRequirements) {
     const marker = hasPyproject ? "pyproject.toml" : "requirements.txt";
     return `Python project detected (\`${marker}\`). Use pip or the project's configured tool for dependency management.`;
   }
-  if (_checkExists(join4("Gemfile.lock"))) {
+  if (_checkExists(join5("Gemfile.lock"))) {
     return "Ruby project detected (`Gemfile.lock`). Use bundler for dependency management.";
   }
-  if (_checkExists(join4("Cargo.lock"))) {
+  if (_checkExists(join5("Cargo.lock"))) {
     return "Rust project detected (`Cargo.lock`). Use cargo for dependency management.";
   }
   return null;
@@ -6799,7 +6800,7 @@ function parseClaudeCodeArtifact(role, raw) {
 }
 var DEV_ITER_SHAPE = '{ "outcome": "implemented" | "already_satisfied" | "blocked", "summary": string, "commit_message"?: string, "reason"?: string, "validation"?: [{ "command": string, "outcome": string }], "notes"?: string[] }';
 var REVIEWER_SHAPE = '{ "approved": boolean, "comment": string }';
-var REFINER_SHAPE = '{ "actions": [...], "touch_paths": string[], "output_locale": "en" | "fr", "audit_summary": string }';
+var REFINER_SHAPE = '{ "actions": [ { "type": "create", "title": string, "description": string } | { "type": "keep", "existing_key": string, "reason": string } | { "type": "mark_stale", "existing_key": string, "reason": string } | { "type": "noop", "reason": string } ], "touch_paths": string[], "output_locale": "en" | "fr", "audit_summary": string }';
 function outcomePromptSuffix(role) {
   const header = `
 
@@ -6809,7 +6810,12 @@ FINAL OUTPUT (claude-code path): the \`done\`/\`finish_review\` tools are not av
     return `${header} Shape: ${REVIEWER_SHAPE}`;
   }
   if (role === "refiner") {
-    return `${header} Shape: ${REFINER_SHAPE} (same as the bundled refiner JSON contract).`;
+    return `
+
+---
+FINAL OUTPUT (claude-code path) \u2014 OVERRIDE.
+Ignore any earlier instruction to "reply with JSON only" or to emit "no prose": those describe the script path. On THIS path there is no \`done\` tool and your chat reply is discarded. You MUST use the \`Write\` tool to create the file \`${CC_OUTPUT_ARTIFACT_PATH}\` as your LAST action \u2014 do not print the JSON to the chat. A run that ends without that file is a failure.
+First explore the repository with the \`Read\`, \`Glob\` and \`Grep\` tools so the sub-task descriptions reference real file paths. Then write a single JSON object matching this exact schema (the bundled refiner contract): ${REFINER_SHAPE}. Each action is one of: \`create\` a new sub-task, \`keep\` an existing one unchanged, \`mark_stale\` a superseded one, or \`noop\` when nothing has changed.`;
   }
   const access = ROLE_ACCESS[role];
   return `${header} Commit and push your work with \`git\` first (there is no \`commit_progress\` tool on this path; access=${access}). Then write: ${DEV_ITER_SHAPE}`;
@@ -7193,6 +7199,7 @@ async function runCcPrepareAction() {
   const envelope = validateEnvelope(parsed);
   const role = parseRole(process.env.FERRY_AGENT_ROLE);
   const repoRoot = process.cwd();
+  mkdirSync(join4(repoRoot, ".ferry"), { recursive: true });
   const ferryCfg = loadFerryConfig(repoRoot);
   enforceProviderGate(ferryCfg);
   const logger = createLogger2(envelope.event_id, "ferry:cc-prepare");

--- a/.ferry/schemas/agent-output.v1.schema.json
+++ b/.ferry/schemas/agent-output.v1.schema.json
@@ -46,21 +46,6 @@
         "review_comment": { "type": "string", "minLength": 1, "maxLength": 65536 },
         "summary": { "type": "string", "minLength": 1, "maxLength": 2000 }
       }
-    },
-    {
-      "type": "object",
-      "required": ["version", "role", "result", "summary"],
-      "additionalProperties": false,
-      "properties": {
-        "version": { "const": "v1" },
-        "role": { "const": "refiner" },
-        "result": { "enum": ["refined", "noop"] },
-        "summary": { "type": "string", "minLength": 1, "maxLength": 2000 },
-        "created": { "type": "integer", "minimum": 0 },
-        "kept": { "type": "integer", "minimum": 0 },
-        "staled": { "type": "integer", "minimum": 0 },
-        "noop_reason": { "type": "string", "minLength": 1, "maxLength": 2000 }
-      }
     }
   ]
 }

--- a/.github/actions/ferry-cc-apply/action.yml
+++ b/.github/actions/ferry-cc-apply/action.yml
@@ -40,10 +40,6 @@ inputs:
     description: PR number for the current cycle (required for reviewer and iterator roles)
     required: false
     default: ''
-  ferry_subtask_count:
-    description: Sub-task count for the refiner noop message
-    required: false
-    default: '0'
   github_token:
     description: GitHub token (reserved for future use and consistency with ferry-run-* actions)
     required: false
@@ -94,7 +90,6 @@ runs:
         FERRY_ITER_TRANSITION_ID: ${{ inputs.ferry_iter_transition_id }}
         FERRY_APPROVE_TRANSITION_ID: ${{ inputs.ferry_approve_transition_id }}
         FERRY_PR_NUMBER: ${{ inputs.ferry_pr_number }}
-        FERRY_SUBTASK_COUNT: ${{ inputs.ferry_subtask_count }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
         GH_TOKEN: ${{ inputs.github_token }}
         GITHUB_REPO: ${{ inputs.github_repo }}

--- a/.github/actions/ferry-cc-apply/cc-apply-action.js
+++ b/.github/actions/ferry-cc-apply/cc-apply-action.js
@@ -188,28 +188,6 @@ function decideContract(output, ctx) {
         exitCode: 0
       };
     }
-    case "refiner": {
-      if (output.result === "noop") {
-        const subtaskCount = ctx.subtaskCount ?? 0;
-        const reason = output.noop_reason ?? "";
-        return {
-          comment: `${m} No changes needed \u2014 existing ${subtaskCount} sub-task(s) still valid. ${reason}`.trimEnd(),
-          labels: [],
-          transitions: [],
-          exitCode: 0
-        };
-      }
-      const runLink = requireCtx(ctx.runLink, "runLink", "refiner", output.result);
-      const created = output.created ?? 0;
-      const kept = output.kept ?? 0;
-      const staled = output.staled ?? 0;
-      return {
-        comment: `${m} Refined. Created ${created}, kept ${kept}, staled ${staled} sub-task(s). See run: ${runLink}`,
-        labels: [],
-        transitions: [],
-        exitCode: 0
-      };
-    }
   }
 }
 
@@ -1661,6 +1639,197 @@ function countPriorIterations(existingComments) {
 
 // src/lib/claude-code/output-artifact.ts
 var CC_OUTPUT_ARTIFACT_PATH = ".ferry/cc-output.json";
+function fail(detail) {
+  throw new Error(`Invalid ${CC_OUTPUT_ARTIFACT_PATH}: ${detail}`);
+}
+function asObject(raw) {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    fail("expected a JSON object");
+  }
+  return raw;
+}
+function nonEmptyString(v) {
+  return typeof v === "string" && v.trim().length > 0;
+}
+function isStringArray(v) {
+  return Array.isArray(v) && v.every((e) => typeof e === "string");
+}
+function parseRefinerAction(a, idx) {
+  const o = asObject(a);
+  switch (o.type) {
+    case "create":
+      if (!nonEmptyString(o.title) || !nonEmptyString(o.description)) {
+        fail(`actions[${idx}] create requires title and description`);
+      }
+      return { type: "create", title: o.title, description: o.description };
+    case "keep":
+    case "mark_stale":
+      if (!nonEmptyString(o.existing_key) || !nonEmptyString(o.reason)) {
+        fail(`actions[${idx}] ${o.type} requires existing_key and reason`);
+      }
+      return {
+        type: o.type,
+        existing_key: o.existing_key,
+        reason: o.reason
+      };
+    case "noop":
+      if (!nonEmptyString(o.reason)) fail(`actions[${idx}] noop requires reason`);
+      return { type: "noop", reason: o.reason };
+    default:
+      return fail(`actions[${idx}] has unknown type ${String(o.type)}`);
+  }
+}
+function parseRefinerCostEstimate(raw) {
+  const o = asObject(raw);
+  if (typeof o.loUsd !== "number" || !Number.isFinite(o.loUsd) || o.loUsd < 0) {
+    fail("cost_estimate.loUsd must be a non-negative number");
+  }
+  if (typeof o.hiUsd !== "number" || !Number.isFinite(o.hiUsd) || o.hiUsd < 0) {
+    fail("cost_estimate.hiUsd must be a non-negative number");
+  }
+  if (o.confidence !== "low" && o.confidence !== "medium" && o.confidence !== "high") {
+    fail("cost_estimate.confidence must be 'low', 'medium', or 'high'");
+  }
+  if (typeof o.baselineRuns !== "number" || !Number.isInteger(o.baselineRuns) || o.baselineRuns < 0) {
+    fail("cost_estimate.baselineRuns must be a non-negative integer");
+  }
+  return {
+    loUsd: o.loUsd,
+    hiUsd: o.hiUsd,
+    confidence: o.confidence,
+    baselineRuns: o.baselineRuns
+  };
+}
+function parseRefinerArtifact(raw) {
+  const o = asObject(raw);
+  if (!Array.isArray(o.actions) || o.actions.length === 0) {
+    fail("actions must be a non-empty array");
+  }
+  if (!isStringArray(o.touch_paths)) fail("touch_paths must be an array of strings");
+  if (o.output_locale !== "en" && o.output_locale !== "fr") {
+    fail("output_locale must be 'en' or 'fr'");
+  }
+  if (!nonEmptyString(o.audit_summary)) fail("audit_summary is required");
+  if (o.attachments !== void 0 && !isStringArray(o.attachments)) {
+    fail("attachments must be an array of strings");
+  }
+  const out = {
+    actions: o.actions.map(parseRefinerAction),
+    touch_paths: o.touch_paths,
+    output_locale: o.output_locale,
+    audit_summary: o.audit_summary
+  };
+  if (o.attachments !== void 0) out.attachments = o.attachments;
+  if (o.cost_estimate !== void 0) {
+    out.cost_estimate = parseRefinerCostEstimate(o.cost_estimate);
+  }
+  return out;
+}
+
+// src/agents/refiner/batch.ts
+import { createHash } from "node:crypto";
+var SUBTASK_CAP = 12;
+function subtaskContentHash(title, description) {
+  return createHash("sha256").update(`${title}
+${description}`).digest("hex").slice(0, 12);
+}
+function prepareBatch(createActions, cap) {
+  const subtaskCap = cap ?? (parseInt(process.env.FERRY_REFINER_SUBTASK_CAP ?? "", 10) || SUBTASK_CAP);
+  const truncated = createActions.length > subtaskCap;
+  const slice = truncated ? createActions.slice(0, subtaskCap) : createActions;
+  const subtasks = slice.map((s) => ({
+    title: s.title,
+    description: `${s.description}
+
+[ferry:refiner-subtask:${subtaskContentHash(s.title, s.description)}]`
+  }));
+  return {
+    subtasks,
+    truncated,
+    originalCount: createActions.length
+  };
+}
+async function applyBatch(prepared, create) {
+  try {
+    const refs = await create(prepared.subtasks);
+    return { createdCount: refs.length, ids: refs.map((r) => r.id) };
+  } catch (e) {
+    throw new FerryError("transient", {
+      reason: "batch-create-failed",
+      cause: e instanceof Error ? e.message : String(e)
+    });
+  }
+}
+
+// src/agents/refiner/idempotency.ts
+var MARKER_REGEX = /\[ferry:refiner-subtask:[^\]]+\]/;
+function extractSubtaskMarker(description) {
+  const match = description.match(MARKER_REGEX);
+  return match ? match[0] : null;
+}
+function filterExistingSubtasks(prepared, existingDescriptions) {
+  const existingMarkers = new Set(
+    existingDescriptions.map(extractSubtaskMarker).filter((m) => m !== null)
+  );
+  const subtasks = prepared.subtasks.filter((s) => {
+    const m = extractSubtaskMarker(s.description);
+    return m === null || !existingMarkers.has(m);
+  });
+  return { ...prepared, subtasks };
+}
+
+// src/agents/refiner/reconcile.ts
+var LOCKED_STATUSES = /* @__PURE__ */ new Set(["In Progress", "Done"]);
+async function applyActions(actions, ctx) {
+  const noopAction = actions.find((a) => a.type === "noop");
+  if (noopAction) {
+    return {
+      createdCount: 0,
+      keptCount: 0,
+      staledCount: 0,
+      noop: true,
+      noopReason: noopAction.reason
+    };
+  }
+  const existingByKey = new Map(ctx.existingSubtasks.map((s) => [s.key, s]));
+  const existingDescriptions = ctx.existingSubtasks.map((s) => s.description);
+  const staleMarkerPrefix = `[ferry:refiner-stale:${ctx.eventId}]`;
+  let keptCount = 0;
+  let staledCount = 0;
+  for (const action of actions) {
+    if (action.type === "keep") {
+      keptCount++;
+      continue;
+    }
+    if (action.type === "mark_stale") {
+      const existing = existingByKey.get(action.existing_key);
+      if (existing && LOCKED_STATUSES.has(existing.status)) {
+        await ctx.tracker.postComment(
+          ctx.ticketKey,
+          `${staleMarkerPrefix} Would mark ${action.existing_key} stale but it is ${existing.status} \u2014 ${action.reason}`
+        );
+      } else {
+        await ctx.tracker.postComment(action.existing_key, `${staleMarkerPrefix} ${action.reason}`);
+      }
+      staledCount++;
+    }
+  }
+  const createActions = actions.filter(
+    (a) => a.type === "create"
+  );
+  let createdCount = 0;
+  if (createActions.length > 0) {
+    const batch = filterExistingSubtasks(prepareBatch(createActions), existingDescriptions);
+    const applied = await applyBatch(
+      batch,
+      (items) => Promise.all(
+        items.map((item) => ctx.tracker.createSubtask(ctx.ticketKey, item.title, item.description))
+      )
+    );
+    createdCount = applied.createdCount;
+  }
+  return { createdCount, keptCount, staledCount, noop: false };
+}
 
 // src/lib/dispatch/cc-apply-action.ts
 var VALID_ROLES = ["refiner", "developer", "reviewer", "iterator"];
@@ -1694,8 +1863,6 @@ async function applyCcArtifact(params) {
     prNumber,
     priorIterations,
     cap,
-    runLink,
-    subtaskCount,
     tracker,
     ticketKey,
     dryRun,
@@ -1711,12 +1878,38 @@ async function applyCcArtifact(params) {
     ...prUrl !== void 0 ? { prUrl } : {},
     ...prNumber !== void 0 ? { prNumber } : {},
     ...priorIterations !== void 0 ? { priorIterations } : {},
-    ...cap !== void 0 ? { cap } : {},
-    ...runLink !== void 0 ? { runLink } : {},
-    ...subtaskCount !== void 0 ? { subtaskCount } : {}
+    ...cap !== void 0 ? { cap } : {}
   };
   const decision = decideContract(output, ctx);
   return applyContract({ tracker, ticketKey, marker, existingComments, decision, dryRun, getEnv });
+}
+async function applyRefinerCcArtifact(params) {
+  const { rawArtifact, marker, existingComments, eventId, ticketKey, runLink, tracker, dryRun } = params;
+  let plan;
+  try {
+    plan = parseRefinerArtifact(rawArtifact);
+  } catch (err) {
+    throw new FerryError("state-invariant", {
+      reason: "agent-output-invalid",
+      paths: [err instanceof Error ? err.message : String(err)]
+    });
+  }
+  if (checkIdempotencyMarker(marker, existingComments).skipped) {
+    return { skipped: true, emitted: false, exitCode: 0 };
+  }
+  if (dryRun === true) {
+    return { skipped: false, emitted: false, exitCode: 0 };
+  }
+  const existingSubtasks = await tracker.getSubtaskDetails(ticketKey);
+  const result = await applyActions(plan.actions, {
+    ticketKey,
+    eventId,
+    existingSubtasks,
+    tracker
+  });
+  const comment = result.noop ? `${marker} No changes needed \u2014 existing ${existingSubtasks.length} sub-task(s) still valid. ${result.noopReason ?? ""}`.trimEnd() : `${marker} Refined. Created ${result.createdCount}, kept ${result.keptCount}, staled ${result.staledCount} sub-task(s). See run: ${runLink}`;
+  await tracker.postComment(ticketKey, comment);
+  return { skipped: false, emitted: true, exitCode: 0 };
 }
 async function runCcApplyAction() {
   const rawPayload = process.env.FERRY_ENVELOPE_PAYLOAD;
@@ -1767,8 +1960,6 @@ async function runCcApplyAction() {
   const cap = role === "reviewer" ? config.limits.max_iterations : void 0;
   const githubRepo = process.env.GITHUB_REPO ?? "unknown";
   const githubRunId = process.env.GITHUB_RUN_ID ?? "0";
-  const runLink = role === "refiner" ? `https://github.com/${githubRepo}/actions/runs/${githubRunId}` : void 0;
-  const subtaskCount = role === "refiner" ? parseInt(process.env.FERRY_SUBTASK_COUNT ?? "0", 10) || 0 : void 0;
   const prNumber = role === "reviewer" || role === "iterator" ? parseInt(process.env.FERRY_PR_NUMBER ?? "", 10) || void 0 : void 0;
   const artifactPath = join2(process.cwd(), CC_OUTPUT_ARTIFACT_PATH);
   let rawArtifact;
@@ -1782,7 +1973,16 @@ async function runCcApplyAction() {
   }
   let result;
   try {
-    result = await applyCcArtifact({
+    result = role === "refiner" ? await applyRefinerCcArtifact({
+      rawArtifact,
+      marker,
+      existingComments,
+      eventId: envelope.event_id,
+      ticketKey: envelope.ticket_key,
+      runLink: `https://github.com/${githubRepo}/actions/runs/${githubRunId}`,
+      tracker,
+      dryRun
+    }) : await applyCcArtifact({
       rawArtifact,
       role,
       marker,
@@ -1791,8 +1991,6 @@ async function runCcApplyAction() {
       prNumber,
       priorIterations,
       cap,
-      runLink,
-      subtaskCount,
       tracker,
       ticketKey: envelope.ticket_key,
       dryRun
@@ -1826,5 +2024,6 @@ if (invokedDirectly) {
 }
 export {
   applyCcArtifact,
+  applyRefinerCcArtifact,
   runCcApplyAction
 };

--- a/.github/actions/ferry-cc-apply/schemas/agent-output.v1.schema.json
+++ b/.github/actions/ferry-cc-apply/schemas/agent-output.v1.schema.json
@@ -46,21 +46,6 @@
         "review_comment": { "type": "string", "minLength": 1, "maxLength": 65536 },
         "summary": { "type": "string", "minLength": 1, "maxLength": 2000 }
       }
-    },
-    {
-      "type": "object",
-      "required": ["version", "role", "result", "summary"],
-      "additionalProperties": false,
-      "properties": {
-        "version": { "const": "v1" },
-        "role": { "const": "refiner" },
-        "result": { "enum": ["refined", "noop"] },
-        "summary": { "type": "string", "minLength": 1, "maxLength": 2000 },
-        "created": { "type": "integer", "minimum": 0 },
-        "kept": { "type": "integer", "minimum": 0 },
-        "staled": { "type": "integer", "minimum": 0 },
-        "noop_reason": { "type": "string", "minLength": 1, "maxLength": 2000 }
-      }
     }
   ]
 }

--- a/.github/actions/ferry-cc-prepare/cc-prepare-action.js
+++ b/.github/actions/ferry-cc-prepare/cc-prepare-action.js
@@ -121,7 +121,8 @@ var require_fast_content_type_parse = __commonJS({
 });
 
 // src/lib/dispatch/cc-prepare-action.ts
-import { appendFileSync } from "node:fs";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join as join4 } from "node:path";
 import { randomBytes } from "node:crypto";
 import { execFileSync as execFileSync5 } from "node:child_process";
 
@@ -2439,13 +2440,13 @@ function packageJsonPath(repoRoot) {
   return path3.join(repoRoot, "package.json");
 }
 function detectPackageManager(repoRoot, _checkExists = existsSync4, _readFile = (p, enc) => readFileSync4(p, enc)) {
-  const join4 = (file) => path3.join(repoRoot, file);
-  if (_checkExists(join4("pnpm-lock.yaml"))) {
+  const join5 = (file) => path3.join(repoRoot, file);
+  if (_checkExists(join5("pnpm-lock.yaml"))) {
     return "pnpm lockfile detected (`pnpm-lock.yaml`). Use pnpm for all install and script commands.";
   }
-  if (_checkExists(join4("package.json"))) {
+  if (_checkExists(join5("package.json"))) {
     try {
-      const pkg = JSON.parse(_readFile(join4("package.json"), "utf8"));
+      const pkg = JSON.parse(_readFile(join5("package.json"), "utf8"));
       const pm = typeof pkg.packageManager === "string" ? pkg.packageManager : "";
       if (pm.startsWith("pnpm")) {
         return "pnpm declared in `package.json` (`packageManager` field). Use pnpm for all install and script commands.";
@@ -2462,25 +2463,25 @@ function detectPackageManager(repoRoot, _checkExists = existsSync4, _readFile = 
     } catch {
     }
   }
-  if (_checkExists(join4("yarn.lock"))) {
+  if (_checkExists(join5("yarn.lock"))) {
     return "yarn lockfile detected (`yarn.lock`). Use yarn for all install and script commands.";
   }
-  if (_checkExists(join4("bun.lockb"))) {
+  if (_checkExists(join5("bun.lockb"))) {
     return "bun lockfile detected (`bun.lockb`). Use bun for all install and script commands.";
   }
-  if (_checkExists(join4("package-lock.json"))) {
+  if (_checkExists(join5("package-lock.json"))) {
     return "npm lockfile detected (`package-lock.json`). Use npm for all install and script commands.";
   }
-  const hasPyproject = _checkExists(join4("pyproject.toml"));
-  const hasRequirements = _checkExists(join4("requirements.txt"));
+  const hasPyproject = _checkExists(join5("pyproject.toml"));
+  const hasRequirements = _checkExists(join5("requirements.txt"));
   if (hasPyproject || hasRequirements) {
     const marker = hasPyproject ? "pyproject.toml" : "requirements.txt";
     return `Python project detected (\`${marker}\`). Use pip or the project's configured tool for dependency management.`;
   }
-  if (_checkExists(join4("Gemfile.lock"))) {
+  if (_checkExists(join5("Gemfile.lock"))) {
     return "Ruby project detected (`Gemfile.lock`). Use bundler for dependency management.";
   }
-  if (_checkExists(join4("Cargo.lock"))) {
+  if (_checkExists(join5("Cargo.lock"))) {
     return "Rust project detected (`Cargo.lock`). Use cargo for dependency management.";
   }
   return null;
@@ -6799,7 +6800,7 @@ function parseClaudeCodeArtifact(role, raw) {
 }
 var DEV_ITER_SHAPE = '{ "outcome": "implemented" | "already_satisfied" | "blocked", "summary": string, "commit_message"?: string, "reason"?: string, "validation"?: [{ "command": string, "outcome": string }], "notes"?: string[] }';
 var REVIEWER_SHAPE = '{ "approved": boolean, "comment": string }';
-var REFINER_SHAPE = '{ "actions": [...], "touch_paths": string[], "output_locale": "en" | "fr", "audit_summary": string }';
+var REFINER_SHAPE = '{ "actions": [ { "type": "create", "title": string, "description": string } | { "type": "keep", "existing_key": string, "reason": string } | { "type": "mark_stale", "existing_key": string, "reason": string } | { "type": "noop", "reason": string } ], "touch_paths": string[], "output_locale": "en" | "fr", "audit_summary": string }';
 function outcomePromptSuffix(role) {
   const header = `
 
@@ -6809,7 +6810,12 @@ FINAL OUTPUT (claude-code path): the \`done\`/\`finish_review\` tools are not av
     return `${header} Shape: ${REVIEWER_SHAPE}`;
   }
   if (role === "refiner") {
-    return `${header} Shape: ${REFINER_SHAPE} (same as the bundled refiner JSON contract).`;
+    return `
+
+---
+FINAL OUTPUT (claude-code path) \u2014 OVERRIDE.
+Ignore any earlier instruction to "reply with JSON only" or to emit "no prose": those describe the script path. On THIS path there is no \`done\` tool and your chat reply is discarded. You MUST use the \`Write\` tool to create the file \`${CC_OUTPUT_ARTIFACT_PATH}\` as your LAST action \u2014 do not print the JSON to the chat. A run that ends without that file is a failure.
+First explore the repository with the \`Read\`, \`Glob\` and \`Grep\` tools so the sub-task descriptions reference real file paths. Then write a single JSON object matching this exact schema (the bundled refiner contract): ${REFINER_SHAPE}. Each action is one of: \`create\` a new sub-task, \`keep\` an existing one unchanged, \`mark_stale\` a superseded one, or \`noop\` when nothing has changed.`;
   }
   const access = ROLE_ACCESS[role];
   return `${header} Commit and push your work with \`git\` first (there is no \`commit_progress\` tool on this path; access=${access}). Then write: ${DEV_ITER_SHAPE}`;
@@ -7193,6 +7199,7 @@ async function runCcPrepareAction() {
   const envelope = validateEnvelope(parsed);
   const role = parseRole(process.env.FERRY_AGENT_ROLE);
   const repoRoot = process.cwd();
+  mkdirSync(join4(repoRoot, ".ferry"), { recursive: true });
   const ferryCfg = loadFerryConfig(repoRoot);
   enforceProviderGate(ferryCfg);
   const logger = createLogger2(envelope.event_id, "ferry:cc-prepare");

--- a/src/lib/cc-wrappers/agent-output.test.ts
+++ b/src/lib/cc-wrappers/agent-output.test.ts
@@ -26,16 +26,6 @@ const ITERATOR_OK = {
   pr_number: 7,
 };
 
-const REFINER_OK = {
-  version: 'v1',
-  role: 'refiner',
-  result: 'refined',
-  summary: 'Reconciled sub-tasks',
-  created: 2,
-  kept: 1,
-  staled: 0,
-};
-
 describe('validateAgentOutput — happy paths', () => {
   it('accepts a developer artifact', () => {
     expect(validateAgentOutput(DEV_OK)).toEqual(DEV_OK);
@@ -47,15 +37,6 @@ describe('validateAgentOutput — happy paths', () => {
 
   it('accepts an iterator artifact', () => {
     expect(validateAgentOutput(ITERATOR_OK)).toEqual(ITERATOR_OK);
-  });
-
-  it('accepts a refiner refined artifact', () => {
-    expect(validateAgentOutput(REFINER_OK)).toEqual(REFINER_OK);
-  });
-
-  it('accepts a refiner noop artifact', () => {
-    const noop = { version: 'v1', role: 'refiner', result: 'noop', summary: 's', noop_reason: 'r' };
-    expect(validateAgentOutput(noop)).toEqual(noop);
   });
 
   it('accepts a JSON string artifact (as written to a file by the action)', () => {
@@ -87,6 +68,13 @@ describe('validateAgentOutput — fail-closed', () => {
     expect(() => validateAgentOutput({ version: 'v1', role: 'planner', summary: 's' })).toThrow(
       FerryError,
     );
+  });
+
+  it('rejects a refiner artifact — the refiner uses a RefinerOutput plan, not this schema', () => {
+    // The refiner artifact is a `RefinerOutput` plan validated by
+    // `parseRefinerArtifact` / `applyRefinerCcArtifact`, never `validateAgentOutput`.
+    const refiner = { version: 'v1', role: 'refiner', result: 'refined', summary: 's' };
+    expect(() => validateAgentOutput(refiner)).toThrow(FerryError);
   });
 
   it('throws for a wrong version', () => {

--- a/src/lib/cc-wrappers/agent-output.ts
+++ b/src/lib/cc-wrappers/agent-output.ts
@@ -27,10 +27,12 @@ const ajvInstance = new ajvModule.Ajv2020({ strict: true });
 
 const validateFn: ValidateFunction = ajvInstance.compile(outputSchema);
 
+// `refiner` stays in the role enum (a valid FERRY_AGENT_ROLE env value), but the
+// refiner artifact is NOT validated here — it is a `RefinerOutput` *plan*, not a
+// terminal outcome. See `applyRefinerCcArtifact` in `dispatch/cc-apply-action.ts`.
 export type AgentOutputRole = 'developer' | 'iterator' | 'reviewer' | 'refiner';
 export type DeveloperOutcome = 'implemented' | 'already_satisfied' | 'blocked';
 export type ReviewerVerdict = 'approved' | 'changes_requested';
-export type RefinerResult = 'refined' | 'noop';
 
 export interface DeveloperAgentOutput {
   version: 'v1';
@@ -58,22 +60,7 @@ export interface ReviewerAgentOutput {
   summary: string;
 }
 
-export interface RefinerAgentOutput {
-  version: 'v1';
-  role: 'refiner';
-  result: RefinerResult;
-  summary: string;
-  created?: number;
-  kept?: number;
-  staled?: number;
-  noop_reason?: string;
-}
-
-export type AgentOutputV1 =
-  | DeveloperAgentOutput
-  | IteratorAgentOutput
-  | ReviewerAgentOutput
-  | RefinerAgentOutput;
+export type AgentOutputV1 = DeveloperAgentOutput | IteratorAgentOutput | ReviewerAgentOutput;
 
 /**
  * Parses + validates the terminal agent artifact. `raw` may be a JSON string

--- a/src/lib/cc-wrappers/contract.test.ts
+++ b/src/lib/cc-wrappers/contract.test.ts
@@ -10,7 +10,6 @@ import type {
   DeveloperAgentOutput,
   IteratorAgentOutput,
   ReviewerAgentOutput,
-  RefinerAgentOutput,
 } from './agent-output.js';
 
 const SHA = 'abc1234def5678';
@@ -275,53 +274,5 @@ describe('decideContract — reviewer (FR24)', () => {
 
   it('fail-closed: reviewer without a PR number throws', () => {
     expect(() => decideContract(rev({}), baseCtx({ marker: M }))).toThrow(FerryError);
-  });
-});
-
-describe('decideContract — refiner (no FR transition)', () => {
-  const M = '[ferry:refiner:EVT-9]';
-  const ref = (o: Partial<RefinerAgentOutput>): RefinerAgentOutput => ({
-    version: 'v1',
-    role: 'refiner',
-    result: 'refined',
-    summary: 's',
-    ...o,
-  });
-
-  it('refined → created/kept/staled + run link, no transition', () => {
-    const d = decideContract(
-      ref({ created: 2, kept: 1, staled: 3 }),
-      baseCtx({ marker: M, runLink: 'https://run/1' }),
-    );
-    expect(d.comment).toBe(
-      `${M} Refined. Created 2, kept 1, staled 3 sub-task(s). See run: https://run/1`,
-    );
-    expect(d.transitions).toEqual([]);
-  });
-
-  it('refined with missing counts → defaults to 0', () => {
-    const d = decideContract(ref({}), baseCtx({ marker: M, runLink: 'https://run/1' }));
-    expect(d.comment).toBe(
-      `${M} Refined. Created 0, kept 0, staled 0 sub-task(s). See run: https://run/1`,
-    );
-  });
-
-  it('noop → existing N still valid, trimmed reason', () => {
-    const d = decideContract(
-      ref({ result: 'noop', noop_reason: 'all valid' }),
-      baseCtx({ marker: M, subtaskCount: 4 }),
-    );
-    expect(d.comment).toBe(
-      `${M} No changes needed — existing 4 sub-task(s) still valid. all valid`,
-    );
-  });
-
-  it('noop without a reason → trailing space trimmed (script parity)', () => {
-    const d = decideContract(ref({ result: 'noop' }), baseCtx({ marker: M, subtaskCount: 0 }));
-    expect(d.comment).toBe(`${M} No changes needed — existing 0 sub-task(s) still valid.`);
-  });
-
-  it('fail-closed: refined without a run link throws', () => {
-    expect(() => decideContract(ref({}), baseCtx({ marker: M }))).toThrow(FerryError);
   });
 });

--- a/src/lib/cc-wrappers/contract.ts
+++ b/src/lib/cc-wrappers/contract.ts
@@ -72,8 +72,6 @@ export interface ContractContext {
   prNumber?: number;
   priorIterations?: number;
   cap?: number;
-  runLink?: string;
-  subtaskCount?: number;
 }
 
 /** Marker role token. Developer uses `dev` (script parity), others = role. */
@@ -258,28 +256,8 @@ export function decideContract(output: AgentOutputV1, ctx: ContractContext): Con
       };
     }
 
-    case 'refiner': {
-      if (output.result === 'noop') {
-        const subtaskCount = ctx.subtaskCount ?? 0;
-        const reason = output.noop_reason ?? '';
-        return {
-          comment:
-            `${m} No changes needed — existing ${subtaskCount} sub-task(s) still valid. ${reason}`.trimEnd(),
-          labels: [],
-          transitions: [],
-          exitCode: 0,
-        };
-      }
-      const runLink = requireCtx(ctx.runLink, 'runLink', 'refiner', output.result);
-      const created = output.created ?? 0;
-      const kept = output.kept ?? 0;
-      const staled = output.staled ?? 0;
-      return {
-        comment: `${m} Refined. Created ${created}, kept ${kept}, staled ${staled} sub-task(s). See run: ${runLink}`,
-        labels: [],
-        transitions: [],
-        exitCode: 0,
-      };
-    }
+    // NB: the refiner role has no `decideContract` case — its claude-code
+    // artifact is a `RefinerOutput` *plan*, applied by `applyRefinerCcArtifact`
+    // (`dispatch/cc-apply-action.ts`), not a terminal outcome transcribed here.
   }
 }

--- a/src/lib/cc-wrappers/index.ts
+++ b/src/lib/cc-wrappers/index.ts
@@ -9,10 +9,8 @@ export type {
   DeveloperAgentOutput,
   IteratorAgentOutput,
   ReviewerAgentOutput,
-  RefinerAgentOutput,
   DeveloperOutcome,
   ReviewerVerdict,
-  RefinerResult,
 } from './agent-output.js';
 
 export { decideContract, markerRoleToken, resolveContractMarker } from './contract.js';

--- a/src/lib/claude-code/output-artifact.test.ts
+++ b/src/lib/claude-code/output-artifact.test.ts
@@ -199,4 +199,33 @@ describe('outcomePromptSuffix', () => {
     expect(outcomePromptSuffix('reviewer')).toContain('approved');
     expect(outcomePromptSuffix('refiner')).toContain('actions');
   });
+
+  describe('refiner suffix (claude-code path override)', () => {
+    const s = outcomePromptSuffix('refiner');
+
+    it('forcefully overrides the bundled "reply with JSON only" instruction', () => {
+      // prompts/refiner.md says "Reply with JSON only. No prose before or after."
+      // twice; on this path the model must instead use the Write tool. The suffix
+      // must explicitly neutralise that instruction.
+      expect(s).toContain('OVERRIDE');
+      expect(s).toContain('Write');
+      expect(s.toLowerCase()).toContain('chat');
+    });
+
+    it('names the exact artifact path', () => {
+      expect(s).toContain(CC_OUTPUT_ARTIFACT_PATH);
+    });
+
+    it('spells out all four RefinerOutput action variants', () => {
+      for (const variant of ['create', 'keep', 'mark_stale', 'noop']) {
+        expect(s).toContain(variant);
+      }
+    });
+
+    it('names the remaining RefinerOutput top-level fields', () => {
+      for (const field of ['touch_paths', 'output_locale', 'audit_summary']) {
+        expect(s).toContain(field);
+      }
+    });
+  });
 });

--- a/src/lib/claude-code/output-artifact.ts
+++ b/src/lib/claude-code/output-artifact.ts
@@ -223,8 +223,12 @@ const DEV_ITER_SHAPE =
 const REVIEWER_SHAPE = '{ "approved": boolean, "comment": string }';
 
 const REFINER_SHAPE =
-  '{ "actions": [...], "touch_paths": string[], "output_locale": "en" | "fr", ' +
-  '"audit_summary": string }';
+  '{ "actions": [ ' +
+  '{ "type": "create", "title": string, "description": string } | ' +
+  '{ "type": "keep", "existing_key": string, "reason": string } | ' +
+  '{ "type": "mark_stale", "existing_key": string, "reason": string } | ' +
+  '{ "type": "noop", "reason": string } ' +
+  '], "touch_paths": string[], "output_locale": "en" | "fr", "audit_summary": string }';
 
 /**
  * The transport instruction appended to the (verbatim) initial prompt by the
@@ -241,7 +245,26 @@ export function outcomePromptSuffix(role: FerryRole): string {
     return `${header} Shape: ${REVIEWER_SHAPE}`;
   }
   if (role === 'refiner') {
-    return `${header} Shape: ${REFINER_SHAPE} (same as the bundled refiner JSON contract).`;
+    // The refiner system prompt (`prompts/refiner.md`) says "Reply with JSON
+    // only. No prose before or after." twice — written for the script path,
+    // where structured-output enforcement makes that instruction safe. On the
+    // claude-code path there is no such enforcement: obeyed literally, the model
+    // prints the JSON to chat and never calls `Write`, so the artifact is never
+    // produced. This suffix therefore explicitly OVERRIDES that instruction.
+    return (
+      `\n\n---\nFINAL OUTPUT (claude-code path) — OVERRIDE.\n` +
+      `Ignore any earlier instruction to "reply with JSON only" or to emit "no ` +
+      `prose": those describe the script path. On THIS path there is no \`done\` ` +
+      `tool and your chat reply is discarded. You MUST use the \`Write\` tool to ` +
+      `create the file \`${CC_OUTPUT_ARTIFACT_PATH}\` as your LAST action — do not ` +
+      `print the JSON to the chat. A run that ends without that file is a failure.\n` +
+      `First explore the repository with the \`Read\`, \`Glob\` and \`Grep\` tools ` +
+      `so the sub-task descriptions reference real file paths. Then write a single ` +
+      `JSON object matching this exact schema (the bundled refiner contract): ` +
+      `${REFINER_SHAPE}. Each action is one of: \`create\` a new sub-task, \`keep\` ` +
+      `an existing one unchanged, \`mark_stale\` a superseded one, or \`noop\` when ` +
+      `nothing has changed.`
+    );
   }
   // developer / iterator
   const access = ROLE_ACCESS[role]; // referenced so the read-write contract is explicit

--- a/src/lib/dispatch/cc-apply-action.test.ts
+++ b/src/lib/dispatch/cc-apply-action.test.ts
@@ -9,10 +9,11 @@
  * Idempotency and fail-closed behaviour are also exercised.
  */
 import { describe, it, expect } from 'vitest';
-import { applyCcArtifact } from './cc-apply-action.js';
+import { applyCcArtifact, applyRefinerCcArtifact } from './cc-apply-action.js';
 import { InMemoryTracker } from '../io/tracker/in-memory.js';
 import { FerryError } from '../errors/index.js';
-import type { TrackerIssue } from '../io/tracker/types.js';
+import { subtaskContentHash } from '../../agents/refiner/batch.js';
+import type { TrackerIssue, TrackerSubtask } from '../io/tracker/types.js';
 
 const MARKER_DEV = '[ferry:dev:abc1234]';
 const MARKER_REVIEWER = '[ferry:reviewer:abc1234]';
@@ -306,94 +307,156 @@ describe('iterator role', () => {
   });
 });
 
-// ── refiner (no transition) ───────────────────────────────────────────────
+// ── refiner (plan artifact → applyActions → audit comment) ────────────────
 
-describe('refiner role', () => {
-  it('refined: posts audit comment with created/kept/staled, no transition', async () => {
-    const artifact = {
-      version: 'v1',
-      role: 'refiner',
-      result: 'refined',
-      summary: 'Sub-tasks updated.',
-      created: 2,
-      kept: 1,
-      staled: 0,
-    };
+describe('refiner role (applyRefinerCcArtifact)', () => {
+  const RUN_LINK = 'https://github.com/o/r/actions/runs/99';
+
+  // A RefinerOutput plan: `create` actions become Jira sub-tasks, `keep` is
+  // counted only, `noop` short-circuits. cc-apply runs the same `applyActions`
+  // reconcile the script path uses.
+  const refinedPlan = {
+    actions: [
+      { type: 'create', title: 'Add validation', description: 'Validate POST /users.' },
+      { type: 'create', title: 'Add tests', description: 'Cover the validation path.' },
+      { type: 'keep', existing_key: 'PROJ-2', reason: 'still valid' },
+    ],
+    touch_paths: ['src/users.ts'],
+    output_locale: 'en',
+    audit_summary: 'Refine the users endpoint.',
+  };
+
+  it('refined: creates sub-tasks via applyActions and posts the audit comment', async () => {
     const tracker = makeTracker();
-    const result = await applyCcArtifact({
-      rawArtifact: artifact,
-      role: 'refiner',
+    const result = await applyRefinerCcArtifact({
+      rawArtifact: refinedPlan,
       marker: MARKER_REFINER,
       existingComments: [],
-      gates: {},
-      runLink: 'https://github.com/o/r/actions/runs/99',
-      subtaskCount: 3,
-      tracker,
+      eventId: 'EVT-1',
       ticketKey: TICKET,
-      getEnv,
+      runLink: RUN_LINK,
+      tracker,
     });
     expect(result).toEqual({ skipped: false, emitted: true, exitCode: 0 });
     expect(tracker.postedTransitions).toEqual([]);
+    expect(tracker.createdSubtasks).toHaveLength(2);
+    expect(tracker.createdSubtasks.map((s) => s.title)).toEqual(['Add validation', 'Add tests']);
+    // Audit comment is byte-identical to the script path (refiner-action.ts:164-167).
     expect(tracker.postedComments).toHaveLength(1);
-    expect(tracker.postedComments[0].body).toContain(MARKER_REFINER);
-    expect(tracker.postedComments[0].body).toContain('Created 2, kept 1, staled 0');
-    expect(tracker.postedComments[0].body).toContain('actions/runs/99');
+    expect(tracker.postedComments[0].body).toBe(
+      `${MARKER_REFINER} Refined. Created 2, kept 1, staled 0 sub-task(s). See run: ${RUN_LINK}`,
+    );
   });
 
-  it('runLink contains owner/repo (not "unknown") when GITHUB_REPO is set', async () => {
-    // Regression: composite action must forward GITHUB_REPO so the refiner
-    // runLink resolves to https://github.com/<owner>/<repo>/actions/runs/<id>
-    // instead of https://github.com/unknown/actions/runs/<id>.
-    const artifact = {
-      version: 'v1',
-      role: 'refiner',
-      result: 'refined',
-      summary: 'Sub-tasks updated.',
-      created: 1,
-      kept: 0,
-      staled: 0,
+  it('noop: posts the audit comment with the fetched existing-subtask count', async () => {
+    const noopPlan = {
+      actions: [{ type: 'noop', reason: 'all sub-tasks still valid' }],
+      touch_paths: [],
+      output_locale: 'en',
+      audit_summary: 'No change.',
     };
     const tracker = makeTracker();
-    await applyCcArtifact({
-      rawArtifact: artifact,
-      role: 'refiner',
+    const existing: TrackerSubtask[] = [
+      { key: 'PROJ-2', title: 'a', description: 'a', status: 'To Do' },
+      { key: 'PROJ-3', title: 'b', description: 'b', status: 'To Do' },
+      { key: 'PROJ-4', title: 'c', description: 'c', status: 'To Do' },
+    ];
+    tracker.seedSubtaskDetails(TICKET, existing);
+    await applyRefinerCcArtifact({
+      rawArtifact: noopPlan,
       marker: MARKER_REFINER,
       existingComments: [],
-      gates: {},
-      runLink: 'https://github.com/big-emotion/ferry/actions/runs/42',
-      subtaskCount: 1,
-      tracker,
+      eventId: 'EVT-1',
       ticketKey: TICKET,
-      getEnv,
+      runLink: RUN_LINK,
+      tracker,
     });
-    const body = tracker.postedComments[0].body;
-    expect(body).toContain('https://github.com/big-emotion/ferry/actions/runs/42');
-    expect(body).not.toContain('github.com/unknown/');
+    expect(tracker.createdSubtasks).toEqual([]);
+    // Byte-identical to the script path noop comment (refiner-action.ts:140-143).
+    expect(tracker.postedComments[0].body).toBe(
+      `${MARKER_REFINER} No changes needed — existing 3 sub-task(s) still valid. all sub-tasks still valid`,
+    );
   });
 
-  it('noop: posts audit comment with subtaskCount', async () => {
-    const artifact = {
-      version: 'v1',
-      role: 'refiner',
-      result: 'noop',
-      summary: 'Nothing changed.',
-      noop_reason: 'all sub-tasks still valid',
-    };
+  it('idempotency: skips all writes when the marker already exists', async () => {
     const tracker = makeTracker();
-    await applyCcArtifact({
-      rawArtifact: artifact,
-      role: 'refiner',
+    const result = await applyRefinerCcArtifact({
+      rawArtifact: refinedPlan,
+      marker: MARKER_REFINER,
+      existingComments: [`earlier ${MARKER_REFINER} run`],
+      eventId: 'EVT-1',
+      ticketKey: TICKET,
+      runLink: RUN_LINK,
+      tracker,
+    });
+    expect(result).toEqual({ skipped: true, emitted: false, exitCode: 0 });
+    expect(tracker.createdSubtasks).toEqual([]);
+    expect(tracker.postedComments).toEqual([]);
+  });
+
+  it('dry-run: suppresses sub-task creation and the audit comment', async () => {
+    const tracker = makeTracker();
+    const result = await applyRefinerCcArtifact({
+      rawArtifact: refinedPlan,
       marker: MARKER_REFINER,
       existingComments: [],
-      gates: {},
-      runLink: 'https://github.com/o/r/actions/runs/99',
-      subtaskCount: 5,
-      tracker,
+      eventId: 'EVT-1',
       ticketKey: TICKET,
-      getEnv,
+      runLink: RUN_LINK,
+      tracker,
+      dryRun: true,
     });
-    expect(tracker.postedTransitions).toEqual([]);
-    expect(tracker.postedComments[0].body).toContain('5 sub-task(s) still valid');
+    expect(result).toEqual({ skipped: false, emitted: false, exitCode: 0 });
+    expect(tracker.createdSubtasks).toEqual([]);
+    expect(tracker.postedComments).toEqual([]);
+  });
+
+  it('content-hash re-run: a sub-task already present is not re-created', async () => {
+    const tracker = makeTracker();
+    // Seed an existing sub-task carrying the content-hash marker of the first
+    // `create` action — filterExistingSubtasks must skip it.
+    const dupHash = subtaskContentHash('Add validation', 'Validate POST /users.');
+    tracker.seedSubtaskDetails(TICKET, [
+      {
+        key: 'PROJ-9',
+        title: 'Add validation',
+        description: `Validate POST /users.\n\n[ferry:refiner-subtask:${dupHash}]`,
+        status: 'To Do',
+      },
+    ]);
+    await applyRefinerCcArtifact({
+      rawArtifact: refinedPlan,
+      marker: MARKER_REFINER,
+      existingComments: [],
+      eventId: 'EVT-1',
+      ticketKey: TICKET,
+      runLink: RUN_LINK,
+      tracker,
+    });
+    expect(tracker.createdSubtasks.map((s) => s.title)).toEqual(['Add tests']);
+    expect(tracker.postedComments[0].body).toContain('Created 1, kept 1, staled 0');
+  });
+
+  it('fail-closed: throws FerryError(agent-output-invalid) for a malformed plan', async () => {
+    const tracker = makeTracker();
+    try {
+      await applyRefinerCcArtifact({
+        rawArtifact: { touch_paths: [], output_locale: 'en', audit_summary: 'x' }, // no actions
+        marker: MARKER_REFINER,
+        existingComments: [],
+        eventId: 'EVT-1',
+        ticketKey: TICKET,
+        runLink: RUN_LINK,
+        tracker,
+      });
+      throw new Error('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(FerryError);
+      expect((err as FerryError).code).toBe('state-invariant');
+      expect((err as FerryError).context?.reason).toBe('agent-output-invalid');
+    }
+    expect(tracker.createdSubtasks).toEqual([]);
+    expect(tracker.postedComments).toEqual([]);
   });
 });
 

--- a/src/lib/dispatch/cc-apply-action.ts
+++ b/src/lib/dispatch/cc-apply-action.ts
@@ -19,7 +19,6 @@
  *   FERRY_ITER_TRANSITION_ID    Jira transition ID for reviewer FR24 changes
  *   FERRY_APPROVE_TRANSITION_ID Jira transition ID for reviewer FR24 approve
  *   FERRY_PR_NUMBER             (reviewer) PR number for the current cycle
- *   FERRY_SUBTASK_COUNT         (refiner) sub-task count for noop message
  *   GITHUB_REPO                 owner/repo (e.g. acme/my-repo)
  *   GITHUB_RUN_ID               Current workflow run ID
  *   GITHUB_OUTPUT               GitHub Actions output file
@@ -46,7 +45,13 @@ import { loadFerryConfig } from '../config.js';
 import { resolveTicketOverrides } from '../labels/overrides.js';
 import { countPriorIterations } from '../../agents/reviewer/changes-guard.js';
 import { requireEnv } from '../agent-runtime/env.js';
-import { CC_OUTPUT_ARTIFACT_PATH } from '../claude-code/output-artifact.js';
+import {
+  CC_OUTPUT_ARTIFACT_PATH,
+  parseRefinerArtifact,
+  type RefinerArtifact,
+} from '../claude-code/output-artifact.js';
+import { checkIdempotencyMarker } from '../io/idempotency.js';
+import { applyActions } from '../../agents/refiner/reconcile.js';
 import type { IssueTracker } from '../io/tracker/types.js';
 import { FerryError } from '../errors/index.js';
 
@@ -81,8 +86,6 @@ export interface ApplyCcArtifactParams {
   prNumber?: number;
   priorIterations?: number;
   cap?: number;
-  runLink?: string;
-  subtaskCount?: number;
   tracker: Pick<IssueTracker, 'postComment' | 'postTransition' | 'addLabel'>;
   ticketKey: string;
   dryRun?: boolean;
@@ -103,8 +106,6 @@ export async function applyCcArtifact(params: ApplyCcArtifactParams): Promise<Ap
     prNumber,
     priorIterations,
     cap,
-    runLink,
-    subtaskCount,
     tracker,
     ticketKey,
     dryRun,
@@ -129,13 +130,85 @@ export async function applyCcArtifact(params: ApplyCcArtifactParams): Promise<Ap
     ...(prNumber !== undefined ? { prNumber } : {}),
     ...(priorIterations !== undefined ? { priorIterations } : {}),
     ...(cap !== undefined ? { cap } : {}),
-    ...(runLink !== undefined ? { runLink } : {}),
-    ...(subtaskCount !== undefined ? { subtaskCount } : {}),
   };
 
   const decision = decideContract(output, ctx);
 
   return applyContract({ tracker, ticketKey, marker, existingComments, decision, dryRun, getEnv });
+}
+
+export interface ApplyRefinerCcArtifactParams {
+  rawArtifact: unknown;
+  marker: string;
+  /** Existing Jira issue comments — scanned for the idempotency marker. */
+  existingComments: string[];
+  eventId: string;
+  ticketKey: string;
+  /** GitHub Actions run link embedded in the `Refined.` audit comment. */
+  runLink: string;
+  tracker: IssueTracker;
+  dryRun?: boolean;
+}
+
+/**
+ * Refiner-only apply core for the claude-code path.
+ *
+ * Unlike developer/iterator/reviewer — whose artifact is a terminal outcome
+ * transcribed by `decideContract` — the refiner artifact is a `RefinerOutput`
+ * *plan*. cc-apply runs the SAME `applyActions` reconcile the script path uses
+ * (`refiner-action.ts:131`) to create / keep / mark-stale Jira sub-tasks, then
+ * posts the byte-identical audit comment. The LLM never writes to Jira; the
+ * deterministic boundary (ADR-0006 §2) is preserved.
+ */
+export async function applyRefinerCcArtifact(
+  params: ApplyRefinerCcArtifactParams,
+): Promise<ApplyContractResult> {
+  const { rawArtifact, marker, existingComments, eventId, ticketKey, runLink, tracker, dryRun } =
+    params;
+
+  // Validate the RefinerOutput plan. `parseRefinerArtifact` throws a plain Error;
+  // re-throw as the FerryError shape `runCcApplyAction`'s catch block keys on.
+  // NFR-S1: its detail strings are structural — never raw artifact field values.
+  let plan: RefinerArtifact;
+  try {
+    plan = parseRefinerArtifact(rawArtifact);
+  } catch (err) {
+    throw new FerryError('state-invariant', {
+      reason: 'agent-output-invalid',
+      paths: [err instanceof Error ? err.message : String(err)],
+    });
+  }
+
+  // Idempotency pre-check. A prior cc run already created the sub-tasks and
+  // posted the audit comment; skipping both is correct and strictly cheaper.
+  // The script path does not pre-gate `applyActions`, but `filterExistingSubtasks`
+  // would dedup the creates and the marker-in-comment would suppress the comment
+  // anyway — so this is a safe, observable-equivalent optimisation.
+  if (checkIdempotencyMarker(marker, existingComments).skipped) {
+    return { skipped: true, emitted: false, exitCode: 0 };
+  }
+
+  // ferry:dry-run suppresses ALL external writes (decisions/0002 §D).
+  if (dryRun === true) {
+    return { skipped: false, emitted: false, exitCode: 0 };
+  }
+
+  const existingSubtasks = await tracker.getSubtaskDetails(ticketKey);
+  const result = await applyActions(plan.actions, {
+    ticketKey,
+    eventId,
+    existingSubtasks,
+    tracker,
+  });
+
+  // Audit comment — byte-identical to the script path
+  // (`refiner-action.ts:140-143` noop / `:164-167` refined).
+  const comment = result.noop
+    ? `${marker} No changes needed — existing ${existingSubtasks.length} sub-task(s) still valid. ${result.noopReason ?? ''}`.trimEnd()
+    : `${marker} Refined. Created ${result.createdCount}, kept ${result.keptCount}, staled ${result.staledCount} sub-task(s). See run: ${runLink}`;
+
+  await tracker.postComment(ticketKey, comment);
+  return { skipped: false, emitted: true, exitCode: 0 };
 }
 
 export async function runCcApplyAction(): Promise<void> {
@@ -211,11 +284,6 @@ export async function runCcApplyAction(): Promise<void> {
 
   const githubRepo = process.env.GITHUB_REPO ?? 'unknown';
   const githubRunId = process.env.GITHUB_RUN_ID ?? '0';
-  const runLink =
-    role === 'refiner' ? `https://github.com/${githubRepo}/actions/runs/${githubRunId}` : undefined;
-
-  const subtaskCount =
-    role === 'refiner' ? parseInt(process.env.FERRY_SUBTASK_COUNT ?? '0', 10) || 0 : undefined;
 
   const prNumber =
     role === 'reviewer' || role === 'iterator'
@@ -234,23 +302,35 @@ export async function runCcApplyAction(): Promise<void> {
   }
 
   // ── apply ─────────────────────────────────────────────────────────────────
+  // Refiner takes a dedicated path: its artifact is a `RefinerOutput` *plan*,
+  // applied via `applyActions`, not a terminal outcome for `decideContract`.
   let result: ApplyContractResult;
   try {
-    result = await applyCcArtifact({
-      rawArtifact,
-      role,
-      marker,
-      existingComments,
-      gates,
-      prNumber,
-      priorIterations,
-      cap,
-      runLink,
-      subtaskCount,
-      tracker,
-      ticketKey: envelope.ticket_key,
-      dryRun,
-    });
+    result =
+      role === 'refiner'
+        ? await applyRefinerCcArtifact({
+            rawArtifact,
+            marker,
+            existingComments,
+            eventId: envelope.event_id,
+            ticketKey: envelope.ticket_key,
+            runLink: `https://github.com/${githubRepo}/actions/runs/${githubRunId}`,
+            tracker,
+            dryRun,
+          })
+        : await applyCcArtifact({
+            rawArtifact,
+            role,
+            marker,
+            existingComments,
+            gates,
+            prNumber,
+            priorIterations,
+            cap,
+            tracker,
+            ticketKey: envelope.ticket_key,
+            dryRun,
+          });
   } catch (err) {
     if (err instanceof FerryError && err.context?.reason === 'agent-output-invalid') {
       const paths = Array.isArray(err.context.paths) ? (err.context.paths as string[]) : [];

--- a/src/lib/dispatch/cc-prepare-action.test.ts
+++ b/src/lib/dispatch/cc-prepare-action.test.ts
@@ -18,7 +18,7 @@
  *            `path == 'claude-code'`, cc-prepare refuses to run).
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -510,6 +510,23 @@ describe('runCcPrepareAction — non-refiner roles are wired into the entrypoint
     // resolves to the test fixture without network IO.
     vi.spyOn(JiraTracker.prototype, 'getIssue').mockResolvedValue(issue);
   }
+
+  it('creates the .ferry/ directory so the agent can write cc-output.json', async () => {
+    // A read-only role has no Bash tool — cc-prepare must create `.ferry/`
+    // deterministically before claude-code-action runs.
+    tmp = withTempRepo('');
+    process.chdir(tmp.cwd);
+    vi.stubEnv('GITHUB_TOKEN', '');
+    for (const [k, v] of Object.entries(
+      baseEnv({ GITHUB_OUTPUT: tmp.outputFile, FERRY_AGENT_ROLE: 'developer', GITHUB_TOKEN: '' }),
+    )) {
+      vi.stubEnv(k, v);
+    }
+    stubJiraGetIssue();
+    // The run throws later (no GITHUB_TOKEN) — but the mkdir runs first.
+    await runCcPrepareAction().catch(() => undefined);
+    expect(existsSync(join(tmp.cwd, '.ferry'))).toBe(true);
+  });
 
   for (const role of ['developer', 'reviewer', 'iterator'] as const) {
     it(`role=${role}: dispatches into the role branch (no #333 refusal)`, async () => {

--- a/src/lib/dispatch/cc-prepare-action.ts
+++ b/src/lib/dispatch/cc-prepare-action.ts
@@ -41,7 +41,8 @@
  *   ANTHROPIC_API_KEY           NOT permitted alongside CLAUDE_CODE_OAUTH_TOKEN
  *   CLAUDE_CODE_OAUTH_TOKEN     forwarded by the composite, never logged
  */
-import { appendFileSync } from 'node:fs';
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 
@@ -514,6 +515,14 @@ export async function runCcPrepareAction(): Promise<CcPrepareOutputs> {
   const role = parseRole(process.env.FERRY_AGENT_ROLE);
 
   const repoRoot = process.cwd();
+
+  // Create the `.ferry/` directory deterministically, before `claude-code-action`
+  // runs. The LLM writes its result to `.ferry/cc-output.json`; a read-only role
+  // (refiner/reviewer) has no `Bash` tool, so it cannot `mkdir` the parent itself.
+  // cc-prepare runs in the same job/workspace immediately before the action, so
+  // the directory persists for the `Write(.ferry/cc-output.json)` grant.
+  mkdirSync(join(repoRoot, '.ferry'), { recursive: true });
+
   const ferryCfg = loadFerryConfig(repoRoot);
   enforceProviderGate(ferryCfg);
 

--- a/src/schemas/agent-output.v1.schema.json
+++ b/src/schemas/agent-output.v1.schema.json
@@ -46,21 +46,6 @@
         "review_comment": { "type": "string", "minLength": 1, "maxLength": 65536 },
         "summary": { "type": "string", "minLength": 1, "maxLength": 2000 }
       }
-    },
-    {
-      "type": "object",
-      "required": ["version", "role", "result", "summary"],
-      "additionalProperties": false,
-      "properties": {
-        "version": { "const": "v1" },
-        "role": { "const": "refiner" },
-        "result": { "enum": ["refined", "noop"] },
-        "summary": { "type": "string", "minLength": 1, "maxLength": 2000 },
-        "created": { "type": "integer", "minimum": 0 },
-        "kept": { "type": "integer", "minimum": 0 },
-        "staled": { "type": "integer", "minimum": 0 },
-        "noop_reason": { "type": "string", "minLength": 1, "maxLength": 2000 }
-      }
     }
   ]
 }


### PR DESCRIPTION
## Problem

The claude-code execution path for the **refiner** is broken end-to-end (seen in production on `big-emotion/ethniafrica`): `ferry-cc-apply` fails with `ENOENT .ferry/cc-output.json`. Root cause is a chain of three defects:

1. **No artifact written.** `claude-code-action` exits `success` but the refiner never calls `Write` — its system prompt (`prompts/refiner.md`) says "Reply with JSON only. No prose before or after." twice, so on the claude-code path (no structured-output enforcement) the model prints JSON to chat instead of writing the file.
2. **Three mismatched refiner schemas** — `prompts/refiner.md` (`{subtasks[]}`), `outcomePromptSuffix` (`{actions[]}`), and `cc-apply`'s validator (`RefinerAgentOutput`) all disagreed.
3. **Nobody created the Jira sub-tasks** — `decideContract`/`applyContract` only post an audit comment.

## Fix (B2 — agent emits a plan, cc-apply applies it)

- **`outcomePromptSuffix('refiner')`** now forcefully overrides the "reply with JSON only" instruction and spells out the full `RefinerOutput` plan schema + the `Write`-tool contract.
- **`applyRefinerCcArtifact`** (new, in `cc-apply`) validates the artifact as a `RefinerOutput` plan and runs the *same* `applyActions` reconcile the script path uses — creating sub-tasks and posting a byte-identical audit comment. The LLM never writes to Jira; the deterministic boundary holds.
- **`cc-prepare`** creates `.ferry/` deterministically so a read-only agent can write the artifact.
- Removes the dead `RefinerAgentOutput` variant (schema, types, `decideContract` case, `FERRY_SUBTASK_COUNT` plumbing).

## Verification

- `typecheck`, `format:check` clean; `eslint` clean on changed files; pre-push gates green.
- 444/444 tests pass in affected areas; new tests cover refined/noop/idempotency/dry-run/invalid/content-hash-rerun.
- `.ferry/` + `.github/actions/` bundles rebuilt via `npm run build:ferry`.

## Accepted divergences / follow-ups

- Cost-estimate comment/label is not produced on the cc path (accepted divergence).
- Reviewer role likely has the same read-only prompt conflict — separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)