### PR TITLE
feat(skills): add project skills, spec bootstrap, and Jira ticket template

### DIFF
--- a/.claude/skills/ferry-audit/SKILL.md
+++ b/.claude/skills/ferry-audit/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: ferry-audit
+description: Production-readiness audit for the Ferry project. Read-only multi-axis assessment that answers four questions — is it production-ready, can a consumer install and run the full Jira→PR→merge cycle, what is the security posture, and is the score close to 8–9/10. Use when the user asks "is Ferry ready", "audit Ferry", "production-readiness check", or invokes /ferry-audit.
+metadata:
+  author: jnk
+  version: '1.3.0'
+---
+
+# Ferry Audit
+
+Read-only audit of the Ferry project. Produces a scored, evidence-based report and refreshes `docs/PRODUCTION-READINESS-AUDIT.md`.
+
+This skill **never** modifies source, never bumps versions, never tags, never pushes. It only reads and writes the audit doc.
+
+## When to Activate
+
+- User asks: "is Ferry production-ready", "audit Ferry", "score the project", "is the project ready to ship".
+- User asks specifically about consumer install flow viability, security posture, or overall score.
+- User invokes `/ferry-audit`.
+
+## Preconditions
+
+Run from the Ferry repo root (`package.json` with `"name": "@big-emotion/ferry"`). If not, stop and tell the user to `cd` into the repo.
+
+## Inputs
+
+Optional argument: `--quick` (skip running the full test suite and coverage; rely on most recent CI run instead).
+
+Default: full audit.
+
+## Workflow
+
+### Step 1 — Snapshot the repo state
+
+Run in parallel via Bash:
+
+- `git status --porcelain` — flag uncommitted changes (audit a dirty tree is fine but report it).
+- `git log --oneline -20` — recent commit cadence.
+- `git tag --sort=-creatordate | head -10` — release tags (expect immutable `v0.x.y` tags plus the floating `v1`).
+- `jq '{name, version, bin}' package.json` — version, bin entries (the consumer CLI surface).
+- `ls .github/workflows/ .github/actions/` — workflow surface. Expected workflows: `ferry-ci.yml`, `codeql.yml`, `release.yml`, `claude.yml`, `claude-code-review.yml`. The agent dispatch workflows live in `examples/consumer-setup/workflows/`, **not** here — flag any doc that claims otherwise.
+- `ls docs/ prompts/ src/agents/ src/lib/ src/cli/ examples/consumer-setup/workflows/` — structural map.
+
+### Step 2 — Read the existing audit (if present)
+
+Read `docs/PRODUCTION-READINESS-AUDIT.md` if it exists. Keep its scoring rubric and section ordering — this skill **updates** that file rather than replacing the format.
+
+The canonical structure is:
+
+1. Scope and method
+2. Overall score (X / 10) — one-line verdict
+3. Score per domain (table, 10 domains)
+4. Strengths (bulleted)
+5. Gaps and risks (per domain, with evidence)
+6. Consumer install flow — end-to-end verdict
+7. Security posture — dedicated section
+8. Prioritized action list (15 max, each tied to an FR or issue)
+9. Conclusion
+
+### Step 3 — Gather evidence
+
+Run these in parallel (skip any that fail and note it in the report):
+
+- `npm run typecheck` — compile gate.
+- `npm run lint` — lint gate.
+- `npm run format:check` — formatting gate.
+- `npm test -- --reporter=basic` (or `--quick` → skip and report last CI run instead).
+- `npm run check:fr-drift` — every `FR\d+` tag in `src/`, `prompts/`, `docs/` has a registry entry in `docs/REQUIREMENTS.md`.
+- `npm run check:bundle` — committed `.ferry/` bundles match `src/` (drift here means consumers execute stale code).
+- `npm run audit:ci` — dependency CVE gate (same command release.yml runs).
+- `git grep -nE "TODO|FIXME|XXX|HACK" src/ | wc -l` — code debt heuristic.
+- `gh run list --limit 5 --workflow=ferry-ci.yml --json status,conclusion,name 2>/dev/null` — recent CI health (best-effort, skip if `gh` not authed).
+
+For security, also check:
+
+- `.gitleaks.toml` exists and is referenced in CI.
+- `.github/workflows/codeql.yml` exists.
+- Composite actions in `.github/actions/*/action.yml` — pin third-party actions by SHA, not `@main` or `@v1`.
+- `src/schemas/event.v1.schema.json` validated in strict AJV mode.
+- `src/agents/**` — confirm no direct `@octokit/rest` or Jira imports (`git grep -n "@octokit/rest\|io/tracker" src/agents/ | grep -v test`).
+- `package.json` `dependencies` — any pinned to git refs or local paths (red flag).
+
+For **release-tag consistency** (every consumer pulls from these same refs, so any drift is a broken install or a stale CI guard):
+
+- Determine the canonical Ferry tag from `package.json` `.version` → expect `@v<version>` everywhere consumers reach.
+- `git grep -nE "big-emotion/ferry/[^@]+@(main|v[0-9.]+)|@big-emotion/ferry@v[0-9.]+" examples/consumer-setup/workflows/` — every Ferry self-reference in the 5 agent stubs should pin to the same tag (both `uses:` lines and the `npx -p @big-emotion/ferry@v…` invocations, including inside `--mcp-config` JSON). Flag every line that:
+  - uses `@main` (mutable; supply-chain risk on every consumer install);
+  - uses a tag that disagrees with `package.json` `.version` (drift);
+  - uses a tag that does not exist in `git tag --list` (broken consumer install).
+- `git grep -nE "FERRY_REF:\s*v[0-9.]+" examples/consumer-setup/workflows/` — the 2 ops stubs must match the same tag.
+- `git grep -nE "@v[0-9.]+|tags/v[0-9.]+" docs/INSTALL.md docs/RELEASING.md docs/CONFIGURATION.md` — doc references must match.
+- Structural tests — the CI gates that hardcode the tag: `src/install-guide.test.ts`, `src/cli/init/templates.test.ts`, `src/cli/doctor/checks/{claude-code-path,codex-cli-path}.test.ts`, `src/lib/codex/config-toml.test.ts`. Confirm they exist AND pass (`npx vitest run <files>`). A passing test that the codebase has drifted past (test asserts an older tag than `package.json`) is a stale guard — flag it.
+- Floating tag: `git rev-parse v1 v<version>` — `v1` should point at the same commit as the latest release tag (release.yml retags it via `scripts/retag-major.sh`). A lagging `v1` silently serves old code to `@v1` consumers.
+
+Report the result as a small consistency table:
+
+```
+| Location                                                        | Pin       | Status     |
+| --------------------------------------------------------------- | --------- | ---------- |
+| package.json .version                                           | 0.17.0    | canonical  |
+| examples/…/ferry-{refine,dev,review,iterate,merge}.yml (uses:)  | @v0.17.0  | match      |
+| examples/…/ferry-*.yml (npx @big-emotion/ferry@v…)              | @v0.17.0  | match      |
+| examples/…/ferry-{reconcile,cost-daily}.yml (FERRY_REF)         | v0.17.0   | match      |
+| docs/{INSTALL,RELEASING,CONFIGURATION}.md                       | @v0.17.0  | match      |
+| structural tests (install-guide, templates, doctor, codex)      | @v0.17.0  | match      |
+| git tag --list                                                  | v0.17.0   | exists     |
+| floating v1 == v0.17.0                                          | same SHA  | match      |
+```
+
+Any row with `MISSING`, `drift`, or `@main` is a P0 supply-chain finding for the Release domain.
+
+### Step 3.5 — Hardcoded values scan (`src/**`)
+
+Ferry's contract is that consumers can tune behavior via env vars / config without forking. Magic numbers and default function parameters embedded in `src/**` are silent coupling — every untunable knob is a future support ticket. Scan and score.
+
+**Scope:** `src/**/*.ts` only. Exclude `*.test.ts`, `__fixtures__/`, `__lint-fixtures__/`, `src/schemas/*.json`.
+
+**What to flag:**
+
+1. **Magic numbers** in runtime logic — timeouts, retries, max attempts, byte/char limits, token caps, thresholds (e.g. spend %), batch sizes, polling intervals, durations (`* 1000`, `* 60`), truncation lengths (`slice(0, N)`, `substring(0, N)`), comparison constants (`if (x > N)`).
+2. **Default function parameters** — `function foo(x = 30)`, `(x: number = 100)`, and literal-RHS coalescing like `opts.timeout ?? 30000`.
+
+**Skip:** `0`/`1`/`-1`/`2` used as indices/exit codes/booleans; HTTP status codes; loop counters; math identities; numbers inside log-message templates that are just text.
+
+**Categories** (use these exact buckets in the report):
+
+- Timeouts / Durations
+- Retry & Backoff
+- Size & Truncation Limits
+- Token & LLM Caps
+- Cost & Budget Thresholds
+- Polling & Batch Sizes
+- Scoring & Heuristic Thresholds
+- Default Parameters
+
+**Severity:**
+
+- **P0** — must externalize. Affects production behavior, cost, or differs per deployment (LLM retry config, spend %, request timeouts, output-size caps that throttle agents).
+- **P1** — should externalize. Likely tuned per consumer (bash/grep timeouts, batch caps, loop iteration caps, file-size limits, default `max_tokens`).
+- **P2** — acceptable as-is. Internal tuning constant unlikely to change (jitter ratio, log-truncation hints, doctor recommendation ceilings).
+
+**How to scan:**
+
+```
+grep -nE '\b[0-9]{3,}\b' src/**/*.ts | grep -vE '\.test\.|__fixtures__|__lint-fixtures__'
+grep -nE '= [0-9]+[,)]|\?\? [0-9]+|\|\| [0-9]+' src/**/*.ts
+grep -nE 'setTimeout|slice\(0,|substring\(0,|\.length > [0-9]' src/**/*.ts
+```
+
+Read each suspect file to confirm the hit is real (not a string literal, not a comment), capture the line number, and bucket by category + severity.
+
+**Output:** flat markdown list grouped by category, P0 first within each group. Each line: `**Pn** path:line — value — one-line description`.
+
+**Score impact** — feed this into Domain 5 (Architecture) and Domain 8 (Consumer DX):
+
+- 0 P0 / ≤ 5 P1 → no penalty.
+- 1–3 P0 or 6–15 P1 → −1 on Domain 5 and Domain 8.
+- ≥ 4 P0 or > 15 P1 → −2 on Domain 5 and Domain 8.
+
+Include the hardcoded-values report verbatim under section 5 ("Gaps and risks") of `docs/PRODUCTION-READINESS-AUDIT.md`, in a subsection titled **"Hardcoded values (P0/P1)"**. Only list P0 + P1 in the audit doc — keep P2 in the chat output for the user.
+
+### Step 4 — Score the 10 domains
+
+Use this rubric (1–10 each, weighted equal):
+
+| #   | Domain                     | What to look for                                                                                                                                                                                                 |
+| --- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Application security       | Input validation (AJV strict), output sanitization, no secrets in logs, idempotent external writes                                                                                                               |
+| 2   | Supply-chain security      | Pinned actions (SHA), Dependabot, gitleaks, `audit:ci` clean, CodeQL, `.ferry/` bundle drift gate (`check:bundle`)                                                                                               |
+| 3   | Correctness & tests        | Coverage, unit + integration, mocked IO, edge cases, e2e replay of agent pipeline                                                                                                                                |
+| 4   | Code quality & lint        | Strict TS, no `any`, ESLint guardrails (agent isolation), Prettier clean                                                                                                                                         |
+| 5   | Architecture & boundaries  | IO abstraction respected, agents decoupled, schema-versioned events, **no untunable magic numbers in `src/**` (see Step 3.5)\*\*                                                                                 |
+| 6   | Reliability & idempotency  | Fingerprinted comments, dedup on retries, audit trail (audit issue), reconciler wired                                                                                                                            |
+| 7   | Observability & ops        | Cost governance wired, audit-emit consistent, error reporting, run-id traceability                                                                                                                               |
+| 8   | Consumer DX (install flow) | `ferry-init` works, `ferry-doctor` covers the failure modes, `ferry-update`/`ferry-uninstall` exist, `docs/INSTALL.md` is accurate, **P0/P1 hardcoded values from Step 3.5 don't trap consumers without a fork** |
+| 9   | Documentation              | README Quick install, CONTRIBUTING, INSTALL.md, CONFIGURATION.md, RELEASING.md, RUNBOOK.md, ADRs, `docs/REQUIREMENTS.md` FR registry in sync (`check:fr-drift`), prompt customization (`*.extra.md`)             |
+| 10  | Release process            | Semver tags, CHANGELOG, **release-tag consistency table from Step 3 has no `MISSING` / `drift` / `@main` rows**, the pinned tag exists in `git tag --list`, floating `v1` up to date                             |
+
+Compute overall score = mean of the 10 domain scores, rounded to one decimal.
+
+### Step 5 — Answer the four user-facing questions
+
+Always include a top section answering the four canonical questions explicitly:
+
+1. **Is the project production-ready?** Yes / No / Conditional, plus the 1–3 blockers.
+2. **Can a consumer install and reach the full Jira → PR → merge cycle?** Walk through `docs/INSTALL.md` mentally:
+   - `ferry-init` scaffolds correctly? `ferry-doctor` catches the common misconfigurations?
+   - All 7 consumer stubs present in `examples/consumer-setup/workflows/` (refine, dev, review, iterate, merge, reconcile, cost-daily)?
+   - The four auto-transitions are exercised end-to-end: FR18 (Dev → In Review), FR24 (Reviewer → Changes Requested), FR28 (Iterator → In Review), FR32 (Merger merges on `ferry-merge` dispatch, optional → Done)?
+   - Any step in the install guide that has no test or no example?
+3. **Security posture?** One short paragraph + bullet list of strengths and gaps. Reference application security, supply chain, secrets handling, and prompt injection / RCE risks in LLM tool calls.
+4. **Is the score close to 8–9/10?** Quote the computed score, compare to target, list the top 3 gaps that would close the distance.
+
+### Step 6 — Write the report
+
+Update `docs/PRODUCTION-READINESS-AUDIT.md` in place (preserve the existing structure if present; if absent, create it). Bump the `Date:` field to today's date.
+
+Then output a concise summary to the user (≤ 25 lines): the four answers + the computed score + the top 3 actions. The full detail lives in the file.
+
+### Step 7 — Verification
+
+Before reporting done:
+
+- [ ] All 10 domain scores justified by at least one piece of evidence (command output, file path, line number).
+- [ ] The four canonical questions are answered explicitly in section 1 of the report.
+- [ ] No score is invented — if a check could not run, mark it `N/A` and explain.
+- [ ] `docs/PRODUCTION-READINESS-AUDIT.md` was updated (or created) and the Date field reflects today.
+- [ ] Step 3.5 ran: P0 + P1 hardcoded values are listed under "Gaps and risks > Hardcoded values" in the audit doc, and Domains 5 and 8 reflect the penalty (or note that the count was below the threshold).
+- [ ] Step 3 release-tag consistency table is included in the Release domain section of the report.
+
+## Output Format
+
+User-facing summary (printed at end):
+
+```
+Ferry Audit — <YYYY-MM-DD>
+Score: X.X / 10 (target 8–9)
+
+1. Production-ready? <verdict + 1-line reason>
+2. Consumer install → Jira → PR → merge cycle? <verdict + 1-line reason>
+3. Security posture? <one line>
+4. Distance to 8–9? <top 3 actions>
+
+Full report: docs/PRODUCTION-READINESS-AUDIT.md
+```
+
+## Out of Scope
+
+- Fixing any gap found. The audit only **reports**.
+- Bumping versions, creating tags, updating CHANGELOG. Use the `ferry-release` skill for that.
+- Hitting real GitHub / Jira / LLM APIs. The audit is local and read-only.

