### PR TITLE
feat(init): support FERRY_RUNNER variable for self-hosted runner label

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -59,6 +59,14 @@ Add these under **Settings → Secrets and variables → Actions → Variables**
 
 All variables marked **wired** below are read directly by the standard consumer workflow stubs in `examples/consumer-setup/workflows/`. Unwired variables are read by `src/lib/config.ts` if present in the agent runtime env, but the standard workflow stubs do not set them — use `ferry.config.yaml` for those instead.
 
+#### Runner label
+
+| Variable       | Default           | Wired?    | Affects    | Description                                                                                                                                                                                                                                                                                 |
+| -------------- | ----------------- | --------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FERRY_RUNNER` | `"ubuntu-latest"` | yes (all) | All agents | GitHub Actions runner label for every Ferry job. Must be a **JSON-encoded** string or array. Set to `"ubuntu-latest"` (with quotes) for GitHub-hosted runners, or to `["self-hosted","Linux","X64"]` (an array) for self-hosted runners. Omitting this variable keeps the default behavior. |
+
+> **JSON encoding requirement:** The value is passed through `fromJSON()` in the workflow expression `runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}`, so it must be valid JSON. A plain string label requires surrounding quotes: `"ubuntu-latest"`. A multi-label array uses standard JSON array syntax: `["self-hosted","Linux","X64"]`.
+
 #### Model and provider overrides
 
 | Variable                 | Default             | Wired?          | Affects         | Description                                                                                                        |
@@ -753,11 +761,11 @@ On the claude-code execution path an agent is one direct `anthropics/claude-code
 Customisation here is a **full override**, not an extension: drop a file in your consumer repository and it **replaces** Ferry's bundled claude-code prompt for that agent entirely.
 
 | File                             | Replaces the bundled claude-code prompt for |
-| -------------------------------- | -------------------------------------------- |
-| `prompts/refiner.claude-code.md` | Refiner                                      |
-| `prompts/dev.claude-code.md`     | Developer                                    |
-| `prompts/review.claude-code.md`  | Reviewer                                     |
-| `prompts/iterate.claude-code.md` | Iterator                                     |
+| -------------------------------- | ------------------------------------------- |
+| `prompts/refiner.claude-code.md` | Refiner                                     |
+| `prompts/dev.claude-code.md`     | Developer                                   |
+| `prompts/review.claude-code.md`  | Reviewer                                    |
+| `prompts/iterate.claude-code.md` | Iterator                                    |
 
 **Rules:**
 

--- a/examples/consumer-setup/workflows/ferry-cost-daily.yml
+++ b/examples/consumer-setup/workflows/ferry-cost-daily.yml
@@ -3,6 +3,7 @@
 #
 # Required variables: FERRY_AUDIT_ISSUE
 # Optional variables: FERRY_SPEND_CAP_EUR (monthly EUR cap — default 200 EUR)
+#                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 # Optional secrets (to apply ferry:paused to Jira tickets on threshold breach):
 #   FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN
 #
@@ -26,7 +27,7 @@ env:
 jobs:
   cost-check:
     name: Check provider spend against cap
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
       issues: write

--- a/examples/consumer-setup/workflows/ferry-dev.yml
+++ b/examples/consumer-setup/workflows/ferry-dev.yml
@@ -10,6 +10,7 @@
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_DEV_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
 #                     FERRY_DEV_PROVIDER (default: anthropic; also: openai, google)
+#                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 #
 # Note: MCP server support is not available for non-Anthropic providers in the Developer agent.
 #                     FERRY_DEV_MAX_INPUT_TOKENS (default: 500000)
@@ -42,7 +43,7 @@ concurrency:
 jobs:
   gate-envelope:
     name: Validate event envelope
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
     steps:
@@ -57,7 +58,7 @@ jobs:
   route:
     name: Resolve execution path
     needs: [gate-envelope]
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
     outputs:
@@ -80,7 +81,7 @@ jobs:
     name: Run Developer agent (script path)
     needs: [route]
     if: needs.route.outputs.path == 'script'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: write
       pull-requests: write
