### PR TITLE
fix(FR32): reviewer script-path gets contents:write + best-effort ferry-merge dispatch

### DIFF
--- a/.ferry/agent.js
+++ b/.ferry/agent.js
@@ -5088,7 +5088,8 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   refine: Object.freeze({ workflow: "ferry-refine.yml", dispatchType: "ferry-refine" }),
   dev: Object.freeze({ workflow: "ferry-dev.yml", dispatchType: "ferry-dev" }),
   review: Object.freeze({ workflow: "ferry-review.yml", dispatchType: "ferry-review" }),
-  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
+  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" }),
+  merge: Object.freeze({ workflow: "ferry-merge.yml", dispatchType: "ferry-merge" })
 });
 
 // src/lib/dispatch/runner/github-actions/index.ts
@@ -10811,6 +10812,11 @@ async function main3(envelope, logger) {
       await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
       if (shouldTransitionApprove) {
         await tracker.postTransition(ticketKey, approveTransitionId);
+      }
+      try {
+        await runner.dispatch("merge", { ...envelope, phase: "merge" });
+      } catch (err) {
+        logger.warn("ferry-merge dispatch failed (non-fatal)", { error: err.message });
       }
     }
   } else {

--- a/.ferry/schemas/event.v1.schema.json
+++ b/.ferry/schemas/event.v1.schema.json
@@ -5,9 +5,14 @@
   "required": ["version", "event_id", "ticket_key", "phase", "source", "ts"],
   "properties": {
     "version": { "const": "v1" },
-    "event_id": { "type": "string", "minLength": 4, "maxLength": 100, "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
+    "event_id": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 100,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$"
+    },
     "ticket_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+-\\d+$" },
-    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile"] },
+    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile", "merge"] },
     "source": {
       "enum": ["jira-column", "jira-label", "jira-mention", "reconciler"]
     },

--- a/.ferry/skip-task-type-action.js
+++ b/.ferry/skip-task-type-action.js
@@ -393,7 +393,8 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   refine: Object.freeze({ workflow: "ferry-refine.yml", dispatchType: "ferry-refine" }),
   dev: Object.freeze({ workflow: "ferry-dev.yml", dispatchType: "ferry-dev" }),
   review: Object.freeze({ workflow: "ferry-review.yml", dispatchType: "ferry-review" }),
-  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
+  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" }),
+  merge: Object.freeze({ workflow: "ferry-merge.yml", dispatchType: "ferry-merge" })
 });
 function shouldSkipForTaskType(issueType2, overrides) {
   if (overrides?.bypassTaskSkip) {

--- a/.github/actions/ferry-envelope-validate/schemas/event.v1.schema.json
+++ b/.github/actions/ferry-envelope-validate/schemas/event.v1.schema.json
@@ -5,9 +5,14 @@
   "required": ["version", "event_id", "ticket_key", "phase", "source", "ts"],
   "properties": {
     "version": { "const": "v1" },
-    "event_id": { "type": "string", "minLength": 4, "maxLength": 100, "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
+    "event_id": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 100,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$"
+    },
     "ticket_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+-\\d+$" },
-    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile"] },
+    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile", "merge"] },
     "source": {
       "enum": ["jira-column", "jira-label", "jira-mention", "reconciler"]
     },

--- a/.github/actions/ferry-route/schemas/event.v1.schema.json
+++ b/.github/actions/ferry-route/schemas/event.v1.schema.json
@@ -5,9 +5,14 @@
   "required": ["version", "event_id", "ticket_key", "phase", "source", "ts"],
   "properties": {
     "version": { "const": "v1" },
-    "event_id": { "type": "string", "minLength": 4, "maxLength": 100, "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
+    "event_id": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 100,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$"
+    },
     "ticket_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+-\\d+$" },
-    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile"] },
+    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile", "merge"] },
     "source": {
       "enum": ["jira-column", "jira-label", "jira-mention", "reconciler"]
     },

--- a/.github/actions/ferry-run-developer/agent.js
+++ b/.github/actions/ferry-run-developer/agent.js
@@ -5088,7 +5088,8 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   refine: Object.freeze({ workflow: "ferry-refine.yml", dispatchType: "ferry-refine" }),
   dev: Object.freeze({ workflow: "ferry-dev.yml", dispatchType: "ferry-dev" }),
   review: Object.freeze({ workflow: "ferry-review.yml", dispatchType: "ferry-review" }),
-  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
+  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" }),
+  merge: Object.freeze({ workflow: "ferry-merge.yml", dispatchType: "ferry-merge" })
 });
 
 // src/lib/dispatch/runner/github-actions/index.ts