--- a/.claude/skills/ferry-release/SKILL.md
+++ b/.claude/skills/ferry-release/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: ferry-release
+description: Prepare and ship a Ferry release. Bumps the semver version, updates CHANGELOG.md (Keep a Changelog format, creates it if missing), refreshes all release-coupled version references (consumer stubs, docs, structural tests), rebuilds .ferry/ bundles, creates an annotated git tag, then asks for explicit confirmation before pushing commit + tag to origin (which triggers release.yml — full CI gate, npm publish with provenance, GitHub Release, floating v1 retag). Use when the user says "release Ferry", "cut a version", "bump version", or invokes /ferry-release.
+metadata:
+  author: jnk
+  version: '1.3.0'
+---
+
+# Ferry Release
+
+Prepare a release locally (bump version, update CHANGELOG and docs, create the tag), then ask for explicit confirmation before pushing.
+
+This skill writes to the local repo first. It only runs `git push` after the user explicitly confirms. Without confirmation, the commit + tag stay local.
+
+The release process contract lives in `docs/RELEASING.md` — read it if anything below disagrees with the repo; the doc wins.
+
+## When to Activate
+
+- User asks: "release Ferry", "cut a release", "bump version", "tag a new version".
+- User invokes `/ferry-release` (optionally with a bump level: `patch | minor | major | <explicit-version>`).
+
+## Preconditions
+
+Verify before any write:
+
+1. cwd is the Ferry repo root (`package.json` `"name": "@big-emotion/ferry"`).
+2. Working tree is clean (`git status --porcelain` empty). If dirty, stop and ask the user to commit or stash.
+3. On `main` branch (or ask explicit confirmation if not).
+4. Local `main` is up to date with `origin/main` (`git fetch origin && git rev-list --count main..origin/main` == 0). If behind, stop and tell the user to pull.
+5. **CI green on HEAD** — the remote gate, not just local:
+   ```bash
+   HEAD_SHA=$(git rev-parse HEAD)
+   gh run list --repo big-emotion/ferry --commit "$HEAD_SHA" \
+     --workflow ferry-ci.yml --limit 1 --json conclusion,status,url
+   ```
+   The latest run must have `conclusion: "success"`. If no run exists for HEAD or it is not green, stop and print the run URL.
+6. CI gates pass locally: `npm run typecheck && npm run lint && npm run format:check && npm test -- --reporter=basic`. If any fail, stop.
+
+If any precondition fails, **do not modify anything** — report the blocker and exit.
+
+## Inputs
+
+Argument is the bump level or explicit version:
+
+- `patch` — `0.17.0 → 0.17.1`
+- `minor` — `0.17.0 → 0.18.0`
+- `major` — `0.17.0 → 1.0.0`
+- `<explicit>` — e.g. `1.0.0-rc.1`, `2.3.4`
+
+If no argument is provided, propose a bump based on the commit messages since the last tag (Conventional Commits heuristic: `feat!:` or `BREAKING CHANGE` → major; `feat:` → minor; otherwise patch), cross-checked against the semver policy table in `docs/RELEASING.md` (schema/contract breaks → MAJOR; new agents/providers/actions → MINOR; fixes/docs/prompt tuning → PATCH). Show the proposal and **ask the user to confirm or override** before proceeding.
+
+## Workflow
+
+### Step 1 — Determine current and target versions
+
+- Read current version from `package.json` (`.version`).
+- Determine `previous_tag` = `git describe --tags --abbrev=0 --exclude='v[0-9]' 2>/dev/null` (exclude the floating `v1`-style major tags; may be empty if no tag yet).
+- Compute `next_version` from the bump level.
+- Validate: target must be strictly greater than current (semver-compare). If not, stop.
+
+### Step 2 — Collect changes since last tag
+
+- `git log --pretty=format:"%h %s" <previous_tag>..HEAD` (or `git log --pretty=format:"%h %s"` if no previous tag).
+- Group commits by Conventional Commit type: **Added** (feat), **Changed** (refactor, perf, style), **Fixed** (fix), **Security** (security:), **Removed** (revert / removal commits), **Deprecated**.
+- Filter out merge commits unless they carry meaningful messages.
+
+### Step 3 — Update or create `CHANGELOG.md`
+
+Use [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format with [Semantic Versioning](https://semver.org/).
+
+If `CHANGELOG.md` does not exist, create it with this skeleton:
+
+```markdown
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [<next_version>] - <YYYY-MM-DD>
+
+### Added
+
+- ...
+
+[Unreleased]: https://github.com/big-emotion/ferry/compare/v<next_version>...HEAD
+[<next_version>]: https://github.com/big-emotion/ferry/releases/tag/v<next_version>
+```
+
+If it exists:
+
+- Move any items under `[Unreleased]` into the new `[<next_version>] - <YYYY-MM-DD>` section.
+- Append the grouped commits from Step 2 under the appropriate subsections (deduplicate).
+- Keep an empty `[Unreleased]` section at the top for the next cycle.
+- Update the link references at the bottom (`[Unreleased]` → `compare/v<next_version>...HEAD`, add `[<next_version>]` → `releases/tag/v<next_version>`).
+
+### Step 4 — Update `package.json`
+
+Set `.version` to `<next_version>` using a targeted Edit — do not reformat the file.
+
+### Step 5 — Update version references across the repo
+
+Consumer stubs, docs, and structural tests all pin the Ferry release tag; a release that misses one produces a broken consumer install or a stale CI guard. The canonical patterns are `@v<version>` for `uses:` lines and `npx -p @big-emotion/ferry@v<version>` invocations, and `v<version>` (no `@`) for `FERRY_REF` env values and `tags/<value>` API paths.
+
+Use this discovery command first — it is the authority; the category list below is the map:
+
+```bash
+git grep -nE "@v[0-9]+(\.[0-9]+){0,2}\b|FERRY_REF:|tags/v[0-9]|@big-emotion/ferry@v" \
+  -- ':!package-lock.json' ':!.ferry/' ':!node_modules/' ':!CHANGELOG.md'
+```
+
+**Files that MUST be updated (release-coupled):**
+
+1. **`examples/consumer-setup/workflows/ferry-{refine,dev,review,iterate,merge}.yml`** — the 5 agent stubs. Each has several `uses: big-emotion/ferry/.github/actions/ferry-*@v<version>` lines, `npx -y -p @big-emotion/ferry@v<version>` invocations (`ferry-cc-prompt`, and `ferry-jira-mcp` **inside the `--mcp-config` JSON string**), and header comments citing the pinned version.
+2. **`examples/consumer-setup/workflows/ferry-{reconcile,cost-daily}.yml`** — the 2 ops stubs. Each has `FERRY_REF: v<version>` (no `@` prefix — it's a checkout ref env value).
+3. **`docs/INSTALL.md`** — the SHA-pinning command (`gh api repos/big-emotion/ferry/git/refs/tags/v<version>`) and any `@v<version>` prose.
+4. **`docs/RELEASING.md`** — the immutable-tag table cells (`v<version>`) and its SHA-pinning example.
+5. **`docs/CONFIGURATION.md`** — `uses: big-emotion/ferry/.github/actions/*@v<version>` example lines.
+6. **Structural tests** — these hardcode the current tag and are the CI gate that catches drift:
+   - `src/install-guide.test.ts` — test names, assertion messages, and the regex `/@v<version-with-escaped-dots>\b/` (escape dots: `/@v0\.18\.0\b/`, not `/@v0.18.0\b/`).
+   - `src/cli/init/templates.test.ts`
+   - `src/cli/doctor/checks/claude-code-path.test.ts`
+   - `src/cli/doctor/checks/codex-cli-path.test.ts`
+   - `src/lib/codex/config-toml.test.ts`
+
+**Files that MUST NOT be touched:**
+
+- `package-lock.json` — refreshed in Step 6.
+- `.ferry/` — rebuilt in Step 6.
+- `prompts/*.md` — agent system prompts, not release-coupled.
+- `src/schemas/event.v1.schema.json` and every `event.v1` / `EventEnvelopeV1` reference — the `v1` here is the **envelope schema version**, not the Ferry release tag.
+- `docs/RUNBOOK.md` — its upgrade examples use `${CURRENT}`/`${TARGET}` shell variables and the **floating** `v1` tag (`tags/v1`); both are version-agnostic by design.
+- Third-party `uses:` lines (e.g. `actions/checkout@…`, `anthropics/claude-code-action@v1`) — unrelated to the Ferry tag.
+- The floating `v1` tag itself — `release.yml` retags it via `scripts/retag-major.sh`; never move it manually.
+
+**After updates, verify with:**
+
+```bash
+# 1. No old version refs left (excluding intentional historical mentions in CHANGELOG):
+git grep -nE "@v<old_version>\b|FERRY_REF: v<old_version>\b|tags/v<old_version>\b|ferry@v<old_version>" -- ':!CHANGELOG.md'
+# 2. The structural tests still pass against the new tag:
+npx vitest run src/install-guide.test.ts src/cli/init/templates.test.ts \
+  src/cli/doctor/checks/claude-code-path.test.ts src/cli/doctor/checks/codex-cli-path.test.ts \
+  src/lib/codex/config-toml.test.ts
+```
+
+For each file changed, show the old → new diff for the version line(s) before saving.
+
+### Step 6 — Refresh lockfile and build
+
+- `npm install --package-lock-only` — refresh `package-lock.json` to reflect the new `package.json` version.
+- `npm run build:ferry` — rebuild `.ferry/` bundles so the committed action artifacts match `src/` (release.yml fails on `.ferry/` drift).
+- `git diff --stat .ferry/` — confirm bundle changes are reasonable (small or expected).
+
+### Step 7 — Re-run CI gates locally
+
+Final verification before commit:
+
+```
+npm run typecheck && npm run lint && npm run format:check && npm test -- --reporter=basic
+```
+
+If any fail, stop. Do not commit. Tell the user what failed.
+
+### Step 8 — Commit and tag (local only)
+
+Stage exactly the files changed in Steps 3–6 (adjust to what actually changed — never `git add -A`, it can pick up unrelated dirty paths):
+
+```
+git add package.json package-lock.json CHANGELOG.md docs/ \
+        examples/consumer-setup/workflows/ \
+        src/install-guide.test.ts src/cli/init/templates.test.ts \
+        src/cli/doctor/checks/ src/lib/codex/config-toml.test.ts \
+        .ferry/
+```
+
+Commit with the message:
+
+```
+release: v<next_version>
+```
+
+(One-line subject. No body unless there are breaking changes — then add a `BREAKING CHANGE:` paragraph in the body.)
+
+**No `Co-Authored-By` trailer** (per user's global rule).
+
+Then create an annotated tag:
+
+```
+git tag -a v<next_version> -m "Ferry v<next_version>"
+```
+
+### Step 9 — Report and ask for push confirmation
+
+Print a summary to the user:
+
+```
+Ferry v<next_version> prepared locally.
+
+Files changed:
+  - package.json (version: <current> → <next_version>)
+  - package-lock.json
+  - CHANGELOG.md (new section [<next_version>])
+  - <consumer stubs / docs / tests touched>
+  - .ferry/ (rebuilt bundles)
+
+Commit:  <short-sha> release: v<next_version>
+Tag:     v<next_version> (annotated, local only)
+
+Ready to push `main` + `v<next_version>` to origin?
+This triggers release.yml: full CI gate → npm publish (provenance) → GitHub Release → floating v1 retag.
+
+Reply `yes` / `push` to proceed, or `no` / `stop` to keep everything local.
+```
+
+**Wait for an explicit confirmation reply.** Do not push without it.
+
+- Affirmative tokens (case-insensitive): `yes`, `y`, `push`, `ship`, `go`, `oui`, `ok`.
+- Anything else (including silence, partial answers, "let me check first") → treat as a stop. Skip Step 10.
+
+### Step 10 — Push (only after confirmation)
+
+Run, in order:
+
+```
+git push origin main
+git push origin v<next_version>
+```
+
+Run them as separate commands (not `--follow-tags`) so a failure on the tag push doesn't leave `main` unpushed and ambiguous. If `git push origin main` fails (e.g. branch protection, non-fast-forward), stop immediately — do not push the tag.
+
+After both succeed, print:
+
+```
+Pushed.
+  - origin/main now at <short-sha>
+  - tag v<next_version> published
+
+release.yml has been triggered. It will:
+  1. Run the full CI gate (typecheck, lint, format, tests, audit:ci, .ferry drift check)
+  2. Build the CLI and publish @big-emotion/ferry to npm with provenance
+  3. Create a GitHub Release with notes from CHANGELOG.md [<next_version>]
+  4. Advance the floating v1 tag (scripts/retag-major.sh)
+
+Watch it at:
+  https://github.com/big-emotion/ferry/actions/workflows/release.yml
+```
+
+Do **not** run `gh release create` or `npm publish` manually — both are handled by the workflow. Mentioning them as a fallback is fine; running them automatically is not.
+
+### Step 11 — Verification checklist
+
+- [ ] Version in `package.json` matches the new tag.
+- [ ] `CHANGELOG.md` has a `[<next_version>]` section dated today.
+- [ ] All version references are consistent (`git grep -n "<old_version>"` shows only intentional historical mentions).
+- [ ] `.ferry/` was rebuilt and committed (release.yml fails on drift otherwise).
+- [ ] CI gates passed locally after the bump.
+- [ ] Exactly one commit was created. Exactly one annotated tag was created.
+- [ ] If user confirmed: both `main` and `v<next_version>` are pushed.
+- [ ] If user did not confirm: commit + tag remain local only, no `git push` was executed.
+
+## Failure Modes — Stop Without Modifying
+
+- Working tree dirty → ask the user to commit or stash.
+- Behind `origin/main` → ask the user to pull.
+- CI not green on HEAD (remote) → print the run URL, exit.
+- CI gate fails locally → report which one, exit.
+- Target version ≤ current → exit, ask for an explicit higher version.
+- `.ferry/` rebuild produces unexpected large drift → show the diffstat, ask before committing.
+
+## Out of Scope
+
+- Pushing without explicit user confirmation in Step 9.
+- Creating the GitHub Release or publishing to npm manually — both run in release.yml on tag push.
+- Moving the floating `v1` tag — `scripts/retag-major.sh` owns it, invoked by release.yml.
+- Editing `prompts/*.md` or any agent behavior — that's a code change, not a release task.
+- Auditing the project — use `ferry-audit` for that.

--- a/.claude/skills/ferry-spec/SKILL.md
+++ b/.claude/skills/ferry-spec/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: ferry-spec
+description: Spec maintainer for Ferry. Reads the Ferry Confluence space (Requirements / Decisions / Architecture) as the source of truth, helps you investigate a problem, structures the reflection, and produces drafts — Pending REQ/DEC/ARCH sections on Confluence + matching Jira tickets in FER using the project template. Append-only on Confluence, Pending only. Use when you face a bug, want to add a feature, or need to refine an idea for Ferry.
+metadata:
+  author: jnk
+  version: '1.0.0'
+---
+
+# Ferry Spec
+
+Maintain the Ferry spec tree on Confluence. Given a free-text problem (bug, feature, refinement idea), read Confluence (`Requirements / Decisions / Architecture`) as the canonical source of truth, structure the reflection, propose `Pending` REQ/DEC/ARCH sections plus matching Jira tickets in `FER`, then — after explicit confirmation — publish Confluence first, Jira second, and close the link loop both ways.
+
+This skill is **append-only on Confluence** and only writes new sections at status `Pending`. Humans transition `Pending → Implemented → Approved` through the Confluence UI. The skill never touches the Status macro of an existing section, never edits the body of a non-`Pending` section, and never deletes an ID.
+
+## Relationship to the in-repo FR registry
+
+Ferry already carries an implementation-level registry: `docs/REQUIREMENTS.md` (FR-NNN entries with status/source/test files, gated by `npm run check:fr-drift`). The two layers are complementary, not competing:
+
+- **Confluence REQ/DEC/ARCH** — the _spec_ layer: what Ferry should do and why, drafted before implementation, human-approved.
+- **`docs/REQUIREMENTS.md` FR entries** — the _shipped-behavior_ registry: written by the implementing PR when a REQ materializes as code carrying an `FRnn` tag. The CI drift gate keeps it honest.
+- A Confluence DEC that changes repo architecture should be mirrored as an ADR under `docs/adr/` by the implementing ticket.
+
+**ferry-spec never writes in-repo docs** — it only drafts Confluence sections and Jira tickets. The FR entry and ADR are acceptance criteria of the resulting ticket, executed downstream.
+
+## When to Activate
+
+- User invokes `/ferry-spec <description>` (explicit command).
+- User writes a natural-language prompt that signals a spec-level reflection about Ferry:
+  - `bug : …` / "il y a un bug" / "the … is broken"
+  - `j'aimerais ajouter …` / "we should add"
+  - `feature idea …` / "what if Ferry"
+  - Any free-text describing a problem, gap, or improvement that lacks a Jira ticket and that may touch a REQ/DEC/ARCH.
+- Do **not** activate when:
+  - The user pastes a Jira ticket URL or key — that path belongs to `ferry-ticket`.
+  - The user asks to flip a Status macro on an existing section — that is a Confluence-UI-only operation; refuse and direct them there.
+
+If the trigger is ambiguous (the description could be either a pure code question or a spec change), default to activating: the worst case is the user replies with anything other than an affirmative token at Step 6 and nothing is written.
+
+## Inputs
+
+A single free-text argument: a description of the change. If empty, ask for the description before doing anything else (clarification gate, not a safety blocker).
+
+## Preconditions (safety blockers — stop and report if any fail)
+
+1. **Config readable** — `docs/confluence-spec/config.json` must be present and parseable, with non-null values for `cloudId`, `siteUrl`, `spaceKey`, `engineeringRootPageId`, `requirementsPageId`, `decisionsPageId`, `architecturePageId`, `obsoletePageId`, `jiraProjectKey`, and `jiraIssueTypeIds.{Epic,Task}`. Any null `*PageId` means the one-time bootstrap (see appendix) was incomplete — stop.
+2. **Bootstrap sentinel exists** — `docs/.confluence-bootstrap-complete` must be present. If absent, stop and point the user at the Bootstrap appendix below.
+3. **Atlassian MCP reachable** — `getAccessibleAtlassianResources` returns at least one site whose ID matches `cloudId`. If not, stop.
+4. **Atlassian identity resolvable** — `atlassianUserInfo` succeeds.
+5. **Jira project visible** — `getVisibleJiraProjects` includes the project whose key is `jiraProjectKey` (currently `FER`). If not, the user lacks access — stop.
+6. **Template available** — `docs/templates/jira-ticket-template.md` exists. If absent, stop.
+
+On a safety blocker: **stop and report**. Do not guess, do not skip a precondition, do not write anything.
+
+## Workflow
+
+The full chain is **read → investigate → dedupe → choose granularity → draft → preview → confirm → write Confluence → write Jira → close link → report**. Steps 1–5 are pure reads + in-memory drafts and write nothing. Step 6 is the single hard gate. Steps 7–9 are the only writes; they happen in strict order (Confluence first, Jira second, back-link last) so any mid-chain failure leaves recoverable state.
+
+### Step 1 — Read config
+
+- Load `docs/confluence-spec/config.json`. Extract every field listed in precondition 1.
+- Verify `docs/.confluence-bootstrap-complete` exists.
+- Read `docs/templates/jira-ticket-template.md` into memory.
+- Resolve `cloudId` via `getAccessibleAtlassianResources` and cross-check against the config; resolve own `accountId` via `atlassianUserInfo` (informational).
+
+### Step 2 — Investigate
+
+- Read the user's description. **Ask ONE clarification question if and only if** the shape of the change is genuinely ambiguous (bug vs feature). Otherwise, **state your assumptions explicitly and proceed**.
+- Fetch the spec tree:
+  - `getConfluencePageDescendants(cloudId, parentId=engineeringRootPageId)` → confirm the four canonical subpages (`Requirements`, `Decisions`, `Architecture`, `Obsolete`).
+  - For each of `requirementsPageId`, `decisionsPageId`, `architecturePageId`: `getConfluencePage` (full body) to retrieve existing REQ/DEC/ARCH sections and their IDs.
+- **Also read the in-repo ground truth** relevant to the description: `docs/REQUIREMENTS.md` (existing FRs covering the same behavior), `docs/adr/` (prior decisions), and the source files the change would touch. A REQ that contradicts a shipped FR must call that out explicitly in the draft.
+- Walk the impact graph `REQ ← DEC ← ARCH`: if a candidate change touches an ARCH, list every DEC that references it; if it touches a DEC, list every REQ that depends on it. Propagation goes **upward**. Detection is text-based: a section is "referenced" if a body contains its ID (`ARCH-007`). Use `searchConfluenceUsingCql` scoped to the engineering root with `text ~ "<ID>"` if a full body scan is impractical. Surface the propagated impact in the preview.
+- Note any section you would propose to `RETIRE` and record its current Status — only `Pending` sections may be edited; non-`Pending` sections can only be marked for retirement via a successor (see Safeguards).
+
+### Step 3 — Search for duplicates
+
+- `searchConfluenceUsingCql` against `space = "<spaceKey>" AND ancestor = <engineeringRootPageId> AND text ~ "<id>"` for each candidate ID.
+- `searchJiraIssuesUsingJql` against `project = <jiraProjectKey> AND statusCategory != Done AND text ~ "<id or keywords>"` to confirm no open ticket already covers the same scope.
+- If a duplicate is found, **fold the draft into the existing artifact** (point at it in the preview, do not create a parallel ID) and tell the user.
+- Before allocating a new ID in Step 5, run one CQL query per type (`REQ`, `DEC`, `ARCH`) to confirm the **highest** existing suffix — the only safeguard against a stale local view between Step 2 and Step 5.
+- The dedupe step is purely informational — it never mutates Confluence or Jira. The user can override at Step 6; the override is logged in the Step 10 report.
+
+### Step 4 — Granularity decision
+
+Decide the Jira shape from the **shape of the Confluence change**, not the code size. FER is a team-managed project with three issue types only — `Epic`, `Tâche` (Task), `Sous-tâche` (Sub-task); there is no Story or Bug type. Use this table verbatim:
+
+| Confluence change                                                    | Jira artifact                   |
+| -------------------------------------------------------------------- | ------------------------------- |
+| ≥2 REQ touched OR new ARCH + ≥2 DEC                                  | Epic + child Tasks              |
+| 1 REQ touched (NEW or EDIT) ± ≤1 DEC                                 | Task                            |
+| Correction of a failing test against an existing REQ, no spec change | Task with label `bug`           |
+| Editorial-only Jira refinement (no REQ/DEC/ARCH change)              | no ticket — comment on existing |
+
+Rules of thumb to disambiguate:
+
+- A bug that proves an **existing** REQ is wrong (the spec is correct, the code is wrong) → `Task` + label `bug`. Do **not** edit the REQ.
+- A bug that proves an **existing** REQ is misleading (the code matches the spec but the spec is wrong) → `Task` with an `EDIT statement` on the REQ.
+- A new behaviour that did not exist in any previous spec → `Task` with a `NEW` REQ.
+- A new behaviour that requires a structural change in `src/` (new module, new boundary, new agent, new IO layer) → `Epic + Tasks` with a `NEW` ARCH and ≥1 `NEW` DEC explaining the choice.
+
+When in doubt, choose the **lighter** artifact (Task over Epic) — humans can split later; the skill never auto-merges.
+
+### Step 5 — Draft everything
+
+For each REQ/DEC/ARCH section to write:
+
+1. **Allocate the next monotonic ID** from the existing IDs read in Step 2 (max suffix + 1). Never reuse an ID. Never renumber a published ID.
+2. Compose the section body with this canonical shape:
+   - **REQ-NNN — \<statement\>**
+     - `Statement:` modal verb preserved verbatim (`must` / `must not` / `should`).
+     - `GWT:` one or more Given / When / Then blocks.
+     - `Status: Pending` (Confluence Status macro, colour grey).
+     - `Related FR:` existing `FRnn` from `docs/REQUIREMENTS.md` if the behavior overlaps one, else `(none yet — the implementing PR registers the FR)`.
+     - `Links → Jira:` block (filled in Step 9).
+   - **DEC-NNN — \<context\>**
+     - `Context / Decision / Alternatives / Tradeoffs / Requirements satisfied`.
+     - `Supersedes: <ID>` if it retires an older decision.
+     - `Related ADR:` `docs/adr/NNNN-…` when one exists or should be created by the implementing ticket.
+     - `Status: Pending`.
+   - **ARCH-NNN — \<summary\>**
+     - `Summary / Source files (expected) / Tests anchoring this contract`.
+     - `Status: Pending`.
+
+For each Jira ticket to create:
+
+1. Apply `docs/templates/jira-ticket-template.md`, filling the conditional sections by shape (bug-labeled Tasks include Reproduction + Expected vs Actual).
+2. The **Confluence impact** section is load-bearing — allowed verbs are exactly `NEW`, `EDIT`, `RETIRE`:
+   ```
+   • REQ-012 — EDIT statement
+     Current:  "<verbatim>"
+     Proposed: "<new>"
+     GWT changes: …
+   • DEC-005 — NEW
+     Context / Decision / Alternatives / Tradeoffs / Requirements satisfied
+   ```
+3. Include a placeholder for the Confluence anchor URL (filled at create time in Step 8 using `<siteUrl>/wiki/spaces/<spaceKey>/pages/<pageId>#<anchor>`).
+4. The ticket title is concise and business-readable; it carries the primary touched ID in parentheses (e.g. `Reviewer: make the CI pre-gate opt-out (REQ-012)`).
+5. Every ticket must be self-sufficient: goal (what + why), scope/out-of-scope, GWT acceptance criteria, affected files/areas, and links. A fresh agent with only the ticket and the codebase must be able to implement it.
+
+### Step 6 — Preview + approval gate (HARD)
+
+Print all drafts: Confluence sections (ID, statement/summary), Jira tickets (type, title, Confluence impact, body preview), and the impact propagation list.
+
+```
+Reply `create` / `go` / `ok` / `oui` / `valide` / `yes` to publish.
+Anything else aborts. Silence aborts.
+```
+
+Wait for explicit confirmation. Affirmative tokens (case-insensitive): `create`, `go`, `ok`, `oui`, `valide`, `yes`. Anything else — including silence, partial answers, "let me check first" — aborts. Implicit confirmation from a prior turn does **not** count.
+
+### Step 7 — Confluence first
+
+For each Pending section to publish, in deterministic order (Requirements → Decisions → Architecture, then Obsolete entries last):
+
+1. `getConfluencePage(cloudId, pageId, …)` — capture the current `version.number`.
+2. `updateConfluencePage(cloudId, pageId, version=<current+1>, body=<current body + new section appended>)` — append. Never overwrite, never reorder existing content.
+3. On `409` / version-mismatch: re-fetch, **re-allocate the ID** (a competing writer may have taken it), reassemble, retry **once**. On a second mismatch, abort and surface the error verbatim.
+
+If a section is a `RETIRE`-successor, the predecessor is **not** edited here — the Obsolete page receives a separate appended entry in the same pass. The predecessor's Status macro stays untouched; humans flip it via the UI.
+
+### Step 8 — Then Jira
+
+After all Confluence writes succeed:
+
+1. If the granularity is `Epic + Tasks`, `createJiraIssue` the Epic first (`jiraIssueTypeIds.Epic`). Capture its key.
+2. Create child Tasks next, each with `parent.key = <epic_key>` (team-managed projects accept `parent` directly).
+3. Standalone Tasks last. Apply the `bug` label via `additional_fields` when the granularity table says so.
+4. Every ticket body includes a clickable Confluence heading-anchor URL for **each** touched REQ/DEC/ARCH.
+
+If a ticket creation fails mid-sequence, **stop and report** the partial state. Do not retry blindly. An orphan Confluence section is recoverable; an orphan Jira ticket is harder to clean up — which is why Confluence comes first.
+
+### Step 9 — Close the loop
+
+For each Confluence section touched in Step 7, re-`updateConfluencePage` (version+1) to append the created Jira key inside its `Links → Jira:` block (`Links → Jira: FER-12, FER-13`). Same version-mismatch retry policy (one retry max, then abort verbatim).
+
+### Step 10 — Return
+
+End-of-turn report: Confluence URLs (heading anchors), Jira keys with browse URLs, per-ticket recap of touched REQ/DEC/ARCH IDs, plus any assumptions made, RETIRE successors proposed, or duplicates folded.
+
+## Safeguards
+
+- Append-only on Confluence. `Pending` only — never touch the Status macro of an existing section.
+- Never modify the body of a non-`Pending` section. Never remove or delete an ID.
+- Never write outside the engineering root subtree (page ID from `config.json`).
+- Confluence-first, then Jira.
+- No invention: if a REQ statement is unclear, leave a `TODO: clarify with <stakeholder>` block and ask.
+- ID stability: never renumber an already-published ID.
+- No silent retries: surface every failure verbatim except the bounded version-mismatch retry (one attempt).
+- Never create without explicit confirmation in the same session.
+- If a new decision supersedes an old one: propose `RETIRE` + Obsolete entry + successor with `Supersedes: <ID>`. No silent edits.
+
+## Required Atlassian MCP tools
+
+Allowed (read + scoped writes): `getAccessibleAtlassianResources`, `atlassianUserInfo`, `getConfluencePage`, `getConfluencePageDescendants`, `searchConfluenceUsingCql`, `searchJiraIssuesUsingJql`, `getJiraIssue`, `getVisibleJiraProjects`, `updateConfluencePage`, `createJiraIssue`.
+
+Forbidden: `editJiraIssue` (this skill never touches existing tickets), Confluence comments (not the spec channel), any write outside the engineering root subtree, any Status-macro flip.
+
+## Failure Modes — Stop Without Modifying
+
+| Condition                                                    | Action                                             |
+| ------------------------------------------------------------ | -------------------------------------------------- |
+| `docs/.confluence-bootstrap-complete` missing                | Stop. Point at the Bootstrap appendix.             |
+| `docs/confluence-spec/config.json` missing or null `*PageId` | Stop. Report which fields are missing.             |
+| `docs/templates/jira-ticket-template.md` missing             | Stop.                                              |
+| Atlassian MCP unreachable / wrong `cloudId`                  | Stop. Surface the error verbatim.                  |
+| Jira project `FER` not visible                               | Stop. The user lacks access.                       |
+| Duplicate REQ/DEC/ARCH ID detected                           | Fold into the existing artifact; tell the user.    |
+| Open Jira ticket already covers the same IDs                 | Fold into that ticket — do not create a duplicate. |
+| No affirmative token at Step 6                               | Stop. Nothing is written.                          |
+| Version-mismatch twice in a row                              | Stop and report verbatim.                          |
+| `createJiraIssue` fails mid-sequence                         | Stop. Report which tickets/sections exist.         |
+| User asks to flip a Status macro or delete an ID             | Refuse. UI-only / propose `RETIRE` + successor.    |
+
+## Out of Scope
+
+- Writing `docs/REQUIREMENTS.md`, `docs/adr/`, or any repo file — those belong to the implementing ticket (`ferry-ticket` or the Ferry pipeline).
+- Editing existing Jira tickets.
+- Implementation. Once tickets exist, the path is `/ferry-ticket <key>` (local) or the Ferry pipeline itself (move the ticket to Refinement).
+- Bulk creation: one user description per invocation.
+- Multi-project routing: only the project whose key is in `config.json`.
+
+## Appendix — Bootstrap (one-time)
+
+ferry-spec expects this scaffolding to exist. If the sentinel is missing, create it once (with explicit user confirmation, since these are external writes):
+
+1. In the Confluence space `<spaceKey>` (currently `Ferry`, homepage = `engineeringRootPageId`), create four child pages of the homepage: **Requirements**, **Decisions**, **Architecture**, **Obsolete**. Each starts with a one-paragraph intro and no sections.
+2. Write `docs/confluence-spec/config.json` with `cloudId`, `siteUrl`, `spaceKey`, `engineeringRootPageId`, the four page IDs, `jiraProjectKey`, `jiraProjectId`, and `jiraIssueTypeIds` (from `getVisibleJiraProjects` with issue types expanded).
+3. Create `docs/.confluence-bootstrap-complete` (empty sentinel file).
+4. Commit both files.
+
+## Relationship to neighbouring skills
+
+- `ferry-ticket` runs **after** this skill: given a FER key created in Step 8, it self-assigns, refines, branches, implements, opens the PR, and transitions to In Review. Spec drafting (this skill, gated) versus implementation (next skill, full-auto) are intentionally split.
+- `ferry-audit` is orthogonal: it scores the repo; its prioritized action list is a natural input to ferry-spec descriptions.
+- The Ferry pipeline itself (Refiner → Developer → Reviewer → Iterator → Merger) is the _cloud_ consumer of the tickets this skill creates — moving a ticket into the Refinement column hands it to Ferry.

--- a/.claude/skills/ferry-ticket/SKILL.md
+++ b/.claude/skills/ferry-ticket/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: ferry-ticket
+description: End-to-end local automation for a single Jira ticket on the Ferry repo. Paste a FER ticket URL (or key) and the skill self-assigns the ticket, reads it, refines it, creates the Jira sub-tasks, branches off main in an isolated git worktree, implements the work test-first (rebuilding .ferry/ bundles when src/ changes), opens the pull request, then moves the ticket to In Review and comments the PR link. Runs fully automatically with no confirmation gates. Use when the user pastes a FER ticket link, says "prends ce ticket", "implémente ce ticket Jira", "traite ce ticket", or invokes /ferry-ticket.
+metadata:
+  author: jnk
+  version: '1.0.0'
+---
+
+# Ferry Ticket
+
+Take a single Jira ticket from link to merge-ready PR, locally and unattended.
+
+This is the **local, interactive, on-demand** counterpart to the Ferry pipeline itself (which runs the same lifecycle async/cloud via Jira Automation → `repository_dispatch`). It does not dispatch Ferry; it does the work directly on the developer's machine. To avoid divergence with the pipeline, **column names and branch settings are read from `ferry.config.json` at runtime when the file exists** — never hard-coded when a config value is available.
+
+## Operating mode — FULL AUTO
+
+The user chose **no confirmation gates**. The skill runs the entire chain — assign → read → refine → sub-tasks → branch → implement → PR → Jira transition + comment — without stopping to ask.
+
+"Full auto" removes _confirmation_ prompts. It does **not** remove _safety blockers_: hard preconditions where proceeding would corrupt shared state or produce a broken PR. On a safety blocker the skill **stops and reports** — it does not guess or force through.
+
+## When to Activate
+
+- User pastes a Jira ticket URL (e.g. `https://big-emotion.atlassian.net/browse/FER-12`) or a bare issue key.
+- User says: "prends ce ticket", "implémente / traite ce ticket Jira", "fais ce ticket".
+- User invokes `/ferry-ticket <jira-url-or-key>`.
+
+## Inputs
+
+A single argument: the Jira ticket URL or issue key.
+
+- Accept `.../browse/KEY-123`, `...selectedIssue=KEY-123`, or a bare `KEY-123`.
+- Extract the issue key with the regex `[A-Z][A-Z0-9]+-\d+`. If zero or more than one distinct key is found, **stop** and ask for the exact key (ambiguous input is a safety blocker).
+
+## Preconditions (safety blockers — stop and report if any fail)
+
+1. **Repo root** — `package.json` `.name` is `@big-emotion/ferry`. If not, stop and tell the user to `cd` in.
+2. **Atlassian MCP reachable** — `getAccessibleAtlassianResources` returns at least one site. Resolve and keep `cloudId` for every subsequent Jira call. If it fails, stop.
+3. **gh authenticated** — `gh auth status` succeeds for `big-emotion/ferry`.
+4. **Base branch fetchable** — `git fetch origin` succeeds and `origin/<base_branch>` exists. Implementation runs in a dedicated worktree (Step 5), so the user's main checkout need not be clean — but the worktree must be cut from a real remote base branch.
+
+Load configuration from `ferry.config.json` **when the file exists at the repo root** (it arrives with the dogfooding install):
+
+- `base_branch` = `.git.base_branch` (fallback when null/absent: `main`)
+- `target_branch` = `.git.target_branch` (fallback: `main`)
+- `review_column` = `.workflow.agents.developer.auto_transition` (fallback: `In Review`)
+
+If the file is absent entirely, use all three fallbacks and note it in the final report. Never substitute literals when a config value is available — if `ferry.config.json` changes, the skill must follow.
+
+## Workflow
+
+### Step 1 — Resolve ticket and Jira identity
+
+- `cloudId` from `getAccessibleAtlassianResources`.
+- `getJiraIssue(cloudId, issueIdOrKey=FER-12)` — fetch summary, description, issue type, status, acceptance criteria, existing sub-tasks, comments.
+- `atlassianUserInfo` → own `accountId` (the assignee).
+
+### Step 2 — Self-assign
+
+- `editJiraIssue(cloudId, FER-12, fields={ assignee: { accountId: <own> } })`.
+- If the ticket is already assigned to someone else, still assign to self (the user explicitly wants to take the ticket) but note the previous assignee in the final report.
+
+### Step 3 — Read & refine
+
+- Summarise the ticket's intent, scope, and acceptance criteria.
+- **Surface assumptions explicitly**: any ambiguous requirement gets a stated assumption rather than a silent guess.
+- **Apply the Ferry repo rules (mandatory — see `CLAUDE.md`):**
+  1. **Bundle rule** — if the ticket touches `src/`, a sub-task (or the closing step of the last sub-task) must run `npm run build:ferry` and commit the regenerated `.ferry/` bundles in the same PR. CI (`check:bundle`) fails on drift. Never edit `.ferry/` directly.
+  2. **Agent isolation** — code under `src/agents/**` never imports `@octokit/rest` or Jira modules directly; all IO goes through `src/lib/dispatch/runner/github-actions/`, `src/lib/io/tracker/factory.ts`, `src/lib/llm/`. ESLint enforces this; plan accordingly.
+  3. **CODEOWNERS caution** — `.github/**`, `src/schemas/**`, and `prompts/*.md` are protected paths. Flag in the refinement when the ticket touches them: schema changes are migrations (backward compat unless intentionally breaking), workflow changes affect all consumers, prompt changes impact production runs.
+  4. **FR registry rule** — if the ticket ships behavior carrying an `FRnn` tag (new or changed), `docs/REQUIREMENTS.md` must gain/update the entry in the same PR; `npm run check:fr-drift` gates it.
+  5. **Idempotency contract** — any new external write (comment, label, transition) must be fingerprinted/repeatable per the `[ferry:<role>:<run-id>]` convention.
+- Write the refined breakdown back to Jira as a comment (`addCommentToJiraIssue`) so the refinement is visible — concise: intent, assumptions, sub-task list with dependency ordering (bundle rebuild last, agent-isolation and CODEOWNERS flags called out).
+
+### Step 4 — Create sub-tasks in Jira
+
+- For each refined item, `createJiraIssue(cloudId, fields={ project: FER, parent: { key: FER-12 }, issuetype "Sous-tâche", summary, description })`.
+  - Resolve the exact sub-task issue type name via `getJiraProjectIssueTypesMetadata` (FER is team-managed; the sub-task type is `Sous-tâche`, id `10286` at the time of writing — always re-resolve).
+- **Order matters**: dependency sub-tasks first; the `.ferry/` rebuild is always the final step before the PR. Each dependency sub-task's description states what cannot start until it is done.
+- Collect the created sub-task keys; they drive the implementation plan and the PR checklist.
+
+### Step 5 — Create an isolated worktree off the base branch
+
+All implementation happens in a **dedicated git worktree**, never in the user's main checkout.
+
+- `git fetch origin`.
+- Branch name: `<prefix>/<key-lower>-<slug>` where:
+  - `prefix` = `fix` if the ticket carries the `bug` label, else `feat`.
+  - `key-lower` = the issue key lowercased; `slug` = kebab-cased, ASCII, ≤ 5 words from the summary.
+  - **Never use the `ferry/` prefix** — that namespace belongs to the Ferry pipeline's own branches (`ferry/<TICKET>`); colliding with it would confuse the Reviewer/Iterator/Merger workflows once dogfooding is live.
+- Worktree path: a sibling of the repo root — `<repo-parent>/ferry-worktrees/<key-lower>-<slug>` (outside the repo so tooling never scans it).
+- Create branch + worktree in one step, cutting from the **remote** base branch:
+  `git worktree add -b <branch> <worktree-path> origin/<base_branch>`
+- **Every subsequent step — implement, verify, commit, push, open PR — runs with the worktree as the working directory.** Pass it as `cwd` to Bash calls and as the repo path in every sub-agent brief.
+
+### Step 6 — Implement (parallel sub-agents)
+
+Follow TDD and KISS (user `CLAUDE.md`): tests before code, simplest design that satisfies acceptance criteria, surgical scope.
+
+Dependency-aware execution:
+
+1. **Independent sub-tasks run in parallel** via the `Agent` tool (`general-purpose`, or `test-engineer` for test-heavy slices), launched in a single message so they run concurrently. Each sub-agent gets a self-contained brief: the worktree path as working directory, the sub-task summary, acceptance criteria, relevant file paths, and the repo constraints — strict TS NodeNext ESM (`.js` import specifiers on local imports, no `any`), tests colocated next to implementation, all external IO mocked in tests, TDD. All sub-agents share the one worktree (different sub-tasks of the same branch) — do not give them separate worktree isolation.
+2. **Prompts discipline** — if a sub-task edits `prompts/*.md`, keep the bundled default generic; consumer-specific behavior belongs in `prompts/*.extra.md` composition, not in the default prompt.
+3. **The `.ferry/` rebuild runs last, alone**, after all `src/` sub-tasks are merged into the branch: `npm run build:ferry`, then commit the `.ferry/` diff.
+
+### Step 7 — Verify (safety blocker if it fails)
+
+Before any PR, all of these must pass on the branch, from the worktree:
+
+```bash
+npm run typecheck && npm run lint && npm run format:check && npm test
+```
+
+Also run when relevant: `npm run check:fr-drift` (FR-tagged behavior changed) and `npm run check:bundle` (src/ changed — proves `.ferry/` matches).
+
+If a check fails, iterate on the implementation to fix the **root cause** (do not disable checks, do not `--no-verify`). If genuinely unrecoverable, **stop and report** — never open a broken PR.
+
+### Step 8 — Commit & push
+
+- Commit per sub-task (or logically grouped), Conventional Commits, message references the Jira key (e.g. `feat(reviewer): make ci gate opt-out (FER-12)`).
+- **Never add `Co-Authored-By` trailers** (user `CLAUDE.md`).
+- Commit messages, code comments, PR body — **English** (user `CLAUDE.md`).
+- `git push -u origin <branch>`.
+
+### Step 9 — Open the pull request
+
+```bash
+gh pr create --repo big-emotion/ferry \
+  --base <target_branch> --head <branch> \
+  --title "<type>(<scope>): <summary> (FER-12)" \
+  --body "$(cat <<'EOF'
+## Summary
+<1-3 bullets — what and why>
+
+Jira: <full ticket URL>
+
+## Sub-tasks
+- [x] <sub-task FER-13 summary>
+- [x] <sub-task FER-14 summary>
+
+## Test plan
+- [ ] <how to verify each acceptance criterion>
+
+## Repo gates
+- [ ] typecheck / lint / format:check / test green locally
+- [ ] .ferry/ rebuilt (`npm run build:ferry`) — or "N/A, no src/ change"
+- [ ] docs/REQUIREMENTS.md updated — or "N/A, no FR-tagged behavior change"
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Capture the PR URL. **Never merge or close the PR. Never push to `main`.** If the ticket touches CODEOWNERS-protected paths, note in the PR body that codeowner review is required.
+
+### Step 10 — Transition Jira to review + comment
+
+- `getTransitionsForJiraIssue(cloudId, FER-12)` → find the transition whose **target status name** equals `review_column` (from `ferry.config.json` when present, else `In Review`). Match on the target status name, not the transition's own name.
+- `transitionJiraIssue(cloudId, FER-12, transition=<id>)`.
+- `addCommentToJiraIssue(cloudId, FER-12, "PR ready for review: <PR URL>")`.
+- If no transition leads to `review_column`, do not invent one — leave the ticket where it is, still post the PR-link comment, and flag the missing transition in the final report.
+
+### Step 11 — Report
+
+End-of-turn summary (one or two sentences): the ticket key, the branch, the worktree path (kept for follow-up — remove with `git worktree remove <path>` once the PR is merged), the PR URL, the Jira status it now sits in, and any flagged anomalies (previous assignee overridden, missing transition, config fallbacks used, assumptions made during refinement).
+
+## Failure handling
+
+- Safety blockers (Preconditions, Step 7 verification, ambiguous issue key) → **stop and report**, leave shared state untouched.
+- Recoverable implementation failures → iterate to root cause within the implementation loop.
+- Never disable quality gates, never `--no-verify`, never force-push, never open a knowingly-broken PR.
+- If a Jira write fails mid-chain (e.g. sub-task creation), report exactly what was created vs. not so the user can reconcile manually — do not retry blindly in a loop.
+
+## Relationship to the Ferry pipeline
+
+Once dogfooding is live, the same ticket could instead be handed to the cloud pipeline by moving it into the Refinement column. Use this skill when you want the work done **now, locally, under your eyes** — e.g. pipeline outages, credentials work the pipeline can't do, or changes to the pipeline itself that would be awkward to self-apply. The two paths share the ticket contract (`docs/templates/jira-ticket-template.md`) and the column names (`ferry.config.json`), so a ticket is portable between them.
+
+## Cleanup
+
+If any temporary files are created during verification, delete them immediately after use (user `CLAUDE.md`).

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,13 @@ _bmad-output/
 # Claude Code
 .claude/*
 !.claude/settings.json
+# Project skills are versioned (ferry-* only — local bmad-*/ai-sdk packs stay untracked)
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/ferry-release/
+!.claude/skills/ferry-audit/
+!.claude/skills/ferry-spec/
+!.claude/skills/ferry-ticket/
 
 # Docs (drafts)
 docs/prd.md

--- a/docs/confluence-spec/config.json
+++ b/docs/confluence-spec/config.json
@@ -1,0 +1,18 @@
+{
+  "cloudId": "75eb33f5-5dd0-4328-b0e6-8bb3f4e0af91",
+  "siteUrl": "https://big-emotion.atlassian.net",
+  "spaceKey": "Ferry",
+  "spaceId": "171507716",
+  "engineeringRootPageId": "171508008",
+  "requirementsPageId": "171540481",
+  "decisionsPageId": "171573249",
+  "architecturePageId": "171606017",
+  "obsoletePageId": "171638785",
+  "jiraProjectKey": "FER",
+  "jiraProjectId": "10167",
+  "jiraIssueTypeIds": {
+    "Epic": "10285",
+    "Task": "10284",
+    "Sub-task": "10286"
+  }
+}

--- a/docs/templates/jira-ticket-template.md
+++ b/docs/templates/jira-ticket-template.md
@@ -1,0 +1,105 @@
+---
+type: Task
+project: FER
+parent_epic: ''
+assignee: ''
+labels: []
+---
+
+# Title
+
+<!-- Concise, business-readable. One short sentence that names the outcome, not the implementation.
+     Example: "Make the Reviewer's CI pre-gate opt-out via config". Avoid jargon and ticket IDs here.
+     FER is a team-managed project with three issue types only: Epic, Task ("Tâche"), Sub-task
+     ("Sous-tâche"). Bugs are Tasks carrying the `bug` label. -->
+
+## Goal
+
+<!-- What + why in one short paragraph. Tie it back to a measurable outcome whenever possible
+     (consumer install success, agent run reliability, cost, supply-chain posture, DX). -->
+
+## Scope
+
+### In
+
+<!-- Bullet list of what IS included in this ticket. -->
+
+### Out
+
+<!-- Bullet list of what is explicitly NOT included (deferred, separate ticket, etc.). -->
+
+## Reproduction steps
+
+<!-- if: label == "bug" -->
+
+1. <step one>
+2. <step two>
+3. <step three>
+   <!-- /if -->
+
+## Expected vs Actual behavior
+
+<!-- if: label == "bug" -->
+
+### Expected
+
+<expected behavior>
+
+### Actual
+
+<actual behavior>
+<!-- /if -->
+
+## Acceptance criteria (Given-When-Then)
+
+<!-- Required always — this is the contract with the Ferry pipeline (Refiner sub-tasks and the
+     Reviewer verdict both anchor on it). One GWT block per REQ touched, or per observable behavior
+     for spec-less tickets. -->
+
+```
+Given <context>
+When <action>
+Then <observable outcome>
+```
+
+## Affected files / areas
+
+<!-- Mandatory. The paths (or areas: prompts/, src/agents/reviewer/, examples/consumer-setup/…)
+     the implementer is expected to touch. Note CODEOWNERS-protected paths explicitly
+     (.github/**, src/schemas/**, prompts/*.md) — changes there need human review.
+     If src/ changes, remind: `npm run build:ferry` must rebuild .ferry/ in the same PR. -->
+
+## Confluence impact (load-bearing)
+
+<!-- MANDATORY when the ticket originates from ferry-spec. List every REQ / DEC / ARCH touched
+     with one of the three allowed verbs: NEW, EDIT, RETIRE. For tickets with no spec impact,
+     write exactly: "None — no REQ/DEC/ARCH touched."
+
+     The bullet character is `•`. Indentation under each bullet is two spaces. -->
+
+• REQ-012 — EDIT statement
+Current: "<verbatim current statement>"
+Proposed: "<new statement>"
+GWT changes: <which GWT blocks change, and how>
+
+• DEC-005 — NEW
+Context: <why this decision is being recorded now>
+Decision: <the decision itself, one sentence>
+Alternatives: <options considered, briefly>
+Tradeoffs: <what we accept by choosing this option>
+Requirements satisfied: <REQ-xxx, REQ-yyy>
+
+## FR registry impact
+
+<!-- Does this ticket ship behavior that must be registered in docs/REQUIREMENTS.md?
+     If yes: name the FR to add/update (the implementing PR owns the edit — check:fr-drift gates it).
+     If no: write "None". -->
+
+## Dependencies
+
+<!-- Optional. Other tickets, PRs, Confluence pages, or external blockers. Keep it brief. -->
+
+## Assumptions / open questions
+
+<!-- Optional. Anything you assumed while writing the ticket, or questions that need a
+     maintainer decision before implementation can start. -->


### PR DESCRIPTION
## Summary
- Add four versioned project skills under `.claude/skills/`: `ferry-release` and `ferry-audit` (migrated from user level and refreshed against the current repo — package name, released workflow surface, v0.17.0 reference map, FR32 Merger), plus new `ferry-spec` and `ferry-ticket` (adapted from the Grande Chancellerie consumer skills).
- Bootstrap the `ferry-spec` Confluence contract: `docs/confluence-spec/config.json` (space Ferry, REQ/DEC/ARCH/Obsolete page IDs, FER project metadata) + `docs/.confluence-bootstrap-complete` sentinel.
- Add `docs/templates/jira-ticket-template.md` — self-sufficient FER ticket template (goal, scope, GWT acceptance criteria, affected files, Confluence/FR impact).
- `.gitignore`: version only the four `ferry-*` skills; local skill packs stay untracked.

Related Jira: [FER-1](https://big-emotion.atlassian.net/browse/FER-1) (dogfooding epic groundwork)

## Test plan
- [x] `npm run typecheck && npm run lint && npm run format:check && npm test` green (pre-push hook)
- [x] `git status --porcelain --untracked-files=all .claude/` shows exactly the four ferry-* SKILL.md files as trackable

🤖 Generated with [Claude Code](https://claude.com/claude-code)