### PR TITLE
[codex] Preserve local overrides across ferry-update

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -816,7 +816,16 @@ To verify which extension files Ferry picked up on a given run, search the agent
 
 On the claude-code execution path an agent is one direct `anthropics/claude-code-action` call — there is no Ferry runtime to assemble the layered prompt above. Instead the workflow's `Resolve agent prompt` step runs the `ferry-cc-prompt` bin, which resolves the system prompt and feeds it to the action via a step output.
 
-Customisation here is a **full override**, not an extension: drop a file in your consumer repository and it **replaces** Ferry's bundled claude-code prompt for that agent entirely.
+Preferred customisation here is an additive local overlay:
+
+| File                                   | Appends local guidance to the bundled claude-code prompt for |
+| -------------------------------------- | ------------------------------------------------------------ |
+| `prompts/refiner.claude-code.local.md` | Refiner                                                      |
+| `prompts/dev.claude-code.local.md`     | Developer                                                    |
+| `prompts/review.claude-code.local.md`  | Reviewer                                                     |
+| `prompts/iterate.claude-code.local.md` | Iterator                                                     |
+
+Legacy full overrides still work, but should be treated as a last resort:
 
 | File                             | Replaces the bundled claude-code prompt for |
 | -------------------------------- | ------------------------------------------- |
@@ -827,13 +836,15 @@ Customisation here is a **full override**, not an extension: drop a file in your
 
 **Rules:**
 
-- Resolution is override-or-default, like `ferry.config.yaml`: if the file is present it is used as-is; if absent, Ferry's bundled default is used (and tracks new releases). `FERRY_PROMPTS_DIR` overrides the lookup directory.
+- Resolution order is: full override `prompts/<agent>.claude-code.md`, then additive local overlay `prompts/<agent>.claude-code.local.md`, then Ferry's bundled default. `FERRY_PROMPTS_DIR` overrides the lookup directory.
+- `*.claude-code.local.md` appends repo-specific guidance to Ferry's bundled prompt and keeps the upstream prompt contract intact.
 - The override **replaces** the whole prompt — it does not append. The `.extra.md` / `_project.md` layering does **not** apply on this path.
 - Keep the placeholder tokens — `ferry-cc-prompt` substitutes them at run time. Bare uppercase tokens: `TICKET_KEY` and `RUN_ID` (all agents); `REVIEW_TRANSITION_ID` (dev, iterate); `APPROVE_TRANSITION_ID` and `CHANGES_TRANSITION_ID` (review). An unrecognised token is left literal.
 - A custom override is **your** contract: the bundled prompts enforce the no-merge rule, the single allowed FR transition, the fingerprinted `[ferry:<role>:<run-id>]` audit comment, and idempotency. Preserve those instructions or you weaken Ferry's guarantees.
-- `ferry-doctor` reports detected overrides (check 19, `CC path: prompt overrides`).
+- Prefer the `.local.md` form whenever possible so new Ferry prompt-contract changes continue to flow into your repo.
+- `ferry-doctor` reports detected overrides and warns on legacy full replacements (check 19, `CC path: prompt overrides`).
 
-To verify which prompt a run used, search the agent's job log for `ferry-cc-prompt: <agent> prompt resolved (source: override|bundled)`.
+To verify which prompt a run used, search the agent's job log for `ferry-cc-prompt: <agent> prompt resolved (source: override|local-overlay|bundled)`.
 
 ---
 

--- a/src/cli/cc-prompt/cli.test.ts
+++ b/src/cli/cc-prompt/cli.test.ts
@@ -136,6 +136,19 @@ describe('renderPrompt', () => {
     expect(result.text).toBe('custom ABC-1');
   });
 