@@ -10811,6 +10812,11 @@ async function main3(envelope, logger) {
       await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
       if (shouldTransitionApprove) {
         await tracker.postTransition(ticketKey, approveTransitionId);
+      }
+      try {
+        await runner.dispatch("merge", { ...envelope, phase: "merge" });
+      } catch (err) {
+        logger.warn("ferry-merge dispatch failed (non-fatal)", { error: err.message });
       }
     }
   } else {

--- a/.github/actions/ferry-run-developer/schemas/event.v1.schema.json
+++ b/.github/actions/ferry-run-developer/schemas/event.v1.schema.json
@@ -5,9 +5,14 @@
   "required": ["version", "event_id", "ticket_key", "phase", "source", "ts"],
   "properties": {
     "version": { "const": "v1" },
-    "event_id": { "type": "string", "minLength": 4, "maxLength": 100, "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
+    "event_id": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 100,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$"
+    },
     "ticket_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+-\\d+$" },
-    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile"] },
+    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile", "merge"] },
     "source": {
       "enum": ["jira-column", "jira-label", "jira-mention", "reconciler"]
     },

--- a/.github/actions/ferry-run-developer/skip-task-type-action.js
+++ b/.github/actions/ferry-run-developer/skip-task-type-action.js
@@ -393,7 +393,8 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   refine: Object.freeze({ workflow: "ferry-refine.yml", dispatchType: "ferry-refine" }),
   dev: Object.freeze({ workflow: "ferry-dev.yml", dispatchType: "ferry-dev" }),
   review: Object.freeze({ workflow: "ferry-review.yml", dispatchType: "ferry-review" }),
-  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
+  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" }),
+  merge: Object.freeze({ workflow: "ferry-merge.yml", dispatchType: "ferry-merge" })
 });
 function shouldSkipForTaskType(issueType2, overrides) {
   if (overrides?.bypassTaskSkip) {

--- a/.github/actions/ferry-run-iterator/agent.js
+++ b/.github/actions/ferry-run-iterator/agent.js
@@ -5088,7 +5088,8 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   refine: Object.freeze({ workflow: "ferry-refine.yml", dispatchType: "ferry-refine" }),
   dev: Object.freeze({ workflow: "ferry-dev.yml", dispatchType: "ferry-dev" }),
   review: Object.freeze({ workflow: "ferry-review.yml", dispatchType: "ferry-review" }),
-  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
+  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" }),
+  merge: Object.freeze({ workflow: "ferry-merge.yml", dispatchType: "ferry-merge" })
 });
 
 // src/lib/dispatch/runner/github-actions/index.ts
@@ -10811,6 +10812,11 @@ async function main3(envelope, logger) {
       await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
       if (shouldTransitionApprove) {
         await tracker.postTransition(ticketKey, approveTransitionId);
+      }
+      try {
+        await runner.dispatch("merge", { ...envelope, phase: "merge" });
+      } catch (err) {
+        logger.warn("ferry-merge dispatch failed (non-fatal)", { error: err.message });
       }
     }
   } else {

--- a/.github/actions/ferry-run-iterator/schemas/event.v1.schema.json
+++ b/.github/actions/ferry-run-iterator/schemas/event.v1.schema.json
@@ -5,9 +5,14 @@
   "required": ["version", "event_id", "ticket_key", "phase", "source", "ts"],
   "properties": {
     "version": { "const": "v1" },
-    "event_id": { "type": "string", "minLength": 4, "maxLength": 100, "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
+    "event_id": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 100,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$"
+    },
     "ticket_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+-\\d+$" },
-    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile"] },
+    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile", "merge"] },
     "source": {
       "enum": ["jira-column", "jira-label", "jira-mention", "reconciler"]
     },

--- a/.github/actions/ferry-run-iterator/skip-task-type-action.js
+++ b/.github/actions/ferry-run-iterator/skip-task-type-action.js
@@ -393,7 +393,8 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   refine: Object.freeze({ workflow: "ferry-refine.yml", dispatchType: "ferry-refine" }),
   dev: Object.freeze({ workflow: "ferry-dev.yml", dispatchType: "ferry-dev" }),
   review: Object.freeze({ workflow: "ferry-review.yml", dispatchType: "ferry-review" }),
-  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
+  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" }),
+  merge: Object.freeze({ workflow: "ferry-merge.yml", dispatchType: "ferry-merge" })
 });
 function shouldSkipForTaskType(issueType2, overrides) {
   if (overrides?.bypassTaskSkip) {

--- a/.github/actions/ferry-run-refiner/agent.js
+++ b/.github/actions/ferry-run-refiner/agent.js
@@ -5088,7 +5088,8 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   refine: Object.freeze({ workflow: "ferry-refine.yml", dispatchType: "ferry-refine" }),
   dev: Object.freeze({ workflow: "ferry-dev.yml", dispatchType: "ferry-dev" }),
   review: Object.freeze({ workflow: "ferry-review.yml", dispatchType: "ferry-review" }),
-  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
+  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" }),
+  merge: Object.freeze({ workflow: "ferry-merge.yml", dispatchType: "ferry-merge" })
 });
 
 // src/lib/dispatch/runner/github-actions/index.ts
