### PR TITLE
feat(reviewer): MCP Phase 2 — migrate Reviewer from tool-loop to agent-loop

### DIFF
--- a/.ferry/agent.js
+++ b/.ferry/agent.js
@@ -6688,7 +6688,9 @@ function prepareReviewer(input) {
     reviewRubric,
     capabilities,
     idempotencyMarker,
-    repoRoot
+    repoRoot,
+    mcpPool,
+    configLabels
   } = input;
   const buildSystem2 = input._buildSystem ?? buildSystem;
   const loadOptionalPrompt2 = input._loadOptionalPrompt ?? loadOptionalPrompt;
@@ -6718,14 +6720,15 @@ function prepareReviewer(input) {
     buildFileList(files),
     "",
     "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
-    "When you have enough information, call finish_review."
+    "When you have enough information, call done."
   ].filter((l) => l !== null).join("\n");
   const baseSystem = buildSystem2("review", repoRoot, {
     extraParts: [loadOptionalPrompt2("review-comment", repoRoot)],
     separator: "\n\n---\n\n"
   });
   const system = applyRubricToPrompt(baseSystem, reviewRubric);
-  const mcpServers = [];
+  const hasLabelsConfig = configLabels !== void 0;
+  const mcpServers = mcpPool !== void 0 ? filterMcpServers(mcpPool, capabilities, hasLabelsConfig) : [];
   return {
     system,
     initialPrompt,
@@ -9984,472 +9987,6 @@ async function main2(envelope, logger) {
   process.exit(0);
 }
 
-// src/lib/llm/tool-loop/index.ts
-import Anthropic4 from "@anthropic-ai/sdk";
-
-// src/lib/llm/tool-loop/anthropic.ts
-function createAnthropicToolCallLoop(opts) {
-  return {
-    async run(runOpts) {
-      const {
-        system,
-        initialPrompt,
-        tools,
-        handlers,
-        finishTool,
-        extractDone,
-        maxIterations,
-        maxTokens
-      } = runOpts;
-      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
-      const anthropicTools = tools.map(
-        (t, i) => i === tools.length - 1 ? { ...t, cache_control: { type: "ephemeral" } } : t
-      );
-      const messages = [
-        {
-          role: "user",
-          content: [{ type: "text", text: initialPrompt, cache_control: { type: "ephemeral" } }]
-        }
-      ];
-      let inputTokens = 0;
-      let outputTokens = 0;
-      let done = null;
-      const toolCounts = {};
-      const toolCallRecords = [];
-      function trackTool(name, outputSize) {
-        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
-        toolCallRecords.push({ name, outputSize });
-      }
-      const loopStart = Date.now();
-      for (let iter = 0; iter < maxIterations; iter++) {
-        const iterStart = Date.now();
-        const response = await opts.client.messages.create({
-          model: opts.model,
-          max_tokens: maxTokens,
-          system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
-          tools: anthropicTools,
-          messages,
-          ...opts.thinking !== void 0 ? { thinking: opts.thinking } : {}
-        });
-        inputTokens += response.usage.input_tokens;
-        outputTokens += response.usage.output_tokens;
-        messages.push({ role: "assistant", content: response.content });
-        const toolCount = response.content.filter((b) => b.type === "tool_use").length;
-        logger.info("turn", {
-          iter: iter + 1,
-          stop: response.stop_reason,
-          tools: toolCount,
-          in: response.usage.input_tokens,
-          out: response.usage.output_tokens
-        });
-        emitDebug(
-          {
-            type: "turn",
-            iter: iter + 1,
-            depth: 0,
-            stop_reason: response.stop_reason ?? "unknown",
-            tools: toolCount,
-            mcp_tools: 0,
-            in: response.usage.input_tokens,
-            cache_w: 0,
-            cache_r: 0,
-            out: response.usage.output_tokens,
-            elapsed_ms: Date.now() - iterStart
-          },
-          logger
-        );
-        if (response.stop_reason !== "tool_use") {
-          throw new FerryError("state-invariant", {
-            reason: "tool-loop-stopped-without-finish",
-            stop_reason: response.stop_reason
-          });
-        }
-        const toolResults = [];
-        for (const block of response.content) {
-          if (block.type !== "tool_use") continue;
-          const input = block.input;
-          if (block.name === finishTool) {
-            done = extractDone(input);
-            toolResults.push({ type: "tool_result", tool_use_id: block.id, content: "ok" });
-            continue;
-          }
-          const handler2 = handlers[block.name];
-          if (handler2) {
-            const result = await handler2(input);
-            trackTool(block.name, result.length);
-            toolResults.push({ type: "tool_result", tool_use_id: block.id, content: result });
-          } else {
-            toolResults.push({
-              type: "tool_result",
-              tool_use_id: block.id,
-              content: `unknown tool: ${block.name}`,
-              is_error: true
-            });
-          }
-        }
-        for (let i = messages.length - 1; i >= 0; i--) {
-          const msg = messages[i];
-          if (msg.role === "user" && Array.isArray(msg.content)) {
-            const content = msg.content;
-            if (content.some((b) => b.type === "tool_result")) {
-              const entry = { ...content[content.length - 1] };
-              delete entry.cache_control;
-              content[content.length - 1] = entry;
-              break;
-            }
-          }
-        }
-        if (toolResults.length > 0) {
-          const last = toolResults[toolResults.length - 1];
-          toolResults[toolResults.length - 1] = { ...last, cache_control: { type: "ephemeral" } };
-        }
-        messages.push({ role: "user", content: toolResults });
-        if (done !== null) {
-          emitDebug(
-            {
-              type: "result",
-              subtype: "success",
-              iterations: iter + 1,
-              total_in: inputTokens,
-              total_out: outputTokens,
-              elapsed_ms: Date.now() - loopStart
-            },
-            logger
-          );
-          return {
-            done,
-            usage: { inputTokens, outputTokens },
-            iterations: iter + 1,
-            toolCounts,
-            toolCallRecords
-          };
-        }
-      }
-      throw new FerryError("state-invariant", {
-        reason: "tool-loop-iteration-cap-exceeded",
-        cap: maxIterations
-      });
-    }
-  };
-}
-
-// src/lib/llm/tool-loop/openai.ts
-import OpenAI3 from "openai";
-function createOpenAIToolCallLoop(opts) {
-  const client = new OpenAI3({ apiKey: opts.apiKey });
-  return {
-    async run(runOpts) {
-      const {
-        system,
-        initialPrompt,
-        tools,
-        handlers,
-        finishTool,
-        extractDone,
-        maxIterations,
-        maxTokens
-      } = runOpts;
-      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
-      const openaiTools = tools.map((t) => ({
-        type: "function",
-        function: {
-          name: t.name,
-          description: t.description,
-          parameters: t.input_schema
-        }
-      }));
-      const messages = [
-        { role: "system", content: system },
-        { role: "user", content: initialPrompt }
-      ];
-      let inputTokens = 0;
-      let outputTokens = 0;
-      let done = null;
-      const toolCounts = {};
-      const toolCallRecords = [];
-      function trackTool(name, outputSize) {
-        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
-        toolCallRecords.push({ name, outputSize });
-      }
-      const loopStart = Date.now();
-      for (let iter = 0; iter < maxIterations; iter++) {
-        const iterStart = Date.now();
-        const response = await client.chat.completions.create({
-          model: opts.model,
-          max_tokens: maxTokens,
-          messages,
-          tools: openaiTools,
-          tool_choice: "required"
-        });
-        const choice = response.choices[0];
-        if (!choice) {
-          throw new FerryError("state-invariant", { reason: "tool-loop-no-response" });
-        }
-        inputTokens += response.usage?.prompt_tokens ?? 0;
-        outputTokens += response.usage?.completion_tokens ?? 0;
-        const assistantMsg = {
-          role: "assistant",
-          content: choice.message.content ?? null,
-          tool_calls: choice.message.tool_calls
-        };
-        messages.push(assistantMsg);
-        const toolCalls = choice.message.tool_calls ?? [];
-        logger.info("turn", {
-          iter: iter + 1,
-          stop: choice.finish_reason,
-          tools: toolCalls.length,
-          in: response.usage?.prompt_tokens ?? 0,
-          out: response.usage?.completion_tokens ?? 0
-        });
-        emitDebug(
-          {
-            type: "turn",
-            iter: iter + 1,
-            depth: 0,
-            stop_reason: choice.finish_reason ?? "unknown",
-            tools: toolCalls.length,
-            mcp_tools: 0,
-            in: response.usage?.prompt_tokens ?? 0,
-            cache_w: 0,
-            cache_r: 0,
-            out: response.usage?.completion_tokens ?? 0,
-            elapsed_ms: Date.now() - iterStart
-          },
-          logger
-        );
-        if (choice.finish_reason !== "tool_calls") {
-          throw new FerryError("state-invariant", {
-            reason: "tool-loop-stopped-without-finish",
-            stop_reason: choice.finish_reason
-          });
-        }
-        for (const toolCall of toolCalls) {
-          if (toolCall.type !== "function") continue;
-          let input;
-          try {
-            input = JSON.parse(toolCall.function.arguments);
-          } catch {
-            messages.push({
-              role: "tool",
-              tool_call_id: toolCall.id,
-              content: "invalid JSON arguments"
-            });
-            continue;
-          }
-          if (toolCall.function.name === finishTool) {
-            done = extractDone(input);
-            messages.push({ role: "tool", tool_call_id: toolCall.id, content: "ok" });
-            continue;
-          }
-          const handler2 = handlers[toolCall.function.name];
-          if (handler2) {
-            const result = await handler2(input);
-            trackTool(toolCall.function.name, result.length);
-            messages.push({ role: "tool", tool_call_id: toolCall.id, content: result });
-          } else {
-            messages.push({
-              role: "tool",
-              tool_call_id: toolCall.id,
-              content: `unknown tool: ${toolCall.function.name}`
-            });
-          }
-        }
-        if (done !== null) {
-          emitDebug(
-            {
-              type: "result",
-              subtype: "success",
-              iterations: iter + 1,
-              total_in: inputTokens,
-              total_out: outputTokens,
-              elapsed_ms: Date.now() - loopStart
-            },
-            logger
-          );
-          return {
-            done,
-            usage: { inputTokens, outputTokens },
-            iterations: iter + 1,
-            toolCounts,
-            toolCallRecords
-          };
-        }
-      }
-      throw new FerryError("state-invariant", {
-        reason: "tool-loop-iteration-cap-exceeded",
-        cap: maxIterations
-      });
-    }
-  };
-}
-
-// src/lib/llm/tool-loop/google.ts
-import { GoogleGenAI as GoogleGenAI3 } from "@google/genai";
-function toGoogleTools(tools) {
-  return [
-    {
-      functionDeclarations: tools.map((t) => ({
-        name: t.name,
-        description: t.description,
-        parametersJsonSchema: t.input_schema
-      }))
-    }
-  ];
-}
-function createGoogleToolCallLoop(opts) {
-  const ai = new GoogleGenAI3({ apiKey: opts.apiKey });
-  return {
-    async run(runOpts) {
-      const {
-        system,
-        initialPrompt,
-        tools,
-        handlers,
-        finishTool,
-        extractDone,
-        maxIterations,
-        maxTokens
-      } = runOpts;
-      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
-      const googleTools = toGoogleTools(tools);
-      const contents = [{ role: "user", parts: [{ text: initialPrompt }] }];
-      let inputTokens = 0;
-      let outputTokens = 0;
-      let done = null;
-      const toolCounts = {};
-      const toolCallRecords = [];
-      function trackTool(name, outputSize) {
-        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
-        toolCallRecords.push({ name, outputSize });
-      }
-      const loopStart = Date.now();
-      for (let iter = 0; iter < maxIterations; iter++) {
-        const iterStart = Date.now();
-        const response = await ai.models.generateContent({
-          model: opts.model,
-          contents,
-          config: {
-            systemInstruction: system,
-            tools: googleTools,
-            maxOutputTokens: maxTokens
-          }
-        });
-        inputTokens += response.usageMetadata?.promptTokenCount ?? 0;
-        outputTokens += response.usageMetadata?.candidatesTokenCount ?? 0;
-        const fnCalls = response.functionCalls ?? [];
-        const modelParts = response.candidates?.[0]?.content?.parts ?? [];
-        if (modelParts.length > 0) {
-          contents.push({ role: "model", parts: modelParts });
-        }
-        logger.info("turn", {
-          iter: iter + 1,
-          tools: fnCalls.length,
-          in: response.usageMetadata?.promptTokenCount ?? 0,
-          out: response.usageMetadata?.candidatesTokenCount ?? 0
-        });
-        emitDebug(
-          {
-            type: "turn",
-            iter: iter + 1,
-            depth: 0,
-            stop_reason: fnCalls.length > 0 ? "tool_use" : "end_turn",
-            tools: fnCalls.length,
-            mcp_tools: 0,
-            in: response.usageMetadata?.promptTokenCount ?? 0,
-            cache_w: 0,
-            cache_r: 0,
-            out: response.usageMetadata?.candidatesTokenCount ?? 0,
-            elapsed_ms: Date.now() - iterStart
-          },
-          logger
-        );
-        if (fnCalls.length === 0) {
-          throw new FerryError("state-invariant", {
-            reason: "tool-loop-stopped-without-finish",
-            stop_reason: "end_turn"
-          });
-        }
-        const responseParts = [];
-        for (const fc of fnCalls) {
-          const name = fc.name ?? "";
-          const input = fc.args ?? {};
-          if (name === finishTool) {
-            done = extractDone(input);
-            responseParts.push({
-              functionResponse: { name, response: { result: "ok" } }
-            });
-            continue;
-          }
-          const handler2 = handlers[name];
-          if (handler2) {
-            const result = await handler2(input);
-            trackTool(name, result.length);
-            responseParts.push({
-              functionResponse: { name, response: { result } }
-            });
-          } else {
-            responseParts.push({
-              functionResponse: { name, response: { error: `unknown tool: ${name}` } }
-            });
-          }
-        }
-        contents.push({ role: "user", parts: responseParts });
-        if (done !== null) {
-          emitDebug(
-            {
-              type: "result",
-              subtype: "success",
-              iterations: iter + 1,
-              total_in: inputTokens,
-              total_out: outputTokens,
-              elapsed_ms: Date.now() - loopStart
-            },
-            logger
-          );
-          return {
-            done,
-            usage: { inputTokens, outputTokens },
-            iterations: iter + 1,
-            toolCounts,
-            toolCallRecords
-          };
-        }
-      }
-      throw new FerryError("state-invariant", {
-        reason: "tool-loop-iteration-cap-exceeded",
-        cap: maxIterations
-      });
-    }
-  };
-}
-
-// src/lib/llm/tool-loop/index.ts
-function requireEnv4(key) {
-  const val = process.env[key];
-  if (!val) {
-    throw new FerryError("state-invariant", { reason: "missing-env", key });
-  }
-  return val;
-}
-function createToolCallLoop(opts) {
-  if (opts.provider === "anthropic") {
-    const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
-    const client = new Anthropic4(auth2);
-    const thinking = resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
-    return createAnthropicToolCallLoop({ client, model: opts.model, thinking });
-  }
-  resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
-  if (opts.provider === "openai") {
-    const apiKey = requireEnv4("FERRY_OPENAI_KEY");
-    return createOpenAIToolCallLoop({ apiKey, model: opts.model });
-  }
-  if (opts.provider === "google") {
-    const apiKey = requireEnv4("FERRY_GOOGLE_AI_KEY");
-    return createGoogleToolCallLoop({ apiKey, model: opts.model });
-  }
-  throw new FerryError("state-invariant", { reason: "unknown-provider", provider: opts.provider });
-}
-
 // src/lib/io/idempotency.ts
 function checkIdempotencyMarker(marker, items) {
   for (const item of items) {
@@ -10493,7 +10030,6 @@ function gateCi(input) {
 // src/agents/reviewer/review-loop.ts
 var MAX_PATCH_CHARS = 2e4;
 var MAX_CONTENT_CHARS = 4e4;
-var MAX_ITERATIONS = 40;
 var REVIEW_TOOL_DEFS = [
   {
     name: "get_file_patch",
@@ -10518,73 +10054,78 @@ var REVIEW_TOOL_DEFS = [
     }
   },
   {
-    name: "finish_review",
+    name: "done",
     description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
     input_schema: {
       type: "object",
       properties: {
+        actionable: {
+          type: "boolean",
+          description: "true if you are approving the PR, false if requesting changes."
+        },
         approved: {
           type: "boolean",
           description: "true = ready to merge, false = changes required."
+        },
+        summary: {
+          type: "string",
+          description: "One sentence summary of the review outcome."
         },
         comment: {
           type: "string",
           description: "Full review comment in Markdown. Follow the required format from the system prompt."
         }
       },
-      required: ["approved", "comment"]
+      required: ["actionable", "approved", "summary", "comment"]
     }
   }
 ];
+function makeReviewExecuteTool(opts) {
+  const { fileMap, runner, owner, repo, headSha, logger } = opts;
+  return async (_repoRoot, name, input) => {
+    if (name === "get_file_patch") {
+      const filename = input.filename;
+      logger.info("tool", { tool: "get_file_patch", file: filename });
+      const patch = fileMap.get(filename);
+      if (patch === void 0) return `(file not found in PR: ${filename})`;
+      if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
+      const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
+      return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
+    }
+    if (name === "get_file_content") {
+      const filename = input.filename;
+      logger.info("tool", { tool: "get_file_content", file: filename });
+      const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
+      const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
+      return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
+    }
+    throw new Error(`Unknown reviewer tool: ${name}`);
+  };
+}
 async function runReviewLoop(opts) {
-  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
-  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
-  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
-  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
-  const {
-    done: result,
-    usage,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  } = await loop.run({
+  const { loop, system, initialPrompt, repoRoot, branchName } = opts;
+  const mcpServers = opts.mcpServers ?? [];
+  const loopResult = await loop.run({
     system,
     initialPrompt,
     tools: REVIEW_TOOL_DEFS,
-    finishTool: "finish_review",
-    extractDone: (input) => ({
-      approved: input.approved,
-      comment: input.comment
-    }),
-    handlers: {
-      get_file_patch: (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_patch", file: filename });
-        const patch = fileMap.get(filename);
-        if (patch === void 0) return `(file not found in PR: ${filename})`;
-        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
-        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
-        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
-      },
-      get_file_content: async (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_content", file: filename });
-        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
-        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
-        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
-      }
-    },
-    maxIterations,
-    maxTokens,
-    logger
+    repoRoot,
+    branchName,
+    secretScan: () => Promise.resolve(),
+    mcpServers
   });
+  const done = loopResult.done;
+  const result = {
+    approved: done.approved,
+    comment: done.comment
+  };
   return {
     result,
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-    iterations,
-    toolCounts,
-    toolCallRecords
+    inputTokens: loopResult.usage.input_tokens,
+    outputTokens: loopResult.usage.output_tokens,
+    iterations: loopResult.iterations,
+    toolCounts: loopResult.toolCounts,
+    toolCallRecords: loopResult.toolCallRecords
   };
 }
 
@@ -10741,6 +10282,12 @@ async function main3(envelope, logger) {
   }
   const files = await runner.listPRFiles({ owner, repo, prNumber });
   const commits = await runner.listPRCommits({ owner, repo, prNumber });
+  const mcpPool = loadMcpServers();
+  const hasLabelsConfig = effectiveCfg.labels !== void 0;
+  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  if (mcpServers.length > 0) {
+    logger.info("MCP servers", { servers: mcpServers.map((s) => s.name) });
+  }
   const prepared = prepareReviewer({
     ticketKey,
     issue,
@@ -10752,10 +10299,21 @@ async function main3(envelope, logger) {
     reviewRubric: reviewRubricOverride,
     capabilities,
     idempotencyMarker,
-    repoRoot: REPO_ROOT3
+    repoRoot: REPO_ROOT3,
+    mcpPool,
+    configLabels: effectiveCfg.labels
   });
   const { system, initialPrompt, fileMap } = prepared;
-  const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
+  const executeTool2 = makeReviewExecuteTool({ fileMap, runner, owner, repo, headSha, logger });
+  const loop = createAgentLoop({
+    provider,
+    model,
+    thinking: thinkingOverride,
+    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
+    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
+    executeTool: executeTool2,
+    logger
+  });
   const {
     result: review,
     inputTokens,
@@ -10767,13 +10325,9 @@ async function main3(envelope, logger) {
     loop,
     system,
     initialPrompt,
-    fileMap,
-    runner,
-    owner,
-    repo,
-    headSha,
-    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
-    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
+    repoRoot: REPO_ROOT3,
+    branchName,
+    mcpServers,
     logger
   });
   logger.info("reviewed", {

--- a/.github/actions/ferry-run-developer/agent.js
+++ b/.github/actions/ferry-run-developer/agent.js
@@ -6688,7 +6688,9 @@ function prepareReviewer(input) {
     reviewRubric,
     capabilities,
     idempotencyMarker,
-    repoRoot
+    repoRoot,
+    mcpPool,
+    configLabels
   } = input;
   const buildSystem2 = input._buildSystem ?? buildSystem;
   const loadOptionalPrompt2 = input._loadOptionalPrompt ?? loadOptionalPrompt;
@@ -6718,14 +6720,15 @@ function prepareReviewer(input) {
     buildFileList(files),
     "",
     "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
-    "When you have enough information, call finish_review."
+    "When you have enough information, call done."
   ].filter((l) => l !== null).join("\n");
   const baseSystem = buildSystem2("review", repoRoot, {
     extraParts: [loadOptionalPrompt2("review-comment", repoRoot)],
     separator: "\n\n---\n\n"
   });
   const system = applyRubricToPrompt(baseSystem, reviewRubric);
-  const mcpServers = [];
+  const hasLabelsConfig = configLabels !== void 0;
+  const mcpServers = mcpPool !== void 0 ? filterMcpServers(mcpPool, capabilities, hasLabelsConfig) : [];
   return {
     system,
     initialPrompt,
@@ -9984,472 +9987,6 @@ async function main2(envelope, logger) {
   process.exit(0);
 }
 
-// src/lib/llm/tool-loop/index.ts
-import Anthropic4 from "@anthropic-ai/sdk";
-
-// src/lib/llm/tool-loop/anthropic.ts
-function createAnthropicToolCallLoop(opts) {
-  return {
-    async run(runOpts) {
-      const {
-        system,
-        initialPrompt,
-        tools,
-        handlers,
-        finishTool,
-        extractDone,
-        maxIterations,
-        maxTokens
-      } = runOpts;
-      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
-      const anthropicTools = tools.map(
-        (t, i) => i === tools.length - 1 ? { ...t, cache_control: { type: "ephemeral" } } : t
-      );
-      const messages = [
-        {
-          role: "user",
-          content: [{ type: "text", text: initialPrompt, cache_control: { type: "ephemeral" } }]
-        }
-      ];
-      let inputTokens = 0;
-      let outputTokens = 0;
-      let done = null;
-      const toolCounts = {};
-      const toolCallRecords = [];
-      function trackTool(name, outputSize) {
-        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
-        toolCallRecords.push({ name, outputSize });
-      }
-      const loopStart = Date.now();
-      for (let iter = 0; iter < maxIterations; iter++) {
-        const iterStart = Date.now();
-        const response = await opts.client.messages.create({
-          model: opts.model,
-          max_tokens: maxTokens,
-          system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
-          tools: anthropicTools,
-          messages,
-          ...opts.thinking !== void 0 ? { thinking: opts.thinking } : {}
-        });
-        inputTokens += response.usage.input_tokens;
-        outputTokens += response.usage.output_tokens;
-        messages.push({ role: "assistant", content: response.content });
-        const toolCount = response.content.filter((b) => b.type === "tool_use").length;
-        logger.info("turn", {
-          iter: iter + 1,
-          stop: response.stop_reason,
-          tools: toolCount,
-          in: response.usage.input_tokens,
-          out: response.usage.output_tokens
-        });
-        emitDebug(
-          {
-            type: "turn",
-            iter: iter + 1,
-            depth: 0,
-            stop_reason: response.stop_reason ?? "unknown",
-            tools: toolCount,
-            mcp_tools: 0,
-            in: response.usage.input_tokens,
-            cache_w: 0,
-            cache_r: 0,
-            out: response.usage.output_tokens,
-            elapsed_ms: Date.now() - iterStart
-          },
-          logger
-        );
-        if (response.stop_reason !== "tool_use") {
-          throw new FerryError("state-invariant", {
-            reason: "tool-loop-stopped-without-finish",
-            stop_reason: response.stop_reason
-          });
-        }
-        const toolResults = [];
-        for (const block of response.content) {
-          if (block.type !== "tool_use") continue;
-          const input = block.input;
-          if (block.name === finishTool) {
-            done = extractDone(input);
-            toolResults.push({ type: "tool_result", tool_use_id: block.id, content: "ok" });
-            continue;
-          }
-          const handler2 = handlers[block.name];
-          if (handler2) {
-            const result = await handler2(input);
-            trackTool(block.name, result.length);
-            toolResults.push({ type: "tool_result", tool_use_id: block.id, content: result });
-          } else {
-            toolResults.push({
-              type: "tool_result",
-              tool_use_id: block.id,
-              content: `unknown tool: ${block.name}`,
-              is_error: true
-            });
-          }
-        }
-        for (let i = messages.length - 1; i >= 0; i--) {
-          const msg = messages[i];
-          if (msg.role === "user" && Array.isArray(msg.content)) {
-            const content = msg.content;
-            if (content.some((b) => b.type === "tool_result")) {
-              const entry = { ...content[content.length - 1] };
-              delete entry.cache_control;
-              content[content.length - 1] = entry;
-              break;
-            }
-          }
-        }
-        if (toolResults.length > 0) {
-          const last = toolResults[toolResults.length - 1];
-          toolResults[toolResults.length - 1] = { ...last, cache_control: { type: "ephemeral" } };
-        }
-        messages.push({ role: "user", content: toolResults });
-        if (done !== null) {
-          emitDebug(
-            {
-              type: "result",
-              subtype: "success",
-              iterations: iter + 1,
-              total_in: inputTokens,
-              total_out: outputTokens,
-              elapsed_ms: Date.now() - loopStart
-            },
-            logger
-          );
-          return {
-            done,
-            usage: { inputTokens, outputTokens },
-            iterations: iter + 1,
-            toolCounts,
-            toolCallRecords
-          };
-        }
-      }
-      throw new FerryError("state-invariant", {
-        reason: "tool-loop-iteration-cap-exceeded",
-        cap: maxIterations
-      });
-    }
-  };
-}
-
-// src/lib/llm/tool-loop/openai.ts
-import OpenAI3 from "openai";
-function createOpenAIToolCallLoop(opts) {
-  const client = new OpenAI3({ apiKey: opts.apiKey });
-  return {
-    async run(runOpts) {
-      const {
-        system,
-        initialPrompt,
-        tools,
-        handlers,
-        finishTool,
-        extractDone,
-        maxIterations,
-        maxTokens
-      } = runOpts;
-      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
-      const openaiTools = tools.map((t) => ({
-        type: "function",
-        function: {
-          name: t.name,
-          description: t.description,
-          parameters: t.input_schema
-        }
-      }));
-      const messages = [
-        { role: "system", content: system },
-        { role: "user", content: initialPrompt }
-      ];
-      let inputTokens = 0;
-      let outputTokens = 0;
-      let done = null;
-      const toolCounts = {};
-      const toolCallRecords = [];
-      function trackTool(name, outputSize) {
-        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
-        toolCallRecords.push({ name, outputSize });
-      }
-      const loopStart = Date.now();
-      for (let iter = 0; iter < maxIterations; iter++) {
-        const iterStart = Date.now();
-        const response = await client.chat.completions.create({
-          model: opts.model,
-          max_tokens: maxTokens,
-          messages,
-          tools: openaiTools,
-          tool_choice: "required"
-        });
-        const choice = response.choices[0];
-        if (!choice) {
-          throw new FerryError("state-invariant", { reason: "tool-loop-no-response" });
-        }
-        inputTokens += response.usage?.prompt_tokens ?? 0;
-        outputTokens += response.usage?.completion_tokens ?? 0;
-        const assistantMsg = {
-          role: "assistant",
-          content: choice.message.content ?? null,
-          tool_calls: choice.message.tool_calls
-        };
-        messages.push(assistantMsg);
-        const toolCalls = choice.message.tool_calls ?? [];
-        logger.info("turn", {
-          iter: iter + 1,
-          stop: choice.finish_reason,
-          tools: toolCalls.length,
-          in: response.usage?.prompt_tokens ?? 0,
-          out: response.usage?.completion_tokens ?? 0
-        });
-        emitDebug(
-          {
-            type: "turn",
-            iter: iter + 1,
-            depth: 0,
-            stop_reason: choice.finish_reason ?? "unknown",
-            tools: toolCalls.length,
-            mcp_tools: 0,
-            in: response.usage?.prompt_tokens ?? 0,
-            cache_w: 0,
-            cache_r: 0,
-            out: response.usage?.completion_tokens ?? 0,
-            elapsed_ms: Date.now() - iterStart
-          },
-          logger
-        );
-        if (choice.finish_reason !== "tool_calls") {
-          throw new FerryError("state-invariant", {
-            reason: "tool-loop-stopped-without-finish",
-            stop_reason: choice.finish_reason
-          });
-        }
-        for (const toolCall of toolCalls) {
-          if (toolCall.type !== "function") continue;
-          let input;
-          try {
-            input = JSON.parse(toolCall.function.arguments);
-          } catch {
-            messages.push({
-              role: "tool",
-              tool_call_id: toolCall.id,
-              content: "invalid JSON arguments"
-            });
-            continue;
-          }
-          if (toolCall.function.name === finishTool) {
-            done = extractDone(input);
-            messages.push({ role: "tool", tool_call_id: toolCall.id, content: "ok" });
-            continue;
-          }
-          const handler2 = handlers[toolCall.function.name];
-          if (handler2) {
-            const result = await handler2(input);
-            trackTool(toolCall.function.name, result.length);
-            messages.push({ role: "tool", tool_call_id: toolCall.id, content: result });
-          } else {
-            messages.push({
-              role: "tool",
-              tool_call_id: toolCall.id,
-              content: `unknown tool: ${toolCall.function.name}`
-            });
-          }
-        }
-        if (done !== null) {
-          emitDebug(
-            {
-              type: "result",
-              subtype: "success",
-              iterations: iter + 1,
-              total_in: inputTokens,
-              total_out: outputTokens,
-              elapsed_ms: Date.now() - loopStart
-            },
-            logger
-          );
-          return {
-            done,
-            usage: { inputTokens, outputTokens },
-            iterations: iter + 1,
-            toolCounts,
-            toolCallRecords
-          };
-        }
-      }
-      throw new FerryError("state-invariant", {
-        reason: "tool-loop-iteration-cap-exceeded",
-        cap: maxIterations
-      });
-    }
-  };
-}
-
-// src/lib/llm/tool-loop/google.ts
-import { GoogleGenAI as GoogleGenAI3 } from "@google/genai";
-function toGoogleTools(tools) {
-  return [
-    {
-      functionDeclarations: tools.map((t) => ({
-        name: t.name,
-        description: t.description,
-        parametersJsonSchema: t.input_schema
-      }))
-    }
-  ];
-}
-function createGoogleToolCallLoop(opts) {
-  const ai = new GoogleGenAI3({ apiKey: opts.apiKey });
-  return {
-    async run(runOpts) {
-      const {
-        system,
-        initialPrompt,
-        tools,
-        handlers,
-        finishTool,
-        extractDone,
-        maxIterations,
-        maxTokens
-      } = runOpts;
-      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
-      const googleTools = toGoogleTools(tools);
-      const contents = [{ role: "user", parts: [{ text: initialPrompt }] }];
-      let inputTokens = 0;
-      let outputTokens = 0;
-      let done = null;
-      const toolCounts = {};
-      const toolCallRecords = [];
-      function trackTool(name, outputSize) {
-        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
-        toolCallRecords.push({ name, outputSize });
-      }
-      const loopStart = Date.now();
-      for (let iter = 0; iter < maxIterations; iter++) {
-        const iterStart = Date.now();
-        const response = await ai.models.generateContent({
-          model: opts.model,
-          contents,
-          config: {
-            systemInstruction: system,
-            tools: googleTools,
-            maxOutputTokens: maxTokens
-          }
-        });
-        inputTokens += response.usageMetadata?.promptTokenCount ?? 0;
-        outputTokens += response.usageMetadata?.candidatesTokenCount ?? 0;
-        const fnCalls = response.functionCalls ?? [];
-        const modelParts = response.candidates?.[0]?.content?.parts ?? [];
-        if (modelParts.length > 0) {
-          contents.push({ role: "model", parts: modelParts });
-        }
-        logger.info("turn", {
-          iter: iter + 1,
-          tools: fnCalls.length,
-          in: response.usageMetadata?.promptTokenCount ?? 0,
-          out: response.usageMetadata?.candidatesTokenCount ?? 0
-        });
-        emitDebug(
-          {
-            type: "turn",
-            iter: iter + 1,
-            depth: 0,
-            stop_reason: fnCalls.length > 0 ? "tool_use" : "end_turn",
-            tools: fnCalls.length,
-            mcp_tools: 0,
-            in: response.usageMetadata?.promptTokenCount ?? 0,
-            cache_w: 0,
-            cache_r: 0,
-            out: response.usageMetadata?.candidatesTokenCount ?? 0,
-            elapsed_ms: Date.now() - iterStart
-          },
-          logger
-        );
-        if (fnCalls.length === 0) {
-          throw new FerryError("state-invariant", {
-            reason: "tool-loop-stopped-without-finish",
-            stop_reason: "end_turn"
-          });
-        }
-        const responseParts = [];
-        for (const fc of fnCalls) {
-          const name = fc.name ?? "";
-          const input = fc.args ?? {};
-          if (name === finishTool) {
-            done = extractDone(input);
-            responseParts.push({
-              functionResponse: { name, response: { result: "ok" } }
-            });
-            continue;
-          }
-          const handler2 = handlers[name];
-          if (handler2) {
-            const result = await handler2(input);
-            trackTool(name, result.length);
-            responseParts.push({
-              functionResponse: { name, response: { result } }
-            });
-          } else {
-            responseParts.push({
-              functionResponse: { name, response: { error: `unknown tool: ${name}` } }
-            });
-          }
-        }
-        contents.push({ role: "user", parts: responseParts });
-        if (done !== null) {
-          emitDebug(
-            {
-              type: "result",
-              subtype: "success",
-              iterations: iter + 1,
-              total_in: inputTokens,
-              total_out: outputTokens,
-              elapsed_ms: Date.now() - loopStart
-            },
-            logger
-          );
-          return {
-            done,
-            usage: { inputTokens, outputTokens },
-            iterations: iter + 1,
-            toolCounts,
-            toolCallRecords
-          };
-        }
-      }
-      throw new FerryError("state-invariant", {
-        reason: "tool-loop-iteration-cap-exceeded",
-        cap: maxIterations
-      });
-    }
-  };
-}
-
-// src/lib/llm/tool-loop/index.ts
-function requireEnv4(key) {
-  const val = process.env[key];
-  if (!val) {
-    throw new FerryError("state-invariant", { reason: "missing-env", key });
-  }
-  return val;
-}
-function createToolCallLoop(opts) {
-  if (opts.provider === "anthropic") {
-    const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
-    const client = new Anthropic4(auth2);
-    const thinking = resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
-    return createAnthropicToolCallLoop({ client, model: opts.model, thinking });
-  }
-  resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
-  if (opts.provider === "openai") {
-    const apiKey = requireEnv4("FERRY_OPENAI_KEY");
-    return createOpenAIToolCallLoop({ apiKey, model: opts.model });
-  }
-  if (opts.provider === "google") {
-    const apiKey = requireEnv4("FERRY_GOOGLE_AI_KEY");
-    return createGoogleToolCallLoop({ apiKey, model: opts.model });
-  }
-  throw new FerryError("state-invariant", { reason: "unknown-provider", provider: opts.provider });
-}
-
 // src/lib/io/idempotency.ts
 function checkIdempotencyMarker(marker, items) {
   for (const item of items) {
@@ -10493,7 +10030,6 @@ function gateCi(input) {
 // src/agents/reviewer/review-loop.ts
 var MAX_PATCH_CHARS = 2e4;
 var MAX_CONTENT_CHARS = 4e4;
-var MAX_ITERATIONS = 40;
 var REVIEW_TOOL_DEFS = [
   {
     name: "get_file_patch",
@@ -10518,73 +10054,78 @@ var REVIEW_TOOL_DEFS = [
     }
   },
   {
-    name: "finish_review",
+    name: "done",
     description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
     input_schema: {
       type: "object",
       properties: {
+        actionable: {
+          type: "boolean",
+          description: "true if you are approving the PR, false if requesting changes."
+        },
         approved: {
           type: "boolean",
           description: "true = ready to merge, false = changes required."
+        },
+        summary: {
+          type: "string",
+          description: "One sentence summary of the review outcome."
         },
         comment: {
           type: "string",
           description: "Full review comment in Markdown. Follow the required format from the system prompt."
         }
       },
-      required: ["approved", "comment"]
+      required: ["actionable", "approved", "summary", "comment"]
     }
   }
 ];
+function makeReviewExecuteTool(opts) {
+  const { fileMap, runner, owner, repo, headSha, logger } = opts;
+  return async (_repoRoot, name, input) => {
+    if (name === "get_file_patch") {
+      const filename = input.filename;
+      logger.info("tool", { tool: "get_file_patch", file: filename });
+      const patch = fileMap.get(filename);
+      if (patch === void 0) return `(file not found in PR: ${filename})`;
+      if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
+      const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
+      return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
+    }
+    if (name === "get_file_content") {
+      const filename = input.filename;
+      logger.info("tool", { tool: "get_file_content", file: filename });
+      const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
+      const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
+      return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
+    }
+    throw new Error(`Unknown reviewer tool: ${name}`);
+  };
+}
 async function runReviewLoop(opts) {
-  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
-  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
-  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
-  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
-  const {
-    done: result,
-    usage,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  } = await loop.run({
+  const { loop, system, initialPrompt, repoRoot, branchName } = opts;
+  const mcpServers = opts.mcpServers ?? [];
+  const loopResult = await loop.run({
     system,
     initialPrompt,
     tools: REVIEW_TOOL_DEFS,
-    finishTool: "finish_review",
-    extractDone: (input) => ({
-      approved: input.approved,
-      comment: input.comment
-    }),
-    handlers: {
-      get_file_patch: (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_patch", file: filename });
-        const patch = fileMap.get(filename);
-        if (patch === void 0) return `(file not found in PR: ${filename})`;
-        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
-        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
-        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
-      },
-      get_file_content: async (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_content", file: filename });
-        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
-        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
-        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
-      }
-    },
-    maxIterations,
-    maxTokens,
-    logger
+    repoRoot,
+    branchName,
+    secretScan: () => Promise.resolve(),
+    mcpServers
   });
+  const done = loopResult.done;
+  const result = {
+    approved: done.approved,
+    comment: done.comment
+  };
   return {
     result,
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-    iterations,
-    toolCounts,
-    toolCallRecords
+    inputTokens: loopResult.usage.input_tokens,
+    outputTokens: loopResult.usage.output_tokens,
+    iterations: loopResult.iterations,
+    toolCounts: loopResult.toolCounts,
+    toolCallRecords: loopResult.toolCallRecords
   };
 }
 
@@ -10741,6 +10282,12 @@ async function main3(envelope, logger) {
   }
   const files = await runner.listPRFiles({ owner, repo, prNumber });
   const commits = await runner.listPRCommits({ owner, repo, prNumber });
+  const mcpPool = loadMcpServers();
+  const hasLabelsConfig = effectiveCfg.labels !== void 0;
+  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  if (mcpServers.length > 0) {
+    logger.info("MCP servers", { servers: mcpServers.map((s) => s.name) });
+  }
   const prepared = prepareReviewer({
     ticketKey,
     issue,
@@ -10752,10 +10299,21 @@ async function main3(envelope, logger) {
     reviewRubric: reviewRubricOverride,
     capabilities,
     idempotencyMarker,
-    repoRoot: REPO_ROOT3
+    repoRoot: REPO_ROOT3,
+    mcpPool,
+    configLabels: effectiveCfg.labels
   });
   const { system, initialPrompt, fileMap } = prepared;
-  const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
+  const executeTool2 = makeReviewExecuteTool({ fileMap, runner, owner, repo, headSha, logger });
+  const loop = createAgentLoop({
+    provider,
+    model,
+    thinking: thinkingOverride,
+    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
+    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
+    executeTool: executeTool2,
+    logger
+  });
   const {
     result: review,
     inputTokens,
@@ -10767,13 +10325,9 @@ async function main3(envelope, logger) {
     loop,
     system,
     initialPrompt,
-    fileMap,
-    runner,
-    owner,
-    repo,
-    headSha,
-    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
-    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
+    repoRoot: REPO_ROOT3,
+    branchName,
+    mcpServers,
     logger
   });
   logger.info("reviewed", {

--- a/.github/actions/ferry-run-iterator/agent.js
+++ b/.github/actions/ferry-run-iterator/agent.js
@@ -6688,7 +6688,9 @@ function prepareReviewer(input) {
     reviewRubric,
     capabilities,
     idempotencyMarker,
-    repoRoot
+    repoRoot,
+    mcpPool,
+    configLabels
   } = input;
   const buildSystem2 = input._buildSystem ?? buildSystem;
   const loadOptionalPrompt2 = input._loadOptionalPrompt ?? loadOptionalPrompt;
@@ -6718,14 +6720,15 @@ function prepareReviewer(input) {
     buildFileList(files),
     "",
     "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
-    "When you have enough information, call finish_review."
+    "When you have enough information, call done."
   ].filter((l) => l !== null).join("\n");
   const baseSystem = buildSystem2("review", repoRoot, {
     extraParts: [loadOptionalPrompt2("review-comment", repoRoot)],
     separator: "\n\n---\n\n"
   });
   const system = applyRubricToPrompt(baseSystem, reviewRubric);
-  const mcpServers = [];
+  const hasLabelsConfig = configLabels !== void 0;
+  const mcpServers = mcpPool !== void 0 ? filterMcpServers(mcpPool, capabilities, hasLabelsConfig) : [];
   return {
     system,
     initialPrompt,
@@ -9984,472 +9987,6 @@ async function main2(envelope, logger) {
   process.exit(0);
 }
 
-// src/lib/llm/tool-loop/index.ts
-import Anthropic4 from "@anthropic-ai/sdk";
-
-// src/lib/llm/tool-loop/anthropic.ts
-function createAnthropicToolCallLoop(opts) {
-  return {
-    async run(runOpts) {
-      const {
-        system,
-        initialPrompt,
-        tools,
-        handlers,
-        finishTool,
-        extractDone,
-        maxIterations,
-        maxTokens
-      } = runOpts;
-      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
-      const anthropicTools = tools.map(
-        (t, i) => i === tools.length - 1 ? { ...t, cache_control: { type: "ephemeral" } } : t
-      );
-      const messages = [
-        {
-          role: "user",
-          content: [{ type: "text", text: initialPrompt, cache_control: { type: "ephemeral" } }]
-        }
-      ];
-      let inputTokens = 0;
-      let outputTokens = 0;
-      let done = null;
-      const toolCounts = {};
-      const toolCallRecords = [];
-      function trackTool(name, outputSize) {
-        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
-        toolCallRecords.push({ name, outputSize });
-      }
-      const loopStart = Date.now();
-      for (let iter = 0; iter < maxIterations; iter++) {
-        const iterStart = Date.now();
-        const response = await opts.client.messages.create({
-          model: opts.model,
-          max_tokens: maxTokens,
-          system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
-          tools: anthropicTools,
-          messages,
-          ...opts.thinking !== void 0 ? { thinking: opts.thinking } : {}
-        });
-        inputTokens += response.usage.input_tokens;
-        outputTokens += response.usage.output_tokens;
-        messages.push({ role: "assistant", content: response.content });
-        const toolCount = response.content.filter((b) => b.type === "tool_use").length;
-        logger.info("turn", {
-          iter: iter + 1,
-          stop: response.stop_reason,
-          tools: toolCount,
-          in: response.usage.input_tokens,
-          out: response.usage.output_tokens
-        });
-        emitDebug(
-          {
-            type: "turn",
-            iter: iter + 1,
-            depth: 0,
-            stop_reason: response.stop_reason ?? "unknown",
-            tools: toolCount,
-            mcp_tools: 0,
-            in: response.usage.input_tokens,
-            cache_w: 0,
-            cache_r: 0,
-            out: response.usage.output_tokens,
-            elapsed_ms: Date.now() - iterStart
-          },
-          logger
-        );
-        if (response.stop_reason !== "tool_use") {
-          throw new FerryError("state-invariant", {
-            reason: "tool-loop-stopped-without-finish",
-            stop_reason: response.stop_reason
-          });
-        }
-        const toolResults = [];
-        for (const block of response.content) {
-          if (block.type !== "tool_use") continue;
-          const input = block.input;
-          if (block.name === finishTool) {
-            done = extractDone(input);
-            toolResults.push({ type: "tool_result", tool_use_id: block.id, content: "ok" });
-            continue;
-          }
-          const handler2 = handlers[block.name];
-          if (handler2) {
-            const result = await handler2(input);
-            trackTool(block.name, result.length);
-            toolResults.push({ type: "tool_result", tool_use_id: block.id, content: result });
-          } else {
-            toolResults.push({
-              type: "tool_result",
-              tool_use_id: block.id,
-              content: `unknown tool: ${block.name}`,
-              is_error: true
-            });
-          }
-        }
-        for (let i = messages.length - 1; i >= 0; i--) {
-          const msg = messages[i];
-          if (msg.role === "user" && Array.isArray(msg.content)) {
-            const content = msg.content;
-            if (content.some((b) => b.type === "tool_result")) {
-              const entry = { ...content[content.length - 1] };
-              delete entry.cache_control;
-              content[content.length - 1] = entry;
-              break;
-            }
-          }
-        }
-        if (toolResults.length > 0) {
-          const last = toolResults[toolResults.length - 1];
-          toolResults[toolResults.length - 1] = { ...last, cache_control: { type: "ephemeral" } };
-        }
-        messages.push({ role: "user", content: toolResults });
-        if (done !== null) {
-          emitDebug(
-            {
-              type: "result",
-              subtype: "success",
-              iterations: iter + 1,
-              total_in: inputTokens,
-              total_out: outputTokens,
-              elapsed_ms: Date.now() - loopStart
-            },
-            logger
-          );
-          return {
-            done,
-            usage: { inputTokens, outputTokens },
-            iterations: iter + 1,
-            toolCounts,
-            toolCallRecords
-          };
-        }
-      }
-      throw new FerryError("state-invariant", {
-        reason: "tool-loop-iteration-cap-exceeded",
-        cap: maxIterations
-      });
-    }
-  };
-}
-
-// src/lib/llm/tool-loop/openai.ts
-import OpenAI3 from "openai";
-function createOpenAIToolCallLoop(opts) {
-  const client = new OpenAI3({ apiKey: opts.apiKey });
-  return {
-    async run(runOpts) {
-      const {
-        system,
-        initialPrompt,
-        tools,
-        handlers,
-        finishTool,
-        extractDone,
-        maxIterations,
-        maxTokens
-      } = runOpts;
-      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
-      const openaiTools = tools.map((t) => ({
-        type: "function",
-        function: {
-          name: t.name,
-          description: t.description,
-          parameters: t.input_schema
-        }
-      }));
-      const messages = [
-        { role: "system", content: system },
-        { role: "user", content: initialPrompt }
-      ];
-      let inputTokens = 0;
-      let outputTokens = 0;
-      let done = null;
-      const toolCounts = {};
-      const toolCallRecords = [];
-      function trackTool(name, outputSize) {
-        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
-        toolCallRecords.push({ name, outputSize });
-      }
-      const loopStart = Date.now();
-      for (let iter = 0; iter < maxIterations; iter++) {
-        const iterStart = Date.now();
-        const response = await client.chat.completions.create({
-          model: opts.model,
-          max_tokens: maxTokens,
-          messages,
-          tools: openaiTools,
-          tool_choice: "required"
-        });
-        const choice = response.choices[0];
-        if (!choice) {
-          throw new FerryError("state-invariant", { reason: "tool-loop-no-response" });
-        }
-        inputTokens += response.usage?.prompt_tokens ?? 0;
-        outputTokens += response.usage?.completion_tokens ?? 0;
-        const assistantMsg = {
-          role: "assistant",
-          content: choice.message.content ?? null,
-          tool_calls: choice.message.tool_calls
-        };
-        messages.push(assistantMsg);
-        const toolCalls = choice.message.tool_calls ?? [];
-        logger.info("turn", {
-          iter: iter + 1,
-          stop: choice.finish_reason,
-          tools: toolCalls.length,
-          in: response.usage?.prompt_tokens ?? 0,
-          out: response.usage?.completion_tokens ?? 0
-        });
-        emitDebug(
-          {
-            type: "turn",
-            iter: iter + 1,
-            depth: 0,
-            stop_reason: choice.finish_reason ?? "unknown",
-            tools: toolCalls.length,
-            mcp_tools: 0,
-            in: response.usage?.prompt_tokens ?? 0,
-            cache_w: 0,
-            cache_r: 0,
-            out: response.usage?.completion_tokens ?? 0,
-            elapsed_ms: Date.now() - iterStart
-          },
-          logger
-        );
-        if (choice.finish_reason !== "tool_calls") {
-          throw new FerryError("state-invariant", {
-            reason: "tool-loop-stopped-without-finish",
-            stop_reason: choice.finish_reason
-          });
-        }
-        for (const toolCall of toolCalls) {
-          if (toolCall.type !== "function") continue;
-          let input;
-          try {
-            input = JSON.parse(toolCall.function.arguments);
-          } catch {
-            messages.push({
-              role: "tool",
-              tool_call_id: toolCall.id,
-              content: "invalid JSON arguments"
-            });
-            continue;
-          }
-          if (toolCall.function.name === finishTool) {
-            done = extractDone(input);
-            messages.push({ role: "tool", tool_call_id: toolCall.id, content: "ok" });
-            continue;
-          }
-          const handler2 = handlers[toolCall.function.name];
-          if (handler2) {
-            const result = await handler2(input);
-            trackTool(toolCall.function.name, result.length);
-            messages.push({ role: "tool", tool_call_id: toolCall.id, content: result });
-          } else {
-            messages.push({
-              role: "tool",
-              tool_call_id: toolCall.id,
-              content: `unknown tool: ${toolCall.function.name}`
-            });
-          }
-        }
-        if (done !== null) {
-          emitDebug(
-            {
-              type: "result",
-              subtype: "success",
-              iterations: iter + 1,
-              total_in: inputTokens,
-              total_out: outputTokens,
-              elapsed_ms: Date.now() - loopStart
-            },
-            logger
-          );
-          return {
-            done,
-            usage: { inputTokens, outputTokens },
-            iterations: iter + 1,
-            toolCounts,
-            toolCallRecords
-          };
-        }
-      }
-      throw new FerryError("state-invariant", {
-        reason: "tool-loop-iteration-cap-exceeded",
-        cap: maxIterations
-      });
-    }
-  };
-}
-
-// src/lib/llm/tool-loop/google.ts
-import { GoogleGenAI as GoogleGenAI3 } from "@google/genai";
-function toGoogleTools(tools) {
-  return [
-    {
-      functionDeclarations: tools.map((t) => ({
-        name: t.name,
-        description: t.description,
-        parametersJsonSchema: t.input_schema
-      }))
-    }
-  ];
-}
-function createGoogleToolCallLoop(opts) {
-  const ai = new GoogleGenAI3({ apiKey: opts.apiKey });
-  return {
-    async run(runOpts) {
-      const {
-        system,
-        initialPrompt,
-        tools,
-        handlers,
-        finishTool,
-        extractDone,
-        maxIterations,
-        maxTokens
-      } = runOpts;
-      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
-      const googleTools = toGoogleTools(tools);
-      const contents = [{ role: "user", parts: [{ text: initialPrompt }] }];
-      let inputTokens = 0;
-      let outputTokens = 0;
-      let done = null;
-      const toolCounts = {};
-      const toolCallRecords = [];
-      function trackTool(name, outputSize) {
-        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
-        toolCallRecords.push({ name, outputSize });
-      }
-      const loopStart = Date.now();
-      for (let iter = 0; iter < maxIterations; iter++) {
-        const iterStart = Date.now();
-        const response = await ai.models.generateContent({
-          model: opts.model,
-          contents,
-          config: {
-            systemInstruction: system,
-            tools: googleTools,
-            maxOutputTokens: maxTokens
-          }
-        });
-        inputTokens += response.usageMetadata?.promptTokenCount ?? 0;
-        outputTokens += response.usageMetadata?.candidatesTokenCount ?? 0;
-        const fnCalls = response.functionCalls ?? [];
-        const modelParts = response.candidates?.[0]?.content?.parts ?? [];
-        if (modelParts.length > 0) {
-          contents.push({ role: "model", parts: modelParts });
-        }
-        logger.info("turn", {
-          iter: iter + 1,
-          tools: fnCalls.length,
-          in: response.usageMetadata?.promptTokenCount ?? 0,
-          out: response.usageMetadata?.candidatesTokenCount ?? 0
-        });
-        emitDebug(
-          {
-            type: "turn",
-            iter: iter + 1,
-            depth: 0,
-            stop_reason: fnCalls.length > 0 ? "tool_use" : "end_turn",
-            tools: fnCalls.length,
-            mcp_tools: 0,
-            in: response.usageMetadata?.promptTokenCount ?? 0,
-            cache_w: 0,
-            cache_r: 0,
-            out: response.usageMetadata?.candidatesTokenCount ?? 0,
-            elapsed_ms: Date.now() - iterStart
-          },
-          logger
-        );
-        if (fnCalls.length === 0) {
-          throw new FerryError("state-invariant", {
-            reason: "tool-loop-stopped-without-finish",
-            stop_reason: "end_turn"
-          });
-        }
-        const responseParts = [];
-        for (const fc of fnCalls) {
-          const name = fc.name ?? "";
-          const input = fc.args ?? {};
-          if (name === finishTool) {
-            done = extractDone(input);
-            responseParts.push({
-              functionResponse: { name, response: { result: "ok" } }
-            });
-            continue;
-          }
-          const handler2 = handlers[name];
-          if (handler2) {
-            const result = await handler2(input);
-            trackTool(name, result.length);
-            responseParts.push({
-              functionResponse: { name, response: { result } }
-            });
-          } else {
-            responseParts.push({
-              functionResponse: { name, response: { error: `unknown tool: ${name}` } }
-            });
-          }
-        }
-        contents.push({ role: "user", parts: responseParts });
-        if (done !== null) {
-          emitDebug(
-            {
-              type: "result",
-              subtype: "success",
-              iterations: iter + 1,
-              total_in: inputTokens,
-              total_out: outputTokens,
-              elapsed_ms: Date.now() - loopStart
-            },
-            logger
-          );
-          return {
-            done,
-            usage: { inputTokens, outputTokens },
-            iterations: iter + 1,
-            toolCounts,
-            toolCallRecords
-          };
-        }
-      }
-      throw new FerryError("state-invariant", {
-        reason: "tool-loop-iteration-cap-exceeded",
-        cap: maxIterations
-      });
-    }
-  };
-}
-
-// src/lib/llm/tool-loop/index.ts
-function requireEnv4(key) {
-  const val = process.env[key];
-  if (!val) {
-    throw new FerryError("state-invariant", { reason: "missing-env", key });
-  }
-  return val;
-}
-function createToolCallLoop(opts) {
-  if (opts.provider === "anthropic") {
-    const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
-    const client = new Anthropic4(auth2);
-    const thinking = resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
-    return createAnthropicToolCallLoop({ client, model: opts.model, thinking });
-  }
-  resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
-  if (opts.provider === "openai") {
-    const apiKey = requireEnv4("FERRY_OPENAI_KEY");
-    return createOpenAIToolCallLoop({ apiKey, model: opts.model });
-  }
-  if (opts.provider === "google") {
-    const apiKey = requireEnv4("FERRY_GOOGLE_AI_KEY");
-    return createGoogleToolCallLoop({ apiKey, model: opts.model });
-  }
-  throw new FerryError("state-invariant", { reason: "unknown-provider", provider: opts.provider });
-}
-
 // src/lib/io/idempotency.ts
 function checkIdempotencyMarker(marker, items) {
   for (const item of items) {
@@ -10493,7 +10030,6 @@ function gateCi(input) {
 // src/agents/reviewer/review-loop.ts
 var MAX_PATCH_CHARS = 2e4;
 var MAX_CONTENT_CHARS = 4e4;
-var MAX_ITERATIONS = 40;
 var REVIEW_TOOL_DEFS = [
   {
     name: "get_file_patch",
@@ -10518,73 +10054,78 @@ var REVIEW_TOOL_DEFS = [
     }
   },
   {
-    name: "finish_review",
+    name: "done",
     description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
     input_schema: {
       type: "object",
       properties: {
+        actionable: {
+          type: "boolean",
+          description: "true if you are approving the PR, false if requesting changes."
+        },
         approved: {
           type: "boolean",
           description: "true = ready to merge, false = changes required."
+        },
+        summary: {
+          type: "string",
+          description: "One sentence summary of the review outcome."
         },
         comment: {
           type: "string",
           description: "Full review comment in Markdown. Follow the required format from the system prompt."
         }
       },
-      required: ["approved", "comment"]
+      required: ["actionable", "approved", "summary", "comment"]
     }
   }
 ];
+function makeReviewExecuteTool(opts) {
+  const { fileMap, runner, owner, repo, headSha, logger } = opts;
+  return async (_repoRoot, name, input) => {
+    if (name === "get_file_patch") {
+      const filename = input.filename;
+      logger.info("tool", { tool: "get_file_patch", file: filename });
+      const patch = fileMap.get(filename);
+      if (patch === void 0) return `(file not found in PR: ${filename})`;
+      if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
+      const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
+      return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
+    }
+    if (name === "get_file_content") {
+      const filename = input.filename;
+      logger.info("tool", { tool: "get_file_content", file: filename });
+      const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
+      const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
+      return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
+    }
+    throw new Error(`Unknown reviewer tool: ${name}`);
+  };
+}
 async function runReviewLoop(opts) {
-  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
-  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
-  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
-  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
-  const {
-    done: result,
-    usage,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  } = await loop.run({
+  const { loop, system, initialPrompt, repoRoot, branchName } = opts;
+  const mcpServers = opts.mcpServers ?? [];
+  const loopResult = await loop.run({
     system,
     initialPrompt,
     tools: REVIEW_TOOL_DEFS,
-    finishTool: "finish_review",
-    extractDone: (input) => ({
-      approved: input.approved,
-      comment: input.comment
-    }),
-    handlers: {
-      get_file_patch: (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_patch", file: filename });
-        const patch = fileMap.get(filename);
-        if (patch === void 0) return `(file not found in PR: ${filename})`;
-        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
-        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
-        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
-      },
-      get_file_content: async (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_content", file: filename });
-        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
-        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
-        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
-      }
-    },
-    maxIterations,
-    maxTokens,
-    logger
+    repoRoot,
+    branchName,
+    secretScan: () => Promise.resolve(),
+    mcpServers
   });
+  const done = loopResult.done;
+  const result = {
+    approved: done.approved,
+    comment: done.comment
+  };
   return {
     result,
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-    iterations,
-    toolCounts,
-    toolCallRecords
+    inputTokens: loopResult.usage.input_tokens,
+    outputTokens: loopResult.usage.output_tokens,
+    iterations: loopResult.iterations,
+    toolCounts: loopResult.toolCounts,
+    toolCallRecords: loopResult.toolCallRecords
   };
 }
 
@@ -10741,6 +10282,12 @@ async function main3(envelope, logger) {
   }
   const files = await runner.listPRFiles({ owner, repo, prNumber });
   const commits = await runner.listPRCommits({ owner, repo, prNumber });
+  const mcpPool = loadMcpServers();
+  const hasLabelsConfig = effectiveCfg.labels !== void 0;
+  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  if (mcpServers.length > 0) {
+    logger.info("MCP servers", { servers: mcpServers.map((s) => s.name) });
+  }
   const prepared = prepareReviewer({
     ticketKey,
     issue,
@@ -10752,10 +10299,21 @@ async function main3(envelope, logger) {
     reviewRubric: reviewRubricOverride,
     capabilities,
     idempotencyMarker,
-    repoRoot: REPO_ROOT3
+    repoRoot: REPO_ROOT3,
+    mcpPool,
+    configLabels: effectiveCfg.labels
   });
   const { system, initialPrompt, fileMap } = prepared;
-  const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
+  const executeTool2 = makeReviewExecuteTool({ fileMap, runner, owner, repo, headSha, logger });
+  const loop = createAgentLoop({
+    provider,
+    model,
+    thinking: thinkingOverride,
+    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
+    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
+    executeTool: executeTool2,
+    logger
+  });
   const {
     result: review,
     inputTokens,
@@ -10767,13 +10325,9 @@ async function main3(envelope, logger) {
     loop,
     system,
     initialPrompt,
-    fileMap,
-    runner,
-    owner,
-    repo,
-    headSha,
-    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
-    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
+    repoRoot: REPO_ROOT3,
+    branchName,
+    mcpServers,
     logger
   });
   logger.info("reviewed", {

--- a/.github/actions/ferry-run-refiner/agent.js
+++ b/.github/actions/ferry-run-refiner/agent.js
@@ -6688,7 +6688,9 @@ function prepareReviewer(input) {
     reviewRubric,
     capabilities,
     idempotencyMarker,
-    repoRoot
+    repoRoot,
+    mcpPool,
+    configLabels
   } = input;
   const buildSystem2 = input._buildSystem ?? buildSystem;
   const loadOptionalPrompt2 = input._loadOptionalPrompt ?? loadOptionalPrompt;
@@ -6718,14 +6720,15 @@ function prepareReviewer(input) {
     buildFileList(files),
     "",
     "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
-    "When you have enough information, call finish_review."
+    "When you have enough information, call done."
   ].filter((l) => l !== null).join("\n");
   const baseSystem = buildSystem2("review", repoRoot, {
     extraParts: [loadOptionalPrompt2("review-comment", repoRoot)],
     separator: "\n\n---\n\n"
   });
   const system = applyRubricToPrompt(baseSystem, reviewRubric);
-  const mcpServers = [];
+  const hasLabelsConfig = configLabels !== void 0;
+  const mcpServers = mcpPool !== void 0 ? filterMcpServers(mcpPool, capabilities, hasLabelsConfig) : [];
   return {
     system,
     initialPrompt,
@@ -9984,472 +9987,6 @@ async function main2(envelope, logger) {
   process.exit(0);
 }
 
-// src/lib/llm/tool-loop/index.ts
-import Anthropic4 from "@anthropic-ai/sdk";
-
-// src/lib/llm/tool-loop/anthropic.ts
-function createAnthropicToolCallLoop(opts) {
-  return {
-    async run(runOpts) {
-      const {
-        system,
-        initialPrompt,
-        tools,
-        handlers,
-        finishTool,
-        extractDone,
-        maxIterations,
-        maxTokens
-      } = runOpts;
-      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
-      const anthropicTools = tools.map(
-        (t, i) => i === tools.length - 1 ? { ...t, cache_control: { type: "ephemeral" } } : t
-      );
-      const messages = [
-        {
-          role: "user",
-          content: [{ type: "text", text: initialPrompt, cache_control: { type: "ephemeral" } }]
-        }
-      ];
-      let inputTokens = 0;
-      let outputTokens = 0;
-      let done = null;
-      const toolCounts = {};
-      const toolCallRecords = [];
-      function trackTool(name, outputSize) {
-        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
-        toolCallRecords.push({ name, outputSize });
-      }
-      const loopStart = Date.now();
-      for (let iter = 0; iter < maxIterations; iter++) {
-        const iterStart = Date.now();
-        const response = await opts.client.messages.create({
-          model: opts.model,
-          max_tokens: maxTokens,
-          system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
-          tools: anthropicTools,
-          messages,
-          ...opts.thinking !== void 0 ? { thinking: opts.thinking } : {}
-        });
-        inputTokens += response.usage.input_tokens;
-        outputTokens += response.usage.output_tokens;
-        messages.push({ role: "assistant", content: response.content });
-        const toolCount = response.content.filter((b) => b.type === "tool_use").length;
-        logger.info("turn", {
-          iter: iter + 1,
-          stop: response.stop_reason,
-          tools: toolCount,
-          in: response.usage.input_tokens,
-          out: response.usage.output_tokens
-        });
-        emitDebug(
-          {
-            type: "turn",
-            iter: iter + 1,
-            depth: 0,
-            stop_reason: response.stop_reason ?? "unknown",
-            tools: toolCount,
-            mcp_tools: 0,
-            in: response.usage.input_tokens,
-            cache_w: 0,
-            cache_r: 0,
-            out: response.usage.output_tokens,
-            elapsed_ms: Date.now() - iterStart
-          },
-          logger
-        );
-        if (response.stop_reason !== "tool_use") {
-          throw new FerryError("state-invariant", {
-            reason: "tool-loop-stopped-without-finish",
-            stop_reason: response.stop_reason
-          });
-        }
-        const toolResults = [];
-        for (const block of response.content) {
-          if (block.type !== "tool_use") continue;
-          const input = block.input;
-          if (block.name === finishTool) {
-            done = extractDone(input);
-            toolResults.push({ type: "tool_result", tool_use_id: block.id, content: "ok" });
-            continue;
-          }
-          const handler2 = handlers[block.name];
-          if (handler2) {
-            const result = await handler2(input);
-            trackTool(block.name, result.length);
-            toolResults.push({ type: "tool_result", tool_use_id: block.id, content: result });
-          } else {
-            toolResults.push({
-              type: "tool_result",
-              tool_use_id: block.id,
-              content: `unknown tool: ${block.name}`,
-              is_error: true
-            });
-          }
-        }
-        for (let i = messages.length - 1; i >= 0; i--) {
-          const msg = messages[i];
-          if (msg.role === "user" && Array.isArray(msg.content)) {
-            const content = msg.content;
-            if (content.some((b) => b.type === "tool_result")) {
-              const entry = { ...content[content.length - 1] };
-              delete entry.cache_control;
-              content[content.length - 1] = entry;
-              break;
-            }
-          }
-        }
-        if (toolResults.length > 0) {
-          const last = toolResults[toolResults.length - 1];
-          toolResults[toolResults.length - 1] = { ...last, cache_control: { type: "ephemeral" } };
-        }
-        messages.push({ role: "user", content: toolResults });
-        if (done !== null) {
-          emitDebug(
-            {
-              type: "result",
-              subtype: "success",
-              iterations: iter + 1,
-              total_in: inputTokens,
-              total_out: outputTokens,
-              elapsed_ms: Date.now() - loopStart
-            },
-            logger
-          );
-          return {
-            done,
-            usage: { inputTokens, outputTokens },
-            iterations: iter + 1,
-            toolCounts,
-            toolCallRecords
-          };
-        }
-      }
-      throw new FerryError("state-invariant", {
-        reason: "tool-loop-iteration-cap-exceeded",
-        cap: maxIterations
-      });
-    }
-  };
-}
-
-// src/lib/llm/tool-loop/openai.ts
-import OpenAI3 from "openai";
-function createOpenAIToolCallLoop(opts) {
-  const client = new OpenAI3({ apiKey: opts.apiKey });
-  return {
-    async run(runOpts) {
-      const {
-        system,
-        initialPrompt,
-        tools,
-        handlers,
-        finishTool,
-        extractDone,
-        maxIterations,
-        maxTokens
-      } = runOpts;
-      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
-      const openaiTools = tools.map((t) => ({
-        type: "function",
-        function: {
-          name: t.name,
-          description: t.description,
-          parameters: t.input_schema
-        }
-      }));
-      const messages = [
-        { role: "system", content: system },
-        { role: "user", content: initialPrompt }
-      ];
-      let inputTokens = 0;
-      let outputTokens = 0;
-      let done = null;
-      const toolCounts = {};
-      const toolCallRecords = [];
-      function trackTool(name, outputSize) {
-        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
-        toolCallRecords.push({ name, outputSize });
-      }
-      const loopStart = Date.now();
-      for (let iter = 0; iter < maxIterations; iter++) {
-        const iterStart = Date.now();
-        const response = await client.chat.completions.create({
-          model: opts.model,
-          max_tokens: maxTokens,
-          messages,
-          tools: openaiTools,
-          tool_choice: "required"
-        });
-        const choice = response.choices[0];
-        if (!choice) {
-          throw new FerryError("state-invariant", { reason: "tool-loop-no-response" });
-        }
-        inputTokens += response.usage?.prompt_tokens ?? 0;
-        outputTokens += response.usage?.completion_tokens ?? 0;
-        const assistantMsg = {
-          role: "assistant",
-          content: choice.message.content ?? null,
-          tool_calls: choice.message.tool_calls
-        };
-        messages.push(assistantMsg);
-        const toolCalls = choice.message.tool_calls ?? [];
-        logger.info("turn", {
-          iter: iter + 1,
-          stop: choice.finish_reason,
-          tools: toolCalls.length,
-          in: response.usage?.prompt_tokens ?? 0,
-          out: response.usage?.completion_tokens ?? 0
-        });
-        emitDebug(
-          {
-            type: "turn",
-            iter: iter + 1,
-            depth: 0,
-            stop_reason: choice.finish_reason ?? "unknown",
-            tools: toolCalls.length,
-            mcp_tools: 0,
-            in: response.usage?.prompt_tokens ?? 0,
-            cache_w: 0,
-            cache_r: 0,
-            out: response.usage?.completion_tokens ?? 0,
-            elapsed_ms: Date.now() - iterStart
-          },
-          logger
-        );
-        if (choice.finish_reason !== "tool_calls") {
-          throw new FerryError("state-invariant", {
-            reason: "tool-loop-stopped-without-finish",
-            stop_reason: choice.finish_reason
-          });
-        }
-        for (const toolCall of toolCalls) {
-          if (toolCall.type !== "function") continue;
-          let input;
-          try {
-            input = JSON.parse(toolCall.function.arguments);
-          } catch {
-            messages.push({
-              role: "tool",
-              tool_call_id: toolCall.id,
-              content: "invalid JSON arguments"
-            });
-            continue;
-          }
-          if (toolCall.function.name === finishTool) {
-            done = extractDone(input);
-            messages.push({ role: "tool", tool_call_id: toolCall.id, content: "ok" });
-            continue;
-          }
-          const handler2 = handlers[toolCall.function.name];
-          if (handler2) {
-            const result = await handler2(input);
-            trackTool(toolCall.function.name, result.length);
-            messages.push({ role: "tool", tool_call_id: toolCall.id, content: result });
-          } else {
-            messages.push({
-              role: "tool",
-              tool_call_id: toolCall.id,
-              content: `unknown tool: ${toolCall.function.name}`
-            });
-          }
-        }
-        if (done !== null) {
-          emitDebug(
-            {
-              type: "result",
-              subtype: "success",
-              iterations: iter + 1,
-              total_in: inputTokens,
-              total_out: outputTokens,
-              elapsed_ms: Date.now() - loopStart
-            },
-            logger
-          );
-          return {
-            done,
-            usage: { inputTokens, outputTokens },
-            iterations: iter + 1,
-            toolCounts,
-            toolCallRecords
-          };
-        }
-      }
-      throw new FerryError("state-invariant", {
-        reason: "tool-loop-iteration-cap-exceeded",
-        cap: maxIterations
-      });
-    }
-  };
-}
-
-// src/lib/llm/tool-loop/google.ts
-import { GoogleGenAI as GoogleGenAI3 } from "@google/genai";
-function toGoogleTools(tools) {
-  return [
-    {
-      functionDeclarations: tools.map((t) => ({
-        name: t.name,
-        description: t.description,
-        parametersJsonSchema: t.input_schema
-      }))
-    }
-  ];
-}
-function createGoogleToolCallLoop(opts) {
-  const ai = new GoogleGenAI3({ apiKey: opts.apiKey });
-  return {
-    async run(runOpts) {
-      const {
-        system,
-        initialPrompt,
-        tools,
-        handlers,
-        finishTool,
-        extractDone,
-        maxIterations,
-        maxTokens
-      } = runOpts;
-      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
-      const googleTools = toGoogleTools(tools);
-      const contents = [{ role: "user", parts: [{ text: initialPrompt }] }];
-      let inputTokens = 0;
-      let outputTokens = 0;
-      let done = null;
-      const toolCounts = {};
-      const toolCallRecords = [];
-      function trackTool(name, outputSize) {
-        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
-        toolCallRecords.push({ name, outputSize });
-      }
-      const loopStart = Date.now();
-      for (let iter = 0; iter < maxIterations; iter++) {
-        const iterStart = Date.now();
-        const response = await ai.models.generateContent({
-          model: opts.model,
-          contents,
-          config: {
-            systemInstruction: system,
-            tools: googleTools,
-            maxOutputTokens: maxTokens
-          }
-        });
-        inputTokens += response.usageMetadata?.promptTokenCount ?? 0;
-        outputTokens += response.usageMetadata?.candidatesTokenCount ?? 0;
-        const fnCalls = response.functionCalls ?? [];
-        const modelParts = response.candidates?.[0]?.content?.parts ?? [];
-        if (modelParts.length > 0) {
-          contents.push({ role: "model", parts: modelParts });
-        }
-        logger.info("turn", {
-          iter: iter + 1,
-          tools: fnCalls.length,
-          in: response.usageMetadata?.promptTokenCount ?? 0,
-          out: response.usageMetadata?.candidatesTokenCount ?? 0
-        });
-        emitDebug(
-          {
-            type: "turn",
-            iter: iter + 1,
-            depth: 0,
-            stop_reason: fnCalls.length > 0 ? "tool_use" : "end_turn",
-            tools: fnCalls.length,
-            mcp_tools: 0,
-            in: response.usageMetadata?.promptTokenCount ?? 0,
-            cache_w: 0,
-            cache_r: 0,
-            out: response.usageMetadata?.candidatesTokenCount ?? 0,
-            elapsed_ms: Date.now() - iterStart
-          },
-          logger
-        );
-        if (fnCalls.length === 0) {
-          throw new FerryError("state-invariant", {
-            reason: "tool-loop-stopped-without-finish",
-            stop_reason: "end_turn"
-          });
-        }
-        const responseParts = [];
-        for (const fc of fnCalls) {
-          const name = fc.name ?? "";
-          const input = fc.args ?? {};
-          if (name === finishTool) {
-            done = extractDone(input);
-            responseParts.push({
-              functionResponse: { name, response: { result: "ok" } }
-            });
-            continue;
-          }
-          const handler2 = handlers[name];
-          if (handler2) {
-            const result = await handler2(input);
-            trackTool(name, result.length);
-            responseParts.push({
-              functionResponse: { name, response: { result } }
-            });
-          } else {
-            responseParts.push({
-              functionResponse: { name, response: { error: `unknown tool: ${name}` } }
-            });
-          }
-        }
-        contents.push({ role: "user", parts: responseParts });
-        if (done !== null) {
-          emitDebug(
-            {
-              type: "result",
-              subtype: "success",
-              iterations: iter + 1,
-              total_in: inputTokens,
-              total_out: outputTokens,
-              elapsed_ms: Date.now() - loopStart
-            },
-            logger
-          );
-          return {
-            done,
-            usage: { inputTokens, outputTokens },
-            iterations: iter + 1,
-            toolCounts,
-            toolCallRecords
-          };
-        }
-      }
-      throw new FerryError("state-invariant", {
-        reason: "tool-loop-iteration-cap-exceeded",
-        cap: maxIterations
-      });
-    }
-  };
-}
-
-// src/lib/llm/tool-loop/index.ts
-function requireEnv4(key) {
-  const val = process.env[key];
-  if (!val) {
-    throw new FerryError("state-invariant", { reason: "missing-env", key });
-  }
-  return val;
-}
-function createToolCallLoop(opts) {
-  if (opts.provider === "anthropic") {
-    const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
-    const client = new Anthropic4(auth2);
-    const thinking = resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
-    return createAnthropicToolCallLoop({ client, model: opts.model, thinking });
-  }
-  resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
-  if (opts.provider === "openai") {
-    const apiKey = requireEnv4("FERRY_OPENAI_KEY");
-    return createOpenAIToolCallLoop({ apiKey, model: opts.model });
-  }
-  if (opts.provider === "google") {
-    const apiKey = requireEnv4("FERRY_GOOGLE_AI_KEY");
-    return createGoogleToolCallLoop({ apiKey, model: opts.model });
-  }
-  throw new FerryError("state-invariant", { reason: "unknown-provider", provider: opts.provider });
-}
-
 // src/lib/io/idempotency.ts
 function checkIdempotencyMarker(marker, items) {
   for (const item of items) {
@@ -10493,7 +10030,6 @@ function gateCi(input) {
 // src/agents/reviewer/review-loop.ts
 var MAX_PATCH_CHARS = 2e4;
 var MAX_CONTENT_CHARS = 4e4;
-var MAX_ITERATIONS = 40;
 var REVIEW_TOOL_DEFS = [
   {
     name: "get_file_patch",
@@ -10518,73 +10054,78 @@ var REVIEW_TOOL_DEFS = [
     }
   },
   {
-    name: "finish_review",
+    name: "done",
     description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
     input_schema: {
       type: "object",
       properties: {
+        actionable: {
+          type: "boolean",
+          description: "true if you are approving the PR, false if requesting changes."
+        },
         approved: {
           type: "boolean",
           description: "true = ready to merge, false = changes required."
+        },
+        summary: {
+          type: "string",
+          description: "One sentence summary of the review outcome."
         },
         comment: {
           type: "string",
           description: "Full review comment in Markdown. Follow the required format from the system prompt."
         }
       },
-      required: ["approved", "comment"]
+      required: ["actionable", "approved", "summary", "comment"]
     }
   }
 ];
+function makeReviewExecuteTool(opts) {
+  const { fileMap, runner, owner, repo, headSha, logger } = opts;
+  return async (_repoRoot, name, input) => {
+    if (name === "get_file_patch") {
+      const filename = input.filename;
+      logger.info("tool", { tool: "get_file_patch", file: filename });
+      const patch = fileMap.get(filename);
+      if (patch === void 0) return `(file not found in PR: ${filename})`;
+      if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
+      const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
+      return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
+    }
+    if (name === "get_file_content") {
+      const filename = input.filename;
+      logger.info("tool", { tool: "get_file_content", file: filename });
+      const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
+      const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
+      return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
+    }
+    throw new Error(`Unknown reviewer tool: ${name}`);
+  };
+}
 async function runReviewLoop(opts) {
-  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
-  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
-  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
-  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
-  const {
-    done: result,
-    usage,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  } = await loop.run({
+  const { loop, system, initialPrompt, repoRoot, branchName } = opts;
+  const mcpServers = opts.mcpServers ?? [];
+  const loopResult = await loop.run({
     system,
     initialPrompt,
     tools: REVIEW_TOOL_DEFS,
-    finishTool: "finish_review",
-    extractDone: (input) => ({
-      approved: input.approved,
-      comment: input.comment
-    }),
-    handlers: {
-      get_file_patch: (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_patch", file: filename });
-        const patch = fileMap.get(filename);
-        if (patch === void 0) return `(file not found in PR: ${filename})`;
-        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
-        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
-        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
-      },
-      get_file_content: async (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_content", file: filename });
-        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
-        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
-        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
-      }
-    },
-    maxIterations,
-    maxTokens,
-    logger
+    repoRoot,
+    branchName,
+    secretScan: () => Promise.resolve(),
+    mcpServers
   });
+  const done = loopResult.done;
+  const result = {
+    approved: done.approved,
+    comment: done.comment
+  };
   return {
     result,
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-    iterations,
-    toolCounts,
-    toolCallRecords
+    inputTokens: loopResult.usage.input_tokens,
+    outputTokens: loopResult.usage.output_tokens,
+    iterations: loopResult.iterations,
+    toolCounts: loopResult.toolCounts,
+    toolCallRecords: loopResult.toolCallRecords
   };
 }
 
@@ -10741,6 +10282,12 @@ async function main3(envelope, logger) {
   }
   const files = await runner.listPRFiles({ owner, repo, prNumber });
   const commits = await runner.listPRCommits({ owner, repo, prNumber });
+  const mcpPool = loadMcpServers();
+  const hasLabelsConfig = effectiveCfg.labels !== void 0;
+  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  if (mcpServers.length > 0) {
+    logger.info("MCP servers", { servers: mcpServers.map((s) => s.name) });
+  }
   const prepared = prepareReviewer({
     ticketKey,
     issue,
@@ -10752,10 +10299,21 @@ async function main3(envelope, logger) {
     reviewRubric: reviewRubricOverride,
     capabilities,
     idempotencyMarker,
-    repoRoot: REPO_ROOT3
+    repoRoot: REPO_ROOT3,
+    mcpPool,
+    configLabels: effectiveCfg.labels
   });
   const { system, initialPrompt, fileMap } = prepared;
-  const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
+  const executeTool2 = makeReviewExecuteTool({ fileMap, runner, owner, repo, headSha, logger });
+  const loop = createAgentLoop({
+    provider,
+    model,
+    thinking: thinkingOverride,
+    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
+    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
+    executeTool: executeTool2,
+    logger
+  });
   const {
     result: review,
     inputTokens,
@@ -10767,13 +10325,9 @@ async function main3(envelope, logger) {
     loop,
     system,
     initialPrompt,
-    fileMap,
-    runner,
-    owner,
-    repo,
-    headSha,
-    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
-    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
+    repoRoot: REPO_ROOT3,
+    branchName,
+    mcpServers,
     logger
   });
   logger.info("reviewed", {

--- a/.github/actions/ferry-run-reviewer/agent.js
+++ b/.github/actions/ferry-run-reviewer/agent.js
@@ -6688,7 +6688,9 @@ function prepareReviewer(input) {
     reviewRubric,
     capabilities,
     idempotencyMarker,
-    repoRoot
+    repoRoot,
+    mcpPool,
+    configLabels
   } = input;
   const buildSystem2 = input._buildSystem ?? buildSystem;
   const loadOptionalPrompt2 = input._loadOptionalPrompt ?? loadOptionalPrompt;
@@ -6718,14 +6720,15 @@ function prepareReviewer(input) {
     buildFileList(files),
     "",
     "Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.",
-    "When you have enough information, call finish_review."
+    "When you have enough information, call done."
   ].filter((l) => l !== null).join("\n");
   const baseSystem = buildSystem2("review", repoRoot, {
     extraParts: [loadOptionalPrompt2("review-comment", repoRoot)],
     separator: "\n\n---\n\n"
   });
   const system = applyRubricToPrompt(baseSystem, reviewRubric);
-  const mcpServers = [];
+  const hasLabelsConfig = configLabels !== void 0;
+  const mcpServers = mcpPool !== void 0 ? filterMcpServers(mcpPool, capabilities, hasLabelsConfig) : [];
   return {
     system,
     initialPrompt,
@@ -9984,472 +9987,6 @@ async function main2(envelope, logger) {
   process.exit(0);
 }
 
-// src/lib/llm/tool-loop/index.ts
-import Anthropic4 from "@anthropic-ai/sdk";
-
-// src/lib/llm/tool-loop/anthropic.ts
-function createAnthropicToolCallLoop(opts) {
-  return {
-    async run(runOpts) {
-      const {
-        system,
-        initialPrompt,
-        tools,
-        handlers,
-        finishTool,
-        extractDone,
-        maxIterations,
-        maxTokens
-      } = runOpts;
-      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
-      const anthropicTools = tools.map(
-        (t, i) => i === tools.length - 1 ? { ...t, cache_control: { type: "ephemeral" } } : t
-      );
-      const messages = [
-        {
-          role: "user",
-          content: [{ type: "text", text: initialPrompt, cache_control: { type: "ephemeral" } }]
-        }
-      ];
-      let inputTokens = 0;
-      let outputTokens = 0;
-      let done = null;
-      const toolCounts = {};
-      const toolCallRecords = [];
-      function trackTool(name, outputSize) {
-        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
-        toolCallRecords.push({ name, outputSize });
-      }
-      const loopStart = Date.now();
-      for (let iter = 0; iter < maxIterations; iter++) {
-        const iterStart = Date.now();
-        const response = await opts.client.messages.create({
-          model: opts.model,
-          max_tokens: maxTokens,
-          system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
-          tools: anthropicTools,
-          messages,
-          ...opts.thinking !== void 0 ? { thinking: opts.thinking } : {}
-        });
-        inputTokens += response.usage.input_tokens;
-        outputTokens += response.usage.output_tokens;
-        messages.push({ role: "assistant", content: response.content });
-        const toolCount = response.content.filter((b) => b.type === "tool_use").length;
-        logger.info("turn", {
-          iter: iter + 1,
-          stop: response.stop_reason,
-          tools: toolCount,
-          in: response.usage.input_tokens,
-          out: response.usage.output_tokens
-        });
-        emitDebug(
-          {
-            type: "turn",
-            iter: iter + 1,
-            depth: 0,
-            stop_reason: response.stop_reason ?? "unknown",
-            tools: toolCount,
-            mcp_tools: 0,
-            in: response.usage.input_tokens,
-            cache_w: 0,
-            cache_r: 0,
-            out: response.usage.output_tokens,
-            elapsed_ms: Date.now() - iterStart
-          },
-          logger
-        );
-        if (response.stop_reason !== "tool_use") {
-          throw new FerryError("state-invariant", {
-            reason: "tool-loop-stopped-without-finish",
-            stop_reason: response.stop_reason
-          });
-        }
-        const toolResults = [];
-        for (const block of response.content) {
-          if (block.type !== "tool_use") continue;
-          const input = block.input;
-          if (block.name === finishTool) {
-            done = extractDone(input);
-            toolResults.push({ type: "tool_result", tool_use_id: block.id, content: "ok" });
-            continue;
-          }
-          const handler2 = handlers[block.name];
-          if (handler2) {
-            const result = await handler2(input);
-            trackTool(block.name, result.length);
-            toolResults.push({ type: "tool_result", tool_use_id: block.id, content: result });
-          } else {
-            toolResults.push({
-              type: "tool_result",
-              tool_use_id: block.id,
-              content: `unknown tool: ${block.name}`,
-              is_error: true
-            });
-          }
-        }
-        for (let i = messages.length - 1; i >= 0; i--) {
-          const msg = messages[i];
-          if (msg.role === "user" && Array.isArray(msg.content)) {
-            const content = msg.content;
-            if (content.some((b) => b.type === "tool_result")) {
-              const entry = { ...content[content.length - 1] };
-              delete entry.cache_control;
-              content[content.length - 1] = entry;
-              break;
-            }
-          }
-        }
-        if (toolResults.length > 0) {
-          const last = toolResults[toolResults.length - 1];
-          toolResults[toolResults.length - 1] = { ...last, cache_control: { type: "ephemeral" } };
-        }
-        messages.push({ role: "user", content: toolResults });
-        if (done !== null) {
-          emitDebug(
-            {
-              type: "result",
-              subtype: "success",
-              iterations: iter + 1,
-              total_in: inputTokens,
-              total_out: outputTokens,
-              elapsed_ms: Date.now() - loopStart
-            },
-            logger
-          );
-          return {
-            done,
-            usage: { inputTokens, outputTokens },
-            iterations: iter + 1,
-            toolCounts,
-            toolCallRecords
-          };
-        }
-      }
-      throw new FerryError("state-invariant", {
-        reason: "tool-loop-iteration-cap-exceeded",
-        cap: maxIterations
-      });
-    }
-  };
-}
-
-// src/lib/llm/tool-loop/openai.ts
-import OpenAI3 from "openai";
-function createOpenAIToolCallLoop(opts) {
-  const client = new OpenAI3({ apiKey: opts.apiKey });
-  return {
-    async run(runOpts) {
-      const {
-        system,
-        initialPrompt,
-        tools,
-        handlers,
-        finishTool,
-        extractDone,
-        maxIterations,
-        maxTokens
-      } = runOpts;
-      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
-      const openaiTools = tools.map((t) => ({
-        type: "function",
-        function: {
-          name: t.name,
-          description: t.description,
-          parameters: t.input_schema
-        }
-      }));
-      const messages = [
-        { role: "system", content: system },
-        { role: "user", content: initialPrompt }
-      ];
-      let inputTokens = 0;
-      let outputTokens = 0;
-      let done = null;
-      const toolCounts = {};
-      const toolCallRecords = [];
-      function trackTool(name, outputSize) {
-        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
-        toolCallRecords.push({ name, outputSize });
-      }
-      const loopStart = Date.now();
-      for (let iter = 0; iter < maxIterations; iter++) {
-        const iterStart = Date.now();
-        const response = await client.chat.completions.create({
-          model: opts.model,
-          max_tokens: maxTokens,
-          messages,
-          tools: openaiTools,
-          tool_choice: "required"
-        });
-        const choice = response.choices[0];
-        if (!choice) {
-          throw new FerryError("state-invariant", { reason: "tool-loop-no-response" });
-        }
-        inputTokens += response.usage?.prompt_tokens ?? 0;
-        outputTokens += response.usage?.completion_tokens ?? 0;
-        const assistantMsg = {
-          role: "assistant",
-          content: choice.message.content ?? null,
-          tool_calls: choice.message.tool_calls
-        };
-        messages.push(assistantMsg);
-        const toolCalls = choice.message.tool_calls ?? [];
-        logger.info("turn", {
-          iter: iter + 1,
-          stop: choice.finish_reason,
-          tools: toolCalls.length,
-          in: response.usage?.prompt_tokens ?? 0,
-          out: response.usage?.completion_tokens ?? 0
-        });
-        emitDebug(
-          {
-            type: "turn",
-            iter: iter + 1,
-            depth: 0,
-            stop_reason: choice.finish_reason ?? "unknown",
-            tools: toolCalls.length,
-            mcp_tools: 0,
-            in: response.usage?.prompt_tokens ?? 0,
-            cache_w: 0,
-            cache_r: 0,
-            out: response.usage?.completion_tokens ?? 0,
-            elapsed_ms: Date.now() - iterStart
-          },
-          logger
-        );
-        if (choice.finish_reason !== "tool_calls") {
-          throw new FerryError("state-invariant", {
-            reason: "tool-loop-stopped-without-finish",
-            stop_reason: choice.finish_reason
-          });
-        }
-        for (const toolCall of toolCalls) {
-          if (toolCall.type !== "function") continue;
-          let input;
-          try {
-            input = JSON.parse(toolCall.function.arguments);
-          } catch {
-            messages.push({
-              role: "tool",
-              tool_call_id: toolCall.id,
-              content: "invalid JSON arguments"
-            });
-            continue;
-          }
-          if (toolCall.function.name === finishTool) {
-            done = extractDone(input);
-            messages.push({ role: "tool", tool_call_id: toolCall.id, content: "ok" });
-            continue;
-          }
-          const handler2 = handlers[toolCall.function.name];
-          if (handler2) {
-            const result = await handler2(input);
-            trackTool(toolCall.function.name, result.length);
-            messages.push({ role: "tool", tool_call_id: toolCall.id, content: result });
-          } else {
-            messages.push({
-              role: "tool",
-              tool_call_id: toolCall.id,
-              content: `unknown tool: ${toolCall.function.name}`
-            });
-          }
-        }
-        if (done !== null) {
-          emitDebug(
-            {
-              type: "result",
-              subtype: "success",
-              iterations: iter + 1,
-              total_in: inputTokens,
-              total_out: outputTokens,
-              elapsed_ms: Date.now() - loopStart
-            },
-            logger
-          );
-          return {
-            done,
-            usage: { inputTokens, outputTokens },
-            iterations: iter + 1,
-            toolCounts,
-            toolCallRecords
-          };
-        }
-      }
-      throw new FerryError("state-invariant", {
-        reason: "tool-loop-iteration-cap-exceeded",
-        cap: maxIterations
-      });
-    }
-  };
-}
-
-// src/lib/llm/tool-loop/google.ts
-import { GoogleGenAI as GoogleGenAI3 } from "@google/genai";
-function toGoogleTools(tools) {
-  return [
-    {
-      functionDeclarations: tools.map((t) => ({
-        name: t.name,
-        description: t.description,
-        parametersJsonSchema: t.input_schema
-      }))
-    }
-  ];
-}
-function createGoogleToolCallLoop(opts) {
-  const ai = new GoogleGenAI3({ apiKey: opts.apiKey });
-  return {
-    async run(runOpts) {
-      const {
-        system,
-        initialPrompt,
-        tools,
-        handlers,
-        finishTool,
-        extractDone,
-        maxIterations,
-        maxTokens
-      } = runOpts;
-      const logger = runOpts.logger ?? createLogger("", "ferry:tool-loop");
-      const googleTools = toGoogleTools(tools);
-      const contents = [{ role: "user", parts: [{ text: initialPrompt }] }];
-      let inputTokens = 0;
-      let outputTokens = 0;
-      let done = null;
-      const toolCounts = {};
-      const toolCallRecords = [];
-      function trackTool(name, outputSize) {
-        toolCounts[name] = (toolCounts[name] ?? 0) + 1;
-        toolCallRecords.push({ name, outputSize });
-      }
-      const loopStart = Date.now();
-      for (let iter = 0; iter < maxIterations; iter++) {
-        const iterStart = Date.now();
-        const response = await ai.models.generateContent({
-          model: opts.model,
-          contents,
-          config: {
-            systemInstruction: system,
-            tools: googleTools,
-            maxOutputTokens: maxTokens
-          }
-        });
-        inputTokens += response.usageMetadata?.promptTokenCount ?? 0;
-        outputTokens += response.usageMetadata?.candidatesTokenCount ?? 0;
-        const fnCalls = response.functionCalls ?? [];
-        const modelParts = response.candidates?.[0]?.content?.parts ?? [];
-        if (modelParts.length > 0) {
-          contents.push({ role: "model", parts: modelParts });
-        }
-        logger.info("turn", {
-          iter: iter + 1,
-          tools: fnCalls.length,
-          in: response.usageMetadata?.promptTokenCount ?? 0,
-          out: response.usageMetadata?.candidatesTokenCount ?? 0
-        });
-        emitDebug(
-          {
-            type: "turn",
-            iter: iter + 1,
-            depth: 0,
-            stop_reason: fnCalls.length > 0 ? "tool_use" : "end_turn",
-            tools: fnCalls.length,
-            mcp_tools: 0,
-            in: response.usageMetadata?.promptTokenCount ?? 0,
-            cache_w: 0,
-            cache_r: 0,
-            out: response.usageMetadata?.candidatesTokenCount ?? 0,
-            elapsed_ms: Date.now() - iterStart
-          },
-          logger
-        );
-        if (fnCalls.length === 0) {
-          throw new FerryError("state-invariant", {
-            reason: "tool-loop-stopped-without-finish",
-            stop_reason: "end_turn"
-          });
-        }
-        const responseParts = [];
-        for (const fc of fnCalls) {
-          const name = fc.name ?? "";
-          const input = fc.args ?? {};
-          if (name === finishTool) {
-            done = extractDone(input);
-            responseParts.push({
-              functionResponse: { name, response: { result: "ok" } }
-            });
-            continue;
-          }
-          const handler2 = handlers[name];
-          if (handler2) {
-            const result = await handler2(input);
-            trackTool(name, result.length);
-            responseParts.push({
-              functionResponse: { name, response: { result } }
-            });
-          } else {
-            responseParts.push({
-              functionResponse: { name, response: { error: `unknown tool: ${name}` } }
-            });
-          }
-        }
-        contents.push({ role: "user", parts: responseParts });
-        if (done !== null) {
-          emitDebug(
-            {
-              type: "result",
-              subtype: "success",
-              iterations: iter + 1,
-              total_in: inputTokens,
-              total_out: outputTokens,
-              elapsed_ms: Date.now() - loopStart
-            },
-            logger
-          );
-          return {
-            done,
-            usage: { inputTokens, outputTokens },
-            iterations: iter + 1,
-            toolCounts,
-            toolCallRecords
-          };
-        }
-      }
-      throw new FerryError("state-invariant", {
-        reason: "tool-loop-iteration-cap-exceeded",
-        cap: maxIterations
-      });
-    }
-  };
-}
-
-// src/lib/llm/tool-loop/index.ts
-function requireEnv4(key) {
-  const val = process.env[key];
-  if (!val) {
-    throw new FerryError("state-invariant", { reason: "missing-env", key });
-  }
-  return val;
-}
-function createToolCallLoop(opts) {
-  if (opts.provider === "anthropic") {
-    const auth2 = resolveAnthropicAuth({ apiKeyEnv: "ANTHROPIC_API_KEY" });
-    const client = new Anthropic4(auth2);
-    const thinking = resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
-    return createAnthropicToolCallLoop({ client, model: opts.model, thinking });
-  }
-  resolveThinkingForProvider(opts.thinking, opts.provider, opts.logger);
-  if (opts.provider === "openai") {
-    const apiKey = requireEnv4("FERRY_OPENAI_KEY");
-    return createOpenAIToolCallLoop({ apiKey, model: opts.model });
-  }
-  if (opts.provider === "google") {
-    const apiKey = requireEnv4("FERRY_GOOGLE_AI_KEY");
-    return createGoogleToolCallLoop({ apiKey, model: opts.model });
-  }
-  throw new FerryError("state-invariant", { reason: "unknown-provider", provider: opts.provider });
-}
-
 // src/lib/io/idempotency.ts
 function checkIdempotencyMarker(marker, items) {
   for (const item of items) {
@@ -10493,7 +10030,6 @@ function gateCi(input) {
 // src/agents/reviewer/review-loop.ts
 var MAX_PATCH_CHARS = 2e4;
 var MAX_CONTENT_CHARS = 4e4;
-var MAX_ITERATIONS = 40;
 var REVIEW_TOOL_DEFS = [
   {
     name: "get_file_patch",
@@ -10518,73 +10054,78 @@ var REVIEW_TOOL_DEFS = [
     }
   },
   {
-    name: "finish_review",
+    name: "done",
     description: "Post the review verdict and end the review loop. Call once you have inspected all relevant files.",
     input_schema: {
       type: "object",
       properties: {
+        actionable: {
+          type: "boolean",
+          description: "true if you are approving the PR, false if requesting changes."
+        },
         approved: {
           type: "boolean",
           description: "true = ready to merge, false = changes required."
+        },
+        summary: {
+          type: "string",
+          description: "One sentence summary of the review outcome."
         },
         comment: {
           type: "string",
           description: "Full review comment in Markdown. Follow the required format from the system prompt."
         }
       },
-      required: ["approved", "comment"]
+      required: ["actionable", "approved", "summary", "comment"]
     }
   }
 ];
+function makeReviewExecuteTool(opts) {
+  const { fileMap, runner, owner, repo, headSha, logger } = opts;
+  return async (_repoRoot, name, input) => {
+    if (name === "get_file_patch") {
+      const filename = input.filename;
+      logger.info("tool", { tool: "get_file_patch", file: filename });
+      const patch = fileMap.get(filename);
+      if (patch === void 0) return `(file not found in PR: ${filename})`;
+      if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
+      const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
+      return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
+    }
+    if (name === "get_file_content") {
+      const filename = input.filename;
+      logger.info("tool", { tool: "get_file_content", file: filename });
+      const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
+      const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
+      return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
+    }
+    throw new Error(`Unknown reviewer tool: ${name}`);
+  };
+}
 async function runReviewLoop(opts) {
-  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
-  const logger = opts.logger ?? createLogger("", "ferry:review-loop");
-  const maxIterations = opts.maxIterations ?? (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? "", 10) || MAX_ITERATIONS);
-  const maxTokens = opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? "", 10) || 16384);
-  const {
-    done: result,
-    usage,
-    iterations,
-    toolCounts,
-    toolCallRecords
-  } = await loop.run({
+  const { loop, system, initialPrompt, repoRoot, branchName } = opts;
+  const mcpServers = opts.mcpServers ?? [];
+  const loopResult = await loop.run({
     system,
     initialPrompt,
     tools: REVIEW_TOOL_DEFS,
-    finishTool: "finish_review",
-    extractDone: (input) => ({
-      approved: input.approved,
-      comment: input.comment
-    }),
-    handlers: {
-      get_file_patch: (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_patch", file: filename });
-        const patch = fileMap.get(filename);
-        if (patch === void 0) return `(file not found in PR: ${filename})`;
-        if (!patch) return "(no patch \u2014 binary, empty, or content unchanged)";
-        const patchLimit = parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? "", 10) || MAX_PATCH_CHARS;
-        return patch.length > patchLimit ? patch.slice(0, patchLimit) + "\n... (truncated)" : patch;
-      },
-      get_file_content: async (input) => {
-        const filename = input.filename;
-        logger.info("tool", { tool: "get_file_content", file: filename });
-        const fileLimit = parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? "", 10) || MAX_CONTENT_CHARS;
-        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
-        return rawContent.length > fileLimit ? rawContent.slice(0, fileLimit) + "\n... (truncated)" : rawContent;
-      }
-    },
-    maxIterations,
-    maxTokens,
-    logger
+    repoRoot,
+    branchName,
+    secretScan: () => Promise.resolve(),
+    mcpServers
   });
+  const done = loopResult.done;
+  const result = {
+    approved: done.approved,
+    comment: done.comment
+  };
   return {
     result,
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-    iterations,
-    toolCounts,
-    toolCallRecords
+    inputTokens: loopResult.usage.input_tokens,
+    outputTokens: loopResult.usage.output_tokens,
+    iterations: loopResult.iterations,
+    toolCounts: loopResult.toolCounts,
+    toolCallRecords: loopResult.toolCallRecords
   };
 }
 
@@ -10741,6 +10282,12 @@ async function main3(envelope, logger) {
   }
   const files = await runner.listPRFiles({ owner, repo, prNumber });
   const commits = await runner.listPRCommits({ owner, repo, prNumber });
+  const mcpPool = loadMcpServers();
+  const hasLabelsConfig = effectiveCfg.labels !== void 0;
+  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  if (mcpServers.length > 0) {
+    logger.info("MCP servers", { servers: mcpServers.map((s) => s.name) });
+  }
   const prepared = prepareReviewer({
     ticketKey,
     issue,
@@ -10752,10 +10299,21 @@ async function main3(envelope, logger) {
     reviewRubric: reviewRubricOverride,
     capabilities,
     idempotencyMarker,
-    repoRoot: REPO_ROOT3
+    repoRoot: REPO_ROOT3,
+    mcpPool,
+    configLabels: effectiveCfg.labels
   });
   const { system, initialPrompt, fileMap } = prepared;
-  const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
+  const executeTool2 = makeReviewExecuteTool({ fileMap, runner, owner, repo, headSha, logger });
+  const loop = createAgentLoop({
+    provider,
+    model,
+    thinking: thinkingOverride,
+    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
+    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
+    executeTool: executeTool2,
+    logger
+  });
   const {
     result: review,
     inputTokens,
@@ -10767,13 +10325,9 @@ async function main3(envelope, logger) {
     loop,
     system,
     initialPrompt,
-    fileMap,
-    runner,
-    owner,
-    repo,
-    headSha,
-    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
-    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
+    repoRoot: REPO_ROOT3,
+    branchName,
+    mcpServers,
     logger
   });
   logger.info("reviewed", {

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -1,7 +1,7 @@
-import { createToolCallLoop } from '../../lib/llm/tool-loop/index.js';
+import { createAgentLoop } from '../../lib/llm/agent-loop/index.js';
 import { checkIdempotencyMarker } from '../../lib/io/idempotency.js';
 import { gateCi } from './ci-gate.js';
-import { runReviewLoop } from './review-loop.js';
+import { runReviewLoop, makeReviewExecuteTool } from './review-loop.js';
 import {
   resolveCapabilities,
   resolveTicketOverrides,
@@ -14,6 +14,7 @@ import {
 } from '../../lib/agent-runtime/index.js';
 import {
   requireEnv,
+  loadMcpServers,
   appendOutput,
   writeStepSummary,
   createGitHubContext,
@@ -22,6 +23,7 @@ import {
   loadFerryConfigFromBaseBranch,
   logCapabilities,
   logTicketOverrides,
+  filterMcpServers,
   byEventId,
   byPrHeadSha,
   prepareReviewer,
@@ -209,6 +211,16 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
   const files = await runner.listPRFiles({ owner, repo, prNumber });
   const commits = await runner.listPRCommits({ owner, repo, prNumber });
 
+  // MCP plumbing: load the full pool, then filter to the servers enabled by
+  // the ticket's capability labels. Reviewer inherits MCP wiring via
+  // createAgentLoop (issue #322).
+  const mcpPool = loadMcpServers();
+  const hasLabelsConfig = effectiveCfg.labels !== undefined;
+  const mcpServers = filterMcpServers(mcpPool, capabilities, hasLabelsConfig);
+  if (mcpServers.length > 0) {
+    logger.info('MCP servers', { servers: mcpServers.map((s) => s.name) });
+  }
+
   // Pre-loop setup: builds the reviewer system prompt (with review-comment
   // overlay + rubric override), the initial prompt, the filename→patch map,
   // and the capability-filtered MCP pool. Extracted into a reusable prepare
@@ -227,10 +239,22 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     capabilities,
     idempotencyMarker,
     repoRoot: REPO_ROOT,
+    mcpPool,
+    configLabels: effectiveCfg.labels,
   });
   const { system, initialPrompt, fileMap } = prepared;
 
-  const loop = createToolCallLoop({ provider, model, thinking: thinkingOverride, logger });
+  const executeTool = makeReviewExecuteTool({ fileMap, runner, owner, repo, headSha, logger });
+
+  const loop = createAgentLoop({
+    provider,
+    model,
+    thinking: thinkingOverride,
+    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
+    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
+    executeTool,
+    logger,
+  });
 
   const {
     result: review,
@@ -243,13 +267,9 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     loop,
     system,
     initialPrompt,
-    fileMap,
-    runner,
-    owner,
-    repo,
-    headSha,
-    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
-    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
+    repoRoot: REPO_ROOT,
+    branchName,
+    mcpServers,
     logger,
   });
 

--- a/src/agents/reviewer/review-loop.test.ts
+++ b/src/agents/reviewer/review-loop.test.ts
@@ -3,70 +3,54 @@ import {
   runReviewLoop,
   detectMergeConflicts,
   buildFileList,
+  makeReviewExecuteTool,
   MAX_PATCH_CHARS,
 } from './review-loop.js';
 import type { PrFile } from './review-loop.js';
 import type { CIRunner } from '../../lib/dispatch/runner/types.js';
-import type {
-  ToolCallLoop,
-  ToolLoopRunOpts,
-  ToolLoopResult,
-} from '../../lib/llm/tool-loop/index.js';
+import type { AgentLoop, AgentLoopResult } from '../../lib/llm/agent-loop/index.js';
 
-/** Creates a mock ToolCallLoop that invokes handlers to simulate an LLM run. */
-function makeMockLoop(
-  scenario: (
-    opts: ToolLoopRunOpts<unknown>,
-  ) => Promise<ToolLoopResult<unknown>> | ToolLoopResult<unknown>,
-): ToolCallLoop {
+function makeAgentLoopResult(
+  approved: boolean,
+  comment: string,
+  overrides: Partial<AgentLoopResult> = {},
+): AgentLoopResult {
   return {
-    run: vi.fn().mockImplementation(scenario),
+    done: {
+      actionable: approved,
+      approved,
+      summary: comment,
+      comment,
+    } as unknown as AgentLoopResult['done'],
+    usage: {
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    },
+    iterations: 1,
+    toolCounts: {},
+    toolCallRecords: [],
+    ...overrides,
   };
 }
 
-/** Simulates a single-turn finish_review call. */
-function makeFinishLoop(approved: boolean, comment: string): ToolCallLoop {
-  return makeMockLoop(async (opts) => {
-    const done = opts.extractDone({ approved, comment });
-    return {
-      done,
-      usage: { inputTokens: 100, outputTokens: 50 },
-      iterations: 1,
-      toolCounts: {},
-      toolCallRecords: [],
-    };
-  });
+function makeAgentLoop(result: AgentLoopResult): AgentLoop {
+  return { run: vi.fn().mockResolvedValue(result) };
 }
 
-/** Simulates: call handler once → finish_review. */
-function makeToolThenFinishLoop(
-  toolName: string,
-  toolInput: Record<string, unknown>,
-  approved: boolean,
-  comment: string,
-): ToolCallLoop {
-  return makeMockLoop(async (opts) => {
-    const handler = opts.handlers[toolName];
-    if (handler) await handler(toolInput);
-    const done = opts.extractDone({ approved, comment });
-    return {
-      done,
-      usage: { inputTokens: 200, outputTokens: 80 },
-      iterations: 2,
-      toolCounts: { [toolName]: 1 },
-      toolCallRecords: [{ name: toolName, outputSize: 10 }],
-    };
-  });
-}
+const noopLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
 
 const baseOpts = {
   system: 'sys',
   initialPrompt: 'review this',
-  fileMap: new Map<string, string | undefined>(),
-  runner: {} as unknown as CIRunner,
-  owner: 'org',
-  repo: 'repo',
-  headSha: 'abc123',
+  repoRoot: '/repo',
+  branchName: 'ferry/PROJ-1',
 };
 
 describe('runReviewLoop', () => {
@@ -75,8 +59,8 @@ describe('runReviewLoop', () => {
     vi.restoreAllMocks();
   });
 
-  it('completes when finish_review is called', async () => {
-    const loop = makeFinishLoop(true, 'LGTM');
+  it('completes when done is called with approved=true', async () => {
+    const loop = makeAgentLoop(makeAgentLoopResult(true, 'LGTM'));
     const result = await runReviewLoop({ ...baseOpts, loop });
     expect(result.result.approved).toBe(true);
     expect(result.result.comment).toBe('LGTM');
@@ -84,119 +68,153 @@ describe('runReviewLoop', () => {
     expect(result.outputTokens).toBe(50);
   });
 
-  it('returns correct iteration count', async () => {
-    const loop = makeFinishLoop(false, 'needs work');
+  it('completes when done is called with approved=false', async () => {
+    const loop = makeAgentLoop(makeAgentLoopResult(false, 'needs work'));
     const result = await runReviewLoop({ ...baseOpts, loop });
-    expect(result.iterations).toBe(1);
+    expect(result.result.approved).toBe(false);
+    expect(result.result.comment).toBe('needs work');
   });
 
-  it('passes get_file_patch handler that returns patch from fileMap', async () => {
+  it('returns correct iteration count', async () => {
+    const loopResult = makeAgentLoopResult(true, 'ok', { iterations: 3 });
+    const loop = makeAgentLoop(loopResult);
+    const result = await runReviewLoop({ ...baseOpts, loop });
+    expect(result.iterations).toBe(3);
+  });
+
+  it('passes tools, repoRoot, branchName, secretScan to loop.run', async () => {
+    const loop = makeAgentLoop(makeAgentLoopResult(true, 'ok'));
+    await runReviewLoop({ ...baseOpts, loop });
+    const runOpts = (loop.run as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(runOpts.repoRoot).toBe('/repo');
+    expect(runOpts.branchName).toBe('ferry/PROJ-1');
+    expect(typeof runOpts.secretScan).toBe('function');
+    expect(runOpts.tools).toBeDefined();
+    expect(runOpts.tools.some((t: { name: string }) => t.name === 'get_file_patch')).toBe(true);
+    expect(runOpts.tools.some((t: { name: string }) => t.name === 'get_file_content')).toBe(true);
+    expect(runOpts.tools.some((t: { name: string }) => t.name === 'done')).toBe(true);
+  });
+
+  it('passes mcpServers to loop.run when provided', async () => {
+    const mcpServers = [{ name: 'atlassian', url: 'https://mcp.atlassian.com' }];
+    const loop = makeAgentLoop(makeAgentLoopResult(true, 'ok'));
+    await runReviewLoop({ ...baseOpts, loop, mcpServers });
+    const runOpts = (loop.run as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(runOpts.mcpServers).toEqual(mcpServers);
+  });
+
+  it('passes empty mcpServers when not provided', async () => {
+    const loop = makeAgentLoop(makeAgentLoopResult(true, 'ok'));
+    await runReviewLoop({ ...baseOpts, loop });
+    const runOpts = (loop.run as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(runOpts.mcpServers).toEqual([]);
+  });
+
+  it('passes through toolCounts and toolCallRecords from the loop', async () => {
+    const loopResult = makeAgentLoopResult(true, 'ok', {
+      toolCounts: { get_file_patch: 2 },
+      toolCallRecords: [{ name: 'get_file_patch', outputSize: 500 }],
+    });
+    const loop = makeAgentLoop(loopResult);
+    const result = await runReviewLoop({ ...baseOpts, loop });
+    expect(result.toolCounts).toEqual({ get_file_patch: 2 });
+    expect(result.toolCallRecords).toEqual([{ name: 'get_file_patch', outputSize: 500 }]);
+  });
+});
+
+describe('makeReviewExecuteTool', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('get_file_patch returns patch from fileMap', async () => {
     const fileMap = new Map<string, string | undefined>([
       ['src/auth.ts', '+export function login() {}'],
     ]);
-    let capturedContent: string | undefined;
-
-    const loop = makeMockLoop(async (opts) => {
-      const handler = opts.handlers['get_file_patch'];
-      capturedContent = await handler!({ filename: 'src/auth.ts' });
-      const done = opts.extractDone({ approved: true, comment: 'ok' });
-      return {
-        done,
-        usage: { inputTokens: 20, outputTokens: 10 },
-        iterations: 2,
-        toolCounts: {},
-        toolCallRecords: [],
-      };
+    const executeTool = makeReviewExecuteTool({
+      fileMap,
+      runner: {} as unknown as CIRunner,
+      owner: 'org',
+      repo: 'repo',
+      headSha: 'abc123',
+      logger: noopLogger as never,
     });
-
-    await runReviewLoop({ ...baseOpts, fileMap, loop });
-    expect(capturedContent).toBe('+export function login() {}');
+    const result = await executeTool('/repo', 'get_file_patch', { filename: 'src/auth.ts' });
+    expect(result).toBe('+export function login() {}');
   });
 
   it('get_file_patch returns not-found message for missing file', async () => {
-    let capturedContent: string | undefined;
-    const loop = makeMockLoop(async (opts) => {
-      capturedContent = await opts.handlers['get_file_patch']!({ filename: 'missing.ts' });
-      const done = opts.extractDone({ approved: false, comment: 'cannot find file' });
-      return {
-        done,
-        usage: { inputTokens: 10, outputTokens: 5 },
-        iterations: 2,
-        toolCounts: {},
-        toolCallRecords: [],
-      };
+    const fileMap = new Map<string, string | undefined>();
+    const executeTool = makeReviewExecuteTool({
+      fileMap,
+      runner: {} as unknown as CIRunner,
+      owner: 'org',
+      repo: 'repo',
+      headSha: 'abc123',
+      logger: noopLogger as never,
     });
-
-    await runReviewLoop({ ...baseOpts, loop });
-    expect(capturedContent).toContain('(file not found in PR: missing.ts)');
+    const result = await executeTool('/repo', 'get_file_patch', { filename: 'missing.ts' });
+    expect(result).toContain('(file not found in PR: missing.ts)');
   });
 
   it('get_file_patch returns no-patch message for empty string', async () => {
     const fileMap = new Map<string, string | undefined>([['binary.png', '']]);
-    let capturedContent: string | undefined;
-    const loop = makeMockLoop(async (opts) => {
-      capturedContent = await opts.handlers['get_file_patch']!({ filename: 'binary.png' });
-      const done = opts.extractDone({ approved: true, comment: 'ok' });
-      return {
-        done,
-        usage: { inputTokens: 10, outputTokens: 5 },
-        iterations: 2,
-        toolCounts: {},
-        toolCallRecords: [],
-      };
+    const executeTool = makeReviewExecuteTool({
+      fileMap,
+      runner: {} as unknown as CIRunner,
+      owner: 'org',
+      repo: 'repo',
+      headSha: 'abc123',
+      logger: noopLogger as never,
     });
-
-    await runReviewLoop({ ...baseOpts, fileMap, loop });
-    expect(capturedContent).toBe('(no patch — binary, empty, or content unchanged)');
+    const result = await executeTool('/repo', 'get_file_patch', { filename: 'binary.png' });
+    expect(result).toBe('(no patch — binary, empty, or content unchanged)');
   });
 
   it('truncates patch when it exceeds MAX_PATCH_CHARS', async () => {
     const longPatch = '+' + 'x'.repeat(MAX_PATCH_CHARS + 100);
     const fileMap = new Map<string, string | undefined>([['big.ts', longPatch]]);
-    let capturedContent: string | undefined;
-    const loop = makeMockLoop(async (opts) => {
-      capturedContent = await opts.handlers['get_file_patch']!({ filename: 'big.ts' });
-      const done = opts.extractDone({ approved: true, comment: 'truncated' });
-      return {
-        done,
-        usage: { inputTokens: 10, outputTokens: 5 },
-        iterations: 2,
-        toolCounts: {},
-        toolCallRecords: [],
-      };
+    const executeTool = makeReviewExecuteTool({
+      fileMap,
+      runner: {} as unknown as CIRunner,
+      owner: 'org',
+      repo: 'repo',
+      headSha: 'abc123',
+      logger: noopLogger as never,
     });
-
-    await runReviewLoop({ ...baseOpts, fileMap, loop });
-    expect(capturedContent).toContain('... (truncated)');
-    expect(capturedContent!.length).toBeLessThan(longPatch.length);
+    const result = await executeTool('/repo', 'get_file_patch', { filename: 'big.ts' });
+    expect(result).toContain('... (truncated)');
+    expect(result.length).toBeLessThan(longPatch.length);
   });
 
   it('get_file_content calls runner.getFileContent', async () => {
     const getFileContent = vi.fn().mockResolvedValue('function foo() { return 42; }');
     const runner = { getFileContent } as unknown as CIRunner;
-    let capturedContent: string | undefined;
-    const loop = makeMockLoop(async (opts) => {
-      capturedContent = await opts.handlers['get_file_content']!({ filename: 'src/foo.ts' });
-      const done = opts.extractDone({ approved: true, comment: 'ok' });
-      return {
-        done,
-        usage: { inputTokens: 15, outputTokens: 8 },
-        iterations: 2,
-        toolCounts: {},
-        toolCallRecords: [],
-      };
+    const fileMap = new Map<string, string | undefined>();
+    const executeTool = makeReviewExecuteTool({
+      fileMap,
+      runner,
+      owner: 'org',
+      repo: 'repo',
+      headSha: 'abc123',
+      logger: noopLogger as never,
     });
-
-    await runReviewLoop({ ...baseOpts, runner, loop });
-    expect(capturedContent).toBe('function foo() { return 42; }');
+    const result = await executeTool('/repo', 'get_file_content', { filename: 'src/foo.ts' });
+    expect(result).toBe('function foo() { return 42; }');
     expect(getFileContent).toHaveBeenCalledWith('org', 'repo', 'src/foo.ts', 'abc123');
   });
 
-  it('passes through toolCounts and toolCallRecords from the loop', async () => {
-    const loop = makeToolThenFinishLoop('get_file_patch', { filename: 'x.ts' }, true, 'ok');
-    const result = await runReviewLoop({ ...baseOpts, loop });
-    expect(result.toolCounts).toEqual({ get_file_patch: 1 });
-    expect(result.toolCallRecords).toEqual([{ name: 'get_file_patch', outputSize: 10 }]);
+  it('throws for unknown tool name', async () => {
+    const executeTool = makeReviewExecuteTool({
+      fileMap: new Map(),
+      runner: {} as unknown as CIRunner,
+      owner: 'org',
+      repo: 'repo',
+      headSha: 'abc123',
+      logger: noopLogger as never,
+    });
+    await expect(executeTool('/repo', 'unknown_tool', {})).rejects.toThrow('Unknown reviewer tool');
   });
 });
 

--- a/src/agents/reviewer/review-loop.ts
+++ b/src/agents/reviewer/review-loop.ts
@@ -1,16 +1,14 @@
 import type { CIRunner, PRFile } from '../../lib/dispatch/runner/types.js';
-import { createLogger } from '../../lib/logger/index.js';
 import type { Logger } from '../../lib/logger/index.js';
 import type { CiStatus } from './ci-gate.js';
-import type { ToolCallLoop, ToolDef } from '../../lib/llm/tool-loop/index.js';
+import type { AgentLoop, AgentTool, McpServerConfig } from '../../lib/llm/agent-loop/index.js';
 
 export const MAX_PATCH_CHARS = 20_000;
 export const MAX_CONTENT_CHARS = 40_000;
-const MAX_ITERATIONS = 40;
 
 export type { CiStatus, PRFile as PrFile };
 
-export const REVIEW_TOOL_DEFS: ToolDef[] = [
+export const REVIEW_TOOL_DEFS: AgentTool[] = [
   {
     name: 'get_file_patch',
     description:
@@ -38,15 +36,23 @@ export const REVIEW_TOOL_DEFS: ToolDef[] = [
     },
   },
   {
-    name: 'finish_review',
+    name: 'done',
     description:
       'Post the review verdict and end the review loop. Call once you have inspected all relevant files.',
     input_schema: {
       type: 'object',
       properties: {
+        actionable: {
+          type: 'boolean',
+          description: 'true if you are approving the PR, false if requesting changes.',
+        },
         approved: {
           type: 'boolean',
           description: 'true = ready to merge, false = changes required.',
+        },
+        summary: {
+          type: 'string',
+          description: 'One sentence summary of the review outcome.',
         },
         comment: {
           type: 'string',
@@ -54,7 +60,7 @@ export const REVIEW_TOOL_DEFS: ToolDef[] = [
             'Full review comment in Markdown. Follow the required format from the system prompt.',
         },
       },
-      required: ['approved', 'comment'],
+      required: ['actionable', 'approved', 'summary', 'comment'],
     },
   },
 ];
@@ -71,17 +77,57 @@ export interface ReviewResult {
 // under src/agents/reviewer/** stay valid.
 export { detectMergeConflicts, buildFileList } from '../../lib/agent-runtime/reviewer-helpers.js';
 
-export async function runReviewLoop(opts: {
-  loop: ToolCallLoop;
-  system: string;
-  initialPrompt: string;
+/**
+ * Factory that returns the reviewer's executeTool function.
+ * Handles get_file_patch and get_file_content; the done tool is handled
+ * by the agent loop internally.
+ */
+export function makeReviewExecuteTool(opts: {
   fileMap: Map<string, string | undefined>;
   runner: CIRunner;
   owner: string;
   repo: string;
   headSha: string;
-  maxIterations?: number;
-  maxTokens?: number;
+  logger: Logger;
+}): (repoRoot: string, name: string, input: Record<string, unknown>) => Promise<string> {
+  const { fileMap, runner, owner, repo, headSha, logger } = opts;
+
+  return async (
+    _repoRoot: string,
+    name: string,
+    input: Record<string, unknown>,
+  ): Promise<string> => {
+    if (name === 'get_file_patch') {
+      const filename = input.filename as string;
+      logger.info('tool', { tool: 'get_file_patch', file: filename });
+      const patch = fileMap.get(filename);
+      if (patch === undefined) return `(file not found in PR: ${filename})`;
+      if (!patch) return '(no patch — binary, empty, or content unchanged)';
+      const patchLimit =
+        parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? '', 10) || MAX_PATCH_CHARS;
+      return patch.length > patchLimit ? patch.slice(0, patchLimit) + '\n... (truncated)' : patch;
+    }
+    if (name === 'get_file_content') {
+      const filename = input.filename as string;
+      logger.info('tool', { tool: 'get_file_content', file: filename });
+      const fileLimit =
+        parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? '', 10) || MAX_CONTENT_CHARS;
+      const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
+      return rawContent.length > fileLimit
+        ? rawContent.slice(0, fileLimit) + '\n... (truncated)'
+        : rawContent;
+    }
+    throw new Error(`Unknown reviewer tool: ${name}`);
+  };
+}
+
+export async function runReviewLoop(opts: {
+  loop: AgentLoop;
+  system: string;
+  initialPrompt: string;
+  repoRoot: string;
+  branchName: string;
+  mcpServers?: McpServerConfig[];
   logger?: Logger;
 }): Promise<{
   result: ReviewResult;
@@ -91,62 +137,35 @@ export async function runReviewLoop(opts: {
   toolCounts: Record<string, number>;
   toolCallRecords: Array<{ name: string; outputSize: number }>;
 }> {
-  const { loop, system, initialPrompt, fileMap, runner, owner, repo, headSha } = opts;
-  const logger = opts.logger ?? createLogger('', 'ferry:review-loop');
-  const maxIterations =
-    opts.maxIterations ??
-    (parseInt(process.env.FERRY_REVIEWER_MAX_ITERATIONS ?? '', 10) || MAX_ITERATIONS);
-  const maxTokens =
-    opts.maxTokens ?? (parseInt(process.env.FERRY_REVIEWER_MAX_TOKENS ?? '', 10) || 16384);
+  const { loop, system, initialPrompt, repoRoot, branchName } = opts;
+  const mcpServers = opts.mcpServers ?? [];
 
-  const {
-    done: result,
-    usage,
-    iterations,
-    toolCounts,
-    toolCallRecords,
-  } = await loop.run<ReviewResult>({
+  const loopResult = await loop.run({
     system,
     initialPrompt,
     tools: REVIEW_TOOL_DEFS,
-    finishTool: 'finish_review',
-    extractDone: (input) => ({
-      approved: input.approved as boolean,
-      comment: input.comment as string,
-    }),
-    handlers: {
-      get_file_patch: (input) => {
-        const filename = input.filename as string;
-        logger.info('tool', { tool: 'get_file_patch', file: filename });
-        const patch = fileMap.get(filename);
-        if (patch === undefined) return `(file not found in PR: ${filename})`;
-        if (!patch) return '(no patch — binary, empty, or content unchanged)';
-        const patchLimit =
-          parseInt(process.env.FERRY_REVIEW_PATCH_TRUNCATE_CHARS ?? '', 10) || MAX_PATCH_CHARS;
-        return patch.length > patchLimit ? patch.slice(0, patchLimit) + '\n... (truncated)' : patch;
-      },
-      get_file_content: async (input) => {
-        const filename = input.filename as string;
-        logger.info('tool', { tool: 'get_file_content', file: filename });
-        const fileLimit =
-          parseInt(process.env.FERRY_REVIEW_FILE_TRUNCATE_CHARS ?? '', 10) || MAX_CONTENT_CHARS;
-        const rawContent = await runner.getFileContent(owner, repo, filename, headSha);
-        return rawContent.length > fileLimit
-          ? rawContent.slice(0, fileLimit) + '\n... (truncated)'
-          : rawContent;
-      },
-    },
-    maxIterations,
-    maxTokens,
-    logger,
+    repoRoot,
+    branchName,
+    secretScan: () => Promise.resolve(),
+    mcpServers,
   });
+
+  const done = loopResult.done as unknown as {
+    approved: boolean;
+    comment: string;
+  };
+
+  const result: ReviewResult = {
+    approved: done.approved,
+    comment: done.comment,
+  };
 
   return {
     result,
-    inputTokens: usage.inputTokens,
-    outputTokens: usage.outputTokens,
-    iterations,
-    toolCounts,
-    toolCallRecords,
+    inputTokens: loopResult.usage.input_tokens,
+    outputTokens: loopResult.usage.output_tokens,
+    iterations: loopResult.iterations,
+    toolCounts: loopResult.toolCounts,
+    toolCallRecords: loopResult.toolCallRecords,
   };
 }

--- a/src/agents/reviewer/reviewer-mcp.test.ts
+++ b/src/agents/reviewer/reviewer-mcp.test.ts
@@ -1,0 +1,162 @@
+/**
+ * MCP Phase 2 regression tests for the Reviewer agent (issue #322).
+ *
+ * Step 2: Verify the loop receives MCP servers after capability-label filtering.
+ * Step 5: CI gate still blocks the review even when MCP servers are enabled.
+ * Step 6: Empty/unmatched capabilities disable all filtered MCP servers.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { filterMcpServers } from '../../lib/agent-runtime/index.js';
+import { gateCi } from './ci-gate.js';
+import { runReviewLoop } from './review-loop.js';
+import type { AgentLoop, AgentLoopResult } from '../../lib/llm/agent-loop/index.js';
+import type { ResolvedCapabilities } from '../../lib/agent-runtime/index.js';
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function makeCapabilities(mcpServerNames: string[]): ResolvedCapabilities {
+  return {
+    mcpServerNames,
+    serverAllowedTools: {},
+    triggeredLabels: [],
+    unknownFerryLabels: [],
+  };
+}
+
+function makeAgentLoop(approved = true): AgentLoop {
+  const result: AgentLoopResult = {
+    done: {
+      actionable: approved,
+      approved,
+      summary: 'review complete',
+      comment: 'LGTM',
+    } as unknown as AgentLoopResult['done'],
+    usage: {
+      input_tokens: 10,
+      output_tokens: 5,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    },
+    iterations: 1,
+    toolCounts: {},
+    toolCallRecords: [],
+  };
+  return { run: vi.fn().mockResolvedValue(result) };
+}
+
+const baseLoopOpts = {
+  system: 'sys',
+  initialPrompt: 'review this',
+  repoRoot: '/repo',
+  branchName: 'ferry/PROJ-1',
+};
+
+// ── Step 2: loop receives filtered MCP servers ────────────────────────────
+
+describe('Reviewer MCP plumbing — loop receives filtered servers (Step 2)', () => {
+  it('passes atlassian server to loop when capability label enables it', async () => {
+    const atlassianServer = { name: 'atlassian', url: 'https://mcp.atlassian.com' };
+    const mcpPool = [atlassianServer, { name: 'other', url: 'https://other.mcp.com' }];
+    const capabilities = makeCapabilities(['atlassian']);
+
+    const mcpServers = filterMcpServers(mcpPool, capabilities, /* hasLabelsConfig */ true);
+    expect(mcpServers).toHaveLength(1);
+    expect(mcpServers[0].name).toBe('atlassian');
+
+    const loop = makeAgentLoop();
+    await runReviewLoop({ ...baseLoopOpts, loop, mcpServers });
+
+    const runOpts = (loop.run as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(runOpts.mcpServers).toHaveLength(1);
+    expect(runOpts.mcpServers[0].name).toBe('atlassian');
+  });
+
+  it('passes all pool servers when hasLabelsConfig is false (no labels section)', () => {
+    const mcpPool = [
+      { name: 'atlassian', url: 'https://mcp.atlassian.com' },
+      { name: 'context7', url: 'https://mcp.context7.com/mcp' },
+    ];
+    const capabilities = makeCapabilities([]);
+
+    // When hasLabelsConfig=false (no labels in ferry.config), the full pool is returned
+    const mcpServers = filterMcpServers(mcpPool, capabilities, /* hasLabelsConfig */ false);
+    expect(mcpServers).toHaveLength(2);
+  });
+});
+
+// ── Step 5: CI gate regression — still blocks with MCP enabled ────────────
+
+describe('CI gate regression — blocks review even with MCP enabled (Step 5)', () => {
+  it('gateCi returns proceed=false when CI is red regardless of MCP config', () => {
+    const mcpPool = [{ name: 'atlassian', url: 'https://mcp.atlassian.com' }];
+    const capabilities = makeCapabilities(['atlassian']);
+
+    // Simulate MCP being enabled
+    const mcpServers = filterMcpServers(mcpPool, capabilities, true);
+    expect(mcpServers).toHaveLength(1);
+
+    // CI gate is purely a function of CI status — MCP plays no part
+    const outcome = gateCi({ status: 'red', failure_summary: 'tests failed' });
+    expect(outcome.proceed).toBe(false);
+    expect(outcome.outcome).toBe('ci-red');
+  });
+
+  it('gateCi allows proceeding (green) even when MCP servers are configured', () => {
+    const mcpPool = [{ name: 'atlassian', url: 'https://mcp.atlassian.com' }];
+    const capabilities = makeCapabilities(['atlassian']);
+    filterMcpServers(mcpPool, capabilities, true);
+
+    const outcome = gateCi({ status: 'green' });
+    expect(outcome.proceed).toBe(true);
+  });
+
+  it('gateCi blocks on pending CI even with MCP servers configured', () => {
+    const mcpPool = [{ name: 'atlassian', url: 'https://mcp.atlassian.com' }];
+    const capabilities = makeCapabilities(['atlassian']);
+    filterMcpServers(mcpPool, capabilities, true);
+
+    const outcome = gateCi({ status: 'pending' });
+    expect(outcome.proceed).toBe(false);
+    expect(outcome.outcome).toBe('pending-ci');
+  });
+});
+
+// ── Step 6: skip label (no matching capabilities) disables MCP ────────────
+
+describe('Skip/rollback — no matching capabilities disables MCP for Reviewer (Step 6)', () => {
+  it('filterMcpServers returns empty list when no capability labels match any server', () => {
+    const mcpPool = [{ name: 'atlassian', url: 'https://mcp.atlassian.com' }];
+    // Capabilities with no mcp server names (e.g. ferry:skip/mcp or unmatched labels)
+    const capabilities = makeCapabilities([]);
+
+    const mcpServers = filterMcpServers(mcpPool, capabilities, /* hasLabelsConfig */ true);
+    expect(mcpServers).toHaveLength(0);
+  });
+
+  it('loop receives empty mcpServers when capabilities do not enable any server', async () => {
+    const mcpPool = [{ name: 'atlassian', url: 'https://mcp.atlassian.com' }];
+    const capabilities = makeCapabilities([]);
+
+    const mcpServers = filterMcpServers(mcpPool, capabilities, true);
+    expect(mcpServers).toHaveLength(0);
+
+    const loop = makeAgentLoop();
+    await runReviewLoop({ ...baseLoopOpts, loop, mcpServers });
+
+    const runOpts = (loop.run as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(runOpts.mcpServers).toEqual([]);
+  });
+
+  it('filterMcpServers returns only servers matching capability labels', () => {
+    const mcpPool = [
+      { name: 'atlassian', url: 'https://mcp.atlassian.com' },
+      { name: 'context7', url: 'https://mcp.context7.com/mcp' },
+      { name: 'github', url: 'https://mcp.github.com' },
+    ];
+    const capabilities = makeCapabilities(['atlassian']);
+
+    const mcpServers = filterMcpServers(mcpPool, capabilities, true);
+    expect(mcpServers).toHaveLength(1);
+    expect(mcpServers[0].name).toBe('atlassian');
+  });
+});

--- a/src/lib/agent-runtime/reviewer-prepare.ts
+++ b/src/lib/agent-runtime/reviewer-prepare.ts
@@ -18,8 +18,13 @@ import {
   buildTicketBlock,
   loadOptionalPrompt as defaultLoadOptionalPrompt,
 } from './prompt.js';
-import { type ResolvedCapabilities, type TicketOverrides } from '../labels/capabilities.js';
+import {
+  type ResolvedCapabilities,
+  type TicketOverrides,
+  filterMcpServers,
+} from '../labels/capabilities.js';
 import { applyRubricToPrompt, detectMergeConflicts, buildFileList } from './reviewer-helpers.js';
+import type { LabelCapability } from '../config.js';
 import type { TrackerIssue } from '../io/tracker/types.js';
 import type { PR, PRFile } from '../dispatch/runner/types.js';
 import type { McpServerConfig } from '../llm/agent-loop/types.js';
@@ -48,6 +53,18 @@ export interface PrepareReviewerInput {
    */
   idempotencyMarker: string;
   repoRoot: string;
+  /**
+   * Full MCP server pool to filter by capabilities. When provided together
+   * with `configLabels`, the returned `mcpServers` is the capability-filtered
+   * subset. When omitted (legacy / test), returns an empty list.
+   */
+  mcpPool?: McpServerConfig[];
+  /**
+   * `effectiveCfg.labels` — used to determine whether a labels section exists.
+   * When undefined (no labels in ferry.config), filterMcpServers returns the
+   * full pool unfiltered (backward-compatible with pre-label configs).
+   */
+  configLabels?: Record<string, LabelCapability>;
   /** Test seam — defaults to the real `buildSystem`. */
   _buildSystem?: typeof defaultBuildSystem;
   /** Test seam — defaults to the real `loadOptionalPrompt`. */
@@ -72,6 +89,8 @@ export function prepareReviewer(input: PrepareReviewerInput): ReviewerPreparedCo
     capabilities,
     idempotencyMarker,
     repoRoot,
+    mcpPool,
+    configLabels,
   } = input;
   const buildSystem = input._buildSystem ?? defaultBuildSystem;
   const loadOptionalPrompt = input._loadOptionalPrompt ?? defaultLoadOptionalPrompt;
@@ -111,7 +130,7 @@ export function prepareReviewer(input: PrepareReviewerInput): ReviewerPreparedCo
     buildFileList(files),
     '',
     'Use get_file_patch to inspect individual file diffs, get_file_content for full file contents.',
-    'When you have enough information, call finish_review.',
+    'When you have enough information, call done.',
   ]
     .filter((l) => l !== null)
     .join('\n');
@@ -122,9 +141,9 @@ export function prepareReviewer(input: PrepareReviewerInput): ReviewerPreparedCo
   });
   const system = applyRubricToPrompt(baseSystem, reviewRubric);
 
-  // The reviewer agent has never used MCP servers; we expose an empty list to
-  // satisfy the shared `RolePreparedContextBase` shape.
-  const mcpServers: McpServerConfig[] = [];
+  const hasLabelsConfig = configLabels !== undefined;
+  const mcpServers: McpServerConfig[] =
+    mcpPool !== undefined ? filterMcpServers(mcpPool, capabilities, hasLabelsConfig) : [];
 
   return {
     system,


### PR DESCRIPTION
Part of #319. Closes #322.

## Summary

- Swaps `createToolCallLoop` → `createAgentLoop` in `review-action.ts` so Reviewer inherits MCP wiring alongside Dev and Iterator
- Replaces `finish_review` terminal tool with a reviewer-specific `done` schema (`approved` + `comment` + `actionable` + `summary`)
- Extracts `makeReviewExecuteTool` factory for `get_file_patch` / `get_file_content`
- Adds inline MCP plumbing (`loadMcpServers` → `filterMcpServers`) in `review-action.ts`
- Updates `reviewer-prepare.ts` to accept `mcpPool` + `configLabels`

## Test plan

- [x] All existing tests pass (145 files, 2105 tests)
- [x] `review-loop.test.ts` rewritten for `AgentLoop` interface
- [x] New `reviewer-mcp.test.ts`: Step 2 (MCP filtering), Step 5 (CI gate regression), Step 6 (skip label/empty capabilities)
- [x] typecheck ✅ · lint ✅ · format ✅ · tests ✅

Generated with [Claude Code](https://claude.ai/code)