### PR TITLE
fix(init): scaffold claude-code workflows with bypassPermissions

### DIFF
--- a/src/cli/init/templates.test.ts
+++ b/src/cli/init/templates.test.ts
@@ -156,9 +156,17 @@ describe('workflowTemplates — claude-code path single-step shape', () => {
   it('claude_args wires the ferry-jira-mcp MCP server', () => {
     for (const tmpl of workflowTemplates('v1')) {
       expect(tmpl.content, `${tmpl.filename}: missing ferry-jira-mcp`).toContain('ferry-jira-mcp');
+      // bypassPermissions is required: in a non-interactive (SDK) run, acceptEdits
+      // only auto-approves file edits — every Jira MCP tool call (and Bash/git/gh)
+      // is otherwise denied with no human to grant permission. The
+      // --disallowedTools list still blocks the dangerous `gh pr merge/close`.
       expect(tmpl.content, `${tmpl.filename}: missing --permission-mode`).toContain(
-        '--permission-mode acceptEdits',
+        '--permission-mode bypassPermissions',
       );
+      expect(
+        tmpl.content,
+        `${tmpl.filename}: acceptEdits would deny Jira MCP tool calls in non-interactive runs`,
+      ).not.toContain('--permission-mode acceptEdits');
     }
   });
 

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -173,7 +173,7 @@ jobs:
             - Keep the comment concise and in English (or match the ticket's language for the summary if it is clearly French).
           claude_args: >-
             --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@${version}","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"\${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"\${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"\${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
-            --permission-mode acceptEdits
+            --permission-mode bypassPermissions
             --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
             --model \${{ vars.FERRY_REFINER_MODEL || 'claude-sonnet-4-6' }}
 
@@ -363,7 +363,7 @@ jobs:
             - If a true blocker prevents progress (contradictory spec, missing access), do not transition — post one \`[ferry:developer:\${{ github.event.client_payload.event_id }}]\` comment explaining the blocker so a human can intervene.
           claude_args: >-
             --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@${version}","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"\${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"\${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"\${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
-            --permission-mode acceptEdits
+            --permission-mode bypassPermissions
             --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
             --model \${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-4-6' }}
 
@@ -587,7 +587,7 @@ jobs:
             - Keep the review concise and in English.
           claude_args: >-
             --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@${version}","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"\${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"\${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"\${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
-            --permission-mode acceptEdits
+            --permission-mode bypassPermissions
             --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
             --model \${{ vars.FERRY_REVIEW_MODEL || 'claude-sonnet-4-6' }}
 
@@ -782,7 +782,7 @@ jobs:
             - If a finding is genuinely not actionable (contradictory, missing access), do not transition — post one \`[ferry:iterator:\${{ github.event.client_payload.event_id }}]\` comment explaining why so a human can intervene.
           claude_args: >-
             --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@${version}","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"\${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"\${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"\${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
-            --permission-mode acceptEdits
+            --permission-mode bypassPermissions
             --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
             --model \${{ vars.FERRY_ITER_MODEL || 'claude-sonnet-4-6' }}
 


### PR DESCRIPTION
## Problem

The four claude-code agent workflows (`ferry-refine/dev/review/iterate.yml`) are scaffolded by `ferry-init` with `--permission-mode acceptEdits`. That mode only auto-approves **file edits** — not MCP tools, not Bash/git/gh.

In a non-interactive (SDK) run there is no human to grant permission, so every `mcp__jira__*` call is denied. Observed on a real consumer repo: a refine run for `ETNI-34` finished as `success` but with `permission_denials_count: 4` — no sub-tasks created, no parent transition.

## Fix

Scaffold the four `claude_args` blocks with `--permission-mode bypassPermissions`. The existing `--disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'` line still blocks the dangerous commands, so Ferry's "never merges" guardrail is preserved.

## Tests

`templates.test.ts` updated (TDD): asserts `bypassPermissions` is present and `acceptEdits` is absent across all four workflow templates. Full `templates.test.ts` suite passes (34), `typecheck` and `format:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)