@@ -10811,6 +10812,11 @@ async function main3(envelope, logger) {
       await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
       if (shouldTransitionApprove) {
         await tracker.postTransition(ticketKey, approveTransitionId);
+      }
+      try {
+        await runner.dispatch("merge", { ...envelope, phase: "merge" });
+      } catch (err) {
+        logger.warn("ferry-merge dispatch failed (non-fatal)", { error: err.message });
       }
     }
   } else {

--- a/.github/actions/ferry-run-refiner/schemas/event.v1.schema.json
+++ b/.github/actions/ferry-run-refiner/schemas/event.v1.schema.json
@@ -5,9 +5,14 @@
   "required": ["version", "event_id", "ticket_key", "phase", "source", "ts"],
   "properties": {
     "version": { "const": "v1" },
-    "event_id": { "type": "string", "minLength": 4, "maxLength": 100, "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
+    "event_id": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 100,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$"
+    },
     "ticket_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+-\\d+$" },
-    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile"] },
+    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile", "merge"] },
     "source": {
       "enum": ["jira-column", "jira-label", "jira-mention", "reconciler"]
     },

--- a/.github/actions/ferry-run-refiner/skip-task-type-action.js
+++ b/.github/actions/ferry-run-refiner/skip-task-type-action.js
@@ -393,7 +393,8 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   refine: Object.freeze({ workflow: "ferry-refine.yml", dispatchType: "ferry-refine" }),
   dev: Object.freeze({ workflow: "ferry-dev.yml", dispatchType: "ferry-dev" }),
   review: Object.freeze({ workflow: "ferry-review.yml", dispatchType: "ferry-review" }),
-  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
+  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" }),
+  merge: Object.freeze({ workflow: "ferry-merge.yml", dispatchType: "ferry-merge" })
 });
 function shouldSkipForTaskType(issueType2, overrides) {
   if (overrides?.bypassTaskSkip) {

--- a/.github/actions/ferry-run-reviewer/agent.js
+++ b/.github/actions/ferry-run-reviewer/agent.js
@@ -5088,7 +5088,8 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   refine: Object.freeze({ workflow: "ferry-refine.yml", dispatchType: "ferry-refine" }),
   dev: Object.freeze({ workflow: "ferry-dev.yml", dispatchType: "ferry-dev" }),
   review: Object.freeze({ workflow: "ferry-review.yml", dispatchType: "ferry-review" }),
-  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
+  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" }),
+  merge: Object.freeze({ workflow: "ferry-merge.yml", dispatchType: "ferry-merge" })
 });
 
 // src/lib/dispatch/runner/github-actions/index.ts
