### PR TITLE
feat(merger): allow gh pr merge for Merger role only + ADR-0005 amendment (FR32)

### DIFF
--- a/docs/adr/0005-no-auto-merge-invariant.md
+++ b/docs/adr/0005-no-auto-merge-invariant.md
@@ -1,7 +1,8 @@
 # 0005 — No Auto-Merge Invariant
 
-**Status:** Accepted  
-**Date:** 2024-01-01
+**Status:** Accepted (amended by FR32)  
+**Date:** 2024-01-01  
+**Amended:** 2026-06-07
 
 ## Context
 
@@ -62,6 +63,52 @@ On the approval path, the Reviewer does **not** auto-transition the Jira ticket 
 
 - Teams that want fully automated end-to-end delivery must add their own merge automation (e.g., a GitHub Action triggered by the `ferry:approved` label, or enabling GitHub's "auto-merge" feature on the PR).
 - The invariant is not enforced by GitHub branch protection alone — a consumer who grants the Ferry GitHub App `Contents: write` permission could theoretically call the merge API outside of Ferry. The deny-list only covers bash commands executed by the agent loop.
+
+## FR32 Amendment — Merger role exception
+
+**FR32** introduces the Merger agent, the single role in the Ferry pipeline that is explicitly permitted to run `gh pr merge`. This is a deliberate, gated exception to the invariant above.
+
+### What changed
+
+The Merger's claude-code path `--disallowedTools` list was updated from:
+
+```
+--disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
+```
+
+to:
+
+```
+--disallowedTools 'Bash(gh pr close),Bash(gh pr close:*)'
+```
+
+`gh pr merge` is no longer on the deny-list for the Merger; `gh pr close` remains blocked for all roles including the Merger.
+
+All four other roles (Refiner, Developer, Reviewer, Iterator) retain the original full ban.
+
+### Gating mechanism
+
+The Merger is triggered exclusively by a `ferry-merge` repository dispatch event. That event is emitted only by the Reviewer agent at approve time (FR24 approve path). The chain is:
+
+```
+Reviewer approve → ferry-merge dispatch → Merger → gh pr merge
+```
+
+No other Ferry agent, workflow, or external caller can trigger the Merger without explicitly dispatching `ferry-merge`.
+
+### Branch-protection caveat
+
+The `ferry:approved` label added by the Reviewer on the `ferry-merge` dispatch is **not** the same as a formal GitHub pull request review approval. GitHub branch protection rules that require a minimum number of PR review approvals are **not satisfied** by the `ferry:approved` label alone.
+
+Consumers who rely on branch-protection rules requiring human PR review approvals must ensure those approvals are in place before the Merger runs, or configure branch protection to allow the Ferry GitHub App to bypass the requirement. See `docs/CONFIGURATION.md` for details on Ferry's permission requirements.
+
+### Regression guard
+
+`src/cli/init/templates.test.ts` contains an explicit regression test (describe block `workflowTemplates — merge authority (FR32)`) that asserts:
+
+- `ferry-merge.yml` does **not** contain `Bash(gh pr merge)` in `--disallowedTools`
+- `ferry-merge.yml` does contain `Bash(gh pr close)` in `--disallowedTools`
+- All four other role templates (`ferry-refine.yml`, `ferry-dev.yml`, `ferry-review.yml`, `ferry-iterate.yml`) still contain `Bash(gh pr merge)` in `--disallowedTools`
 
 ## Alternatives Considered
 

--- a/examples/consumer-setup/workflows/ferry-merge.yml
+++ b/examples/consumer-setup/workflows/ferry-merge.yml
@@ -138,7 +138,7 @@ jobs:
           claude_args: >-
             --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@v0.16.0","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
             --permission-mode bypassPermissions
-            --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
+            --disallowedTools 'Bash(gh pr close),Bash(gh pr close:*)'
             --model ${{ vars.FERRY_MERGER_MODEL || 'claude-sonnet-4-6' }}
 
   emit-audit:

--- a/src/cli/init/templates.test.ts
+++ b/src/cli/init/templates.test.ts
@@ -333,6 +333,48 @@ describe('workflowTemplates — review ci-gate emit-audit ci-red wiring', () => 
   });
 });
 
+describe('workflowTemplates — merge authority (FR32)', () => {
+  // The Merger is the only role permitted to run `gh pr merge`.
+  // All other roles must keep the ban. This test is the regression guard for
+  // ADR-0005 §FR32: removing a role from the exception list re-bans it here.
+
+  const NON_MERGER_FILES = [
+    'ferry-refine.yml',
+    'ferry-dev.yml',
+    'ferry-review.yml',
+    'ferry-iterate.yml',
+  ];
+
+  it('ferry-merge.yml Merger cc-path does NOT disallow gh pr merge (FR32 exception)', () => {
+    const merge = workflowTemplates('v1').find((t) => t.filename === 'ferry-merge.yml');
+    expect(merge, 'ferry-merge.yml not found').toBeDefined();
+    // gh pr merge must NOT appear in --disallowedTools
+    expect(
+      merge!.content,
+      'ferry-merge.yml: Merger must be allowed to run gh pr merge (FR32)',
+    ).not.toContain('Bash(gh pr merge)');
+  });
+
+  it('ferry-merge.yml Merger cc-path still disallows gh pr close', () => {
+    const merge = workflowTemplates('v1').find((t) => t.filename === 'ferry-merge.yml');
+    expect(merge, 'ferry-merge.yml not found').toBeDefined();
+    expect(
+      merge!.content,
+      'ferry-merge.yml: Merger must still be blocked from gh pr close',
+    ).toContain('Bash(gh pr close)');
+  });
+
+  it('all non-Merger roles still disallow gh pr merge', () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      if (!NON_MERGER_FILES.includes(tmpl.filename)) continue;
+      expect(
+        tmpl.content,
+        `${tmpl.filename}: non-Merger role must not be allowed to run gh pr merge`,
+      ).toContain('Bash(gh pr merge)');
+    }
+  });
+});
+
 describe('workflowTemplates — supply-chain action pinning', () => {
   // anthropics/claude-code-action is a token-scoped action — tag refs like @v1 are
   // mutable, so we require a 40-char commit SHA with a trailing version comment.

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -833,7 +833,7 @@ jobs:
           claude_args: >-
             --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@${version}","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"\${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"\${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"\${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
             --permission-mode bypassPermissions
-            --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
+            --disallowedTools 'Bash(gh pr close),Bash(gh pr close:*)'
             --model \${{ vars.FERRY_MERGER_MODEL || 'claude-sonnet-4-6' }}
 
   emit-audit:


### PR DESCRIPTION
Closes #386

## Summary

- Remove `Bash(gh pr merge)` and `Bash(gh pr merge:*)` from the Merger claude-code path `--disallowedTools`; `Bash(gh pr close)` remains blocked
- All four other roles (Refiner, Developer, Reviewer, Iterator) retain the full ban
- Adds `workflowTemplates — merge authority (FR32)` regression tests in `templates.test.ts`
- Amends `docs/adr/0005-no-auto-merge-invariant.md` with FR32 exception section, gating mechanism, and branch-protection caveat

## Test plan

- [x] `npm test` — 2143 tests pass
- [x] `npm run typecheck` — clean
- [x] Pre-push hooks (typecheck, lint, format, tests, build) all green

Generated with [Claude Code](https://claude.ai/code)