### PR TITLE
fix(claude-code): grant CI-read permissions and check out target version in agent jobs

### DIFF
--- a/examples/consumer-setup/workflows/ferry-dev.yml
+++ b/examples/consumer-setup/workflows/ferry-dev.yml
@@ -136,9 +136,14 @@ jobs:
       contents: write
       pull-requests: write
       issues: read
+      checks: read # PR check-runs / statusCheckRollup
+      actions: read # gh run view --log-failed / actions/runs
       id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ vars.FERRY_INTEGRATION_BRANCH || 'main' }}
+          fetch-depth: 0
       # Resolve the system prompt: prompts/dev.claude-code.md from this repo if
       # present, otherwise Ferry's bundled default. To customise the prompt edit
       # that file — no need to touch this workflow. See docs/CONFIGURATION.md.

--- a/examples/consumer-setup/workflows/ferry-iterate.yml
+++ b/examples/consumer-setup/workflows/ferry-iterate.yml
@@ -140,9 +140,14 @@ jobs:
       contents: write
       pull-requests: write
       issues: read
+      checks: read # PR check-runs / statusCheckRollup
+      actions: read # gh run view --log-failed / actions/runs
       id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ferry/${{ github.event.client_payload.ticket_key }}
+          fetch-depth: 0
       # Resolve the system prompt: prompts/iterate.claude-code.md from this repo
       # if present, otherwise Ferry's bundled default. To customise the prompt
       # edit that file — no need to touch this workflow. See docs/CONFIGURATION.md.

--- a/examples/consumer-setup/workflows/ferry-merge.yml
+++ b/examples/consumer-setup/workflows/ferry-merge.yml
@@ -118,9 +118,14 @@ jobs:
       contents: write
       pull-requests: write
       issues: read
+      checks: read # PR check-runs / statusCheckRollup
+      actions: read # gh run view --log-failed / actions/runs
       id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ferry/${{ github.event.client_payload.ticket_key }}
+          fetch-depth: 0
       # Resolve the system prompt: prompts/merge.claude-code.md from this repo
       # if present, otherwise Ferry's bundled default. To customise the prompt
       # edit that file — no need to touch this workflow. See docs/CONFIGURATION.md.

--- a/examples/consumer-setup/workflows/ferry-refine.yml
+++ b/examples/consumer-setup/workflows/ferry-refine.yml
@@ -121,6 +121,9 @@ jobs:
       id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ vars.FERRY_INTEGRATION_BRANCH || 'main' }}
+          fetch-depth: 0
       # Resolve the system prompt: prompts/refiner.claude-code.md from this repo
       # if present, otherwise Ferry's bundled default. To customise the prompt
       # edit that file — no need to touch this workflow. See docs/CONFIGURATION.md.

--- a/examples/consumer-setup/workflows/ferry-review.yml
+++ b/examples/consumer-setup/workflows/ferry-review.yml
@@ -167,6 +167,9 @@ jobs:
       id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ferry/${{ github.event.client_payload.ticket_key }}
+          fetch-depth: 0
       # Resolve the system prompt: prompts/review.claude-code.md from this repo
       # if present, otherwise Ferry's bundled default. To customise the prompt
       # edit that file — no need to touch this workflow. See docs/CONFIGURATION.md.

--- a/src/cli/init/templates.test.ts
+++ b/src/cli/init/templates.test.ts
@@ -275,10 +275,10 @@ describe('workflowTemplates — role-specific wiring', () => {
     );
   });
 
-  it('ferry-iterate.yml uses fetch-depth: 0 for the script-path checkout', () => {
+  it('ferry-iterate.yml uses fetch-depth: 0 for both script-path and claude-code-path checkouts', () => {
     const iterate = workflowTemplates('v1').find((t) => t.filename === 'ferry-iterate.yml');
     const fetchDepthCount = (iterate?.content.match(/fetch-depth: 0/g) ?? []).length;
-    expect(fetchDepthCount).toBe(1);
+    expect(fetchDepthCount).toBe(2);
   });
 
   it('ferry-review.yml declares checks: read on run-agent and the ci-gate job', () => {
@@ -387,6 +387,68 @@ describe('workflowTemplates — supply-chain action pinning', () => {
         tmpl.content,
         `${tmpl.filename}: claude-code-action still uses a mutable tag`,
       ).not.toMatch(TAG_PIN);
+    }
+  });
+});
+
+describe('workflowTemplates — claude-code path CI permissions and checkout refs (#396)', () => {
+  // dev/iterate/merge instruct the agent to drive CI to green via `gh pr checks`,
+  // `gh run view`, and the GraphQL statusCheckRollup — all need checks: read and
+  // actions: read. Without them every check-status endpoint returns HTTP 403 and
+  // the agent resolves CI as unknown, never transitioning the ticket.
+  it('dev/iterate/merge run-agent-claude-code grants checks: read and actions: read', () => {
+    for (const filename of ['ferry-dev.yml', 'ferry-iterate.yml', 'ferry-merge.yml']) {
+      const tmpl = workflowTemplates('v1').find((t) => t.filename === filename);
+      expect(tmpl, `${filename} not found`).toBeDefined();
+      const ccBlock = tmpl!.content
+        .split('  run-agent-claude-code:')[1]
+        .split('\n  emit-audit:')[0];
+      expect(ccBlock, `${filename}: run-agent-claude-code missing checks: read`).toContain(
+        'checks: read',
+      );
+      expect(ccBlock, `${filename}: run-agent-claude-code missing actions: read`).toContain(
+        'actions: read',
+      );
+    }
+  });
+
+  // On repository_dispatch, a bare actions/checkout checks out the default branch.
+  // refiner/dev must work against the integration branch; iterate/review/merge must
+  // work against the PR branch ferry/<ticket_key>.
+  it('refiner/dev claude-code path checks out the integration branch (FERRY_INTEGRATION_BRANCH)', () => {
+    for (const filename of ['ferry-refine.yml', 'ferry-dev.yml']) {
+      const tmpl = workflowTemplates('v1').find((t) => t.filename === filename);
+      expect(tmpl, `${filename} not found`).toBeDefined();
+      const ccBlock = tmpl!.content
+        .split('  run-agent-claude-code:')[1]
+        .split('\n  emit-audit:')[0];
+      expect(
+        ccBlock,
+        `${filename}: claude-code checkout must target FERRY_INTEGRATION_BRANCH`,
+      ).toContain("ref: ${{ vars.FERRY_INTEGRATION_BRANCH || 'main' }}");
+    }
+  });
+
+  it('iterate/review/merge claude-code path checks out the PR branch (ferry/<ticket_key>)', () => {
+    for (const filename of ['ferry-iterate.yml', 'ferry-review.yml', 'ferry-merge.yml']) {
+      const tmpl = workflowTemplates('v1').find((t) => t.filename === filename);
+      expect(tmpl, `${filename} not found`).toBeDefined();
+      const ccBlock = tmpl!.content
+        .split('  run-agent-claude-code:')[1]
+        .split('\n  emit-audit:')[0];
+      expect(ccBlock, `${filename}: claude-code checkout must target the PR branch`).toContain(
+        'ref: ferry/${{ github.event.client_payload.ticket_key }}',
+      );
+    }
+  });
+
+  it('every run-agent-claude-code checkout uses fetch-depth: 0 (avoids shallow-clone on merge-base)', () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      const ccBlock =
+        tmpl.content.split('  run-agent-claude-code:')[1]?.split('\n  emit-audit:')[0] ?? '';
+      expect(ccBlock, `${tmpl.filename}: claude-code checkout missing fetch-depth: 0`).toContain(
+        'fetch-depth: 0',
+      );
     }
   });
 });

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -130,6 +130,9 @@ jobs:
       id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: \${{ vars.FERRY_INTEGRATION_BRANCH || 'main' }}