@@ -10811,6 +10812,11 @@ async function main3(envelope, logger) {
       await runner.commentOnPR({ owner, repo, prNumber }, review.comment);
       if (shouldTransitionApprove) {
         await tracker.postTransition(ticketKey, approveTransitionId);
+      }
+      try {
+        await runner.dispatch("merge", { ...envelope, phase: "merge" });
+      } catch (err) {
+        logger.warn("ferry-merge dispatch failed (non-fatal)", { error: err.message });
       }
     }
   } else {

--- a/.github/actions/ferry-run-reviewer/schemas/event.v1.schema.json
+++ b/.github/actions/ferry-run-reviewer/schemas/event.v1.schema.json
@@ -5,9 +5,14 @@
   "required": ["version", "event_id", "ticket_key", "phase", "source", "ts"],
   "properties": {
     "version": { "const": "v1" },
-    "event_id": { "type": "string", "minLength": 4, "maxLength": 100, "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
+    "event_id": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 100,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$"
+    },
     "ticket_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+-\\d+$" },
-    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile"] },
+    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile", "merge"] },
     "source": {
       "enum": ["jira-column", "jira-label", "jira-mention", "reconciler"]
     },

--- a/.github/actions/ferry-run-reviewer/skip-task-type-action.js
+++ b/.github/actions/ferry-run-reviewer/skip-task-type-action.js
@@ -393,7 +393,8 @@ var PHASE_TO_WORKFLOW = Object.freeze({
   refine: Object.freeze({ workflow: "ferry-refine.yml", dispatchType: "ferry-refine" }),
   dev: Object.freeze({ workflow: "ferry-dev.yml", dispatchType: "ferry-dev" }),
   review: Object.freeze({ workflow: "ferry-review.yml", dispatchType: "ferry-review" }),
-  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" })
+  iterate: Object.freeze({ workflow: "ferry-iterate.yml", dispatchType: "ferry-iterate" }),
+  merge: Object.freeze({ workflow: "ferry-merge.yml", dispatchType: "ferry-merge" })
 });
 function shouldSkipForTaskType(issueType2, overrides) {
   if (overrides?.bypassTaskSkip) {

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -152,6 +152,19 @@ When `state.iteration >= limits.max_iterations` (default 3) and findings remain,
 
 ---
 
+### FR32 — Reviewer best-effort dispatches ferry-merge on approve
+
+|                     |                                                                              |
+| ------------------- | ---------------------------------------------------------------------------- |
+| **Status**          | shipped                                                                      |
+| **Source files**    | `src/agents/reviewer/review-action.ts`, `src/cli/init/templates.ts`          |
+| **Test files**      | `src/cli/init/templates.test.ts`                                             |
+| **Date introduced** | 2026-06-06                                                                   |
+
+When the Reviewer verdict is `merge-ready`, Ferry attempts a best-effort `repository_dispatch` to trigger `ferry-merge.yml`. The dispatch is wrapped in try/catch so a failure never loses the approval. The reviewer `run-agent` step requires `contents: write` to issue the dispatch event.
+
+---
+
 ### FR45 — Daily provider spend check against configurable EUR cap
 
 |                     |                                           |

--- a/examples/consumer-setup/workflows/ferry-merge.yml
+++ b/examples/consumer-setup/workflows/ferry-merge.yml
@@ -1,0 +1,169 @@
+# Copy this file to .github/workflows/ferry-merge.yml in your repository.
+# Replace @v0.16.0 with the Ferry release tag you want to pin.
+# Required secrets: FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN
+#                   ANTHROPIC_API_KEY    — required when FERRY_MERGER_PROVIDER=anthropic (default)
+#                   OPENAI_API_KEY       — required when FERRY_MERGER_PROVIDER=openai
+#                   GOOGLE_API_KEY       — required when FERRY_MERGER_PROVIDER=google
+#                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
+#                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path).
+# Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
+# Optional variables: FERRY_MERGER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#                     FERRY_MERGER_PROVIDER (default: anthropic; also: openai, google)
+#                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
+# claude-code path:   When execution_path=claude-code the Merger runs as ONE direct
+#                     anthropics/claude-code-action call. The agent does its own Jira work via the
+#                     ferry-jira-mcp MCP server (npx -p @big-emotion/ferry@v0.16.0 ferry-jira-mcp).
+#                     Cost tracking on this path is best-effort — audit token/cost are emitted as 0.
+# Triggered by:       The Reviewer agent dispatches ferry-merge automatically on approve (FR32).
+
+# Managed by ferry-init. Re-run `npx -p @big-emotion/ferry ferry-init` to update.
+# Required secrets: FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN
+#                   ANTHROPIC_API_KEY  — required when FERRY_MERGER_PROVIDER=anthropic (default)
+#                   OPENAI_API_KEY     — required when FERRY_MERGER_PROVIDER=openai
+#                   GOOGLE_API_KEY     — required when FERRY_MERGER_PROVIDER=google
+#                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
+#                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path)
+# Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
+# Optional variables: FERRY_MERGER_PROVIDER (default: anthropic; also: openai, google)
+#                     FERRY_MERGER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
+
+name: Ferry — Merge
+
+on:
+  repository_dispatch:
+    types: [ferry-merge]
+
+# cancel-in-progress: false — merge must complete atomically; cancellation mid-merge = inconsistent PR state
+concurrency:
+  group: ferry-${{ github.workflow }}-${{ github.event.client_payload.ticket_key || 'ferry-invalid-payload-sinkhole' }}
+  cancel-in-progress: false
+
+jobs:
+  gate-envelope:
+    name: Validate event envelope
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate event envelope
+        uses: big-emotion/ferry/.github/actions/ferry-envelope-validate@v0.16.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+
+  route:
+    name: Resolve execution path
+    needs: [gate-envelope]
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+    outputs:
+      path: ${{ steps.route.outputs.path }}
+      reason: ${{ steps.route.outputs.reason }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve execution path
+        id: route
+        uses: big-emotion/ferry/.github/actions/ferry-route@v0.16.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          role: merger
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+
+  run-agent:
+    name: Run Merger agent (script path)
+    needs: [route]
+    if: needs.route.outputs.path == 'script'
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    outputs:
+      input_tokens: ${{ steps.run-merger.outputs.input_tokens }}
+      output_tokens: ${{ steps.run-merger.outputs.output_tokens }}
+      cost_eur: ${{ steps.run-merger.outputs.cost_eur }}
+      model: ${{ steps.run-merger.outputs.model }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Merger agent
+        id: run-merger
+        uses: big-emotion/ferry/.github/actions/ferry-run-merger@v0.16.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          google_api_key: ${{ secrets.GOOGLE_API_KEY }}
+          github_token: ${{ github.token }}
+          github_repo: ${{ github.repository }}
+          ferry_merger_model: ${{ vars.FERRY_MERGER_MODEL || 'claude-sonnet-4-6' }}
+
+  run-agent-claude-code:
+    name: Run Merger agent (claude-code path)
+    needs: [route]
+    if: needs.route.outputs.path == 'claude-code'
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+      id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # Resolve the system prompt: prompts/merge.claude-code.md from this repo
+      # if present, otherwise Ferry's bundled default. To customise the prompt
+      # edit that file — no need to touch this workflow. See docs/CONFIGURATION.md.
+      - name: Resolve agent prompt
+        id: prompt
+        run: >-
+          npx -y -p @big-emotion/ferry@v0.16.0 ferry-cc-prompt
+          --agent merge
+          --ticket-key "${{ github.event.client_payload.ticket_key }}"
+          --run-id "${{ github.event.client_payload.event_id }}"
+      - uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.prompt.outputs.prompt }}
+          claude_args: >-
+            --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@v0.16.0","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
+            --permission-mode bypassPermissions
+            --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
+            --model ${{ vars.FERRY_MERGER_MODEL || 'claude-sonnet-4-6' }}
+
+  emit-audit:
+    name: Emit audit line
+    needs: [run-agent, run-agent-claude-code]
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Emit audit line
+        uses: big-emotion/ferry/.github/actions/ferry-emit-audit@v0.16.0
+        with:
+          ticket: ${{ github.event.client_payload.ticket_key }}
+          phase: merge
+          run_id: ${{ github.event.client_payload.event_id }}
+          model: ${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
+          outcome: ${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
+          input_tokens: ${{ needs.run-agent.outputs.input_tokens || '0' }}
+          output_tokens: ${{ needs.run-agent.outputs.output_tokens || '0' }}
+          cost_eur: ${{ needs.run-agent.outputs.cost_eur || '0' }}
+          start_ms: ${{ github.run_id }}
+          audit_issue: ${{ vars.FERRY_AUDIT_ISSUE }}
+          github_token: ${{ github.token }}

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -290,6 +290,13 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
       if (shouldTransitionApprove) {
         await tracker.postTransition(ticketKey, approveTransitionId);
       }
+      // FR32: dispatch ferry-merge best-effort — a dispatch failure must never lose an approval.
+      // The reviewer job on the script path requires contents: write for repository_dispatch.
+      try {
+        await runner.dispatch('merge', { ...envelope, phase: 'merge' });
+      } catch (err) {
+        logger.warn('ferry-merge dispatch failed (non-fatal)', { error: (err as Error).message });
+      }
     }
   } else {
     const priorIterations = countPriorIterations(existingComments);

--- a/src/cli/init/init.test.ts
+++ b/src/cli/init/init.test.ts
@@ -141,8 +141,8 @@ describe('buildJiraBundle', () => {
 // ── workflowTemplates ─────────────────────────────────────────────────────────
 
 describe('workflowTemplates', () => {
-  it('returns 4 workflow files', () => {
-    expect(workflowTemplates('v1')).toHaveLength(4);
+  it('returns 5 workflow files', () => {
+    expect(workflowTemplates('v1')).toHaveLength(5);
   });
 
   it('includes all required workflow filenames', () => {
@@ -151,6 +151,7 @@ describe('workflowTemplates', () => {
     expect(names).toContain('ferry-dev.yml');
     expect(names).toContain('ferry-review.yml');
     expect(names).toContain('ferry-iterate.yml');
+    expect(names).toContain('ferry-merge.yml');
   });
 
   it('embeds the ferry version tag in each agent workflow', () => {
@@ -160,6 +161,7 @@ describe('workflowTemplates', () => {
       'ferry-dev.yml',
       'ferry-review.yml',
       'ferry-iterate.yml',
+      'ferry-merge.yml',
     ];
     for (const tmpl of templates) {
       if (agentFiles.includes(tmpl.filename)) {
@@ -174,6 +176,7 @@ describe('workflowTemplates', () => {
       'ferry-dev.yml',
       'ferry-review.yml',
       'ferry-iterate.yml',
+      'ferry-merge.yml',
     ];
     for (const tmpl of workflowTemplates('v1')) {
       if (agentFiles.includes(tmpl.filename)) {

--- a/src/cli/init/templates.test.ts
+++ b/src/cli/init/templates.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect } from 'vitest';
 import { parse as parseYaml } from 'yaml';
 import { workflowTemplates } from './templates.js';
 
-const AGENT_FILES = ['ferry-refine.yml', 'ferry-dev.yml', 'ferry-review.yml', 'ferry-iterate.yml'];
+const AGENT_FILES = [
+  'ferry-refine.yml',
+  'ferry-dev.yml',
+  'ferry-review.yml',
+  'ferry-iterate.yml',
+  'ferry-merge.yml',
+];
 
 // Validates that a rendered template is structurally sound YAML for GitHub Actions:
 // - Uses only spaces, no tabs (YAML is space-sensitive)
@@ -41,8 +47,8 @@ function assertValidWorkflowYaml(content: string, filename: string): void {
 }
 
 describe('workflowTemplates — count and filenames', () => {
-  it('returns exactly 4 workflow templates', () => {
-    expect(workflowTemplates('v1')).toHaveLength(4);
+  it('returns exactly 5 workflow templates', () => {
+    expect(workflowTemplates('v1')).toHaveLength(5);
   });
 
   it('includes all four agent workflow filenames', () => {
@@ -201,6 +207,7 @@ describe('workflowTemplates — claude-code path single-step shape', () => {
       'ferry-dev.yml': "--model ${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-4-6' }}",
       'ferry-review.yml': "--model ${{ vars.FERRY_REVIEW_MODEL || 'claude-sonnet-4-6' }}",
       'ferry-iterate.yml': "--model ${{ vars.FERRY_ITER_MODEL || 'claude-sonnet-4-6' }}",
+      'ferry-merge.yml': "--model ${{ vars.FERRY_MERGER_MODEL || 'claude-sonnet-4-6' }}",
     };
     for (const tmpl of workflowTemplates('v1')) {
       const expected = modelVars[tmpl.filename];
@@ -230,6 +237,23 @@ describe('workflowTemplates — role-specific wiring', () => {
     expect(dev?.content).toContain(
       'ferry_review_transition_id: ${{ secrets.FERRY_REVIEW_TRANSITION_ID }}',
     );
+  });
+
+  it('ferry-review.yml run-agent (script path) has contents: write — required for repository_dispatch (FR32)', () => {
+    // The reviewer dispatches ferry-merge on approve; repos.createDispatchEvent requires
+    // contents: write. contents: read silently 403s and crashes the job after approval.
+    const review = workflowTemplates('v1').find((t) => t.filename === 'ferry-review.yml');
+    expect(review, 'ferry-review.yml not found').toBeDefined();
+    // Extract the run-agent job block (ends before the ci-gate job).
+    const runAgentBlock = review!.content.split('  ci-gate:')[0].split('  run-agent:')[1];
+    expect(
+      runAgentBlock,
+      'ferry-review.yml run-agent permissions block must have contents: write (not read)',
+    ).toContain('contents: write');
+    expect(
+      runAgentBlock,
+      'ferry-review.yml run-agent must not downgrade to contents: read',
+    ).not.toMatch(/contents: read/);
   });
 
   it('ferry-review.yml wires FERRY_ITER_TRANSITION_ID into run-agent and ci-gate (FR24 changes)', () => {
@@ -363,6 +387,7 @@ describe('workflowTemplates — run-agent-claude-code permissions include id-tok
     { filename: 'ferry-dev.yml', role: 'developer' },
     { filename: 'ferry-review.yml', role: 'reviewer' },
     { filename: 'ferry-iterate.yml', role: 'iterator' },
+    { filename: 'ferry-merge.yml', role: 'merger' },
   ] as const;
 
   for (const { filename, role } of roles) {

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -414,7 +414,7 @@ jobs:
     if: needs.route.outputs.path == 'script'
     runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       checks: read
@@ -697,6 +697,161 @@ jobs:
         with:
           ticket: \${{ github.event.client_payload.ticket_key }}
           phase: iterate
+          run_id: \${{ github.event.client_payload.event_id }}
+          model: \${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
+          outcome: \${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
+          input_tokens: \${{ needs.run-agent.outputs.input_tokens || '0' }}
+          output_tokens: \${{ needs.run-agent.outputs.output_tokens || '0' }}
+          cost_eur: \${{ needs.run-agent.outputs.cost_eur || '0' }}
+          start_ms: \${{ github.run_id }}
+          audit_issue: \${{ vars.FERRY_AUDIT_ISSUE }}
+          github_token: \${{ github.token }}
+`,
+    },
+    {
+      filename: 'ferry-merge.yml',
+      content: `# Managed by ferry-init. Re-run \`npx -p @big-emotion/ferry ferry-init\` to update.
+# Required secrets: FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN
+#                   ANTHROPIC_API_KEY  — required when FERRY_MERGER_PROVIDER=anthropic (default)
+#                   OPENAI_API_KEY     — required when FERRY_MERGER_PROVIDER=openai
+#                   GOOGLE_API_KEY     — required when FERRY_MERGER_PROVIDER=google
+#                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
+#                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path)
+# Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
+# Optional variables: FERRY_MERGER_PROVIDER (default: anthropic; also: openai, google)
+#                     FERRY_MERGER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
+
+name: Ferry — Merge
+
+on:
+  repository_dispatch:
+    types: [ferry-merge]
+
+# cancel-in-progress: false — merge must complete atomically; cancellation mid-merge = inconsistent PR state
+concurrency:
+  group: ferry-\${{ github.workflow }}-\${{ github.event.client_payload.ticket_key || 'ferry-invalid-payload-sinkhole' }}
+  cancel-in-progress: false
+
+jobs:
+  gate-envelope:
+    name: Validate event envelope
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate event envelope
+        uses: big-emotion/ferry/.github/actions/ferry-envelope-validate@${version}
+        with:
+          payload: \${{ toJson(github.event.client_payload) }}
+
+  route:
+    name: Resolve execution path
+    needs: [gate-envelope]
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+    outputs:
+      path: \${{ steps.route.outputs.path }}
+      reason: \${{ steps.route.outputs.reason }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve execution path
+        id: route
+        uses: big-emotion/ferry/.github/actions/ferry-route@${version}
+        with:
+          payload: \${{ toJson(github.event.client_payload) }}
+          role: merger
+          jira_base_url: \${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: \${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
+
+  run-agent:
+    name: Run Merger agent (script path)
+    needs: [route]
+    if: needs.route.outputs.path == 'script'
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    outputs:
+      input_tokens: \${{ steps.run-merger.outputs.input_tokens }}
+      output_tokens: \${{ steps.run-merger.outputs.output_tokens }}
+      cost_eur: \${{ steps.run-merger.outputs.cost_eur }}
+      model: \${{ steps.run-merger.outputs.model }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Merger agent
+        id: run-merger
+        uses: big-emotion/ferry/.github/actions/ferry-run-merger@${version}
+        with:
+          payload: \${{ toJson(github.event.client_payload) }}
+          jira_base_url: \${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: \${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
+          anthropic_api_key: \${{ secrets.ANTHROPIC_API_KEY }}
+          openai_api_key: \${{ secrets.OPENAI_API_KEY }}
+          google_api_key: \${{ secrets.GOOGLE_API_KEY }}
+          github_token: \${{ github.token }}
+          github_repo: \${{ github.repository }}
+          ferry_merger_model: \${{ vars.FERRY_MERGER_MODEL || 'claude-sonnet-4-6' }}
+
+  run-agent-claude-code:
+    name: Run Merger agent (claude-code path)
+    needs: [route]
+    if: needs.route.outputs.path == 'claude-code'
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+      id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # Resolve the system prompt: prompts/merge.claude-code.md from this repo
+      # if present, otherwise Ferry's bundled default. To customise the prompt
+      # edit that file — no need to touch this workflow. See docs/CONFIGURATION.md.
+      - name: Resolve agent prompt
+        id: prompt
+        run: >-
+          npx -y -p @big-emotion/ferry@${version} ferry-cc-prompt
+          --agent merge
+          --ticket-key "\${{ github.event.client_payload.ticket_key }}"
+          --run-id "\${{ github.event.client_payload.event_id }}"
+      - uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
+        with:
+          claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: \${{ steps.prompt.outputs.prompt }}
+          claude_args: >-
+            --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@${version}","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"\${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"\${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"\${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
+            --permission-mode bypassPermissions
+            --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
+            --model \${{ vars.FERRY_MERGER_MODEL || 'claude-sonnet-4-6' }}
+
+  emit-audit:
+    name: Emit audit line
+    needs: [run-agent, run-agent-claude-code]
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Emit audit line
+        uses: big-emotion/ferry/.github/actions/ferry-emit-audit@${version}
+        with:
+          ticket: \${{ github.event.client_payload.ticket_key }}
+          phase: merge
           run_id: \${{ github.event.client_payload.event_id }}
           model: \${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
           outcome: \${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}

--- a/src/lib/dispatch/routing.test.ts
+++ b/src/lib/dispatch/routing.test.ts
@@ -15,6 +15,7 @@ describe('PHASE_TO_WORKFLOW table', () => {
       dev: { workflow: 'ferry-dev.yml', dispatchType: 'ferry-dev' },
       review: { workflow: 'ferry-review.yml', dispatchType: 'ferry-review' },
       iterate: { workflow: 'ferry-iterate.yml', dispatchType: 'ferry-iterate' },
+      merge: { workflow: 'ferry-merge.yml', dispatchType: 'ferry-merge' },
     });
   });
 

--- a/src/lib/dispatch/routing.ts
+++ b/src/lib/dispatch/routing.ts
@@ -13,8 +13,14 @@ export type WorkflowFile =
   | 'ferry-refine.yml'
   | 'ferry-dev.yml'
   | 'ferry-review.yml'
-  | 'ferry-iterate.yml';
-export type DispatchType = 'ferry-refine' | 'ferry-dev' | 'ferry-review' | 'ferry-iterate';
+  | 'ferry-iterate.yml'
+  | 'ferry-merge.yml';
+export type DispatchType =
+  | 'ferry-refine'
+  | 'ferry-dev'
+  | 'ferry-review'
+  | 'ferry-iterate'
+  | 'ferry-merge';
 
 export type PhaseRoute = Readonly<{
   workflow: WorkflowFile;
@@ -28,6 +34,7 @@ export const PHASE_TO_WORKFLOW: RoutingTable = Object.freeze({
   dev: Object.freeze({ workflow: 'ferry-dev.yml', dispatchType: 'ferry-dev' }),
   review: Object.freeze({ workflow: 'ferry-review.yml', dispatchType: 'ferry-review' }),
   iterate: Object.freeze({ workflow: 'ferry-iterate.yml', dispatchType: 'ferry-iterate' }),
+  merge: Object.freeze({ workflow: 'ferry-merge.yml', dispatchType: 'ferry-merge' }),
 }) as RoutingTable;
 
 export function phaseToWorkflow(phase: keyof RoutingTable): WorkflowFile {

--- a/src/lib/envelope/types.ts
+++ b/src/lib/envelope/types.ts
@@ -1,4 +1,4 @@
-export type EventPhase = 'refine' | 'dev' | 'review' | 'iterate' | 'reconcile';
+export type EventPhase = 'refine' | 'dev' | 'review' | 'iterate' | 'reconcile' | 'merge';
 
 export type EventSource = 'jira-column' | 'jira-label' | 'jira-mention' | 'reconciler';
 

--- a/src/schemas/event.v1.schema.json
+++ b/src/schemas/event.v1.schema.json
@@ -5,9 +5,14 @@
   "required": ["version", "event_id", "ticket_key", "phase", "source", "ts"],
   "properties": {
     "version": { "const": "v1" },
-    "event_id": { "type": "string", "minLength": 4, "maxLength": 100, "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$" },
+    "event_id": {
+      "type": "string",
+      "minLength": 4,
+      "maxLength": 100,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]*$"
+    },
     "ticket_key": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]+-\\d+$" },
-    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile"] },
+    "phase": { "enum": ["refine", "dev", "review", "iterate", "reconcile", "merge"] },
     "source": {
       "enum": ["jira-column", "jira-label", "jira-mention", "reconciler"]
     },

--- a/src/schemas/schemas.test.ts
+++ b/src/schemas/schemas.test.ts
@@ -109,9 +109,9 @@ describe('event.v1.schema.json', () => {
     expect(validateEvent).toBeDefined();
   });
 
-  it('phase enum contains all 5 values', () => {
+  it('phase enum contains all 6 values', () => {
     const phases = eventSchema.properties.phase.enum as string[];
-    for (const v of ['refine', 'dev', 'review', 'iterate', 'reconcile']) {
+    for (const v of ['refine', 'dev', 'review', 'iterate', 'reconcile', 'merge']) {
       expect(phases, `phase enum must contain "${v}"`).toContain(v);
     }
   });


### PR DESCRIPTION
Fixes #374

## Changes

- `src/lib/envelope/types.ts` — add `'merge'` to `EventPhase`
- `src/schemas/event.v1.schema.json` — add `'merge'` to phase enum
- `src/lib/dispatch/routing.ts` — add `merge` route (`ferry-merge.yml` / `ferry-merge`)
- `src/cli/init/templates.ts` — fix reviewer `run-agent` permissions: `contents: read` → `contents: write`; add `ferry-merge.yml` template
- `src/agents/reviewer/review-action.ts` — best-effort `runner.dispatch('merge', …)` on approve (try/catch + warn)
- Tests updated: count (4→5), regression test for `contents: write`, merge routing
- `examples/consumer-setup/workflows/ferry-merge.yml` — consumer stub

Generated with [Claude Code](https://claude.ai/code)