### PR TITLE
docs: make GitLab consumer install path step-by-step

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Ferry
 
-> **GitHub Actions–native agent pipeline for Jira-driven automated development.**
+> **Agent pipeline for Jira-driven automated development on GitHub Actions, with experimental GitLab CI support.**
 
 [![CI](https://github.com/big-emotion/ferry/actions/workflows/ferry-ci.yml/badge.svg)](https://github.com/big-emotion/ferry/actions/workflows/ferry-ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -23,7 +23,7 @@ Ferry connects your Jira board to a fully autonomous dev loop — Refiner, Devel
 
 ## Get started
 
-> Requires Node ≥ 20, a Jira Cloud project, and a GitHub App. See the [install guide](docs/INSTALL.md) for prerequisites and the four follow-up steps after the wizard.
+> Requires Node ≥ 20 and a Jira Cloud project. See the [install guide](docs/INSTALL.md) for the GitHub Actions path and the experimental GitLab CI path.
 
 ```bash
 npx -p @big-emotion/ferry ferry-init
@@ -41,7 +41,7 @@ See [docs/CLI.md](docs/CLI.md) — `ferry-init`, `ferry-doctor`, `ferry-update`,
 
 ## Documentation
 
-- [Install guide](docs/INSTALL.md) — prerequisites, wizard walkthrough, Jira automation setup
+- [Install guide](docs/INSTALL.md) — GitHub Actions setup and the experimental GitLab CI setup
 - [How Ferry works](docs/OVERVIEW.md) — what it is and isn't, agent phases, auto-transitions
 - [Configuration reference](docs/CONFIGURATION.md) — includes the [Execution paths & accepted divergences](docs/CONFIGURATION.md#execution-paths--accepted-divergences) reference (script vs. `claude-code-action` paths, the prompt-enforced trade-off, the required branch-protection setting, `ferry-jira-mcp`, and `ferry-ci-gate`)
 - [MCP servers](docs/MCP.md)

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -9,6 +9,15 @@
 | `npx -p @big-emotion/ferry ferry-update`    | Upgrade Ferry to a newer version |
 | `npx -p @big-emotion/ferry ferry-uninstall` | Remove Ferry from a repo         |
 
+GitLab CI uses the same four lifecycle commands with `--forge gitlab`:
+
+| Command                                                    | What it does                                              |
+| ---------------------------------------------------------- | --------------------------------------------------------- |
+| `npx -p @big-emotion/ferry ferry-init --forge gitlab`      | Scaffold `ci/ferry/*.gitlab-ci.yml` into a GitLab repo    |
+| `npx -p @big-emotion/ferry ferry-doctor --forge gitlab`    | Validate the GitLab project token, trigger, and variables |
+| `npx -p @big-emotion/ferry ferry-update --forge gitlab`    | Rewrite pinned Ferry versions in GitLab CI files          |
+| `npx -p @big-emotion/ferry ferry-uninstall --forge gitlab` | Plan or remove the local GitLab install                   |
+
 `ferry-doctor` will warn when a newer version is available:
 
 ```

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -2,24 +2,41 @@
 
 ## Requirements
 
-- GitHub repository (target repo where Ferry runs)
-- **GitHub App** installed on the target repo with `contents: write`, `pull-requests: write`, and `issues: write`. The wizard's first step prompts for the App ID and the private-key PEM file — have both ready before running `ferry-init`. (The App is used by `ferry-doctor` to validate the install; the agent workflows themselves run on `${{ github.token }}`.)
+### Common
+
 - Jira Cloud Standard or Premium (outbound web requests required)
 - Anthropic account (required for all phases); OpenAI or Google AI accounts if you configure those providers for the Refiner
 - **Story** issue type (and Task, Bug, Spike if your project uses them) must be enabled in the Jira project
-- Local tooling: `gh` CLI authenticated against the target repo (`gh auth status`), Node ≥ 20
+- Node ≥ 20
+
+### GitHub Actions
+
+- GitHub repository (target repo where Ferry runs)
+- **GitHub App** installed on the target repo with `contents: write`, `pull-requests: write`, and `issues: write`. The wizard's first step prompts for the App ID and the private-key PEM file — have both ready before running `ferry-init`. (The App is used by `ferry-doctor` to validate the install; the agent workflows themselves run on `${{ github.token }}`.)
+- `gh` CLI authenticated against the target repo (`gh auth status`)
+
+### GitLab CI (experimental)
+
+- GitLab project
+- GitLab project access token with `api` scope (`FERRY_GITLAB_TOKEN`)
+- GitLab pipeline trigger token (`FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN`)
+- Optional self-managed GitLab API base (`FERRY_GITLAB_API_BASE`) if you do not use `https://gitlab.com/api/v4`
 
 ---
 
 ## Quick install
 
-> **Forge:** Ferry runs natively on **GitHub Actions** (production-ready) and on **GitLab CI** (experimental — see [#210](https://github.com/big-emotion/ferry/issues/210)). The wizard targets GitHub; GitLab consumers should copy the templates from [`examples/consumer-setup-gitlab/`](../examples/consumer-setup-gitlab) and follow the [GitLab section in `docs/CONFIGURATION.md`](CONFIGURATION.md#gitlab-experimental).
+> **Forge:** Ferry runs natively on **GitHub Actions** (production-ready) and on **GitLab CI** (experimental — see [#210](https://github.com/big-emotion/ferry/issues/210)). Pick the install path that matches your forge.
 
 ```bash
 npx -p @big-emotion/ferry ferry-init
 ```
 
 The wizard collects your Jira URL, credentials, column status names (prompts with defaults: **Refinement** / **In Development** / **In Review** / **Changes Requested** / **Ready to Merge**), and LLM provider selection per phase. Ferry supports **Anthropic** (default), **OpenAI**, and **Google AI** — see the [provider × phase matrix](CONFIGURATION.md#provider--phase-matrix) for a full breakdown and caveats. Custom status names work — enter them when prompted.
+
+After the wizard finishes, complete the manual setup for your forge.
+
+## GitHub Actions install
 
 After the wizard finishes, complete four manual steps:
 
@@ -113,6 +130,134 @@ Set `event_type` and `phase` to `ferry-dev` / `ferry-review` / `ferry-iterate` f
 > **PAT:** Use a GitHub fine-grained PAT with **Contents: write** on `YOUR_ORG/YOUR_REPO`. Marking `Authorization` as secret keeps the token out of Jira's audit log.
 
 > **Generated reference files:** `ferry-init` writes `ferry-jira-automation-setup.md` (per-rule UI walkthrough) and `ferry-jira-automation-rules.beta.json` into your repo root. The Markdown file mirrors the steps above. The JSON can be loaded via **Automation → ⋮ → Import rules**, but that feature is beta and breaks across Jira Cloud releases — treat it as a reference only.
+
+---
+
+## GitLab CI install (experimental)
+
+GitLab support is **experimental**: the adapter and CLI paths ship in Ferry, but the full Jira → MR production loop has not yet completed the promotion checklist in [#210](https://github.com/big-emotion/ferry/issues/210). Expect the install flow to work, but treat minor-version upgrades with more caution than the GitHub path.
+
+### Step 1 — Scaffold the GitLab templates
+
+Run the GitLab branch of the installer:
+
+```bash
+npx -p @big-emotion/ferry ferry-init --forge gitlab
+```
+
+The wizard detects the GitLab project from `origin` when possible and writes six templates under `ci/ferry/`:
+
+- `ci/ferry/refine.gitlab-ci.yml`
+- `ci/ferry/dev.gitlab-ci.yml`
+- `ci/ferry/review.gitlab-ci.yml`
+- `ci/ferry/iterate.gitlab-ci.yml`
+- `ci/ferry/reconcile.gitlab-ci.yml`
+- `ci/ferry/cost-daily.gitlab-ci.yml`
+
+Include them from the project root `.gitlab-ci.yml`:
+
+```yaml
+variables:
+  FERRY_FORGE: gitlab
+  FERRY_GITLAB_API_BASE: '$CI_API_V4_URL'
+  FERRY_GITLAB_TRIGGER_REF: '$CI_DEFAULT_BRANCH'
+  GITHUB_REPO: '$CI_PROJECT_PATH'
+  GITHUB_TOKEN: '$FERRY_GITLAB_TOKEN'
+
+include:
+  - local: ci/ferry/refine.gitlab-ci.yml
+  - local: ci/ferry/dev.gitlab-ci.yml
+  - local: ci/ferry/review.gitlab-ci.yml
+  - local: ci/ferry/iterate.gitlab-ci.yml
+  # Optional scheduled jobs:
+  # - local: ci/ferry/reconcile.gitlab-ci.yml
+  # - local: ci/ferry/cost-daily.gitlab-ci.yml
+```
+
+### Step 2 — Set GitLab CI/CD variables
+
+Under **Settings → CI/CD → Variables**, create:
+
+- `FERRY_VERSION` — pinned Ferry version, e.g. `v0.17.0`
+- `FERRY_JIRA_BASE_URL`, `FERRY_JIRA_EMAIL`, `FERRY_JIRA_API_TOKEN`
+- `FERRY_GITLAB_TOKEN`, `FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN`
+- `FERRY_REVIEW_TRANSITION_ID`, `FERRY_ITER_TRANSITION_ID`, `FERRY_APPROVE_TRANSITION_ID`
+- `FERRY_AUDIT_ISSUE`
+- At least one of `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`
+
+Mark every token-bearing variable as **Masked** and **Protected**.
+
+### Step 3 — Connect Jira → GitLab
+
+Create one Jira Automation rule per Ferry column. Each rule should POST to the GitLab pipeline trigger endpoint:
+
+```http
+POST https://gitlab.example/api/v4/projects/<encoded-path>/trigger/pipeline
+Content-Type: application/x-www-form-urlencoded
+
+token=<FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN>&
+ref=main&
+variables[FERRY_DISPATCH_TYPE]=ferry-refine&
+variables[FERRY_ENVELOPE_PAYLOAD]={"version":"v1","event_id":"{{issue.key}}-{{issue.id}}","ticket_key":"{{issue.key}}","phase":"refine","source":"jira-column","ts":"{{now.jiraDate}}"}
+```
+
+Required form fields:
+
+- `token` — the GitLab pipeline trigger token
+- `ref` — usually the default branch
+- `variables[FERRY_DISPATCH_TYPE]` — one of `ferry-refine`, `ferry-dev`, `ferry-review`, `ferry-iterate`
+- `variables[FERRY_ENVELOPE_PAYLOAD]` — the JSON envelope Ferry consumes
+
+### Step 4 — Add scheduled jobs (recommended)
+
+To enable the reconciler and cost-governance jobs, include `ci/ferry/reconcile.gitlab-ci.yml` and `ci/ferry/cost-daily.gitlab-ci.yml`, then create GitLab schedules:
+
+- Reconciler: every 10 minutes with CI variable `schedule_reconcile=true`
+- Cost governance: daily with CI variable `schedule_cost_daily=true`
+
+### Step 5 — Smoke test and validate
+
+Create a Jira **Story**, move it to **Refinement**, and verify that a GitLab pipeline starts with `FERRY_DISPATCH_TYPE=ferry-refine`. After the first successful trigger, validate the install with:
+
+```bash
+npx -p @big-emotion/ferry ferry-doctor --forge gitlab \
+  --project owner/repo \
+  --token "$FERRY_GITLAB_TOKEN" \
+  --trigger-token "$FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN"
+```
+
+`ferry-doctor --forge gitlab` checks project access, token scope visibility, trigger registration, CI/CD variables, and a manual Jira-webhook confirmation step.
+
+### Step 6 — Update and uninstall
+
+Upgrade the GitLab templates in place:
+
+```bash
+npx -p @big-emotion/ferry@<new-version> ferry-update --forge gitlab
+```
+
+Plan or remove the install locally:
+
+```bash
+# Plan only
+npx -p @big-emotion/ferry ferry-uninstall --forge gitlab
+
+# Apply cleanup
+npx -p @big-emotion/ferry ferry-uninstall --forge gitlab --apply
+```
+
+### GitLab install checklist
+
+```
+[ ] ferry-init --forge gitlab run successfully
+[ ] ci/ferry/*.gitlab-ci.yml files written and included from .gitlab-ci.yml
+[ ] GitLab CI/CD variables created and token-bearing ones marked Masked + Protected
+[ ] Jira Automation rules POST to /projects/<id>/trigger/pipeline
+[ ] variables[FERRY_DISPATCH_TYPE] and variables[FERRY_ENVELOPE_PAYLOAD] set in each rule
+[ ] Smoke test passed (pipeline starts from Jira transition)
+[ ] ferry-doctor --forge gitlab reports no FAIL lines
+[ ] reconcile / cost-daily schedules added if you want maintenance automation
+```
 
 ---
 

--- a/examples/consumer-setup-gitlab/README.md
+++ b/examples/consumer-setup-gitlab/README.md
@@ -17,15 +17,34 @@ Copy-pasteable GitLab CI templates that wire Ferry's four agents (Refiner / Deve
 
 ## Install
 
-1. **Copy these files** to the root of your project (or into your existing `.gitlab-ci.yml` via `include:`).
-2. **Set the CI/CD variables** (Settings → CI/CD → Variables). Mark every token-bearing variable as both **Protected** and **Masked**:
-   - `FERRY_VERSION` — e.g. `v0.11.0` (the npm version of `@big-emotion/ferry`)
+1. **Run the GitLab installer**:
+
+   ```bash
+   npx -p @big-emotion/ferry ferry-init --forge gitlab
+   ```
+
+   This writes the canonical templates under `ci/ferry/`.
+
+2. **Include the generated templates** from your root `.gitlab-ci.yml`:
+
+   ```yaml
+   include:
+     - local: ci/ferry/refine.gitlab-ci.yml
+     - local: ci/ferry/dev.gitlab-ci.yml
+     - local: ci/ferry/review.gitlab-ci.yml
+     - local: ci/ferry/iterate.gitlab-ci.yml
+   ```
+
+   Add `ci/ferry/reconcile.gitlab-ci.yml` and `ci/ferry/cost-daily.gitlab-ci.yml` if you want the scheduled maintenance jobs.
+
+3. **Set the CI/CD variables** (Settings → CI/CD → Variables). Mark every token-bearing variable as both **Protected** and **Masked**:
+   - `FERRY_VERSION` — e.g. `v0.17.0` (the npm version of `@big-emotion/ferry`)
    - `FERRY_JIRA_BASE_URL`, `FERRY_JIRA_EMAIL`, `FERRY_JIRA_API_TOKEN`
    - `FERRY_GITLAB_TOKEN`, `FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN`
    - `FERRY_REVIEW_TRANSITION_ID`, `FERRY_ITER_TRANSITION_ID`, `FERRY_APPROVE_TRANSITION_ID`
    - `FERRY_AUDIT_ISSUE` — the Jira issue key used as the audit log
    - At least one of `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`
-3. **Wire Jira Automation** for each column transition you want to trigger an agent. Each rule sends a webhook of the form:
+4. **Wire Jira Automation** for each column transition you want to trigger an agent. Each rule sends a webhook of the form:
 
    ```http
    POST https://gitlab.example/api/v4/projects/<encoded-path>/trigger/pipeline
@@ -39,14 +58,25 @@ Copy-pasteable GitLab CI templates that wire Ferry's four agents (Refiner / Deve
 
    The `FERRY_DISPATCH_TYPE` values for the four roles are: `ferry-refine`, `ferry-dev`, `ferry-review`, `ferry-iterate`.
 
-4. **(Optional) Scheduled jobs** — under Settings → CI/CD → Schedules, add one schedule for the reconciler (recommended every 10 minutes, set CI variable `schedule_reconcile=true`) and one for cost governance (daily, `schedule_cost_daily=true`). Include `reconcile.gitlab-ci.yml` and `cost-daily.gitlab-ci.yml` from the top-level pipeline file to wire them in.
+5. **Run a smoke test** — move a Jira Story to the Ferry refinement column and confirm that GitLab starts a pipeline with `FERRY_DISPATCH_TYPE=ferry-refine`.
+
+6. **Validate the install**:
+
+   ```bash
+   npx -p @big-emotion/ferry ferry-doctor --forge gitlab \
+     --project owner/repo \
+     --token "$FERRY_GITLAB_TOKEN" \
+     --trigger-token "$FERRY_GITLAB_PIPELINE_TRIGGER_TOKEN"
+   ```
+
+7. **(Optional) Scheduled jobs** — under Settings → CI/CD → Schedules, add one schedule for the reconciler (recommended every 10 minutes, set CI variable `schedule_reconcile=true`) and one for cost governance (daily, `schedule_cost_daily=true`). Include `ci/ferry/reconcile.gitlab-ci.yml` and `ci/ferry/cost-daily.gitlab-ci.yml` from the top-level pipeline file to wire them in.
 
 ## Status
 
 GitLab support is **experimental** until a real consumer has run a full Refiner → Developer → Reviewer → Iterator cycle in production for at least two weeks. The promotion checklist lives on [#210](https://github.com/big-emotion/ferry/issues/210). Until then:
 
 - The bundled artifact may break across minor releases.
-- `ferry-doctor --forge gitlab` is not yet shipped (planned in [#214](https://github.com/big-emotion/ferry/issues/214)).
-- Record-replay HTTP fixtures in Ferry's own CI are planned in [#215](https://github.com/big-emotion/ferry/issues/215).
+- `ferry-doctor --forge gitlab` ships today, but its Jira webhook verification step remains manual because Ferry cannot probe Jira Automation from the CLI.
+- Record-replay HTTP fixtures in Ferry's own CI now cover the adapter, but a real consumer production loop is still the gate to remove the experimental label.
 
 If you hit issues, please open a bug report on [big-emotion/ferry](https://github.com/big-emotion/ferry/issues) referencing #210.

--- a/src/install-guide.test.ts
+++ b/src/install-guide.test.ts
@@ -372,6 +372,38 @@ describe('Quick install — smoke test documented (INSTALL.md §Smoke test)', ()
 });
 
 // ---------------------------------------------------------------------------
+// 14.5 GitLab install path documented end-to-end
+// ---------------------------------------------------------------------------
+
+describe('GitLab install path — end-to-end docs (issue #406)', () => {
+  it('INSTALL.md documents the GitLab init command', async () => {
+    const doc = await readFile('docs/INSTALL.md');
+    expect(doc).toContain('npx -p @big-emotion/ferry ferry-init --forge gitlab');
+  });
+
+  it('INSTALL.md documents including ci/ferry templates from .gitlab-ci.yml', async () => {
+    const doc = await readFile('docs/INSTALL.md');
+    expect(doc).toContain('ci/ferry/');
+    expect(doc).toContain('.gitlab-ci.yml');
+    expect(doc).toContain('include:');
+  });
+
+  it('INSTALL.md documents the Jira Automation trigger fields used by GitLab', async () => {
+    const doc = await readFile('docs/INSTALL.md');
+    expect(doc).toContain('trigger/pipeline');
+    expect(doc).toContain('FERRY_DISPATCH_TYPE');
+    expect(doc).toContain('FERRY_ENVELOPE_PAYLOAD');
+  });
+
+  it('INSTALL.md documents GitLab validation, update, and uninstall commands', async () => {
+    const doc = await readFile('docs/INSTALL.md');
+    expect(doc).toContain('ferry-doctor --forge gitlab');
+    expect(doc).toContain('ferry-update --forge gitlab');
+    expect(doc).toContain('ferry-uninstall --forge gitlab');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 14. No-auto-merge invariant cross-check
 // ---------------------------------------------------------------------------
 
@@ -518,5 +550,36 @@ describe('supply-chain — npm audit step in ferry-ci.yml (issue #105)', () => {
   it('ferry-ci.yml declares an audit job', async () => {
     const content = await readFile('.github/workflows/ferry-ci.yml');
     expect(content, 'ferry-ci.yml must have an "audit:" job').toMatch(/^  audit:\s*$/m);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 19. CLI docs include forge-aware lifecycle commands
+// ---------------------------------------------------------------------------
+
+describe('CLI docs — GitLab forge variants (issue #406)', () => {
+  it('docs/CLI.md mentions --forge gitlab for every lifecycle command', async () => {
+    const doc = await readFile('docs/CLI.md');
+    expect(doc).toContain('ferry-init --forge gitlab');
+    expect(doc).toContain('ferry-doctor --forge gitlab');
+    expect(doc).toContain('ferry-update --forge gitlab');
+    expect(doc).toContain('ferry-uninstall --forge gitlab');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 20. GitLab example docs must not describe shipped commands as pending
+// ---------------------------------------------------------------------------
+
+describe('GitLab example docs — shipped command status (issue #406)', () => {
+  it('examples/consumer-setup-gitlab/README.md does not say ferry-doctor is planned', async () => {
+    const doc = await readFile('examples/consumer-setup-gitlab/README.md');
+    expect(doc).not.toContain('not yet shipped');
+    expect(doc).not.toContain('planned in [#214]');
+  });
+
+  it('examples/consumer-setup-gitlab/README.md includes a validation path with ferry-doctor --forge gitlab', async () => {
+    const doc = await readFile('examples/consumer-setup-gitlab/README.md');
+    expect(doc).toContain('ferry-doctor --forge gitlab');
   });
 });


### PR DESCRIPTION
## Summary
- add a dedicated GitLab CI install path to the install guide with prerequisites, include wiring, Jira automation, validation, update, and uninstall steps
- document the `--forge gitlab` lifecycle commands in the CLI docs and refresh the GitLab consumer example README
- add acceptance tests that lock the GitLab install path and remove the stale "planned" claim for `ferry-doctor --forge gitlab`

Closes #406