+          fetch-depth: 0
       # Resolve the system prompt: prompts/refiner.claude-code.md from this repo
       # if present, otherwise Ferry's bundled default. To customise the prompt
       # edit that file — no need to touch this workflow. See docs/CONFIGURATION.md.
@@ -291,9 +294,14 @@ jobs:
       contents: write
       pull-requests: write
       issues: read
+      checks: read     # PR check-runs / statusCheckRollup
+      actions: read    # gh run view --log-failed / actions/runs
       id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: \${{ vars.FERRY_INTEGRATION_BRANCH || 'main' }}
+          fetch-depth: 0
       # Resolve the system prompt: prompts/dev.claude-code.md from this repo if
       # present, otherwise Ferry's bundled default. To customise the prompt edit
       # that file — no need to touch this workflow. See docs/CONFIGURATION.md.
@@ -489,6 +497,9 @@ jobs:
       id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ferry/\${{ github.event.client_payload.ticket_key }}
+          fetch-depth: 0
       # Resolve the system prompt: prompts/review.claude-code.md from this repo
       # if present, otherwise Ferry's bundled default. To customise the prompt
       # edit that file — no need to touch this workflow. See docs/CONFIGURATION.md.
@@ -657,9 +668,14 @@ jobs:
       contents: write
       pull-requests: write
       issues: read
+      checks: read     # PR check-runs / statusCheckRollup
+      actions: read    # gh run view --log-failed / actions/runs
       id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ferry/\${{ github.event.client_payload.ticket_key }}
+          fetch-depth: 0
       # Resolve the system prompt: prompts/iterate.claude-code.md from this repo
       # if present, otherwise Ferry's bundled default. To customise the prompt
       # edit that file — no need to touch this workflow. See docs/CONFIGURATION.md.
@@ -813,9 +829,14 @@ jobs:
       contents: write
       pull-requests: write
       issues: read
+      checks: read     # PR check-runs / statusCheckRollup
+      actions: read    # gh run view --log-failed / actions/runs
       id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ferry/\${{ github.event.client_payload.ticket_key }}
+          fetch-depth: 0
       # Resolve the system prompt: prompts/merge.claude-code.md from this repo
       # if present, otherwise Ferry's bundled default. To customise the prompt
       # edit that file — no need to touch this workflow. See docs/CONFIGURATION.md.


### PR DESCRIPTION
Fixes #396.

## Changes

On the claude-code execution path, `run-agent-claude-code` jobs had two structural gaps:

**Problem 1: Missing CI-read permissions**
The `dev`, `iterate`, and `merge` agent jobs lacked `checks: read` and `actions: read`, so every call to `gh pr checks`, `gh run view`, and the `statusCheckRollup` GraphQL endpoint returned HTTP 403. The agent resolved CI as unknown and never transitioned the ticket.

**Problem 2: Wrong checkout ref**
A bare `actions/checkout` on `repository_dispatch` checks out the default branch (shallow). `refiner`/`dev` now check out `${{ vars.FERRY_INTEGRATION_BRANCH || 'main' }}` with `fetch-depth: 0`; `iterate`/`review`/`merge` check out `ferry/${{ github.event.client_payload.ticket_key }}` with `fetch-depth: 0`, matching the script-path behaviour.

## Files changed

- `src/cli/init/templates.ts` — workflow template generator
- `src/cli/init/templates.test.ts` — updated fetch-depth count assertion, added 4 regression-guard tests
- `examples/consumer-setup/workflows/*.yml` — all 5 example files updated to match

Generated with [Claude Code](https://claude.ai/code)