### PR TITLE
[codex] complete codex-cli execution path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Ferry uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Complete `codex-cli` workflow execution path** — the generated consumer workflows now include a real `run-agent-codex-cli` job for all five roles, backed by `openai/codex-action`, `ferry-action-prompt --path codex-cli`, and a generated `codex-home/config.toml` that wires Ferry's Jira MCP server into Codex. `ferry-init` now offers `codex-cli` as an install-time execution path, `ferry-doctor` validates `OPENAI_API_KEY` / provider-gate / workflow shape for that path, and `ferry-update` documents the regeneration step in `MIGRATIONS.md`.
+
 ---
 
 ## [0.17.0] — 2026-06-07

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -53,6 +53,13 @@ If there are no consumer-visible changes, omit the section (or note `(none — i
 
 ---
 
+## v0.17.x → v0.18.0
+
+- **(action)** **`codex-cli` workflow jobs are now generated for all five roles.** Run `npx -p @big-emotion/ferry@v0.18.0 ferry-update` to regenerate your workflow stubs so `path=codex-cli` resolves to a real `run-agent-codex-cli` job instead of silently skipping the agent phase.
+- **(info)** **Codex direct-action runs now use Ferry-managed Jira MCP wiring through `codex-home/config.toml`.** The generated workflows create `codex-home/config.toml` with `ferry-codex-config` and pass it to `openai/codex-action`. Jira credentials still come from the existing `FERRY_JIRA_*` secrets; no new Jira secret is required.
+
+---
+
 ## v0.16.x → v0.17.0
 
 - **(action)** **New `ferry-merge.yml` workflow (Merger agent, FR32).** Run `npx -p @big-emotion/ferry@v0.17.0 ferry-update` to add the merge workflow stub to your `.github/workflows/`. Alternatively, copy `examples/consumer-setup/workflows/ferry-merge.yml` by hand. Without this file, the Reviewer's `ferry-merge` `repository_dispatch` event is never handled and PRs are never automatically merged — they stay in their current state until a human merges them.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See [docs/CLI.md](docs/CLI.md) — `ferry-init`, `ferry-doctor`, `ferry-update`,
 
 - [Install guide](docs/INSTALL.md) — prerequisites, wizard walkthrough, Jira automation setup
 - [How Ferry works](docs/OVERVIEW.md) — what it is and isn't, agent phases, auto-transitions
-- [Configuration reference](docs/CONFIGURATION.md) — includes the [Execution paths & accepted divergences](docs/CONFIGURATION.md#execution-paths--accepted-divergences) reference (script vs. `claude-code-action` paths, the prompt-enforced trade-off, the required branch-protection setting, `ferry-jira-mcp`, and `ferry-ci-gate`)
+- [Configuration reference](docs/CONFIGURATION.md) — includes the [Execution paths & accepted divergences](docs/CONFIGURATION.md#execution-paths--accepted-divergences) reference (script vs. `claude-code-action` vs. `codex-cli`, the prompt-enforced trade-off, the required branch-protection setting, `ferry-jira-mcp`, and `ferry-ci-gate`)
 - [MCP servers](docs/MCP.md)
 - [Cost governance](docs/COST.md)
 - [Runbook](docs/RUNBOOK.md)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -613,25 +613,25 @@ Let a Jira ticket run Ferry without producing side effects — to validate promp
 
 **Use case:** validate a new MCP server configuration or refined prompt by running the full agent loop on a real ticket without touching the repo or the Jira board.
 
-##### Execution-path routing (`ferry:claude-code`, `ferry:no-claude-code`)
+##### Execution-path routing (`ferry:claude-code`, `ferry:no-claude-code`, `ferry:codex-cli`, `ferry:no-codex-cli`)
 
 > **Read the trade-off first.** The `claude-code-action` path is a direct call into `anthropics/claude-code-action` with no Ferry wrapper around it — see [Execution paths & accepted divergences](#execution-paths--accepted-divergences). Several invariants that the bundled-script path enforces in code become **prompt-enforced** on this path.
 
 Which execution path an agent run takes is decided by a deterministic resolver ([ADR-0006](./adr/0006-claude-code-action-execution-path.md) §3, [#300](https://github.com/big-emotion/ferry/issues/300)). Precedence, highest first:
 
 1. **Explicit `execution_path: "script"`** in `ferry.config.*` — a hard lock; never overridden by the label or the heuristic.
-2. **Per-ticket label** — `ferry:claude-code` forces the claude-code-action path; `ferry:no-claude-code` forces the bundled script. Both labels present is **not** a `LabelConflictError`: it fails closed to the safe `script` path.
+2. **Per-ticket label** — `ferry:claude-code` forces the claude-code-action path; `ferry:codex-cli` forces the Codex direct-action path; `ferry:no-claude-code` / `ferry:no-codex-cli` force the bundled script. Conflicting direct-action labels fail closed to the safe `script` path.
 3. **Automatic heuristic** — a `developer` / `iterator` run with `priorRoundTrips >= routing.claude_code_round_trip_threshold` escalates an otherwise-script default to claude-code.
 4. **Conditional default** — explicit `execution_path: "claude-code"`, else `claude-code` for an Anthropic-only consumer, else `script`.
 
 The resolved path **and the reason** (`label` / `heuristic` / `default`) are recorded in the audit comment so the Reconciler observes which path ran and why.
 
-| Config key                                 | Default   | Effect                                                                                     |
-| ------------------------------------------ | --------- | ------------------------------------------------------------------------------------------ |
-| `execution_path`                           | _(unset)_ | `"script"` (hard lock) or `"claude-code"` (explicit). Unset → conditional default applies. |
-| `routing.claude_code_round_trip_threshold` | `2`       | Positive integer N for the developer/iterator escalation heuristic.                        |
+| Config key                                 | Default   | Effect                                                                                                     |
+| ------------------------------------------ | --------- | ---------------------------------------------------------------------------------------------------------- |
+| `execution_path`                           | _(unset)_ | `"script"` (hard lock), `"claude-code"`, or `"codex-cli"` (explicit). Unset → conditional default applies. |
+| `routing.claude_code_round_trip_threshold` | `2`       | Positive integer N for the developer/iterator escalation heuristic.                                        |
 
-`ferry:claude-code` only _selects_ the path — it does not provision the `CLAUDE_CODE_OAUTH_TOKEN` the path needs. The merge boundary holds regardless of how the path was chosen: the Refiner, Developer, Reviewer, and Iterator **never merge code** — on the claude-code path enforced by `claude-code-action`'s `--disallowedTools` deny-list plus consumer branch protection. Merging is confined to the separate, gated **Merger** agent (FR32), triggered only by a `ferry-merge` dispatch on Reviewer approval (see [Execution paths & accepted divergences](#execution-paths--accepted-divergences)).
+`ferry:claude-code` only _selects_ the path — it does not provision the `CLAUDE_CODE_OAUTH_TOKEN` the path needs. Likewise, `ferry:codex-cli` only selects the path — it still requires `OPENAI_API_KEY` and OpenAI providers for the agents that run on it. The merge boundary holds regardless of how the path was chosen: the Refiner, Developer, Reviewer, and Iterator **never merge code** — on the direct-action paths enforced by the action deny-lists plus consumer branch protection. Merging is confined to the separate, gated **Merger** agent (FR32), triggered only by a `ferry-merge` dispatch on Reviewer approval (see [Execution paths & accepted divergences](#execution-paths--accepted-divergences)).
 
 ##### Extended thinking (`ferry:thinking/*`)
 
@@ -878,12 +878,13 @@ Secrets (`ANTHROPIC_API_KEY`, `FERRY_OPENAI_KEY`, `FERRY_GOOGLE_AI_KEY`) are cre
 
 ## Execution paths & accepted divergences
 
-Ferry's five agents (Refiner, Developer, Reviewer, Iterator, Merger) run via one of two execution paths behind the same `repository_dispatch` boundary:
+Ferry's five agents (Refiner, Developer, Reviewer, Iterator, Merger) run via one of three execution paths behind the same `repository_dispatch` boundary:
 
 | Path                     | Reasoning core                          | Providers                   | Per-run EUR cap  | Auth                                     |
 | ------------------------ | --------------------------------------- | --------------------------- | ---------------- | ---------------------------------------- |
 | **Bundled script**       | Ferry's deterministic agent loop        | Anthropic / OpenAI / Google | Enforced         | `ANTHROPIC_API_KEY` / provider keys      |
 | **`claude-code-action`** | `anthropics/claude-code-action@v1` loop | Anthropic only              | **Not enforced** | `CLAUDE_CODE_OAUTH_TOKEN` (subscription) |
+| **`codex-cli`**          | `openai/codex-action@v1` loop           | OpenAI only                 | **Not enforced** | `OPENAI_API_KEY`                         |
 
 The **bundled-script path is unchanged** — its deterministic agent loop, structured-output schema, code-enforced idempotency, audit-line emission, and per-run EUR cap all behave exactly as documented elsewhere in this reference.
 
@@ -892,6 +893,12 @@ The **bundled-script path is unchanged** — its deterministic agent loop, struc
 For a `ferry:claude-code` ticket each agent job is **one direct call** into `anthropics/claude-code-action@v1`: a `checkout` step followed by that single action step. There is **no Ferry wrapper** around it — no prepare/apply composite actions, no intermediate JSON artifact, no structured-output "contract" layer. The agent does its own Jira work through a Ferry-shipped MCP server ([`ferry-jira-mcp`](#ferry-jira-mcp-jira-access-for-the-claude-code-path)) and its own GitHub work through `claude-code-action`'s native `git` / `gh` tools. The reviewer job is additionally fronted by the deterministic [`ferry-ci-gate`](#ferry-ci-gate-reviewer-ci-pre-gate) composite action.
 
 Authentication is `CLAUDE_CODE_OAUTH_TOKEN` only — `ANTHROPIC_API_KEY` is **forbidden** on this path ([ADR-0006](./adr/0006-claude-code-action-execution-path.md) §6). The provider gate still applies: the claude-code path is only available to an Anthropic-only consumer configuration.
+
+### How the codex-cli path runs
+
+For a `ferry:codex-cli` ticket each agent job is one direct `openai/codex-action@v1` call. The workflow resolves the role prompt with `ferry-action-prompt --path codex-cli`, generates `codex-home/config.toml` with `ferry-codex-config`, and passes that `codex-home` directory to the action. Ferry owns the Jira bridge here too: Codex has **no native Jira-label integration**, so the agent reaches Jira only through Ferry's `ferry-jira-mcp` server declared in `codex-home/config.toml`.
+
+Authentication is `OPENAI_API_KEY`. The provider gate still applies: the codex-cli path is only available when the relevant agent provider is `openai`.
 
 ### The accepted trade-off: prompt-enforced, not code-enforced
 
@@ -920,13 +927,13 @@ These remain accepted, by-design differences on the claude-code path — all are
 
 3. **EUR-cost telemetry is `0` on the claude-code path.** With no wrapper to capture token/cost values, the `cost_eur` and token audit fields are emitted as `0` (best-effort by design). See [COST.md → Cost telemetry on the claude-code path](./COST.md#cost-telemetry-on-the-claude-code-execution-path).
 
-### `ferry-jira-mcp` — Jira access for the claude-code path
+### `ferry-jira-mcp` — Jira access for the direct-action paths
 
-On the claude-code path the agent reaches Jira through **`ferry-jira-mcp`**, a Ferry-owned stdio MCP server shipped as the `ferry-jira-mcp` bin of the `@big-emotion/ferry` npm package. It authenticates with the same token-auth env Ferry already uses — `FERRY_JIRA_BASE_URL`, `FERRY_JIRA_EMAIL`, `FERRY_JIRA_API_TOKEN`.
+On the direct-action paths the agent reaches Jira through **`ferry-jira-mcp`**, a Ferry-owned stdio MCP server shipped as the `ferry-jira-mcp` bin of the `@big-emotion/ferry` npm package. It authenticates with the same token-auth env Ferry already uses — `FERRY_JIRA_BASE_URL`, `FERRY_JIRA_EMAIL`, `FERRY_JIRA_API_TOKEN`.
 
 It exposes six tools: `get_issue`, `list_subtasks`, `create_subtask`, `get_transitions`, `transition_issue`, `post_comment`.
 
-The consumer's claude-code workflow wires it into `claude-code-action` via `claude_args --mcp-config`, launching the server with `npx -y -p @big-emotion/ferry ferry-jira-mcp`.
+The consumer's claude-code workflow wires it into `claude-code-action` via `claude_args --mcp-config`, while the codex-cli workflow writes the same server definition into `codex-home/config.toml` and passes `codex-home` to `openai/codex-action`. In both cases the launched command is `npx -y -p @big-emotion/ferry ferry-jira-mcp`.
 
 ### `ferry-ci-gate` — reviewer CI pre-gate
 

--- a/docs/adr/0007-codex-cli-jira-mcp-wiring.md
+++ b/docs/adr/0007-codex-cli-jira-mcp-wiring.md
@@ -1,0 +1,26 @@
+# 0007 — Codex CLI execution path uses Ferry-managed Jira MCP wiring
+
+Status: Accepted
+
+Date: 2026-06-13
+
+## Context
+
+Ferry already had routing support for `execution_path: codex-cli`, `ferry:codex-cli`, bundled `*.codex-cli.md` prompts, and `ferry-action-prompt --path codex-cli`. The missing piece was downstream of routing: no generated workflow consumed `path=codex-cli`, so a ticket could opt into the path and then silently run no agent job.
+
+Codex also has no native Jira-label delegation. If Ferry wants Codex to read tickets, create sub-tasks, transition columns, and post fingerprinted audit comments, Ferry must provide that bridge itself.
+
+## Decision
+
+1. Generated consumer workflows include a `run-agent-codex-cli` job for all five roles, gated by `if: needs.route.outputs.path == 'codex-cli'`.
+2. The direct Codex invocation is `openai/codex-action`, SHA-pinned in generated workflows.
+3. Jira access is provided by Ferry's existing `ferry-jira-mcp` server, declared in a generated `codex-home/config.toml` file produced by the `ferry-codex-config` bin.
+4. The generated TOML is secret-free. Jira credentials stay in the workflow job environment via the existing `FERRY_JIRA_*` secrets.
+5. `emit-audit` treats Codex like the other direct-action path: job outcome is recorded, token/cost telemetry is emitted as `0`.
+6. The Merger has codex-cli parity with the claude-code path: `gh pr merge` is allowed only there, while `gh pr close` remains denied.
+
+## Consequences
+
+- Every route output now has a matching workflow job; `codex-cli` no longer fails by silent skip.
+- `ferry-init` and `ferry-doctor` can expose `codex-cli` as a supported execution path instead of a half-wired preview.
+- Ferry remains the owner of Jira integration on the Codex path; users should not assume Codex can infer Jira labels or transitions without Ferry's MCP bridge.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,6 +12,7 @@ This directory contains Architecture Decision Records (ADRs) for the Ferry proje
 | [0004](./0004-idempotency-via-comment-markers.md)   | Idempotency via comment markers                              | Accepted |
 | [0005](./0005-no-auto-merge-invariant.md)           | No auto-merge invariant                                      | Accepted |
 | [0006](./0006-claude-code-action-execution-path.md) | claude-code-action as the conditional default execution path | Accepted |
+| [0007](./0007-codex-cli-jira-mcp-wiring.md)         | codex-cli execution path uses Ferry-managed Jira MCP wiring  | Accepted |
 
 ## ADR Template
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "ferry-action-prompt": "dist/cli/cc-prompt/index.js",
         "ferry-agent": "dist/cli/agent/run.js",
         "ferry-cc-prompt": "dist/cli/cc-prompt/index.js",
+        "ferry-codex-config": "dist/cli/codex-config/index.js",
         "ferry-cost-advice": "dist/cli/cost/advice-cmd.js",
         "ferry-cost-reconcile": "dist/cli/cost/reconcile-cmd.js",
         "ferry-cost-report": "dist/cli/cost/run.js",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "ferry-cost-advice": "./dist/cli/cost/advice-cmd.js",
     "ferry-cost-stats": "./dist/cli/cost/stats.js",
     "ferry-jira-mcp": "./dist/cli/jira-mcp/index.js",
+    "ferry-codex-config": "./dist/cli/codex-config/index.js",
     "ferry-cc-prompt": "./dist/cli/cc-prompt/index.js",
     "ferry-action-prompt": "./dist/cli/cc-prompt/index.js"
   },
@@ -57,6 +58,7 @@
     "ferry-cost-advice": "tsx src/cli/cost/advice-cmd.ts",
     "ferry-cost-stats": "tsx src/cli/cost/stats-cmd.ts",
     "ferry-cc-prompt": "tsx src/cli/cc-prompt/index.ts",
+    "ferry-codex-config": "tsx src/cli/codex-config/index.ts",
     "ferry-action-prompt": "tsx src/cli/cc-prompt/index.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/src/cli/codex-config/index.ts
+++ b/src/cli/codex-config/index.ts
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { createRequire } from 'node:module';
+import { renderCodexConfigToml } from '../../lib/codex/config-toml.js';
+
+const _require = createRequire(import.meta.url);
+
+function packageVersion(): string {
+  try {
+    const pkg = _require('../../../package.json') as { version: string };
+    return `v${pkg.version}`;
+  } catch {
+    return 'v0.0.0';
+  }
+}
+
+process.stdout.write(renderCodexConfigToml({ version: packageVersion() }));

--- a/src/cli/doctor/checks/codex-cli-path.test.ts
+++ b/src/cli/doctor/checks/codex-cli-path.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const mockExecSync = vi.hoisted(() => vi.fn());
+const mockLoadFerryConfig = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  execSync: mockExecSync,
+}));
+
+vi.mock('../../../lib/config.js', () => ({
+  loadFerryConfig: mockLoadFerryConfig,
+}));
+
+import {
+  resolveExecutionPath,
+  checkCodexCliPath,
+  checkProviderGate,
+  checkWorkflowShape,
+} from './codex-cli-path.js';
+
+function makeRepoRoot(): string {
+  return mkdtempSync(join(tmpdir(), 'ferry-codex-path-'));
+}
+
+function writeConfig(root: string, obj: unknown): void {
+  writeFileSync(join(root, 'ferry.config.json'), JSON.stringify(obj, null, 2));
+}
+
+function writeWorkflow(root: string, filename: string, content: string): void {
+  const dir = join(root, '.github', 'workflows');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, filename), content);
+}
+
+const WORKFLOW_FILES = [
+  'ferry-refine.yml',
+  'ferry-dev.yml',
+  'ferry-review.yml',
+  'ferry-iterate.yml',
+  'ferry-merge.yml',
+];
+
+const CURRENT_WORKFLOW_CONTENT = `
+jobs:
+  route:
+    name: Resolve execution path
+    steps:
+      - uses: big-emotion/ferry/.github/actions/ferry-route@v0.17.0
+  run-agent-codex-cli:
+    steps:
+      - uses: openai/codex-action@a26d2d4d8b78a694338b8e3715c3630254340b2c # v1
+`;
+
+const MISSING_STEP_CONTENT = `
+jobs:
+  route:
+    name: Resolve execution path
+  run-agent:
+    steps:
+      - uses: big-emotion/ferry/.github/actions/ferry-run-refiner@v0.17.0
+`;
+
+const ALL_OPENAI_CONFIG = {
+  models: {
+    refiner: { provider: 'openai', model: 'gpt-5-codex' },
+    dev: { provider: 'openai', model: 'gpt-5-codex' },
+    review: { provider: 'openai', model: 'gpt-5-codex' },
+    iterate: { provider: 'openai', model: 'gpt-5-codex' },
+    merger: { provider: 'openai', model: 'gpt-5-codex' },
+  },
+};
+
+describe('resolveExecutionPath', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = makeRepoRoot();
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('returns codex-cli when execution_path is "codex-cli"', () => {
+    writeConfig(root, { execution_path: 'codex-cli' });
+    expect(resolveExecutionPath(root)).toBe('codex-cli');
+  });
+});
+
+describe('checkCodexCliPath', () => {
+  let root: string;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    root = makeRepoRoot();
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('skips when execution_path is script', async () => {
+    writeConfig(root, { execution_path: 'script' });
+    const res = await checkCodexCliPath({ repoRoot: root, repo: 'owner/repo' });
+    expect(res.status).toBe('skip');
+  });
+
+  it('is red when execution_path is codex-cli and OPENAI_API_KEY is absent', async () => {
+    writeConfig(root, { execution_path: 'codex-cli' });
+    mockExecSync.mockReturnValue(JSON.stringify([{ name: 'FERRY_APP_ID' }]));
+    const res = await checkCodexCliPath({ repoRoot: root, repo: 'owner/repo' });
+    expect(res.status).toBe('red');
+    expect(res.detail).toContain('OPENAI_API_KEY');
+  });
+
+  it('is green when execution_path is codex-cli and the secret exists in the repo', async () => {
+    writeConfig(root, { execution_path: 'codex-cli' });
+    mockExecSync.mockReturnValue(
+      JSON.stringify([{ name: 'FERRY_APP_ID' }, { name: 'OPENAI_API_KEY' }]),
+    );
+    const res = await checkCodexCliPath({ repoRoot: root, repo: 'owner/repo' });
+    expect(res.status).toBe('green');
+  });
+});
+
+describe('checkProviderGate', () => {
+  let root: string;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    root = makeRepoRoot();
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('is green when execution_path is codex-cli and all configured providers are openai', () => {
+    writeConfig(root, { execution_path: 'codex-cli' });
+    mockLoadFerryConfig.mockReturnValue(ALL_OPENAI_CONFIG);
+    const res = checkProviderGate({ repoRoot: root });
+    expect(res.status).toBe('green');
+  });
+
+  it('is red when a configured agent uses a non-openai provider', () => {
+    writeConfig(root, { execution_path: 'codex-cli' });
+    mockLoadFerryConfig.mockReturnValue({
+      models: {
+        refiner: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+        dev: { provider: 'openai', model: 'gpt-5-codex' },
+      },
+    });
+    const res = checkProviderGate({ repoRoot: root });
+    expect(res.status).toBe('red');
+    expect(res.detail).toContain('refiner');
+    expect(res.detail).toContain('OpenAI');
+  });
+});
+
+describe('checkWorkflowShape', () => {
+  let root: string;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    root = makeRepoRoot();
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('is green when all five workflows contain run-agent-codex-cli with openai/codex-action', () => {
+    writeConfig(root, { execution_path: 'codex-cli' });
+    for (const f of WORKFLOW_FILES) {
+      writeWorkflow(root, f, CURRENT_WORKFLOW_CONTENT);
+    }
+    const res = checkWorkflowShape({ repoRoot: root });
+    expect(res.status).toBe('green');
+  });
+
+  it('is yellow when workflows are missing the codex-action step', () => {
+    writeConfig(root, { execution_path: 'codex-cli' });
+    for (const f of WORKFLOW_FILES) {
+      writeWorkflow(root, f, MISSING_STEP_CONTENT);
+    }
+    const res = checkWorkflowShape({ repoRoot: root });
+    expect(res.status).toBe('yellow');
+    expect(res.detail).toContain('run-agent-codex-cli');
+  });
+});

--- a/src/cli/doctor/checks/codex-cli-path.ts
+++ b/src/cli/doctor/checks/codex-cli-path.ts
@@ -106,7 +106,7 @@ export function checkProviderGate(opts: { repoRoot: string }): CheckResult {
   try {
     const cfg = loadFerryConfig(repoRoot);
     const invalid: string[] = [];
-    for (const role of ['refiner', 'dev', 'review', 'iterate', 'merger'] as const) {
+    for (const role of ['refiner', 'dev', 'review', 'iterate'] as const) {
       const provider = cfg.models?.[role]?.provider;
       if (provider && provider !== 'openai') invalid.push(role);
     }

--- a/src/cli/doctor/checks/codex-cli-path.ts
+++ b/src/cli/doctor/checks/codex-cli-path.ts
@@ -1,0 +1,172 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+import { listRepoSecrets } from './secrets.js';
+import { loadFerryConfig } from '../../../lib/config.js';
+import type { CheckResult } from '../types.js';
+
+const _require = createRequire(import.meta.url);
+
+const LABEL = 'Codex-cli path';
+const PROVIDER_GATE_LABEL = 'Codex path: provider gate';
+const WORKFLOW_SHAPE_LABEL = 'Codex path: workflow shape';
+const API_KEY_SECRET = 'OPENAI_API_KEY';
+
+const WORKFLOW_FILES = [
+  'ferry-refine.yml',
+  'ferry-dev.yml',
+  'ferry-review.yml',
+  'ferry-iterate.yml',
+  'ferry-merge.yml',
+];
+
+export type ExecutionPath = 'script' | 'codex-cli';
+
+function readConfigRaw(repoRoot: string): Record<string, unknown> | null {
+  const jsonPath = join(repoRoot, 'ferry.config.json');
+  if (existsSync(jsonPath)) {
+    try {
+      return JSON.parse(readFileSync(jsonPath, 'utf8')) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+  const yamlPath = existsSync(join(repoRoot, 'ferry.config.yaml'))
+    ? join(repoRoot, 'ferry.config.yaml')
+    : join(repoRoot, 'ferry.config.yml');
+  if (existsSync(yamlPath)) {
+    try {
+      const mod = _require('yaml') as { parse: (s: string) => unknown };
+      return mod.parse(readFileSync(yamlPath, 'utf8')) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+export function resolveExecutionPath(repoRoot: string): ExecutionPath {
+  const raw = readConfigRaw(repoRoot);
+  if (!raw) return 'script';
+  return raw.execution_path === 'codex-cli' ? 'codex-cli' : 'script';
+}
+
+export async function checkCodexCliPath(opts: {
+  repoRoot: string;
+  repo?: string;
+  openaiApiKey?: string;
+}): Promise<CheckResult> {
+  const { repoRoot, repo, openaiApiKey } = opts;
+  const path = resolveExecutionPath(repoRoot);
+
+  if (path !== 'codex-cli') {
+    return {
+      label: LABEL,
+      status: 'skip',
+      detail: `execution_path = script — ${API_KEY_SECRET} not required for the bundled-script path`,
+    };
+  }
+
+  if ((openaiApiKey ?? '').trim()) {
+    return {
+      label: LABEL,
+      status: 'green',
+      detail: `execution_path = codex-cli; ${API_KEY_SECRET} present`,
+    };
+  }
+
+  const secrets = repo ? listRepoSecrets(repo) : [];
+  if (secrets.includes(API_KEY_SECRET)) {
+    return {
+      label: LABEL,
+      status: 'green',
+      detail: `execution_path = codex-cli; ${API_KEY_SECRET} present in repo secrets (value not verifiable locally)`,
+    };
+  }
+
+  return {
+    label: LABEL,
+    status: 'red',
+    detail: `execution_path = codex-cli but ${API_KEY_SECRET} is not set — the codex-cli path cannot authenticate`,
+    remedy: `Set \`${API_KEY_SECRET}\` with \`gh secret set ${API_KEY_SECRET} --repo ${repo ?? '<owner/repo>'}\`, or change execution_path to "script" in ferry.config.json`,
+  };
+}
+
+export function checkProviderGate(opts: { repoRoot: string }): CheckResult {
+  const { repoRoot } = opts;
+  const path = resolveExecutionPath(repoRoot);
+  if (path !== 'codex-cli') {
+    return {
+      label: PROVIDER_GATE_LABEL,
+      status: 'skip',
+      detail: 'execution_path = script — provider gate not applicable',
+    };
+  }
+
+  try {
+    const cfg = loadFerryConfig(repoRoot);
+    const invalid: string[] = [];
+    for (const role of ['refiner', 'dev', 'review', 'iterate', 'merger'] as const) {
+      const provider = cfg.models?.[role]?.provider;
+      if (provider && provider !== 'openai') invalid.push(role);
+    }
+
+    if (invalid.length === 0) {
+      return {
+        label: PROVIDER_GATE_LABEL,
+        status: 'green',
+        detail: 'All configured codex-cli agents use the OpenAI provider',
+      };
+    }
+
+    return {
+      label: PROVIDER_GATE_LABEL,
+      status: 'red',
+      detail: `Non-OpenAI providers configured for codex-cli: ${invalid.join(', ')}. The runtime resolver will force the script path for those agents.`,
+      remedy: `Set the listed providers to 'openai', or change execution_path to 'script'.`,
+    };
+  } catch {
+    return {
+      label: PROVIDER_GATE_LABEL,
+      status: 'yellow',
+      detail: 'ferry.config.* could not be parsed; codex-cli provider gate could not be verified',
+    };
+  }
+}
+
+export function checkWorkflowShape(opts: { repoRoot: string }): CheckResult {
+  const { repoRoot } = opts;
+  const path = resolveExecutionPath(repoRoot);
+  if (path !== 'codex-cli') {
+    return {
+      label: WORKFLOW_SHAPE_LABEL,
+      status: 'skip',
+      detail: 'execution_path = script — workflow shape check not applicable',
+    };
+  }
+
+  const stale: string[] = [];
+  for (const file of WORKFLOW_FILES) {
+    const workflowPath = join(repoRoot, '.github', 'workflows', file);
+    if (!existsSync(workflowPath)) continue;
+    const content = readFileSync(workflowPath, 'utf8');
+    if (!content.includes('run-agent-codex-cli:') || !content.includes('openai/codex-action@')) {
+      stale.push(file);
+    }
+  }
+
+  if (stale.length === 0) {
+    return {
+      label: WORKFLOW_SHAPE_LABEL,
+      status: 'green',
+      detail: 'All codex-cli workflows contain run-agent-codex-cli backed by openai/codex-action',
+    };
+  }
+
+  return {
+    label: WORKFLOW_SHAPE_LABEL,
+    status: 'yellow',
+    detail: `These workflows are missing the run-agent-codex-cli / openai-codex-action job shape: ${stale.join(', ')}`,
+    remedy: 'Run `npx -p @big-emotion/ferry ferry-update` to regenerate the workflow stubs.',
+  };
+}

--- a/src/cli/doctor/index.ts
+++ b/src/cli/doctor/index.ts
@@ -22,6 +22,11 @@ import {
   checkProviderGate,
   checkWorkflowShape,
 } from './checks/claude-code-path.js';
+import {
+  checkCodexCliPath,
+  checkProviderGate as checkCodexProviderGate,
+  checkWorkflowShape as checkCodexWorkflowShape,
+} from './checks/codex-cli-path.js';
 import { checkClaudeCodePromptOverrides } from './checks/claude-code-prompts.js';
 import { renderTable } from './table.js';
 import { parseGitLabConfig, runGitLabDoctor } from './gitlab/index.js';
@@ -165,6 +170,9 @@ Checks run in order:
   17. CC path: provider gate — all four agent providers must be anthropic when execution_path = claude-code
   18. CC path: workflow shape — claude-code workflows use a direct claude-code-action call (no ferry-cc-prepare/apply)
   19. CC path: prompt overrides — report consumer prompts/<agent>.claude-code.md overrides resolved by ferry-cc-prompt
+  20. Codex-cli path        — when execution_path = codex-cli, OPENAI_API_KEY present
+  21. Codex path: provider gate — all configured codex-cli agent providers must be OpenAI
+  22. Codex path: workflow shape — workflows include run-agent-codex-cli backed by openai/codex-action
 
 Exit code: 0 if all checks green/yellow, 1 if any check red.
 `);
@@ -230,6 +238,13 @@ Exit code: 0 if all checks green/yellow, 1 if any check red.
     checkProviderGate({ repoRoot: config.repoRoot }),
     checkWorkflowShape({ repoRoot: config.repoRoot }),
     checkClaudeCodePromptOverrides({ repoRoot: config.repoRoot }),
+    checkCodexCliPath({
+      repoRoot: config.repoRoot,
+      repo: config.repo,
+      openaiApiKey: config.openaiApiKey,
+    }),
+    checkCodexProviderGate({ repoRoot: config.repoRoot }),
+    checkCodexWorkflowShape({ repoRoot: config.repoRoot }),
   ]);
 
   process.stdout.write(renderTable(results));

--- a/src/cli/init/index.ts
+++ b/src/cli/init/index.ts
@@ -169,7 +169,7 @@ async function main(): Promise<void> {
   print('Execution path (ADR-0006):');
   print(`  ${EXECUTION_PATH_QUESTION}`);
   const executionPath: ExecutionPath = parseExecutionPathChoice(
-    await ask('Execution path (a=script / b=claude-code)', 'a'),
+    await ask('Execution path (a=script / b=claude-code / c=codex-cli)', 'a'),
   );
 
   function validateProvider(input: string): LlmProvider {
@@ -196,6 +196,16 @@ async function main(): Promise<void> {
     print('claude-code-action path selected — agents run on your Claude subscription.');
     print('  Obtain a token by running:  claude setup-token   (needs Claude Pro/Max)');
     claudeCodeOauthToken = await askSecret('Claude Code OAuth token');
+  } else if (executionPath === 'codex-cli') {
+    print('');
+    print('codex-cli path selected — agents run via openai/codex-action.');
+    print('  All direct-action agents must use the OpenAI provider on this path.');
+    refinerProvider = 'openai';
+    devProvider = 'openai';
+    reviewProvider = 'openai';
+    iterateProvider = 'openai';
+    needsOpenAI = true;
+    openaiApiKey = await askSecret('OpenAI API key (sk-...)');
   } else {
     print('');
     print('LLM provider per phase (anthropic / openai / google, default: anthropic):');
@@ -354,7 +364,12 @@ async function main(): Promise<void> {
           );
           return { ok: true };
         })()
-      : await stepVerify(config.anthropicApiKey);
+      : config.executionPath === 'codex-cli'
+        ? ((): { ok: true } => {
+            printSkip('codex-cli path: OPENAI_API_KEY validity is probed by `ferry-doctor`');
+            return { ok: true };
+          })()
+        : await stepVerify(config.anthropicApiKey);
 
   // ── Summary ───────────────────────────────────────────────────────────────
   print('');
@@ -387,6 +402,9 @@ async function main(): Promise<void> {
       `  ${nextStep++}. Execution path: claude-code (recorded in ferry.config.yaml). Agents run`,
     );
     print('     on your Claude subscription via CLAUDE_CODE_OAUTH_TOKEN — no ANTHROPIC_API_KEY.');
+  } else if (config.executionPath === 'codex-cli') {
+    print(`  ${nextStep++}. Execution path: codex-cli (recorded in ferry.config.yaml). Agents run`);
+    print('     via OPENAI_API_KEY on openai/codex-action with Ferry-managed Jira MCP wiring.');
   }
   print(`  ${nextStep}. Move a Jira ticket to "Refinement" — watch the Actions tab!`);
   print('');

--- a/src/cli/init/steps/execution-path.test.ts
+++ b/src/cli/init/steps/execution-path.test.ts
@@ -12,9 +12,15 @@ describe('parseExecutionPathChoice', () => {
     expect(parseExecutionPathChoice('B')).toBe('claude-code');
   });
 
+  it('selects "codex-cli" for the (c) answer', () => {
+    expect(parseExecutionPathChoice('c')).toBe('codex-cli');
+    expect(parseExecutionPathChoice('C')).toBe('codex-cli');
+  });
+
   it('accepts explicit path names (case/space-insensitive)', () => {
     expect(parseExecutionPathChoice('  Claude-Code ')).toBe('claude-code');
     expect(parseExecutionPathChoice('claude-code-action')).toBe('claude-code');
+    expect(parseExecutionPathChoice(' codex-cli ')).toBe('codex-cli');
     expect(parseExecutionPathChoice('script')).toBe('script');
   });
 
@@ -27,5 +33,6 @@ describe('parseExecutionPathChoice', () => {
   it('exposes a prompt that names both options', () => {
     expect(EXECUTION_PATH_QUESTION).toMatch(/script/i);
     expect(EXECUTION_PATH_QUESTION).toMatch(/claude-code/i);
+    expect(EXECUTION_PATH_QUESTION).toMatch(/codex-cli/i);
   });
 });

--- a/src/cli/init/steps/execution-path.ts
+++ b/src/cli/init/steps/execution-path.ts
@@ -8,7 +8,8 @@ import type { ExecutionPath } from '../../../lib/config.js';
  */
 export const EXECUTION_PATH_QUESTION =
   'Execution path: (a) bundled script [multi-provider, per-run EUR cap — default] ' +
-  'or (b) claude-code-action [Anthropic subscription, free agent loop, requires CLAUDE_CODE_OAUTH_TOKEN]';
+  'or (b) claude-code-action [Anthropic subscription, free agent loop, requires CLAUDE_CODE_OAUTH_TOKEN] ' +
+  'or (c) codex-cli [OpenAI direct action, requires OPENAI_API_KEY]';
 
 /**
  * Parse the wizard answer into an {@link ExecutionPath}. Anything that is not an
@@ -18,6 +19,9 @@ export function parseExecutionPathChoice(answer: string): ExecutionPath {
   const v = answer.trim().toLowerCase();
   if (v === 'b' || v === 'claude-code' || v === 'claude-code-action') {
     return 'claude-code';
+  }
+  if (v === 'c' || v === 'codex-cli') {
+    return 'codex-cli';
   }
   return 'script';
 }

--- a/src/cli/init/steps/secrets.ts
+++ b/src/cli/init/steps/secrets.ts
@@ -39,7 +39,7 @@ export function buildSecrets(config: {
       value: config.claudeCodeOauthToken ?? '',
       description: 'Claude Code OAuth token (claude setup-token; Claude Pro/Max subscription)',
     });
-  } else {
+  } else if (config.executionPath !== 'codex-cli') {
     secrets.push({
       name: 'ANTHROPIC_API_KEY',
       value: config.anthropicApiKey ?? '',
@@ -47,10 +47,10 @@ export function buildSecrets(config: {
     });
   }
 
-  if (config.openaiApiKey) {
+  if (config.executionPath === 'codex-cli' || config.openaiApiKey) {
     secrets.push({
       name: 'OPENAI_API_KEY',
-      value: config.openaiApiKey,
+      value: config.openaiApiKey ?? '',
       description: 'OpenAI API key',
     });
   }

--- a/src/cli/init/templates.test.ts
+++ b/src/cli/init/templates.test.ts
@@ -105,14 +105,22 @@ describe('workflowTemplates — routing structure', () => {
     }
   });
 
+  it('run-agent-codex-cli is gated on route output', () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      expect(tmpl.content, `${tmpl.filename}: codex path missing if gate`).toContain(
+        "if: needs.route.outputs.path == 'codex-cli'",
+      );
+    }
+  });
+
   it('emit-audit depends on both agent jobs (and ci-gate on the review template)', () => {
     for (const tmpl of workflowTemplates('v1')) {
       // The review template adds the deterministic ci-gate job to the cc path,
       // so its emit-audit must also depend on ci-gate to surface the ci-red case.
       const expectedNeeds =
         tmpl.filename === 'ferry-review.yml'
-          ? 'needs: [run-agent, run-agent-claude-code, ci-gate]'
-          : 'needs: [run-agent, run-agent-claude-code]';
+          ? 'needs: [run-agent, run-agent-claude-code, run-agent-codex-cli, ci-gate]'
+          : 'needs: [run-agent, run-agent-claude-code, run-agent-codex-cli]';
       expect(tmpl.content, `${tmpl.filename}: emit-audit missing dependency`).toContain(
         expectedNeeds,
       );
@@ -231,6 +239,84 @@ describe('workflowTemplates — claude-code path single-step shape', () => {
   });
 });
 
+describe('workflowTemplates — codex-cli path single-step shape', () => {
+  it('run-agent-codex-cli calls openai/codex-action directly', () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      expect(tmpl.content, `${tmpl.filename}: missing openai/codex-action`).toContain(
+        'openai/codex-action@',
+      );
+    }
+  });
+
+  it('codex-action receives the OPENAI_API_KEY input and a shared codex-home', () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      expect(tmpl.content, `${tmpl.filename}: missing openai-api-key wiring`).toContain(
+        'openai-api-key: ${{ secrets.OPENAI_API_KEY }}',
+      );
+      expect(tmpl.content, `${tmpl.filename}: missing codex-home input`).toContain(
+        'codex-home: codex-home',
+      );
+    }
+  });
+
+  it('codex-action resolves prompts via ferry-action-prompt with --path codex-cli, never inline', () => {
+    for (const tmpl of workflowTemplates('v1')) {
+      expect(tmpl.content, `${tmpl.filename}: codex prompt must not be inlined`).not.toContain(
+        'prompt: |',
+      );
+      expect(tmpl.content, `${tmpl.filename}: missing ferry-action-prompt step`).toContain(
+        'ferry-action-prompt',
+      );
+      expect(tmpl.content, `${tmpl.filename}: missing --path codex-cli`).toContain(
+        '--path codex-cli',
+      );
+      expect(
+        tmpl.content,
+        `${tmpl.filename}: codex-action must read the resolved prompt`,
+      ).toContain('prompt: ${{ steps.prompt.outputs.prompt }}');
+    }
+  });
+
+  it('codex-action wires model, effort, sandbox, safety strategy, and optional version through vars', () => {
+    const expectedModelLines: Record<string, string> = {
+      'ferry-refine.yml': "model: ${{ vars.FERRY_REFINER_MODEL || 'gpt-5-codex' }}",
+      'ferry-dev.yml': "model: ${{ vars.FERRY_DEV_MODEL || 'gpt-5-codex' }}",
+      'ferry-review.yml': "model: ${{ vars.FERRY_REVIEW_MODEL || 'gpt-5-codex' }}",
+      'ferry-iterate.yml': "model: ${{ vars.FERRY_ITER_MODEL || 'gpt-5-codex' }}",
+      'ferry-merge.yml': "model: ${{ vars.FERRY_MERGER_MODEL || 'gpt-5-codex' }}",
+    };
+    for (const tmpl of workflowTemplates('v1')) {
+      expect(tmpl.content, `${tmpl.filename}: missing expected model line`).toContain(
+        expectedModelLines[tmpl.filename],
+      );
+      expect(tmpl.content, `${tmpl.filename}: missing effort var`).toContain(
+        "effort: ${{ vars.FERRY_CODEX_EFFORT || '' }}",
+      );
+      expect(tmpl.content, `${tmpl.filename}: missing sandbox var`).toContain(
+        "sandbox: ${{ vars.FERRY_CODEX_SANDBOX || 'workspace-write' }}",
+      );
+      expect(tmpl.content, `${tmpl.filename}: missing safety strategy var`).toContain(
+        "safety-strategy: ${{ vars.FERRY_CODEX_SAFETY_STRATEGY || 'drop-sudo' }}",
+      );
+      expect(tmpl.content, `${tmpl.filename}: missing optional codex version var`).toContain(
+        "codex-version: ${{ vars.FERRY_CODEX_VERSION || '' }}",
+      );
+    }
+  });
+
+  it('codex job generates codex-home/config.toml with ferry-codex-config before the action step', () => {
+    for (const tmpl of workflowTemplates('v0.17.0')) {
+      expect(tmpl.content, `${tmpl.filename}: missing ferry-codex-config step`).toContain(
+        'ferry-codex-config > codex-home/config.toml',
+      );
+      expect(
+        tmpl.content,
+        `${tmpl.filename}: ferry-codex-config package must be version-pinned`,
+      ).toContain('@big-emotion/ferry@v0.17.0');
+    }
+  });
+});
+
 describe('workflowTemplates — role-specific wiring', () => {
   it('ferry-dev.yml wires FERRY_REVIEW_TRANSITION_ID into the script-path run-agent (FR18)', () => {
     const dev = workflowTemplates('v1').find((t) => t.filename === 'ferry-dev.yml');
@@ -284,7 +370,7 @@ describe('workflowTemplates — role-specific wiring', () => {
   it('ferry-review.yml declares checks: read on run-agent and the ci-gate job', () => {
     const review = workflowTemplates('v1').find((t) => t.filename === 'ferry-review.yml');
     const checksCount = (review?.content.match(/checks: read/g) ?? []).length;
-    expect(checksCount).toBe(2);
+    expect(checksCount).toBe(3);
   });
 
   it('ferry-review.yml runs the deterministic ci-gate before the reviewer cc job', () => {
@@ -312,8 +398,8 @@ describe('workflowTemplates — emit-audit outcome shape', () => {
       // its shape is parenthesised; the other three keep the plain two-branch form.
       const expectedOutcome =
         tmpl.filename === 'ferry-review.yml'
-          ? "outcome: ${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || (needs.ci-gate.outputs.outcome == 'ci-red' && 'ci-red') || needs.run-agent-claude-code.result }}"
-          : "outcome: ${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}";
+          ? "outcome: ${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || (needs.run-agent-codex-cli.result != 'skipped' && needs.run-agent-codex-cli.result) || (needs.ci-gate.outputs.outcome == 'ci-red' && 'ci-red') || needs.run-agent-codex-cli.result || needs.run-agent-claude-code.result }}"
+          : "outcome: ${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || needs.run-agent-codex-cli.result }}";
       expect(
         tmpl.content,
         `${tmpl.filename}: outcome ternary missing != 'skipped' shape`,
@@ -328,7 +414,9 @@ describe('workflowTemplates — review ci-gate emit-audit ci-red wiring', () => 
   it('ferry-review.yml emit-audit surfaces the ci-gate ci-red outcome', () => {
     const review = workflowTemplates('v1').find((t) => t.filename === 'ferry-review.yml');
     expect(review, 'ferry-review.yml not found').toBeDefined();
-    expect(review!.content).toContain('needs: [run-agent, run-agent-claude-code, ci-gate]');
+    expect(review!.content).toContain(
+      'needs: [run-agent, run-agent-claude-code, run-agent-codex-cli, ci-gate]',
+    );
     expect(review!.content).toContain("needs.ci-gate.outputs.outcome == 'ci-red'");
   });
 });
@@ -373,6 +461,15 @@ describe('workflowTemplates — merge authority (FR32)', () => {
       ).toContain('Bash(gh pr merge)');
     }
   });
+
+  it('ferry-merge.yml Merger codex path still disallows gh pr close', () => {
+    const merge = workflowTemplates('v1').find((t) => t.filename === 'ferry-merge.yml');
+    expect(merge, 'ferry-merge.yml not found').toBeDefined();
+    expect(
+      merge!.content,
+      'ferry-merge.yml: Merger codex path must still be blocked from gh pr close',
+    ).toContain('gh pr close');
+  });
 });
 
 describe('workflowTemplates — supply-chain action pinning', () => {
@@ -387,6 +484,17 @@ describe('workflowTemplates — supply-chain action pinning', () => {
         tmpl.content,
         `${tmpl.filename}: claude-code-action still uses a mutable tag`,
       ).not.toMatch(TAG_PIN);
+    }
+  });
+
+  it('codex-action is SHA-pinned (not tag-pinned)', () => {
+    const SHA_PIN = /openai\/codex-action@[0-9a-f]{40}\s*#\s*v\d+/;
+    const TAG_PIN = /openai\/codex-action@v\d+\s*$/m;
+    for (const tmpl of workflowTemplates('v1')) {
+      expect(tmpl.content, `${tmpl.filename}: codex-action not SHA-pinned`).toMatch(SHA_PIN);
+      expect(tmpl.content, `${tmpl.filename}: codex-action still uses a mutable tag`).not.toMatch(
+        TAG_PIN,
+      );
     }
   });
 });

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -9,14 +9,24 @@ const CLAUDE_CODE_HEADER =
   '# Required secret: CLAUDE_CODE_OAUTH_TOKEN (run `claude setup-token`; Claude Pro/Max subscription).\n' +
   '# Set execution_path: script in ferry.config.yaml to revert to the bundled multi-provider path.\n';
 
+const CODEX_HEADER =
+  '# Execution path: codex-cli — agents run via openai/codex-action.\n' +
+  '# Required secret: OPENAI_API_KEY.\n' +
+  '# Set execution_path: script in ferry.config.yaml to revert to the bundled multi-provider path.\n';
+
+const CLAUDE_CODE_ACTION_PIN =
+  'anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127';
+const CODEX_ACTION_PIN = 'openai/codex-action@a26d2d4d8b78a694338b8e3715c3630254340b2c # v1';
+
 function applyExecutionPath(
   templates: WorkflowEntry[],
   executionPath: ExecutionPath,
 ): WorkflowEntry[] {
-  if (executionPath !== 'claude-code') return templates;
+  if (executionPath === 'script') return templates;
+  const header = executionPath === 'claude-code' ? CLAUDE_CODE_HEADER : CODEX_HEADER;
   return templates.map((t) => ({
     filename: t.filename,
-    content: t.content.replace(MANAGED_BY_LINE, MANAGED_BY_LINE + CLAUDE_CODE_HEADER),
+    content: t.content.replace(MANAGED_BY_LINE, MANAGED_BY_LINE + header),
   }));
 }
 
@@ -140,7 +150,7 @@ jobs:
           --agent refiner
           --ticket-key "\${{ github.event.client_payload.ticket_key }}"
           --run-id "\${{ github.event.client_payload.event_id }}"
-      - uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
+      - uses: ${CLAUDE_CODE_ACTION_PIN}
         with:
           claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: \${{ steps.prompt.outputs.prompt }}
@@ -150,10 +160,43 @@ jobs:
             --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
             --model \${{ vars.FERRY_REFINER_MODEL || 'claude-sonnet-4-6' }}
 
+  run-agent-codex-cli:
+    name: Run Refiner agent (codex-cli path)
+    needs: [route]
+    if: needs.route.outputs.path == 'codex-cli'
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve agent prompt
+        id: prompt
+        run: >-
+          npx -y -p @big-emotion/ferry@${version} ferry-action-prompt
+          --path codex-cli
+          --agent refiner
+          --ticket-key "\${{ github.event.client_payload.ticket_key }}"
+          --run-id "\${{ github.event.client_payload.event_id }}"
+      - name: Generate Codex config
+        run: |
+          mkdir -p codex-home
+          npx -y -p @big-emotion/ferry@${version} ferry-codex-config > codex-home/config.toml
+      - uses: ${CODEX_ACTION_PIN}
+        with:
+          openai-api-key: \${{ secrets.OPENAI_API_KEY }}
+          prompt: \${{ steps.prompt.outputs.prompt }}
+          model: \${{ vars.FERRY_REFINER_MODEL || 'gpt-5-codex' }}
+          effort: \${{ vars.FERRY_CODEX_EFFORT || '' }}
+          sandbox: \${{ vars.FERRY_CODEX_SANDBOX || 'workspace-write' }}
+          safety-strategy: \${{ vars.FERRY_CODEX_SAFETY_STRATEGY || 'drop-sudo' }}
+          codex-version: \${{ vars.FERRY_CODEX_VERSION || '' }}
+          codex-home: codex-home
+
   emit-audit:
     name: Emit audit line
-    needs: [run-agent, run-agent-claude-code]
-    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
+    needs: [run-agent, run-agent-claude-code, run-agent-codex-cli]
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped' || needs.run-agent-codex-cli.result != 'skipped')
     runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
@@ -168,7 +211,7 @@ jobs:
           phase: refine
           run_id: \${{ github.event.client_payload.event_id }}
           model: claude-sonnet-4-6
-          outcome: \${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          outcome: \${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || needs.run-agent-codex-cli.result }}
           # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
           input_tokens: '0'
           output_tokens: '0'
@@ -305,7 +348,7 @@ jobs:
           --ticket-key "\${{ github.event.client_payload.ticket_key }}"
           --run-id "\${{ github.event.client_payload.event_id }}"
           --review-transition-id "\${{ secrets.FERRY_REVIEW_TRANSITION_ID }}"
-      - uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
+      - uses: ${CLAUDE_CODE_ACTION_PIN}
         with:
           claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: \${{ steps.prompt.outputs.prompt }}
@@ -315,10 +358,45 @@ jobs:
             --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
             --model \${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-4-6' }}
 
+  run-agent-codex-cli:
+    name: Run Developer agent (codex-cli path)
+    needs: [route]
+    if: needs.route.outputs.path == 'codex-cli'
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve agent prompt
+        id: prompt
+        run: >-
+          npx -y -p @big-emotion/ferry@${version} ferry-action-prompt
+          --path codex-cli
+          --agent dev
+          --ticket-key "\${{ github.event.client_payload.ticket_key }}"
+          --run-id "\${{ github.event.client_payload.event_id }}"
+          --review-transition-id "\${{ secrets.FERRY_REVIEW_TRANSITION_ID }}"
+      - name: Generate Codex config
+        run: |
+          mkdir -p codex-home
+          npx -y -p @big-emotion/ferry@${version} ferry-codex-config > codex-home/config.toml
+      - uses: ${CODEX_ACTION_PIN}
+        with:
+          openai-api-key: \${{ secrets.OPENAI_API_KEY }}
+          prompt: \${{ steps.prompt.outputs.prompt }}
+          model: \${{ vars.FERRY_DEV_MODEL || 'gpt-5-codex' }}
+          effort: \${{ vars.FERRY_CODEX_EFFORT || '' }}
+          sandbox: \${{ vars.FERRY_CODEX_SANDBOX || 'workspace-write' }}
+          safety-strategy: \${{ vars.FERRY_CODEX_SAFETY_STRATEGY || 'drop-sudo' }}
+          codex-version: \${{ vars.FERRY_CODEX_VERSION || '' }}
+          codex-home: codex-home
+
   emit-audit:
     name: Emit audit line
-    needs: [run-agent, run-agent-claude-code]
-    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
+    needs: [run-agent, run-agent-claude-code, run-agent-codex-cli]
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped' || needs.run-agent-codex-cli.result != 'skipped')
     runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
@@ -333,7 +411,7 @@ jobs:
           phase: dev
           run_id: \${{ github.event.client_payload.event_id }}
           model: claude-sonnet-4-6
-          outcome: \${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          outcome: \${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || needs.run-agent-codex-cli.result }}
           # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
           input_tokens: \${{ needs.run-agent.outputs.input_tokens || '0' }}
           output_tokens: \${{ needs.run-agent.outputs.output_tokens || '0' }}
@@ -452,7 +530,7 @@ jobs:
   ci-gate:
     name: Reviewer CI pre-gate
     needs: [route]
-    if: needs.route.outputs.path == 'claude-code'
+    if: needs.route.outputs.path == 'claude-code' || needs.route.outputs.path == 'codex-cli'
     runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
@@ -501,7 +579,7 @@ jobs:
           --run-id "\${{ github.event.client_payload.event_id }}"
           --approve-transition-id "\${{ secrets.FERRY_APPROVE_TRANSITION_ID }}"
           --changes-transition-id "\${{ secrets.FERRY_ITER_TRANSITION_ID }}"
-      - uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
+      - uses: ${CLAUDE_CODE_ACTION_PIN}
         with:
           claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: \${{ steps.prompt.outputs.prompt }}
@@ -511,10 +589,47 @@ jobs:
             --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
             --model \${{ vars.FERRY_REVIEW_MODEL || 'claude-sonnet-4-6' }}
 
+  run-agent-codex-cli:
+    name: Run Reviewer agent (codex-cli path)
+    needs: [route, ci-gate]
+    if: needs.route.outputs.path == 'codex-cli' && needs.ci-gate.outputs.proceed == 'true'
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+      checks: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve agent prompt
+        id: prompt
+        run: >-
+          npx -y -p @big-emotion/ferry@${version} ferry-action-prompt
+          --path codex-cli
+          --agent review
+          --ticket-key "\${{ github.event.client_payload.ticket_key }}"
+          --run-id "\${{ github.event.client_payload.event_id }}"
+          --approve-transition-id "\${{ secrets.FERRY_APPROVE_TRANSITION_ID }}"
+          --changes-transition-id "\${{ secrets.FERRY_ITER_TRANSITION_ID }}"
+      - name: Generate Codex config
+        run: |
+          mkdir -p codex-home
+          npx -y -p @big-emotion/ferry@${version} ferry-codex-config > codex-home/config.toml
+      - uses: ${CODEX_ACTION_PIN}
+        with:
+          openai-api-key: \${{ secrets.OPENAI_API_KEY }}
+          prompt: \${{ steps.prompt.outputs.prompt }}
+          model: \${{ vars.FERRY_REVIEW_MODEL || 'gpt-5-codex' }}
+          effort: \${{ vars.FERRY_CODEX_EFFORT || '' }}
+          sandbox: \${{ vars.FERRY_CODEX_SANDBOX || 'workspace-write' }}
+          safety-strategy: \${{ vars.FERRY_CODEX_SAFETY_STRATEGY || 'drop-sudo' }}
+          codex-version: \${{ vars.FERRY_CODEX_VERSION || '' }}
+          codex-home: codex-home
+
   emit-audit:
     name: Emit audit line
-    needs: [run-agent, run-agent-claude-code, ci-gate]
-    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped' || (needs.ci-gate.result != 'skipped' && needs.ci-gate.outputs.outcome == 'ci-red'))
+    needs: [run-agent, run-agent-claude-code, run-agent-codex-cli, ci-gate]
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped' || needs.run-agent-codex-cli.result != 'skipped' || (needs.ci-gate.result != 'skipped' && needs.ci-gate.outputs.outcome == 'ci-red'))
     runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
@@ -529,7 +644,7 @@ jobs:
           phase: review
           run_id: \${{ github.event.client_payload.event_id }}
           model: \${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
-          outcome: \${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || (needs.ci-gate.outputs.outcome == 'ci-red' && 'ci-red') || needs.run-agent-claude-code.result }}
+          outcome: \${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || (needs.run-agent-codex-cli.result != 'skipped' && needs.run-agent-codex-cli.result) || (needs.ci-gate.outputs.outcome == 'ci-red' && 'ci-red') || needs.run-agent-codex-cli.result || needs.run-agent-claude-code.result }}
           # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
           input_tokens: \${{ needs.run-agent.outputs.input_tokens || '0' }}
           output_tokens: \${{ needs.run-agent.outputs.output_tokens || '0' }}
@@ -671,7 +786,7 @@ jobs:
           --ticket-key "\${{ github.event.client_payload.ticket_key }}"
           --run-id "\${{ github.event.client_payload.event_id }}"
           --review-transition-id "\${{ secrets.FERRY_REVIEW_TRANSITION_ID }}"
-      - uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
+      - uses: ${CLAUDE_CODE_ACTION_PIN}
         with:
           claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: \${{ steps.prompt.outputs.prompt }}
@@ -681,10 +796,45 @@ jobs:
             --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
             --model \${{ vars.FERRY_ITER_MODEL || 'claude-sonnet-4-6' }}
 
+  run-agent-codex-cli:
+    name: Run Iterator agent (codex-cli path)
+    needs: [route]
+    if: needs.route.outputs.path == 'codex-cli'
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve agent prompt
+        id: prompt
+        run: >-
+          npx -y -p @big-emotion/ferry@${version} ferry-action-prompt
+          --path codex-cli
+          --agent iterate
+          --ticket-key "\${{ github.event.client_payload.ticket_key }}"
+          --run-id "\${{ github.event.client_payload.event_id }}"
+          --review-transition-id "\${{ secrets.FERRY_REVIEW_TRANSITION_ID }}"
+      - name: Generate Codex config
+        run: |
+          mkdir -p codex-home
+          npx -y -p @big-emotion/ferry@${version} ferry-codex-config > codex-home/config.toml
+      - uses: ${CODEX_ACTION_PIN}
+        with:
+          openai-api-key: \${{ secrets.OPENAI_API_KEY }}
+          prompt: \${{ steps.prompt.outputs.prompt }}
+          model: \${{ vars.FERRY_ITER_MODEL || 'gpt-5-codex' }}
+          effort: \${{ vars.FERRY_CODEX_EFFORT || '' }}
+          sandbox: \${{ vars.FERRY_CODEX_SANDBOX || 'workspace-write' }}
+          safety-strategy: \${{ vars.FERRY_CODEX_SAFETY_STRATEGY || 'drop-sudo' }}
+          codex-version: \${{ vars.FERRY_CODEX_VERSION || '' }}
+          codex-home: codex-home
+
   emit-audit:
     name: Emit audit line
-    needs: [run-agent, run-agent-claude-code]
-    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
+    needs: [run-agent, run-agent-claude-code, run-agent-codex-cli]
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped' || needs.run-agent-codex-cli.result != 'skipped')
     runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
@@ -699,7 +849,7 @@ jobs:
           phase: iterate
           run_id: \${{ github.event.client_payload.event_id }}
           model: \${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
-          outcome: \${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          outcome: \${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || needs.run-agent-codex-cli.result }}
           # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
           input_tokens: \${{ needs.run-agent.outputs.input_tokens || '0' }}
           output_tokens: \${{ needs.run-agent.outputs.output_tokens || '0' }}
@@ -826,7 +976,7 @@ jobs:
           --agent merge
           --ticket-key "\${{ github.event.client_payload.ticket_key }}"
           --run-id "\${{ github.event.client_payload.event_id }}"
-      - uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
+      - uses: ${CLAUDE_CODE_ACTION_PIN}
         with:
           claude_code_oauth_token: \${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: \${{ steps.prompt.outputs.prompt }}
@@ -836,10 +986,44 @@ jobs:
             --disallowedTools 'Bash(gh pr close),Bash(gh pr close:*)'
             --model \${{ vars.FERRY_MERGER_MODEL || 'claude-sonnet-4-6' }}
 
+  run-agent-codex-cli:
+    name: Run Merger agent (codex-cli path)
+    needs: [route]
+    if: needs.route.outputs.path == 'codex-cli'
+    runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve agent prompt
+        id: prompt
+        run: >-
+          npx -y -p @big-emotion/ferry@${version} ferry-action-prompt
+          --path codex-cli
+          --agent merge
+          --ticket-key "\${{ github.event.client_payload.ticket_key }}"
+          --run-id "\${{ github.event.client_payload.event_id }}"
+      - name: Generate Codex config
+        run: |
+          mkdir -p codex-home
+          npx -y -p @big-emotion/ferry@${version} ferry-codex-config > codex-home/config.toml
+      - uses: ${CODEX_ACTION_PIN}
+        with:
+          openai-api-key: \${{ secrets.OPENAI_API_KEY }}
+          prompt: \${{ steps.prompt.outputs.prompt }}
+          model: \${{ vars.FERRY_MERGER_MODEL || 'gpt-5-codex' }}
+          effort: \${{ vars.FERRY_CODEX_EFFORT || '' }}
+          sandbox: \${{ vars.FERRY_CODEX_SANDBOX || 'workspace-write' }}
+          safety-strategy: \${{ vars.FERRY_CODEX_SAFETY_STRATEGY || 'drop-sudo' }}
+          codex-version: \${{ vars.FERRY_CODEX_VERSION || '' }}
+          codex-home: codex-home
+
   emit-audit:
     name: Emit audit line
-    needs: [run-agent, run-agent-claude-code]
-    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
+    needs: [run-agent, run-agent-claude-code, run-agent-codex-cli]
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped' || needs.run-agent-codex-cli.result != 'skipped')
     runs-on: \${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
     permissions:
       contents: read
@@ -854,7 +1038,7 @@ jobs:
           phase: merge
           run_id: \${{ github.event.client_payload.event_id }}
           model: \${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
-          outcome: \${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          outcome: \${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || needs.run-agent-codex-cli.result }}
           # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
           input_tokens: \${{ needs.run-agent.outputs.input_tokens || '0' }}
           output_tokens: \${{ needs.run-agent.outputs.output_tokens || '0' }}

--- a/src/cli/update/local-overrides.test.ts
+++ b/src/cli/update/local-overrides.test.ts
@@ -170,13 +170,18 @@ describe('applyLocalOverrides — review.ciGate: disabled', () => {
     const review = result.find((t) => t.filename === 'ferry-review.yml')!;
     expect(review.content).not.toContain("ci-gate.outputs.proceed == 'true'");
     expect(review.content).toContain("    if: needs.route.outputs.path == 'claude-code'\n");
+    expect(review.content).toContain("    if: needs.route.outputs.path == 'codex-cli'\n");
   });
 
   it('removes ci-gate from emit-audit needs', () => {
     const result = applyLocalOverrides(templates, { review: { ciGate: 'disabled' } });
     const review = result.find((t) => t.filename === 'ferry-review.yml')!;
-    expect(review.content).not.toContain('needs: [run-agent, run-agent-claude-code, ci-gate]');
-    expect(review.content).toContain('    needs: [run-agent, run-agent-claude-code]\n');
+    expect(review.content).not.toContain(
+      'needs: [run-agent, run-agent-claude-code, run-agent-codex-cli, ci-gate]',
+    );
+    expect(review.content).toContain(
+      '    needs: [run-agent, run-agent-claude-code, run-agent-codex-cli]\n',
+    );
   });
 
   it('simplifies emit-audit if expression', () => {
@@ -184,7 +189,7 @@ describe('applyLocalOverrides — review.ciGate: disabled', () => {
     const review = result.find((t) => t.filename === 'ferry-review.yml')!;
     expect(review.content).not.toContain("needs.ci-gate.result != 'skipped'");
     expect(review.content).toContain(
-      "    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')\n",
+      "    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped' || needs.run-agent-codex-cli.result != 'skipped')\n",
     );
   });
 
@@ -193,7 +198,7 @@ describe('applyLocalOverrides — review.ciGate: disabled', () => {
     const review = result.find((t) => t.filename === 'ferry-review.yml')!;
     expect(review.content).not.toContain('ci-gate.outputs.outcome');
     expect(review.content).toContain(
-      "          outcome: ${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || needs.run-agent-claude-code.result }}\n",
+      "          outcome: ${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || needs.run-agent-codex-cli.result }}\n",
     );
   });
 
@@ -214,6 +219,7 @@ describe('applyLocalOverrides — review.ciGate: disabled', () => {
     expect(review.content).toContain('\n  route:\n');
     expect(review.content).toContain('\n  run-agent:\n');
     expect(review.content).toContain('\n  run-agent-claude-code:\n');
+    expect(review.content).toContain('\n  run-agent-codex-cli:\n');
     expect(review.content).toContain('\n  emit-audit:\n');
   });
 

--- a/src/cli/update/local-overrides.ts
+++ b/src/cli/update/local-overrides.ts
@@ -185,31 +185,35 @@ function applyReviewCiGateDisabled(content: string): string {
   //    not including) the blank-line separator before "  run-agent-claude-code:".
   let result = content.replace(/\n\n  ci-gate:\n[\s\S]*?(?=\n\n  run-agent-claude-code:)/, '');
 
-  // 2. run-agent-claude-code: remove ci-gate from needs
-  result = result.replace('    needs: [route, ci-gate]\n', '    needs: [route]\n');
+  // 2. direct-action jobs: remove ci-gate from needs
+  result = result.replaceAll('    needs: [route, ci-gate]\n', '    needs: [route]\n');
 
-  // 3. run-agent-claude-code: drop the ci-gate proceed guard from if
+  // 3. direct-action jobs: drop the ci-gate proceed guard from if
   result = result.replace(
     "    if: needs.route.outputs.path == 'claude-code' && needs.ci-gate.outputs.proceed == 'true'\n",
     "    if: needs.route.outputs.path == 'claude-code'\n",
   );
+  result = result.replace(
+    "    if: needs.route.outputs.path == 'codex-cli' && needs.ci-gate.outputs.proceed == 'true'\n",
+    "    if: needs.route.outputs.path == 'codex-cli'\n",
+  );
 
   // 4. emit-audit: remove ci-gate from needs
   result = result.replace(
-    '    needs: [run-agent, run-agent-claude-code, ci-gate]\n',
-    '    needs: [run-agent, run-agent-claude-code]\n',
+    '    needs: [run-agent, run-agent-claude-code, run-agent-codex-cli, ci-gate]\n',
+    '    needs: [run-agent, run-agent-claude-code, run-agent-codex-cli]\n',
   );
 
   // 5. emit-audit: simplify the if expression
   result = result.replace(
-    "    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped' || (needs.ci-gate.result != 'skipped' && needs.ci-gate.outputs.outcome == 'ci-red'))\n",
-    "    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')\n",
+    "    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped' || needs.run-agent-codex-cli.result != 'skipped' || (needs.ci-gate.result != 'skipped' && needs.ci-gate.outputs.outcome == 'ci-red'))\n",
+    "    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped' || needs.run-agent-codex-cli.result != 'skipped')\n",
   );
 
   // 6. emit-audit outcome: remove ci-gate references from the outcome expression
   result = result.replace(
-    "          outcome: ${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || (needs.ci-gate.outputs.outcome == 'ci-red' && 'ci-red') || needs.run-agent-claude-code.result }}\n",
-    "          outcome: ${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || needs.run-agent-claude-code.result }}\n",
+    "          outcome: ${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || (needs.run-agent-codex-cli.result != 'skipped' && needs.run-agent-codex-cli.result) || (needs.ci-gate.outputs.outcome == 'ci-red' && 'ci-red') || needs.run-agent-codex-cli.result || needs.run-agent-claude-code.result }}\n",
+    "          outcome: ${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || needs.run-agent-codex-cli.result }}\n",
   );
 
   return result;

--- a/src/lib/codex/config-toml.test.ts
+++ b/src/lib/codex/config-toml.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { renderCodexConfigToml } from './config-toml.js';
+
+describe('renderCodexConfigToml', () => {
+  it('renders a jira MCP server that launches ferry-jira-mcp through npx', () => {
+    const toml = renderCodexConfigToml({ version: 'v0.17.0' });
+    expect(toml).toContain('[mcp_servers.jira]');
+    expect(toml).toContain('command = "npx"');
+    expect(toml).toContain('"@big-emotion/ferry@v0.17.0"');
+    expect(toml).toContain('"ferry-jira-mcp"');
+  });
+
+  it('contains no embedded Jira secret values', () => {
+    const toml = renderCodexConfigToml({ version: 'v0.17.0' });
+    expect(toml).not.toContain('FERRY_JIRA_BASE_URL=');
+    expect(toml).not.toContain('FERRY_JIRA_EMAIL=');
+    expect(toml).not.toContain('FERRY_JIRA_API_TOKEN=');
+  });
+});

--- a/src/lib/codex/config-toml.ts
+++ b/src/lib/codex/config-toml.ts
@@ -1,0 +1,10 @@
+export function renderCodexConfigToml(opts: { version: string }): string {
+  const { version } = opts;
+
+  return [
+    '[mcp_servers.jira]',
+    'command = "npx"',
+    `args = ["-y", "-p", "@big-emotion/ferry@${version}", "ferry-jira-mcp"]`,
+    '',
+  ].join('\n');
+}


### PR DESCRIPTION
## Summary
- add a real `run-agent-codex-cli` workflow branch for all five generated agent workflows
- generate and validate Codex Jira MCP wiring via `ferry-codex-config`, `ferry-init`, and `ferry-doctor`
- document the codex-cli upgrade path and execution-path behavior

## Testing
- `npx vitest run`
- pre-push gates: `tsc --noEmit`, `eslint src`, `prettier --check 'src/**/*.ts'`, `npm run build:ferry && git diff --exit-code .ferry/ .github/actions/`