### PR TITLE
fix(init): add checks: read + actions: read to dev/iterate/merge claude-code workflows

### DIFF
--- a/src/cli/init/templates.test.ts
+++ b/src/cli/init/templates.test.ts
@@ -444,6 +444,48 @@ describe('workflowTemplates — run-agent-claude-code permissions include id-tok
   }
 });
 
+describe('workflowTemplates — CI-driving roles include checks: read + actions: read (#395)', () => {
+  // Developer, Iterator, and Merger agents call gh pr checks, gh run view, and the
+  // GraphQL statusCheckRollup to drive CI before transitioning. Without checks: read
+  // and actions: read, GitHub returns HTTP 403 and the agent treats CI as unknown,
+  // never transitioning the ticket. This regression guard ensures the missing scopes
+  // cannot be reintroduced by a future template edit.
+  const ciRoles = [
+    { filename: 'ferry-dev.yml', role: 'developer' },
+    { filename: 'ferry-iterate.yml', role: 'iterator' },
+    { filename: 'ferry-merge.yml', role: 'merger' },
+  ] as const;
+
+  for (const { filename, role } of ciRoles) {
+    it(`${filename} (${role}): run-agent-claude-code permissions block contains checks: read`, () => {
+      const tmpl = workflowTemplates('v1').find((t) => t.filename === filename);
+      expect(tmpl, `${filename} not found`).toBeDefined();
+      expect(
+        tmpl!.content,
+        `${filename}: run-agent-claude-code job is missing checks: read (fixes #395)`,
+      ).toContain('checks: read');
+    });
+
+    it(`${filename} (${role}): run-agent-claude-code permissions block contains actions: read`, () => {
+      const tmpl = workflowTemplates('v1').find((t) => t.filename === filename);
+      expect(tmpl, `${filename} not found`).toBeDefined();
+      expect(
+        tmpl!.content,
+        `${filename}: run-agent-claude-code job is missing actions: read (fixes #395)`,
+      ).toContain('actions: read');
+    });
+  }
+
+  it('ferry-refine.yml does not gain unnecessary checks: read (no CI interaction)', () => {
+    const tmpl = workflowTemplates('v1').find((t) => t.filename === 'ferry-refine.yml');
+    expect(tmpl, 'ferry-refine.yml not found').toBeDefined();
+    expect(
+      tmpl!.content,
+      'ferry-refine.yml should not have checks: read — refiner has no CI interaction',
+    ).not.toContain('checks: read');
+  });
+});
+
 describe('workflowTemplates — execution path variants', () => {
   it('script path is byte-identical whether implicit or explicit', () => {
     expect(workflowTemplates('v1', 'script')).toEqual(workflowTemplates('v1'));

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -291,6 +291,8 @@ jobs:
       contents: write
       pull-requests: write
       issues: read
+      checks: read # gh pr checks / statusCheckRollup
+      actions: read # gh run view --log-failed / actions/runs
       id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -657,6 +659,8 @@ jobs:
       contents: write
       pull-requests: write
       issues: read
+      checks: read # gh pr checks / statusCheckRollup
+      actions: read # gh run view --log-failed / actions/runs
       id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -813,6 +817,8 @@ jobs:
       contents: write
       pull-requests: write
       issues: read
+      checks: read # gh pr checks / statusCheckRollup
+      actions: read # gh run view --log-failed / actions/runs
       id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
CI-driving agents (Developer, Iterator, Merger) call `gh pr checks`, `gh run view --log-failed`, and the GraphQL statusCheckRollup to gate transitions. Without `checks: read` and `actions: read`, GitHub returns HTTP 403 on all check-status endpoints, causing the agent to treat CI as unknown and never transition the ticket.

Adds both permissions to the `run-agent-claude-code` job for the three CI-driving roles in `src/cli/init/templates.ts`. Refiner and Reviewer are unaffected. Adds 7 regression tests so this contract cannot silently drift again.

Fixes #395

Generated with [Claude Code](https://claude.ai/code)