+  it('appends a local overlay when prompts/<agent>.<path>.local.md exists', () => {
+    const result = renderPrompt(
+      args,
+      BUNDLED,
+      (p) => p === '/repo/prompts/dev.claude-code.local.md',
+      () => 'local REVIEW_TRANSITION_ID',
+    );
+    expect(result.source).toBe('local-overlay');
+    expect(result.text).toBe(
+      'dev default ABC-1 r9 31\n\n## Project-specific guidance for dev (claude-code)\n\nlocal 31',
+    );
+  });
+
   it('throws when the consumer override is empty', () => {
     expect(() =>
       renderPrompt(

--- a/src/cli/cc-prompt/index.ts
+++ b/src/cli/cc-prompt/index.ts
@@ -9,9 +9,11 @@ Usage:
   ferry-action-prompt --path <claude-code|codex-cli> --agent <refiner|dev|review|iterate|merge> --ticket-key <key> --run-id <id> [options]
   ferry-cc-prompt --agent <refiner|dev|review|iterate|merge> --ticket-key <key> --run-id <id> [options]
 
-Resolves prompts/<agent>.<path>.md from the consumer repo when present,
-otherwise Ferry's bundled default; substitutes runtime tokens; writes the result
-to $GITHUB_OUTPUT (key: --output-name, default "prompt") or to stdout.
+Resolves prompts/<agent>.<path>.md from the consumer repo when present.
+Otherwise, if prompts/<agent>.<path>.local.md exists, Ferry appends that local
+guidance to the bundled default. If neither file exists, Ferry uses the bundled
+default as-is; substitutes runtime tokens; writes the result to $GITHUB_OUTPUT
+(key: --output-name, default "prompt") or to stdout.
 
 Options:
   --path                   Direct-action path: claude-code | codex-cli (default: claude-code)

--- a/src/cli/doctor/checks/claude-code-prompts.test.ts
+++ b/src/cli/doctor/checks/claude-code-prompts.test.ts
@@ -21,14 +21,31 @@ describe('checkClaudeCodePromptOverrides', () => {
     expect(result.detail).toMatch(/bundled defaults/);
   });
 
-  it('is green and lists each detected override', () => {
+  it('warns and lists each detected legacy full override', () => {
     mkdirSync(join(dir, 'prompts'), { recursive: true });
     writeFileSync(join(dir, 'prompts', 'dev.claude-code.md'), 'custom');
     writeFileSync(join(dir, 'prompts', 'review.claude-code.md'), 'custom');
     const result = checkClaudeCodePromptOverrides({ repoRoot: dir });
-    expect(result.status).toBe('green');
+    expect(result.status).toBe('yellow');
     expect(result.detail).toContain('prompts/dev.claude-code.md');
     expect(result.detail).toContain('prompts/review.claude-code.md');
+  });
+
+  it('warns when a legacy claude-code full override is present', () => {
+    mkdirSync(join(dir, 'prompts'), { recursive: true });
+    writeFileSync(join(dir, 'prompts', 'dev.claude-code.md'), 'custom');
+    const result = checkClaudeCodePromptOverrides({ repoRoot: dir });
+    expect(result.status).toBe('yellow');
+    expect(result.detail).toContain('prompts/dev.claude-code.md');
+    expect(result.detail).toContain('prompts/dev.claude-code.local.md');
+  });
+
+  it('is green when only a local overlay is present', () => {
+    mkdirSync(join(dir, 'prompts'), { recursive: true });
+    writeFileSync(join(dir, 'prompts', 'dev.claude-code.local.md'), 'custom');
+    const result = checkClaudeCodePromptOverrides({ repoRoot: dir });
+    expect(result.status).toBe('green');
+    expect(result.detail).toContain('prompts/dev.claude-code.local.md');
   });
 
   it('ignores a script-path <agent>.md override', () => {

--- a/src/cli/doctor/checks/claude-code-prompts.ts
+++ b/src/cli/doctor/checks/claude-code-prompts.ts
@@ -16,8 +16,11 @@ export function checkClaudeCodePromptOverrides(opts: { repoRoot: string }): Chec
   const overrides = CC_AGENTS.filter((agent) =>
     existsSync(join(promptsDir, `${agent}.claude-code.md`)),
   );
+  const overlays = CC_AGENTS.filter((agent) =>
+    existsSync(join(promptsDir, `${agent}.claude-code.local.md`)),
+  );
 
-  if (overrides.length === 0) {
+  if (overrides.length === 0 && overlays.length === 0) {
     return {
       label: 'CC path: prompt overrides',
       status: 'green',
@@ -25,11 +28,27 @@ export function checkClaudeCodePromptOverrides(opts: { repoRoot: string }): Chec
     };
   }
 
+  if (overrides.length > 0) {
+    return {
+      label: 'CC path: prompt overrides',
+      status: 'yellow',
+      detail: `Legacy claude-code full override(s) detected: ${overrides
+        .map((agent) => `prompts/${agent}.claude-code.md`)
+        .join(
+          ', ',
+        )}. These replace Ferry's bundled direct-action prompt entirely and can freeze the prompt contract. Prefer additive local overlays such as ${overrides
+        .map((agent) => `prompts/${agent}.claude-code.local.md`)
+        .join(', ')}.`,
+      remedy:
+        'Move repo-specific direct-action guidance into prompts/<agent>.claude-code.local.md when possible',
+    };
+  }
+
   return {
     label: 'CC path: prompt overrides',
     status: 'green',
-    detail: `${overrides.length} claude-code prompt override(s) resolved by ferry-cc-prompt: ${overrides
-      .map((agent) => `prompts/${agent}.claude-code.md`)
+    detail: `${overlays.length} claude-code local overlay(s) resolved by ferry-cc-prompt: ${overlays
+      .map((agent) => `prompts/${agent}.claude-code.local.md`)
       .join(', ')}`,
   };
 }

--- a/src/cli/update/detect.ts
+++ b/src/cli/update/detect.ts
@@ -31,6 +31,11 @@ export function detectInstalledVersion(repoRoot: string): string | undefined {
   return undefined;
 }
 
+export interface ComputeWorkflowChangeOptions {
+  fromVersion?: string;
+  overrides?: LocalOverrides;
+}
+
 /**
  * Compute what changes applying `toVersion` templates would make.
  * Returns one entry per workflow template file.
@@ -42,11 +47,17 @@ export function detectInstalledVersion(repoRoot: string): string | undefined {
 export function computeWorkflowChanges(
   repoRoot: string,
   toVersion: string,
-  overrides?: LocalOverrides,
+  options?: LocalOverrides | ComputeWorkflowChangeOptions,
 ): WorkflowChange[] {
   const workflowDir = join(repoRoot, '.github', 'workflows');
   const base = workflowTemplates(toVersion);
-  const templates = overrides ? applyLocalOverrides(base, overrides) : base;
+  const normalized = normalizeOptions(options);
+  const templates = normalized.overrides ? applyLocalOverrides(base, normalized.overrides) : base;
+  const baselineTemplates = normalized.fromVersion
+    ? normalized.overrides
+      ? applyLocalOverrides(workflowTemplates(normalized.fromVersion), normalized.overrides)
+      : workflowTemplates(normalized.fromVersion)
+    : null;
   const changes: WorkflowChange[] = [];
 
   for (const tmpl of templates) {
@@ -63,11 +74,28 @@ export function computeWorkflowChanges(
       continue;
     }
 
+    const baseline = baselineTemplates?.find((entry) => entry.filename === tmpl.filename);
+    if (baseline && existing !== baseline.content && existing !== tmpl.content) {
+      const diff = computeUnifiedDiff(tmpl.filename, existing, tmpl.content);
+      changes.push({ filename: tmpl.filename, status: 'drifted', diff });
+      continue;
+    }
+
     const diff = computeUnifiedDiff(tmpl.filename, existing, tmpl.content);
     changes.push({ filename: tmpl.filename, status: 'updated', diff });
   }
 
   return changes;
+}
+
+function normalizeOptions(
+  options?: LocalOverrides | ComputeWorkflowChangeOptions,
+): ComputeWorkflowChangeOptions {
+  if (!options) return {};
+  if ('fromVersion' in options || 'overrides' in options) {
+    return options as ComputeWorkflowChangeOptions;
+  }
+  return { overrides: options as LocalOverrides };
 }
 
 function computeUnifiedDiff(filename: string, oldContent: string, newContent: string): string {

--- a/src/cli/update/index.ts
+++ b/src/cli/update/index.ts
@@ -276,6 +276,10 @@ What is NOT touched:
   • Jira Automation rules themselves (consumer-side, manual)
   • GitHub App installation
 
+Important:
+  • Direct edits inside .github/workflows/ferry-*.yml are not a durable customisation surface.
+    Ferry warns on unmanaged drift before overwrite; move supported workflow changes into ferry.local.yml.
+
 Exit code: 0 on success, 1 on error.
 `);
     process.exit(0);
@@ -337,12 +341,16 @@ Exit code: 0 on success, 1 on error.
 
   // ── Compute changes ───────────────────────────────────────────────────────
   printStep(2, 3, 'Computing changes');
-  const changes = computeWorkflowChanges(config.repoRoot, toVersion, localOverrides ?? undefined);
+  const changes = computeWorkflowChanges(config.repoRoot, toVersion, {
+    fromVersion,
+    overrides: localOverrides ?? undefined,
+  });
   const toUpdate = changes.filter((c) => c.status === 'updated');
   const toAdd = changes.filter((c) => c.status === 'added');
+  const drifted = changes.filter((c) => c.status === 'drifted');
   const unchanged = changes.filter((c) => c.status === 'unchanged');
 
-  if (toUpdate.length === 0 && toAdd.length === 0) {
+  if (toUpdate.length === 0 && toAdd.length === 0 && drifted.length === 0) {
     printSkip('All workflow files already match the target version — nothing to do.');
     // A code-only range stays silent; a range that declares a newly-required
     // secret is still gated even when no workflow file changed (e.g. re-run).
@@ -371,12 +379,18 @@ Exit code: 0 on success, 1 on error.
       print(`    • ${c.filename}`);
     }
   }
+  if (drifted.length > 0) {
+    print(`  Files with unmanaged local drift (${drifted.length}):`);
+    for (const c of drifted) {
+      print(`    • ${c.filename}`);
+    }
+  }
   if (unchanged.length > 0) {
     print(`  Unchanged (${unchanged.length}): ${unchanged.map((c) => c.filename).join(', ')}`);
   }
 
   // Print diffs
-  const changed = [...toUpdate, ...toAdd];
+  const changed = [...toUpdate, ...toAdd, ...drifted];
   if (changed.length > 0) {
     print('');
     print('─── Unified diff ───────────────────────────────────────────────────');
@@ -390,6 +404,11 @@ Exit code: 0 on success, 1 on error.
 
   if (config.dryRun) {
     print('');
+    if (drifted.length > 0) {
+      printWarn(
+        'Dry-run detected unmanaged local workflow edits. Ferry would not overwrite these files without explicit confirmation.',
+      );
+    }
     print('Dry-run mode — no changes written.');
     const gate = await runCredentialGate({
       repoRoot: config.repoRoot,
@@ -406,8 +425,17 @@ Exit code: 0 on success, 1 on error.
   // ── Confirm ───────────────────────────────────────────────────────────────
   if (!config.yes) {
     print('');
+    if (drifted.length > 0) {
+      printWarn('Unmanaged local workflow edits detected. Ferry will not overwrite them silently.');
+      for (const c of drifted) {
+        printWarn(
+          `${c.filename}: move durable changes into ferry.local.yml or confirm the overwrite intentionally`,
+        );
+      }
+      print('');
+    }
     const ok = await confirm(
-      `Apply ${toUpdate.length + toAdd.length} file change(s) to .github/workflows/?`,
+      `Apply ${toUpdate.length + toAdd.length + drifted.length} file change(s) to .github/workflows/?`,
       true,
     );
     if (!ok) {

--- a/src/cli/update/types.ts
+++ b/src/cli/update/types.ts
@@ -8,6 +8,6 @@ export interface UpdateConfig {
 
 export interface WorkflowChange {
   filename: string;
-  status: 'updated' | 'unchanged' | 'added';
+  status: 'updated' | 'unchanged' | 'added' | 'drifted';
   diff: string;
 }

--- a/src/cli/update/update.test.ts
+++ b/src/cli/update/update.test.ts
@@ -11,6 +11,7 @@ vi.mock('node:child_process', () => ({
 }));
 
 import { detectInstalledVersion, computeWorkflowChanges } from './detect.js';
+import { applyLocalOverrides } from './local-overrides.js';
 import { getRelevantMigrations } from './migrations.js';
 import { workflowTemplates } from '../init/templates.js';
 
@@ -146,6 +147,39 @@ describe('computeWorkflowChanges', () => {
 
     const changes = computeWorkflowChanges(dir, 'v0.3.1');
     expect(changes.every((c) => c.status === 'unchanged')).toBe(true);
+    cleanup(dir);
+  });
+
+  it('classifies unmanaged local workflow edits as drifted when fromVersion is provided', () => {
+    const dir = makeTempRepo();
+    const templates = workflowTemplates('v0.3.0');
+    const tmpl = templates[0]!;
+    writeFileSync(
+      join(dir, '.github', 'workflows', tmpl.filename),
+      `${tmpl.content}\n# local unmanaged edit\n`,
+      'utf8',
+    );
+
+    const changes = computeWorkflowChanges(dir, 'v0.3.1', { fromVersion: 'v0.3.0' });
+    const change = changes.find((c) => c.filename === tmpl.filename);
+    expect(change?.status).toBe('drifted');
+    cleanup(dir);
+  });
+
+  it('does not mark a supported ferry.local.yml overlay as drift', () => {
+    const dir = makeTempRepo();
+    const baseline = applyLocalOverrides(workflowTemplates('v0.3.0'), {
+      global: { runner: 'self-hosted' },
+    });
+    const tmpl = baseline[0]!;
+    writeFileSync(join(dir, '.github', 'workflows', tmpl.filename), tmpl.content, 'utf8');
+
+    const changes = computeWorkflowChanges(dir, 'v0.3.1', {
+      fromVersion: 'v0.3.0',
+      overrides: { global: { runner: 'self-hosted' } },
+    });
+    const change = changes.find((c) => c.filename === tmpl.filename);
+    expect(change?.status).toBe('updated');
     cleanup(dir);
   });
 });

--- a/src/lib/prompts/cc-prompt.test.ts
+++ b/src/lib/prompts/cc-prompt.test.ts
@@ -57,6 +57,35 @@ describe('resolveCcPrompt', () => {
     expect(resolveCcPrompt('dev', REPO_ROOT, 'B', check).source).toBe('bundled');
     expect(resolveCcPrompt('iterate', REPO_ROOT, 'B', check, () => 'I').source).toBe('override');
   });
+
+  it('appends a local claude-code overlay when no full override exists', () => {
+    const check = (p: string) => p === '/workspace/repo/prompts/dev.claude-code.local.md';
+    const read = vi.fn(() => 'LOCAL');
+    const result = resolveCcPrompt('dev', REPO_ROOT, 'BUNDLED', check, read);
+    expect(result).toEqual({
+      source: 'local-overlay',
+      text: 'BUNDLED\n\n## Project-specific guidance for dev (claude-code)\n\nLOCAL',
+    });
+  });
+
+  it('prefers a full override over a local claude-code overlay', () => {
+    const check = (p: string) =>
+      p === '/workspace/repo/prompts/dev.claude-code.md' ||
+      p === '/workspace/repo/prompts/dev.claude-code.local.md';
+    const read = vi.fn((p: string) => (p.endsWith('.local.md') ? 'LOCAL' : 'OVERRIDE'));
+    const result = resolveCcPrompt('dev', REPO_ROOT, 'BUNDLED', check, read);
+    expect(result).toEqual({ source: 'override', text: 'OVERRIDE' });
+  });
+
+  it('appends a local codex-cli overlay when no full override exists', () => {
+    const check = (p: string) => p === '/workspace/repo/prompts/dev.codex-cli.local.md';
+    const read = vi.fn(() => 'LOCAL');
+    const result = resolveActionPrompt('codex-cli', 'dev', REPO_ROOT, 'BUNDLED', check, read);
+    expect(result).toEqual({
+      source: 'local-overlay',
+      text: 'BUNDLED\n\n## Project-specific guidance for dev (codex-cli)\n\nLOCAL',
+    });
+  });
 });
 
 describe('substituteTokens', () => {

--- a/src/lib/prompts/cc-prompt.ts
+++ b/src/lib/prompts/cc-prompt.ts
@@ -26,8 +26,8 @@ export const CC_PROMPT_TOKENS: Record<CcAgent, readonly string[]> = {
 };
 
 export interface CcPromptResolution {
-  /** `override` when a consumer file was used, `bundled` when Ferry's default was. */
-  source: 'override' | 'bundled';
+  /** `override` when a consumer file was used, `local-overlay` when local guidance was appended, `bundled` when Ferry's default was. */
+  source: 'override' | 'local-overlay' | 'bundled';
   text: string;
 }
 
@@ -48,6 +48,14 @@ export function resolveActionPrompt(
   const overridePath = path.join(overridesDir, `${agent}.${actionPath}.md`);
   if (_checkExists(overridePath)) {
     return { source: 'override', text: _readFile(overridePath, 'utf8') };
+  }
+  const localOverlayPath = path.join(overridesDir, `${agent}.${actionPath}.local.md`);
+  if (_checkExists(localOverlayPath)) {
+    const local = _readFile(localOverlayPath, 'utf8');
+    return {
+      source: 'local-overlay',
+      text: `${bundledDefault}\n\n## Project-specific guidance for ${agent} (${actionPath})\n\n${local}`,
+    };
   }
   return { source: 'bundled', text: bundledDefault };
 }


### PR DESCRIPTION
## Summary
- detect unmanaged drift in generated `ferry-*.yml` workflows by comparing the on-disk file against the expected `fromVersion` baseline plus `ferry.local.yml` overlays
- warn before overwriting drifted workflows during `ferry-update`, while still allowing intentional overwrite through the normal confirmation flow or `--yes`
- add additive direct-action prompt overlays via `prompts/<agent>.claude-code.local.md` and warn in `ferry-doctor` when consumers still use legacy full prompt replacements

## Why
Issue #410 describes two durability problems:
1. `ferry-update` could silently clobber consumer-local edits inside generated workflow files.
2. direct-action prompt customization only supported full replacement files, which froze the bundled Ferry prompt contract.

This change keeps workflow YAML managed, makes unmanaged drift visible before overwrite, and adds a safer additive path for direct-action prompt customization.

## Validation
- `npx vitest run src/cli/update/*.test.ts src/lib/prompts/*.test.ts src/cli/cc-prompt/*.test.ts src/cli/doctor/*.test.ts src/cli/doctor/checks/*.test.ts`
- pre-push hooks passed: `tsc --noEmit`, `eslint src`, `prettier --check 'src/**/*.ts'`, `vitest run`, `npm run check:bundle`

Closes #410