### PR TITLE
feat(update): introduce ferry.local.yml consumer-side overlay

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -4,11 +4,12 @@ This document is the canonical reference for all consumer-configurable parameter
 
 ## Quick Summary
 
-Ferry is configured through three layers, applied in order (later layers override earlier ones):
+Ferry is configured through four layers, applied in order (later layers override earlier ones):
 
-1. **`ferry.config.json`** in your repository root — model selection, limits, MCP label mapping
-2. **GitHub repository variables** (`vars.*`) — per-repo overrides without touching the config file
-3. **GitHub secrets** (`secrets.*`) — credentials and transition IDs
+1. **`ferry.config.json`** (or `ferry.config.yaml`) in your repository root — model selection, limits, MCP label mapping
+2. **`ferry.local.yml`** in your repository root — consumer-side workflow overrides that survive `ferry-update` (see [Local overrides](#local-overrides-ferryLocalYml))
+3. **GitHub repository variables** (`vars.*`) — per-repo overrides without touching the config file
+4. **GitHub secrets** (`secrets.*`) — credentials and transition IDs
 
 ---
 
@@ -161,6 +162,59 @@ steps:
       # ... required inputs ...
       pre_agent_command: npm ci --prefer-offline
 ```
+
+---
+
+## Local overrides (`ferry.local.yml`) {#local-overrides-ferryLocalYml}
+
+`ferry.local.yml` is an optional file at your repository root that declares consumer-side divergences from Ferry's upstream workflow templates. Its purpose is to survive `ferry-update`: instead of editing the generated `ferry-*.yml` files directly (which get clobbered on the next update), you declare the override once in `ferry.local.yml` and `ferry-update` re-applies it every time it regenerates workflows.
+
+### How it works
+
+When `ferry-update` runs, it reads `ferry.local.yml` (if present) and applies the declared overrides to the template content **before** comparing with the on-disk files. This means:
+
+- The `--dry-run` diff shows only genuine upstream changes — not the overlay being re-applied.
+- The written files are deterministic from `(ferry version, ferry.local.yml)`.
+- The file lives in version control, is visible in PRs, and can be owned by `CODEOWNERS`.
+
+### Schema
+
+```yaml
+# ferry.local.yml  (place at your repo root, next to ferry.config.yaml)
+version: 1 # required; must be 1
+
+review:
+  # Disable the CI pre-gate on the claude-code path.
+  # Use this when the review event can fire before CI has reported or before
+  # a PR exists, and you want the Reviewer to run unconditionally.
+  ciGate: disabled
+
+global:
+  # Pin the runner across all Ferry workflow files.
+  # Replaces the ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }} expression.
+  # Accepts a plain string or an array of labels.
+  runner: ubuntu-latest
+  # runner: ["self-hosted", "X64"]
+```
+
+All top-level keys are optional.
+
+### Supported overrides
+
+#### `review.ciGate: disabled`
+
+Removes the `ci-gate` job from `ferry-review.yml` and rewrites the downstream `needs:`/`if:`/`outcome:` expressions so the Reviewer agent (`run-agent-claude-code`) runs unconditionally on the `claude-code` execution path.
+
+**When to use:** The built-in `ci-gate` treats "no PR found" or "CI checks still pending" as `proceed=false`, blocking the review silently. In Jira-driven flows where the `ferry-review` dispatch can fire before the developer's PR has been opened or before the consumer's CI has a result, this produces missed reviews with no audit signal. Setting `ciGate: disabled` removes the gate entirely.
+
+#### `global.runner`
+
+Pins the GitHub Actions runner label across all four Ferry workflow files (`ferry-refine.yml`, `ferry-dev.yml`, `ferry-review.yml`, `ferry-iterate.yml`).
+
+- `runner: ubuntu-latest` — plain string runner label
+- `runner: ["self-hosted", "X64"]` — YAML sequence of labels (rendered as `${{ fromJSON('["self-hosted","X64"]') }}`)
+
+> **Note:** If you only need to change the runner at runtime (not bake it into the file), use the `FERRY_RUNNER` repository variable instead — see the [Repository Variables](#repository-variables) section.
 
 ---
 

--- a/src/cli/update/detect.ts
+++ b/src/cli/update/detect.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { workflowTemplates } from '../init/templates.js';
+import { applyLocalOverrides, type LocalOverrides } from './local-overrides.js';
 import type { WorkflowChange } from './types.js';
 
 const FERRY_WORKFLOW_PATTERN = /uses:\s+big-emotion\/ferry\/.+@(v[\w.-]+)/;
@@ -33,10 +34,19 @@ export function detectInstalledVersion(repoRoot: string): string | undefined {
 /**
  * Compute what changes applying `toVersion` templates would make.
  * Returns one entry per workflow template file.
+ *
+ * When `overrides` is provided the templates are post-processed with
+ * `applyLocalOverrides` before comparison, so the diff reflects only
+ * upstream changes (not the overlay itself).
  */
-export function computeWorkflowChanges(repoRoot: string, toVersion: string): WorkflowChange[] {
+export function computeWorkflowChanges(
+  repoRoot: string,
+  toVersion: string,
+  overrides?: LocalOverrides,
+): WorkflowChange[] {
   const workflowDir = join(repoRoot, '.github', 'workflows');
-  const templates = workflowTemplates(toVersion);
+  const base = workflowTemplates(toVersion);
+  const templates = overrides ? applyLocalOverrides(base, overrides) : base;
   const changes: WorkflowChange[] = [];
 
   for (const tmpl of templates) {

--- a/src/cli/update/index.ts
+++ b/src/cli/update/index.ts
@@ -19,6 +19,7 @@ import { getRelevantMigrations } from './migrations.js';
 import { runCredentialGate } from './credential-gate-run.js';
 import { extractJiraConfigFromSetupFile } from './extract-jira-config.js';
 import { resolveForgeFromArgv, type ForgeKind } from '../lib/forge.js';
+import { loadLocalOverrides, applyLocalOverrides, type LocalOverrides } from './local-overrides.js';
 import { rewriteGitLabVersion } from './gitlab/rewriter.js';
 import type { UpdateConfig } from './types.js';
 
@@ -312,9 +313,31 @@ Exit code: 0 on success, 1 on error.
     process.exit(0);
   }
 
+  // ── Load consumer-side overlay (ferry.local.yml) ──────────────────────────
+  let localOverrides: LocalOverrides | null = null;
+  try {
+    localOverrides = loadLocalOverrides(config.repoRoot);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    printError(msg);
+    closePrompt();
+    process.exit(1);
+  }
+  if (localOverrides) {
+    const keys: string[] = [];
+    if (localOverrides.review?.ciGate) keys.push(`review.ciGate=${localOverrides.review.ciGate}`);
+    if (localOverrides.global?.runner !== undefined) {
+      const r = localOverrides.global.runner;
+      keys.push(`global.runner=${Array.isArray(r) ? JSON.stringify(r) : r}`);
+    }
+    if (keys.length > 0) {
+      print(`  Local overrides (ferry.local.yml): ${keys.join(', ')}`);
+    }
+  }
+
   // ── Compute changes ───────────────────────────────────────────────────────
   printStep(2, 3, 'Computing changes');
-  const changes = computeWorkflowChanges(config.repoRoot, toVersion);
+  const changes = computeWorkflowChanges(config.repoRoot, toVersion, localOverrides ?? undefined);
   const toUpdate = changes.filter((c) => c.status === 'updated');
   const toAdd = changes.filter((c) => c.status === 'added');
   const unchanged = changes.filter((c) => c.status === 'unchanged');
@@ -408,7 +431,10 @@ Exit code: 0 on success, 1 on error.
   // ── Apply ─────────────────────────────────────────────────────────────────
   printStep(3, 3, 'Applying changes');
   const workflowDir = join(config.repoRoot, '.github', 'workflows');
-  const templates = workflowTemplates(toVersion);
+  const baseTemplates = workflowTemplates(toVersion);
+  const templates = localOverrides
+    ? applyLocalOverrides(baseTemplates, localOverrides)
+    : baseTemplates;
 
   let errors = 0;
   for (const tmpl of templates) {

--- a/src/cli/update/local-overrides.test.ts
+++ b/src/cli/update/local-overrides.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  validateLocalOverrides,
+  loadLocalOverrides,
+  applyLocalOverrides,
+} from './local-overrides.js';
+import { workflowTemplates } from '../init/templates.js';
+
+function makeTempDir(): string {
+  return mkdtempSync(join(tmpdir(), 'ferry-local-overrides-test-'));
+}
+
+function cleanup(dir: string): void {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+// ── validateLocalOverrides ────────────────────────────────────────────────────
+
+describe('validateLocalOverrides', () => {
+  it('accepts null/undefined as empty overrides', () => {
+    expect(validateLocalOverrides(null)).toEqual({ valid: true, value: {} });
+    expect(validateLocalOverrides(undefined)).toEqual({ valid: true, value: {} });
+  });
+
+  it('accepts an empty object', () => {
+    expect(validateLocalOverrides({})).toEqual({ valid: true, value: {} });
+  });
+
+  it('accepts version: 1', () => {
+    const r = validateLocalOverrides({ version: 1 });
+    expect(r.valid).toBe(true);
+    if (r.valid) expect(r.value.version).toBe(1);
+  });
+
+  it('rejects unknown version', () => {
+    const r = validateLocalOverrides({ version: 2 });
+    expect(r.valid).toBe(false);
+    if (!r.valid) expect(r.errors[0]).toMatch(/version/);
+  });
+
+  it('accepts review.ciGate: disabled', () => {
+    const r = validateLocalOverrides({ review: { ciGate: 'disabled' } });
+    expect(r.valid).toBe(true);
+    if (r.valid) expect(r.value.review?.ciGate).toBe('disabled');
+  });
+
+  it('rejects unknown review.ciGate value', () => {
+    const r = validateLocalOverrides({ review: { ciGate: 'partial' } });
+    expect(r.valid).toBe(false);
+    if (!r.valid) expect(r.errors[0]).toMatch(/review\.ciGate/);
+  });
+
+  it('accepts global.runner as string', () => {
+    const r = validateLocalOverrides({ global: { runner: 'ubuntu-latest' } });
+    expect(r.valid).toBe(true);
+    if (r.valid) expect(r.value.global?.runner).toBe('ubuntu-latest');
+  });
+
+  it('accepts global.runner as string array', () => {
+    const r = validateLocalOverrides({ global: { runner: ['self-hosted', 'X64'] } });
+    expect(r.valid).toBe(true);
+    if (r.valid) expect(r.value.global?.runner).toEqual(['self-hosted', 'X64']);
+  });
+
+  it('rejects empty string runner', () => {
+    const r = validateLocalOverrides({ global: { runner: '' } });
+    expect(r.valid).toBe(false);
+    if (!r.valid) expect(r.errors[0]).toMatch(/global\.runner/);
+  });
+
+  it('rejects empty array runner', () => {
+    const r = validateLocalOverrides({ global: { runner: [] } });
+    expect(r.valid).toBe(false);
+    if (!r.valid) expect(r.errors[0]).toMatch(/global\.runner/);
+  });
+
+  it('rejects runner as a number', () => {
+    const r = validateLocalOverrides({ global: { runner: 42 } });
+    expect(r.valid).toBe(false);
+  });
+
+  it('rejects array with non-string element', () => {
+    const r = validateLocalOverrides({ global: { runner: ['self-hosted', 42] } });
+    expect(r.valid).toBe(false);
+  });
+
+  it('collects multiple errors', () => {
+    const r = validateLocalOverrides({
+      version: 99,
+      review: { ciGate: 'partial' },
+    });
+    expect(r.valid).toBe(false);
+    if (!r.valid) expect(r.errors.length).toBeGreaterThan(1);
+  });
+});
+
+// ── loadLocalOverrides ────────────────────────────────────────────────────────
+
+describe('loadLocalOverrides', () => {
+  it('returns null when file does not exist', () => {
+    const dir = makeTempDir();
+    expect(loadLocalOverrides(dir)).toBeNull();
+    cleanup(dir);
+  });
+
+  it('parses a valid ferry.local.yml', () => {
+    const dir = makeTempDir();
+    writeFileSync(
+      join(dir, 'ferry.local.yml'),
+      `version: 1\nreview:\n  ciGate: disabled\n`,
+      'utf8',
+    );
+    const result = loadLocalOverrides(dir);
+    expect(result?.review?.ciGate).toBe('disabled');
+    cleanup(dir);
+  });
+
+  it('parses global.runner as array', () => {
+    const dir = makeTempDir();
+    writeFileSync(
+      join(dir, 'ferry.local.yml'),
+      `version: 1\nglobal:\n  runner:\n    - self-hosted\n    - X64\n`,
+      'utf8',
+    );
+    const result = loadLocalOverrides(dir);
+    expect(result?.global?.runner).toEqual(['self-hosted', 'X64']);
+    cleanup(dir);
+  });
+
+  it('throws on malformed YAML', () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, 'ferry.local.yml'), '{{invalid: yaml: [', 'utf8');
+    expect(() => loadLocalOverrides(dir)).toThrow(/ferry\.local\.yml/);
+    cleanup(dir);
+  });
+
+  it('throws on invalid schema', () => {
+    const dir = makeTempDir();
+    writeFileSync(join(dir, 'ferry.local.yml'), 'review:\n  ciGate: unknown\n', 'utf8');
+    expect(() => loadLocalOverrides(dir)).toThrow(/ferry\.local\.yml/);
+    cleanup(dir);
+  });
+});
+
+// ── applyLocalOverrides ───────────────────────────────────────────────────────
+
+describe('applyLocalOverrides — review.ciGate: disabled', () => {
+  const templates = workflowTemplates('vTEST');
+  const reviewTmpl = templates.find((t) => t.filename === 'ferry-review.yml')!;
+
+  it('removes the ci-gate job from ferry-review.yml', () => {
+    const result = applyLocalOverrides(templates, { review: { ciGate: 'disabled' } });
+    const review = result.find((t) => t.filename === 'ferry-review.yml')!;
+    expect(review.content).not.toContain('ci-gate:');
+    expect(review.content).not.toContain('ferry-ci-gate@');
+  });
+
+  it('removes ci-gate from run-agent-claude-code needs', () => {
+    const result = applyLocalOverrides(templates, { review: { ciGate: 'disabled' } });
+    const review = result.find((t) => t.filename === 'ferry-review.yml')!;
+    expect(review.content).not.toContain('needs: [route, ci-gate]');
+    expect(review.content).toContain('    needs: [route]\n');
+  });
+
+  it('removes ci-gate proceed guard from run-agent-claude-code if', () => {
+    const result = applyLocalOverrides(templates, { review: { ciGate: 'disabled' } });
+    const review = result.find((t) => t.filename === 'ferry-review.yml')!;
+    expect(review.content).not.toContain("ci-gate.outputs.proceed == 'true'");
+    expect(review.content).toContain("    if: needs.route.outputs.path == 'claude-code'\n");
+  });
+
+  it('removes ci-gate from emit-audit needs', () => {
+    const result = applyLocalOverrides(templates, { review: { ciGate: 'disabled' } });
+    const review = result.find((t) => t.filename === 'ferry-review.yml')!;
+    expect(review.content).not.toContain('needs: [run-agent, run-agent-claude-code, ci-gate]');
+    expect(review.content).toContain('    needs: [run-agent, run-agent-claude-code]\n');
+  });
+
+  it('simplifies emit-audit if expression', () => {
+    const result = applyLocalOverrides(templates, { review: { ciGate: 'disabled' } });
+    const review = result.find((t) => t.filename === 'ferry-review.yml')!;
+    expect(review.content).not.toContain("needs.ci-gate.result != 'skipped'");
+    expect(review.content).toContain(
+      "    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')\n",
+    );
+  });
+
+  it('removes ci-gate references from emit-audit outcome', () => {
+    const result = applyLocalOverrides(templates, { review: { ciGate: 'disabled' } });
+    const review = result.find((t) => t.filename === 'ferry-review.yml')!;
+    expect(review.content).not.toContain('ci-gate.outputs.outcome');
+    expect(review.content).toContain(
+      "          outcome: ${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || needs.run-agent-claude-code.result }}\n",
+    );
+  });
+
+  it('does not modify non-review templates', () => {
+    const result = applyLocalOverrides(templates, { review: { ciGate: 'disabled' } });
+    for (const tmpl of result) {
+      if (tmpl.filename === 'ferry-review.yml') continue;
+      const original = templates.find((t) => t.filename === tmpl.filename)!;
+      expect(tmpl.content).toBe(original.content);
+    }
+  });
+
+  it('produces valid YAML structure (jobs: block is intact)', () => {
+    const result = applyLocalOverrides(templates, { review: { ciGate: 'disabled' } });
+    const review = result.find((t) => t.filename === 'ferry-review.yml')!;
+    // Essential jobs should still be present
+    expect(review.content).toContain('\n  gate-envelope:\n');
+    expect(review.content).toContain('\n  route:\n');
+    expect(review.content).toContain('\n  run-agent:\n');
+    expect(review.content).toContain('\n  run-agent-claude-code:\n');
+    expect(review.content).toContain('\n  emit-audit:\n');
+  });
+
+  it('is idempotent — applying twice gives the same result', () => {
+    const once = applyLocalOverrides(templates, { review: { ciGate: 'disabled' } });
+    const twice = applyLocalOverrides(once, { review: { ciGate: 'disabled' } });
+    const review1 = once.find((t) => t.filename === 'ferry-review.yml')!;
+    const review2 = twice.find((t) => t.filename === 'ferry-review.yml')!;
+    expect(review2.content).toBe(review1.content);
+  });
+
+  it('original template still contains ci-gate (sanity check)', () => {
+    expect(reviewTmpl.content).toContain('\n  ci-gate:\n');
+    expect(reviewTmpl.content).toContain('    needs: [route, ci-gate]\n');
+  });
+});
+
+describe('applyLocalOverrides — global.runner', () => {
+  const templates = workflowTemplates('vTEST');
+
+  it('replaces runner expression with a plain string in all templates', () => {
+    const result = applyLocalOverrides(templates, { global: { runner: 'my-runner' } });
+    for (const tmpl of result) {
+      expect(tmpl.content).not.toContain(
+        `\${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}`,
+      );
+      expect(tmpl.content).toContain('    runs-on: my-runner\n');
+    }
+  });
+
+  it('replaces runner expression with fromJSON array syntax', () => {
+    const result = applyLocalOverrides(templates, {
+      global: { runner: ['self-hosted', 'X64'] },
+    });
+    for (const tmpl of result) {
+      expect(tmpl.content).not.toContain(
+        `\${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}`,
+      );
+      expect(tmpl.content).toContain(`    runs-on: \${{ fromJSON('["self-hosted","X64"]') }}\n`);
+    }
+  });
+
+  it('applies runner to all four workflow templates', () => {
+    const result = applyLocalOverrides(templates, { global: { runner: 'fast-runner' } });
+    expect(result).toHaveLength(templates.length);
+    for (const tmpl of result) {
+      const original = templates.find((t) => t.filename === tmpl.filename)!;
+      expect(tmpl.content).not.toBe(original.content);
+      expect(tmpl.content).toContain('    runs-on: fast-runner\n');
+    }
+  });
+});
+
+describe('applyLocalOverrides — combined overrides', () => {
+  const templates = workflowTemplates('vTEST');
+
+  it('applies both ciGate:disabled and global.runner together', () => {
+    const result = applyLocalOverrides(templates, {
+      review: { ciGate: 'disabled' },
+      global: { runner: 'my-runner' },
+    });
+    const review = result.find((t) => t.filename === 'ferry-review.yml')!;
+    // ci-gate removed
+    expect(review.content).not.toContain('ci-gate:');
+    // runner replaced
+    expect(review.content).not.toContain('fromJSON(vars.FERRY_RUNNER');
+    expect(review.content).toContain('    runs-on: my-runner\n');
+  });
+});

--- a/src/cli/update/local-overrides.ts
+++ b/src/cli/update/local-overrides.ts
@@ -1,0 +1,216 @@
+import { createRequire } from 'node:module';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { WorkflowEntry } from '../init/types.js';
+
+const _require = createRequire(import.meta.url);
+
+export interface LocalOverridesReview {
+  /**
+   * When set to `"disabled"`, the `ci-gate` pre-gate job is omitted from
+   * `ferry-review.yml` and all references to its outputs are removed. This
+   * makes the Reviewer agent run unconditionally on the claude-code path,
+   * without waiting for CI to go green or a PR to exist — useful when the
+   * review event can fire before CI has reported.
+   */
+  ciGate?: 'disabled';
+}
+
+export interface LocalOverridesGlobal {
+  /**
+   * Pin the GitHub Actions runner across all Ferry workflow files.
+   * Accepts a plain string (e.g. `ubuntu-latest`) or an array of runner
+   * labels (e.g. `["self-hosted", "X64"]`).
+   *
+   * When set, this replaces the `${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}`
+   * expression so the runner is explicit in the generated file rather than
+   * driven by a repo variable.
+   */
+  runner?: string | string[];
+}
+
+export interface LocalOverrides {
+  version?: number;
+  review?: LocalOverridesReview;
+  global?: LocalOverridesGlobal;
+}
+
+const LOCAL_OVERRIDES_FILE = 'ferry.local.yml';
+
+export function loadLocalOverrides(repoRoot: string): LocalOverrides | null {
+  const filePath = join(repoRoot, LOCAL_OVERRIDES_FILE);
+  if (!existsSync(filePath)) return null;
+
+  const raw = readFileSync(filePath, 'utf8');
+
+  let parsed: unknown;
+  try {
+    const yaml = _require('yaml') as { parse: (s: string) => unknown };
+    parsed = yaml.parse(raw);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`${LOCAL_OVERRIDES_FILE}: failed to parse YAML — ${msg}`);
+  }
+
+  const result = validateLocalOverrides(parsed);
+  if (!result.valid) {
+    throw new Error(`${LOCAL_OVERRIDES_FILE}: ${result.errors.join('; ')}`);
+  }
+
+  return result.value;
+}
+
+type ValidationResult = { valid: true; value: LocalOverrides } | { valid: false; errors: string[] };
+
+export function validateLocalOverrides(raw: unknown): ValidationResult {
+  if (raw === null || raw === undefined) {
+    return { valid: true, value: {} };
+  }
+  if (typeof raw !== 'object' || Array.isArray(raw)) {
+    return { valid: false, errors: ['must be a YAML mapping'] };
+  }
+
+  const obj = raw as Record<string, unknown>;
+  const errors: string[] = [];
+
+  if (obj.version !== undefined && obj.version !== 1) {
+    errors.push(`version: must be 1 (got ${String(obj.version)})`);
+  }
+
+  if (obj.review !== undefined) {
+    if (!obj.review || typeof obj.review !== 'object' || Array.isArray(obj.review)) {
+      errors.push('review: must be a mapping');
+    } else {
+      const review = obj.review as Record<string, unknown>;
+      if (review.ciGate !== undefined && review.ciGate !== 'disabled') {
+        errors.push(`review.ciGate: must be "disabled" (got ${String(review.ciGate)})`);
+      }
+    }
+  }
+
+  if (obj.global !== undefined) {
+    if (!obj.global || typeof obj.global !== 'object' || Array.isArray(obj.global)) {
+      errors.push('global: must be a mapping');
+    } else {
+      const global = obj.global as Record<string, unknown>;
+      if (global.runner !== undefined) {
+        if (typeof global.runner === 'string') {
+          if (global.runner.trim() === '') {
+            errors.push('global.runner: must be a non-empty string');
+          }
+        } else if (Array.isArray(global.runner)) {
+          if (global.runner.length === 0) {
+            errors.push('global.runner: array must not be empty');
+          } else if (global.runner.some((r) => typeof r !== 'string' || r.trim() === '')) {
+            errors.push('global.runner: array elements must be non-empty strings');
+          }
+        } else {
+          errors.push('global.runner: must be a string or array of strings');
+        }
+      }
+    }
+  }
+
+  if (errors.length > 0) return { valid: false, errors };
+
+  const value: LocalOverrides = {};
+
+  if (typeof obj.version === 'number') value.version = obj.version;
+
+  if (obj.review && typeof obj.review === 'object' && !Array.isArray(obj.review)) {
+    const review = obj.review as Record<string, unknown>;
+    const r: LocalOverridesReview = {};
+    if (review.ciGate === 'disabled') r.ciGate = 'disabled';
+    if (Object.keys(r).length > 0) value.review = r;
+  }
+
+  if (obj.global && typeof obj.global === 'object' && !Array.isArray(obj.global)) {
+    const global = obj.global as Record<string, unknown>;
+    const g: LocalOverridesGlobal = {};
+    if (global.runner !== undefined) {
+      g.runner = global.runner as string | string[];
+    }
+    if (Object.keys(g).length > 0) value.global = g;
+  }
+
+  return { valid: true, value };
+}
+
+export function applyLocalOverrides(
+  templates: WorkflowEntry[],
+  overrides: LocalOverrides,
+): WorkflowEntry[] {
+  return templates.map((tmpl) => {
+    let content = tmpl.content;
+
+    if (overrides.global?.runner !== undefined) {
+      content = applyGlobalRunner(content, overrides.global.runner);
+    }
+
+    if (tmpl.filename === 'ferry-review.yml' && overrides.review?.ciGate === 'disabled') {
+      content = applyReviewCiGateDisabled(content);
+    }
+
+    return { filename: tmpl.filename, content };
+  });
+}
+
+// The expression used in every template for the runner.
+const RUNNER_EXPR = `\${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}`;
+
+function formatRunner(runner: string | string[]): string {
+  if (typeof runner === 'string') return runner;
+  return `\${{ fromJSON('${JSON.stringify(runner)}') }}`;
+}
+
+function applyGlobalRunner(content: string, runner: string | string[]): string {
+  return content.replaceAll(
+    `    runs-on: ${RUNNER_EXPR}\n`,
+    `    runs-on: ${formatRunner(runner)}\n`,
+  );
+}
+
+/**
+ * Remove the `ci-gate` job from `ferry-review.yml` and rewrite all
+ * downstream `needs:`/`if:`/`outcome:` expressions that referenced it.
+ *
+ * The regex targets the stable structural markers in the template; the
+ * `ferry-ci-gate@<version>` reference inside the job body is version-variable
+ * but is entirely removed as part of the block, so no version-aware logic is
+ * needed here.
+ */
+function applyReviewCiGateDisabled(content: string): string {
+  // 1. Remove the ci-gate job block.
+  //    Match from the blank-line separator before "  ci-gate:" up to (but
+  //    not including) the blank-line separator before "  run-agent-claude-code:".
+  let result = content.replace(/\n\n  ci-gate:\n[\s\S]*?(?=\n\n  run-agent-claude-code:)/, '');
+
+  // 2. run-agent-claude-code: remove ci-gate from needs
+  result = result.replace('    needs: [route, ci-gate]\n', '    needs: [route]\n');
+
+  // 3. run-agent-claude-code: drop the ci-gate proceed guard from if
+  result = result.replace(
+    "    if: needs.route.outputs.path == 'claude-code' && needs.ci-gate.outputs.proceed == 'true'\n",
+    "    if: needs.route.outputs.path == 'claude-code'\n",
+  );
+
+  // 4. emit-audit: remove ci-gate from needs
+  result = result.replace(
+    '    needs: [run-agent, run-agent-claude-code, ci-gate]\n',
+    '    needs: [run-agent, run-agent-claude-code]\n',
+  );
+
+  // 5. emit-audit: simplify the if expression
+  result = result.replace(
+    "    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped' || (needs.ci-gate.result != 'skipped' && needs.ci-gate.outputs.outcome == 'ci-red'))\n",
+    "    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')\n",
+  );
+
+  // 6. emit-audit outcome: remove ci-gate references from the outcome expression
+  result = result.replace(
+    "          outcome: ${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || (needs.ci-gate.outputs.outcome == 'ci-red' && 'ci-red') || needs.run-agent-claude-code.result }}\n",
+    "          outcome: ${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || needs.run-agent-claude-code.result }}\n",
+  );
+
+  return result;
+}


### PR DESCRIPTION
Implements #371.

Adds a `ferry.local.yml` file that consumers place at their repo root to declare workflow overrides that survive `ferry-update`.

**MVP overrides:**
- `review.ciGate: disabled` — removes the `ci-gate` pre-gate job from `ferry-review.yml` and rewrites all downstream expressions
- `global.runner` — pins the runner label across all four workflow files

Generated with [Claude Code](https://claude.ai/code)