### PR TITLE
feat(fr32): dispatch ferry-merge from cc-path reviewer on approve

### DIFF
--- a/.ferry/schemas/event.v1.schema.json
+++ b/.ferry/schemas/event.v1.schema.json
@@ -5,11 +5,16 @@
   "required": ["version", "event_id", "ticket_key", "phase", "source", "ts"],
   "properties": {
     "version": { "const": "v1" },
-    "event_id": { "type": "string", "minLength": 4, "maxLength": 100, "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
+    "event_id": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 100,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$"
+    },
     "ticket_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+-\\d+$" },
-    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile"] },
+    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile", "merge"] },
     "source": {
-      "enum": ["jira-column", "jira-label", "jira-mention", "reconciler"]
+      "enum": ["jira-column", "jira-label", "jira-mention", "reconciler", "ferry-agent"]
     },
     "instructions": { "type": "string" },
     "ticket_type": { "enum": ["Story", "Task", "Bug", "Spike"] },

--- a/.github/actions/ferry-envelope-validate/schemas/event.v1.schema.json
+++ b/.github/actions/ferry-envelope-validate/schemas/event.v1.schema.json
@@ -5,11 +5,16 @@
   "required": ["version", "event_id", "ticket_key", "phase", "source", "ts"],
   "properties": {
     "version": { "const": "v1" },
-    "event_id": { "type": "string", "minLength": 4, "maxLength": 100, "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
+    "event_id": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 100,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$"
+    },
     "ticket_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+-\\d+$" },
-    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile"] },
+    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile", "merge"] },
     "source": {
-      "enum": ["jira-column", "jira-label", "jira-mention", "reconciler"]
+      "enum": ["jira-column", "jira-label", "jira-mention", "reconciler", "ferry-agent"]
     },
     "instructions": { "type": "string" },
     "ticket_type": { "enum": ["Story", "Task", "Bug", "Spike"] },

--- a/.github/actions/ferry-route/schemas/event.v1.schema.json
+++ b/.github/actions/ferry-route/schemas/event.v1.schema.json
@@ -5,11 +5,16 @@
   "required": ["version", "event_id", "ticket_key", "phase", "source", "ts"],
   "properties": {
     "version": { "const": "v1" },
-    "event_id": { "type": "string", "minLength": 4, "maxLength": 100, "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
+    "event_id": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 100,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$"
+    },
     "ticket_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+-\\d+$" },
-    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile"] },
+    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile", "merge"] },
     "source": {
-      "enum": ["jira-column", "jira-label", "jira-mention", "reconciler"]
+      "enum": ["jira-column", "jira-label", "jira-mention", "reconciler", "ferry-agent"]
     },
     "instructions": { "type": "string" },
     "ticket_type": { "enum": ["Story", "Task", "Bug", "Spike"] },

--- a/.github/actions/ferry-run-developer/schemas/event.v1.schema.json
+++ b/.github/actions/ferry-run-developer/schemas/event.v1.schema.json
@@ -5,11 +5,16 @@
   "required": ["version", "event_id", "ticket_key", "phase", "source", "ts"],
   "properties": {
     "version": { "const": "v1" },
-    "event_id": { "type": "string", "minLength": 4, "maxLength": 100, "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
+    "event_id": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 100,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$"
+    },
     "ticket_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+-\\d+$" },
-    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile"] },
+    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile", "merge"] },
     "source": {
-      "enum": ["jira-column", "jira-label", "jira-mention", "reconciler"]
+      "enum": ["jira-column", "jira-label", "jira-mention", "reconciler", "ferry-agent"]
     },
     "instructions": { "type": "string" },
     "ticket_type": { "enum": ["Story", "Task", "Bug", "Spike"] },