@@ -130,7 +131,7 @@ jobs:
     name: Run Developer agent (claude-code path)
     needs: [route]
     if: needs.route.outputs.path == 'claude-code'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: write
       pull-requests: write
@@ -163,7 +164,7 @@ jobs:
     name: Emit audit line
     needs: [run-agent, run-agent-claude-code]
     if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
       issues: write

--- a/examples/consumer-setup/workflows/ferry-iterate.yml
+++ b/examples/consumer-setup/workflows/ferry-iterate.yml
@@ -10,6 +10,7 @@
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_ITER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
 #                     FERRY_ITER_PROVIDER (default: anthropic; also: openai, google)
+#                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 #
 # Note: MCP server support is not available for non-Anthropic providers in the Iterator agent.
 #                     FERRY_ITER_MAX_INPUT_TOKENS (default: 500000)
@@ -43,7 +44,7 @@ concurrency:
 jobs:
   gate-envelope:
     name: Validate event envelope
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
     steps:
@@ -58,7 +59,7 @@ jobs:
   route:
     name: Resolve execution path
     needs: [gate-envelope]
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
     outputs:
@@ -81,7 +82,7 @@ jobs:
     name: Run Iterator agent (script path)
     needs: [route]
     if: needs.route.outputs.path == 'script'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: write
       issues: write
@@ -134,7 +135,7 @@ jobs:
     name: Run Iterator agent (claude-code path)
     needs: [route]
     if: needs.route.outputs.path == 'claude-code'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: write
       pull-requests: write
@@ -167,7 +168,7 @@ jobs:
     name: Emit audit line
     needs: [run-agent, run-agent-claude-code]
     if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
       issues: write

--- a/examples/consumer-setup/workflows/ferry-reconcile.yml
+++ b/examples/consumer-setup/workflows/ferry-reconcile.yml
@@ -3,6 +3,7 @@
 #
 # Required variables: FERRY_AUDIT_ISSUE
 # Optional variables: FERRY_JIRA_PROJECT (Jira project key, e.g. "CHAN")
+#                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 # Required secrets (if FERRY_JIRA_PROJECT is set): FERRY_JIRA_BASE_URL,
 #                                                    FERRY_JIRA_EMAIL,
 #                                                    FERRY_JIRA_API_TOKEN
@@ -26,7 +27,7 @@ env:
 jobs:
   reconcile:
     name: Sweep for stalled tickets
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
       issues: write

--- a/examples/consumer-setup/workflows/ferry-refine.yml
+++ b/examples/consumer-setup/workflows/ferry-refine.yml
@@ -9,6 +9,7 @@
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_REFINER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
 #                     FERRY_REFINER_PROVIDER (default: anthropic; also: openai, google)
+#                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 #                     FERRY_REFINER_SUBTASK_CAP (default: 12)
 #                     FERRY_MAX_COST_EUR_PER_RUN (default: 10)
 #                     FERRY_LLM_RETRY_MAX_ATTEMPTS (default: 3)
@@ -35,7 +36,7 @@ concurrency:
 jobs:
   gate-envelope:
     name: Validate event envelope
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
     steps:
@@ -50,7 +51,7 @@ jobs:
   route:
     name: Resolve execution path
     needs: [gate-envelope]
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
     outputs:
@@ -73,7 +74,7 @@ jobs:
     name: Run Refiner agent (script path)
     needs: [route]
     if: needs.route.outputs.path == 'script'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
     steps:
@@ -112,7 +113,7 @@ jobs:
     name: Run Refiner agent (claude-code path)
     needs: [route]
     if: needs.route.outputs.path == 'claude-code'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: write
       pull-requests: write
@@ -144,7 +145,7 @@ jobs:
     name: Emit audit line
     needs: [run-agent, run-agent-claude-code]
     if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
       issues: write

