### PR TITLE
feat(actions): commit ferry-run-merger composite action + build wiring

### DIFF
--- a/.github/actions/ferry-run-merger/action.yml
+++ b/.github/actions/ferry-run-merger/action.yml
@@ -1,0 +1,133 @@
+name: Ferry — Run Merger Agent
+description: >
+  Runs the Merger agent. Self-contained; no .ferry/ needed in the consumer workspace.
+  Bundle and dependencies are resolved from github.action_path (the ferry repo).
+inputs:
+  payload:
+    description: JSON-encoded event envelope payload
+    required: true
+  jira_base_url:
+    description: Jira base URL
+    required: true
+  jira_email:
+    description: Jira account email
+    required: true
+  jira_api_token:
+    description: Jira API token
+    required: true
+  anthropic_api_key:
+    description: Anthropic API key (required when ferry_merger_provider=anthropic)
+    required: false
+    default: ''
+  openai_api_key:
+    description: OpenAI API key (required when ferry_merger_provider=openai)
+    required: false
+    default: ''
+  google_api_key:
+    description: Google AI API key (required when ferry_merger_provider=google)
+    required: false
+    default: ''
+  github_token:
+    description: GitHub token with contents:write and pull-requests:write
+    required: true
+  github_repo:
+    description: GitHub repository (owner/repo)
+    required: true
+  ferry_merger_model:
+    description: Model override (e.g. claude-sonnet-4-6)
+    required: false
+    default: ''
+  ferry_max_cost_eur_per_run:
+    description: Cost budget in EUR per agent run (overrides limits.max_cost_eur_per_run)
+    required: false
+    default: ''
+  ferry_llm_retry_max_attempts:
+    description: Maximum retry attempts for LLM utility calls
+    required: false
+    default: ''
+  ferry_jira_retry_max_attempts:
+    description: Maximum Jira API retry attempts per operation
+    required: false
+    default: ''
+  pre_agent_command:
+    description: Optional shell command to run after checkout but before the agent (e.g. npm ci, cache restore)
+    required: false
+    default: ''
+  pre_agent_timeout_minutes:
+    description: Timeout in minutes for the pre-agent command (default 3)
+    required: false
+    default: '3'
+  post_agent_command:
+    description: Optional shell command to run after the agent; always executes (e.g. cleanup, reporting)
+    required: false
+    default: ''
+outputs:
+  input_tokens:
+    description: Number of LLM input tokens consumed
+    value: ${{ steps.run-merger.outputs.input_tokens }}
+  output_tokens:
+    description: Number of LLM output tokens consumed
+    value: ${{ steps.run-merger.outputs.output_tokens }}
+  model:
+    description: Model ID actually used
+    value: ${{ steps.run-merger.outputs.model }}
+  cost_eur:
+    description: Cost in EUR for this agent run
+    value: ${{ steps.run-merger.outputs.cost_eur }}
+  cache_read_tokens:
+    description: Number of cache read input tokens consumed
+    value: ${{ steps.run-merger.outputs.cache_read_tokens }}
+  cache_write_tokens:
+    description: Number of cache write input tokens consumed
+    value: ${{ steps.run-merger.outputs.cache_write_tokens }}
+runs:
+  using: composite
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+      with:
+        node-version: '20'
+    - name: Install Ferry agent dependencies
+      shell: bash
+      run: npm ci --prefer-offline
+      working-directory: ${{ github.action_path }}
+    - name: Skip Task tickets (FR6)
+      shell: bash
+      run: node ${{ github.action_path }}/skip-task-type-action.js
+      env:
+        FERRY_AGENT_ROLE: merger
+        FERRY_ENVELOPE_PAYLOAD: ${{ inputs.payload }}
+        FERRY_JIRA_BASE_URL: ${{ inputs.jira_base_url }}
+        FERRY_JIRA_EMAIL: ${{ inputs.jira_email }}
+        FERRY_JIRA_API_TOKEN: ${{ inputs.jira_api_token }}
+    - name: Pre-agent setup
+      if: inputs.pre_agent_command != ''
+      shell: bash
+      env:
+        FERRY_PRE_AGENT_COMMAND: ${{ inputs.pre_agent_command }}
+        FERRY_PRE_AGENT_TIMEOUT_MINUTES: ${{ inputs.pre_agent_timeout_minutes }}
+      run: timeout "${FERRY_PRE_AGENT_TIMEOUT_MINUTES}m" bash -c "$FERRY_PRE_AGENT_COMMAND"
+    - name: Run Merger agent
+      id: run-merger
+      shell: bash
+      run: node ${{ github.action_path }}/agent.js run --role merger
+      env:
+        FERRY_ENVELOPE_PAYLOAD: ${{ inputs.payload }}
+        FERRY_JIRA_BASE_URL: ${{ inputs.jira_base_url }}
+        FERRY_JIRA_EMAIL: ${{ inputs.jira_email }}
+        FERRY_JIRA_API_TOKEN: ${{ inputs.jira_api_token }}
+        ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key }}
+        FERRY_OPENAI_KEY: ${{ inputs.openai_api_key }}
+        FERRY_GOOGLE_AI_KEY: ${{ inputs.google_api_key }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        GH_TOKEN: ${{ inputs.github_token }}
+        GITHUB_REPO: ${{ inputs.github_repo }}
+        FERRY_MERGER_MODEL: ${{ inputs.ferry_merger_model }}
+        FERRY_MAX_COST_EUR_PER_RUN: ${{ inputs.ferry_max_cost_eur_per_run }}
+        FERRY_LLM_RETRY_MAX_ATTEMPTS: ${{ inputs.ferry_llm_retry_max_attempts }}
+        FERRY_JIRA_RETRY_MAX_ATTEMPTS: ${{ inputs.ferry_jira_retry_max_attempts }}
+        FERRY_BUNDLED_PROMPTS_DIR: ${{ github.action_path }}/prompts
+    - name: Post-agent command
+      if: always() && inputs.post_agent_command != ''
+      shell: bash
+      run: ${{ inputs.post_agent_command }}

--- a/scripts/build-ferry-actions.mjs
+++ b/scripts/build-ferry-actions.mjs
@@ -254,6 +254,12 @@ const agentActions = [
     prompts: ['iterate'],
     legacyBundle: 'iterate-action.js',
   },
+  {
+    actionDir: '.github/actions/ferry-run-merger',
+    packageName: 'ferry-run-merger-action',
+    prompts: [],
+    legacyBundle: 'merger-action.js',
+  },
 ];
 
 for (const agent of agentActions) {

--- a/scripts/smoke-bundle.sh
+++ b/scripts/smoke-bundle.sh
@@ -30,6 +30,7 @@ ROLES=(
   developer
   reviewer
   iterator
+  merger
 )
 BUNDLE_PATH=".ferry/agent.js"
 


### PR DESCRIPTION
Part of #382 (FR32 Merger).

## Changes

- Add `.github/actions/ferry-run-merger/action.yml` mirroring the other `ferry-run-*` composites (inputs: `payload`, `jira_*`, `*_api_key`, `github_token`, `github_repo`, `ferry_merger_model`; outputs: `input_tokens` / `output_tokens` / `cost_eur` / `model` / `cache_read/write_tokens`)
- Wire merger into `scripts/build-ferry-actions.mjs` `agentActions` (`prompts: []` until `src/agents/merger` is implemented)
- Add `merger` to `ROLES` in `scripts/smoke-bundle.sh`

Closes #384

Generated with [Claude Code](https://claude.ai/code)