--- a/.github/actions/ferry-run-iterator/schemas/event.v1.schema.json
+++ b/.github/actions/ferry-run-iterator/schemas/event.v1.schema.json
@@ -5,11 +5,16 @@
   "required": ["version", "event_id", "ticket_key", "phase", "source", "ts"],
   "properties": {
     "version": { "const": "v1" },
-    "event_id": { "type": "string", "minLength": 4, "maxLength": 100, "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
+    "event_id": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 100,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$"
+    },
     "ticket_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+-\\d+$" },
-    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile"] },
+    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile", "merge"] },
     "source": {
-      "enum": ["jira-column", "jira-label", "jira-mention", "reconciler"]
+      "enum": ["jira-column", "jira-label", "jira-mention", "reconciler", "ferry-agent"]
     },
     "instructions": { "type": "string" },
     "ticket_type": { "enum": ["Story", "Task", "Bug", "Spike"] },

--- a/.github/actions/ferry-run-refiner/schemas/event.v1.schema.json
+++ b/.github/actions/ferry-run-refiner/schemas/event.v1.schema.json
@@ -5,11 +5,16 @@
   "required": ["version", "event_id", "ticket_key", "phase", "source", "ts"],
   "properties": {
     "version": { "const": "v1" },
-    "event_id": { "type": "string", "minLength": 4, "maxLength": 100, "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
+    "event_id": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 100,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$"
+    },
     "ticket_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+-\\d+$" },
-    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile"] },
+    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile", "merge"] },
     "source": {
-      "enum": ["jira-column", "jira-label", "jira-mention", "reconciler"]
+      "enum": ["jira-column", "jira-label", "jira-mention", "reconciler", "ferry-agent"]
     },
     "instructions": { "type": "string" },
     "ticket_type": { "enum": ["Story", "Task", "Bug", "Spike"] },

--- a/.github/actions/ferry-run-reviewer/schemas/event.v1.schema.json
+++ b/.github/actions/ferry-run-reviewer/schemas/event.v1.schema.json
@@ -5,11 +5,16 @@
   "required": ["version", "event_id", "ticket_key", "phase", "source", "ts"],
   "properties": {
     "version": { "const": "v1" },
-    "event_id": { "type": "string", "minLength": 4, "maxLength": 100, "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
+    "event_id": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 100,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$"
+    },
     "ticket_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+-\\d+$" },
-    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile"] },
+    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile", "merge"] },
     "source": {
-      "enum": ["jira-column", "jira-label", "jira-mention", "reconciler"]
+      "enum": ["jira-column", "jira-label", "jira-mention", "reconciler", "ferry-agent"]
     },
     "instructions": { "type": "string" },
     "ticket_type": { "enum": ["Story", "Task", "Bug", "Spike"] },

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -152,6 +152,20 @@ When `state.iteration >= limits.max_iterations` (default 3) and findings remain,
 
 ---
 
+### FR32 — Reviewer dispatches `ferry-merge` on Approved verdict (cc-path)
+
+|                     |                                                              |
+| ------------------- | ------------------------------------------------------------ |
+| **Status**          | shipped                                                      |
+| **Source files**    | `prompts/review.claude-code.md`, `src/lib/dispatch/routing.ts` |
+| **Test files**      | `src/schemas/schemas.test.ts`                                |
+| **Docs**            | `docs/CONFIGURATION.md`                                      |
+| **Date introduced** | 2026-06-06                                                   |
+
+On the claude-code execution path, when the Reviewer verdict is Approved, the agent emits a `ferry-merge` `repository_dispatch` event (phase `"merge"`, source `"ferry-agent"`) via `gh api`. This triggers the Merger agent without human intervention. The `"merge"` phase is excluded from `RoutingTable` (handled outside the standard phase-to-workflow table, same as `"reconcile"`).
+
+---
+
 ### FR45 — Daily provider spend check against configurable EUR cap
 
 |                     |                                           |

--- a/examples/consumer-setup/workflows/ferry-review.yml
+++ b/examples/consumer-setup/workflows/ferry-review.yml
@@ -161,7 +161,7 @@ jobs:
     if: needs.route.outputs.path == 'claude-code' && needs.ci-gate.outputs.proceed == 'true'
     runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