--- a/examples/consumer-setup/workflows/ferry-review.yml
+++ b/examples/consumer-setup/workflows/ferry-review.yml
@@ -10,6 +10,7 @@
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_REVIEW_MODEL (default: claude-sonnet-4-6)
 #                     FERRY_REVIEW_PROVIDER (default: anthropic; also: openai, google)
+#                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 #                     FERRY_REVIEWER_MAX_ITERATIONS (default: 40)
 #                     FERRY_REVIEWER_MAX_TOKENS (default: 16384)
 #                     FERRY_MAX_COST_EUR_PER_RUN (default: 10)
@@ -42,7 +43,7 @@ concurrency:
 jobs:
   gate-envelope:
     name: Validate event envelope
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
     steps:
@@ -57,7 +58,7 @@ jobs:
   route:
     name: Resolve execution path
     needs: [gate-envelope]
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
     outputs:
@@ -80,7 +81,7 @@ jobs:
     name: Run Reviewer agent (script path)
     needs: [route]
     if: needs.route.outputs.path == 'script'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
       pull-requests: write
@@ -130,7 +131,7 @@ jobs:
     name: Reviewer CI pre-gate
     needs: [route]
     if: needs.route.outputs.path == 'claude-code'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
       pull-requests: write
@@ -158,7 +159,7 @@ jobs:
     name: Run Reviewer agent (claude-code path)
     needs: [route, ci-gate]
     if: needs.route.outputs.path == 'claude-code' && needs.ci-gate.outputs.proceed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
       pull-requests: write
@@ -192,7 +193,7 @@ jobs:
     name: Emit audit line
     needs: [run-agent, run-agent-claude-code, ci-gate]
     if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped' || (needs.ci-gate.result != 'skipped' && needs.ci-gate.outputs.outcome == 'ci-red'))
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
       issues: write

--- a/src/cli/init/templates.test.ts
+++ b/src/cli/init/templates.test.ts
@@ -325,6 +325,20 @@ describe('workflowTemplates — supply-chain action pinning', () => {
   });
 });
 