-      contents: read
+      contents: write # required to dispatch ferry-merge (FR32) via POST /repos/.../dispatches
       pull-requests: write
       issues: read
       id-token: write # required by anthropics/claude-code-action@v1 OIDC auth

--- a/prompts/review.claude-code.md
+++ b/prompts/review.claude-code.md
@@ -8,7 +8,7 @@ A deterministic CI pre-gate runs **before** this job. If CI was red the gate alr
 
 - Ticket key: `TICKET_KEY`
 - Run id: `RUN_ID`
-- Approve transition id: `APPROVE_TRANSITION_ID` (FR24 — moves the ticket into the **Ready / Approved** column). May be empty when the consumer disables approve transitions.
+- Approve transition id: `APPROVE_TRANSITION_ID` (FR24 — moves the ticket into the **Ready / Approved** column). May be empty when the consumer disables approve transitions. On approve you also dispatch a `ferry-merge` `repository_dispatch` event (FR32) — see step 7.
 - Changes transition id: `CHANGES_TRANSITION_ID` (FR24 — moves the ticket into the **Changes Requested** column).
 
 ## Tools
@@ -47,14 +47,26 @@ A deterministic CI pre-gate runs **before** this job. If CI was red the gate alr
    ```
 
    Omit the "Issues requiring changes" section entirely when approving. Keep the review under 600 words. Every issue's **Why** must cite specific evidence.
+
 6. **Transition the ticket** — FR24:
    - **Approved** → if `APPROVE_TRANSITION_ID` is non-empty, call `transition_issue("TICKET_KEY", "APPROVE_TRANSITION_ID")`. If it is empty, do not transition (the consumer drives it).
    - **Changes requested** → call `transition_issue("TICKET_KEY", "CHANGES_TRANSITION_ID")`.
-7. **Post exactly one audit comment** — call `post_comment("TICKET_KEY", body)` with a body that **starts** with `[ferry:reviewer:RUN_ID]` followed by one paragraph: the verdict, the PR URL, and the transition applied. Post it **once**.
+7. **Dispatch ferry-merge** — FR32 — **Approved verdicts only**:
+   Run the following shell command exactly once. If it exits non-zero, log the error and continue — do **not** block the audit comment.
+   ```bash
+   jq -cn \
+     --arg key "TICKET_KEY" \
+     --arg id "RUN_ID-merge" \
+     --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+     '{event_type:"ferry-merge",client_payload:{version:"v1",event_id:$id,ticket_key:$key,phase:"merge",source:"ferry-agent",ts:$ts}}' \
+     | gh api repos/$GITHUB_REPOSITORY/dispatches --method POST --input -
+   ```
+   Do **not** run this command on a "Changes requested" verdict.
+8. **Post exactly one audit comment** — call `post_comment("TICKET_KEY", body)` with a body that **starts** with `[ferry:reviewer:RUN_ID]` followed by one paragraph: the verdict, the PR URL, and the transition applied. Post it **once**.
 
 ## Rules
 
 - **Never merge code. Never close PRs.** Reviewers post a review and a verdict only.
-- Agents **rarely** transition Jira columns — Reviewer's single allowed transition is FR24 (→ Ready on approve, → Changes Requested on changes).
+- Agents **rarely** transition Jira columns — Reviewer's single allowed transition is FR24 (→ Ready on approve, → Changes Requested on changes). On approve you also dispatch `ferry-merge` (FR32) but never merge directly.
 - **Idempotency is your responsibility** — if a `[ferry:reviewer:*]` review for this run already exists, do not post a duplicate; post exactly one fingerprinted comment.
 - Keep the review concise and in English.

--- a/src/lib/dispatch/routing.ts
+++ b/src/lib/dispatch/routing.ts
@@ -21,7 +21,7 @@ export type PhaseRoute = Readonly<{
   dispatchType: DispatchType;
 }>;
 
-type RoutingTable = Readonly<Record<Exclude<EventPhase, 'reconcile'>, PhaseRoute>>;
+type RoutingTable = Readonly<Record<Exclude<EventPhase, 'reconcile' | 'merge'>, PhaseRoute>>;
 
 export const PHASE_TO_WORKFLOW: RoutingTable = Object.freeze({
   refine: Object.freeze({ workflow: 'ferry-refine.yml', dispatchType: 'ferry-refine' }),

--- a/src/lib/envelope/types.ts
+++ b/src/lib/envelope/types.ts
@@ -1,6 +1,11 @@
-export type EventPhase = 'refine' | 'dev' | 'review' | 'iterate' | 'reconcile';
+export type EventPhase = 'refine' | 'dev' | 'review' | 'iterate' | 'reconcile' | 'merge';
 
-export type EventSource = 'jira-column' | 'jira-label' | 'jira-mention' | 'reconciler';
+export type EventSource =
+  | 'jira-column'
+  | 'jira-label'
+  | 'jira-mention'
+  | 'reconciler'
+  | 'ferry-agent';
 
 export type TicketType = 'Story' | 'Task' | 'Bug' | 'Spike';
 

--- a/src/schemas/event.v1.schema.json
+++ b/src/schemas/event.v1.schema.json
@@ -5,11 +5,16 @@
   "required": ["version", "event_id", "ticket_key", "phase", "source", "ts"],
   "properties": {
     "version": { "const": "v1" },
-    "event_id": { "type": "string", "minLength": 4, "maxLength": 100, "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
+    "event_id": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 100,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$"
+    },
     "ticket_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+-\\d+$" },
-    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile"] },
+    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile", "merge"] },
     "source": {
-      "enum": ["jira-column", "jira-label", "jira-mention", "reconciler"]
+      "enum": ["jira-column", "jira-label", "jira-mention", "reconciler", "ferry-agent"]
     },
     "instructions": { "type": "string" },
     "ticket_type": { "enum": ["Story", "Task", "Bug", "Spike"] },

--- a/src/schemas/schemas.test.ts
+++ b/src/schemas/schemas.test.ts
@@ -109,9 +109,9 @@ describe('event.v1.schema.json', () => {
     expect(validateEvent).toBeDefined();
   });
 
-  it('phase enum contains all 5 values', () => {
+  it('phase enum contains all 6 values', () => {
     const phases = eventSchema.properties.phase.enum as string[];
-    for (const v of ['refine', 'dev', 'review', 'iterate', 'reconcile']) {
+    for (const v of ['refine', 'dev', 'review', 'iterate', 'reconcile', 'merge']) {
       expect(phases, `phase enum must contain "${v}"`).toContain(v);
     }
   });


### PR DESCRIPTION
Fixes #375

## Summary

On the claude-code execution path, the Reviewer agent now emits a `ferry-merge` `repository_dispatch` event whenever the verdict is Approved (FR32). Previously nothing dispatched this event on the cc-path, so the Merger agent never triggered.

## Changes

- `prompts/review.claude-code.md`: new step 7 dispatches `ferry-merge` via `jq | gh api`; Context and Rules updated to accurately describe the Merger trigger
- `src/schemas/event.v1.schema.json`: add "merge" phase + "ferry-agent" source
- `src/lib/envelope/types.ts`: extend `EventPhase` and `EventSource` types
- `src/lib/dispatch/routing.ts`: exclude "merge" from `RoutingTable` (same as "reconcile")
- `src/schemas/schemas.test.ts`: phase enum test 5 → 6 values
- `examples/consumer-setup/workflows/ferry-review.yml`: `contents: write` on cc job (dispatches API requires it)
- `.github/actions/*/schemas/`: rebuilt bundled schema copies

Generated with [Claude Code](https://claude.ai/code)