+describe('workflowTemplates — FERRY_RUNNER runner label (#364)', () => {
+  it('every template uses fromJSON(vars.FERRY_RUNNER) for runs-on (no hardcoded ubuntu-latest)', () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      expect(
+        tmpl.content,
+        `${tmpl.filename}: still contains hardcoded runs-on: ubuntu-latest`,
+      ).not.toContain('runs-on: ubuntu-latest');
+      expect(tmpl.content, `${tmpl.filename}: missing FERRY_RUNNER fromJSON expression`).toContain(
+        'fromJSON(vars.FERRY_RUNNER || \'"ubuntu-latest"\')',
+      );
+    }
+  });
+});
+
 describe('workflowTemplates — cc-path role coverage is complete', () => {
   // All four roles now run end-to-end on the claude-code path (#350), so no
   // template should carry a "not yet wired" guard step.

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -37,6 +37,7 @@ export function workflowTemplates(
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_REFINER_PROVIDER (default: anthropic; also: openai, google)
 #                     FERRY_REFINER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 
 name: Ferry — Refine
 
@@ -52,7 +53,7 @@ concurrency:
 jobs:
   gate-envelope:
     name: Validate event envelope
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
     steps:
@@ -67,7 +68,7 @@ jobs:
   route:
     name: Resolve execution path
     needs: [gate-envelope]
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
     outputs:
@@ -90,7 +91,7 @@ jobs:
     name: Run Refiner agent (script path)
     needs: [route]
     if: needs.route.outputs.path == 'script'
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
     steps:
@@ -121,7 +122,7 @@ jobs:
     name: Run Refiner agent (claude-code path)
     needs: [route]
     if: needs.route.outputs.path == 'claude-code'
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: write
       pull-requests: write
@@ -153,7 +154,7 @@ jobs:
     name: Emit audit line
     needs: [run-agent, run-agent-claude-code]
     if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
       issues: write
@@ -190,6 +191,7 @@ jobs:
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_DEV_PROVIDER (default: anthropic; also: openai, google)
 #                     FERRY_DEV_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 #
 # Note: MCP server support is not available for non-Anthropic providers in the Developer agent.
 
@@ -207,7 +209,7 @@ concurrency:
 jobs:
   gate-envelope:
     name: Validate event envelope
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
     steps:
@@ -222,7 +224,7 @@ jobs:
   route:
     name: Resolve execution path
     needs: [gate-envelope]
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
     outputs:
@@ -245,7 +247,7 @@ jobs:
     name: Run Developer agent (script path)
     needs: [route]
     if: needs.route.outputs.path == 'script'
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: write
       pull-requests: write
@@ -284,7 +286,7 @@ jobs:
     name: Run Developer agent (claude-code path)
     needs: [route]
     if: needs.route.outputs.path == 'claude-code'
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: write
       pull-requests: write
@@ -317,7 +319,7 @@ jobs:
     name: Emit audit line
     needs: [run-agent, run-agent-claude-code]
     if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
       issues: write
@@ -354,6 +356,7 @@ jobs:
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_REVIEW_PROVIDER (default: anthropic; also: openai, google)
 #                     FERRY_REVIEW_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 #
 # Note: MCP server support is not available for non-Anthropic providers in the Reviewer agent.
 
@@ -371,7 +374,7 @@ concurrency:
 jobs:
   gate-envelope:
     name: Validate event envelope
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
     steps:
@@ -386,7 +389,7 @@ jobs:
   route:
     name: Resolve execution path
     needs: [gate-envelope]
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
     outputs:
@@ -409,7 +412,7 @@ jobs:
     name: Run Reviewer agent (script path)
     needs: [route]
     if: needs.route.outputs.path == 'script'
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
       pull-requests: write
@@ -450,7 +453,7 @@ jobs:
     name: Reviewer CI pre-gate
     needs: [route]
     if: needs.route.outputs.path == 'claude-code'
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
       pull-requests: write
@@ -478,7 +481,7 @@ jobs:
     name: Run Reviewer agent (claude-code path)
     needs: [route, ci-gate]
     if: needs.route.outputs.path == 'claude-code' && needs.ci-gate.outputs.proceed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: write
       pull-requests: write
@@ -512,7 +515,7 @@ jobs:
     name: Emit audit line
     needs: [run-agent, run-agent-claude-code, ci-gate]
     if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped' || (needs.ci-gate.result != 'skipped' && needs.ci-gate.outputs.outcome == 'ci-red'))
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
       issues: write
@@ -550,6 +553,7 @@ jobs:
 # Optional variables: FERRY_ITER_PROVIDER (default: anthropic; also: openai, google)
 #                     FERRY_ITER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
 #                     FERRY_ITER_MAX_INPUT_TOKENS (default: 500000)
+#                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 #
 # Note: MCP server support is not available for non-Anthropic providers in the Iterator agent.
 
@@ -567,7 +571,7 @@ concurrency:
 jobs:
   gate-envelope:
     name: Validate event envelope
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
     steps:
@@ -582,7 +586,7 @@ jobs:
   route:
     name: Resolve execution path
     needs: [gate-envelope]
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
     outputs:
@@ -605,7 +609,7 @@ jobs:
     name: Run Iterator agent (script path)
     needs: [route]
     if: needs.route.outputs.path == 'script'
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: write
       issues: write
@@ -648,7 +652,7 @@ jobs:
     name: Run Iterator agent (claude-code path)
     needs: [route]
     if: needs.route.outputs.path == 'claude-code'
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: write
       pull-requests: write
@@ -681,7 +685,7 @@ jobs:
     name: Emit audit line
     needs: [run-agent, run-agent-claude-code]
     if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
-    runs-on: ubuntu-latest
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
Closes #364

Replace hardcoded `runs-on: ubuntu-latest` across all four agent workflow templates and all six example workflows with `${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}`.

Consumers on self-hosted runners set `FERRY_RUNNER` to a JSON-encoded string or array at the repo/org level; the default is unchanged.

Also adds a regression test and documents the new variable in CONFIGURATION.md.

Generated with [Claude Code](https://claude.ai/code)