### PR TITLE
feat(dogfooding): install Ferry on its own repo (FER-3, FER-4, FER-7)

### DIFF
--- a/.github/workflows/ferry-dev.yml
+++ b/.github/workflows/ferry-dev.yml
@@ -1,0 +1,193 @@
+# Installed from examples/consumer-setup/workflows/ferry-dev.yml (dogfooding, FER-3).
+# Pinned to @v0.17.0 — bump alongside the release reference map (see .claude/skills/ferry-release).
+# Required secrets: FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN,
+#                   FERRY_REVIEW_TRANSITION_ID
+#                   ANTHROPIC_API_KEY    — required when FERRY_DEV_PROVIDER=anthropic (default)
+#                   OPENAI_API_KEY       — required when FERRY_DEV_PROVIDER=openai
+#                   GOOGLE_API_KEY       — required when FERRY_DEV_PROVIDER=google
+#                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
+#                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path).
+# Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
+# Optional variables: FERRY_DEV_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#                     FERRY_DEV_PROVIDER (default: anthropic; also: openai, google)
+#                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
+#
+# Note: MCP server support is not available for non-Anthropic providers in the Developer agent.
+#                     FERRY_DEV_MAX_INPUT_TOKENS (default: 500000)
+#                     FERRY_DEV_MAX_TOKENS (default: 16384)
+#                     FERRY_DEV_MAX_ITERATIONS (default: 200)
+#                     FERRY_BASH_TIMEOUT_MAX_MS (default: 300000)
+#                     FERRY_MAX_COST_EUR_PER_RUN (default: 10)
+#                     FERRY_LLM_RETRY_MAX_ATTEMPTS (default: 3)
+#                     FERRY_JIRA_RETRY_MAX_ATTEMPTS (default: 3)
+# Action inputs:      pre_agent_command (optional) — shell command to run before the agent (e.g. npm ci)
+#                     pre_agent_timeout_minutes (optional, default: 3)
+#                     post_agent_command (optional) — shell command to run after the agent (always runs)
+# claude-code path:   When execution_path=claude-code the Developer runs as ONE direct
+#                     anthropics/claude-code-action call. The agent opens the PR with native
+#                     git/gh tools and does its own Jira work via the ferry-jira-mcp MCP server
+#                     (npx -p @big-emotion/ferry@v0.17.0 ferry-jira-mcp). It never merges or closes PRs.
+#                     Cost tracking on this path is best-effort — audit token/cost are emitted as 0.
+
+name: Ferry — Dev
+
+on:
+  repository_dispatch:
+    types: [ferry-dev]
+
+# cancel-in-progress: false — writes .ferry/state.json, branch, and PR; cancellation mid-commit = state/branch divergence
+concurrency:
+  group: ferry-${{ github.workflow }}-${{ github.event.client_payload.ticket_key || 'ferry-invalid-payload-sinkhole' }}
+  cancel-in-progress: false
+
+jobs:
+  gate-envelope:
+    name: Validate event envelope
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate event envelope
+        uses: big-emotion/ferry/.github/actions/ferry-envelope-validate@v0.17.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+
+  route:
+    name: Resolve execution path
+    needs: [gate-envelope]
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+    outputs:
+      path: ${{ steps.route.outputs.path }}
+      reason: ${{ steps.route.outputs.reason }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve execution path
+        id: route
+        uses: big-emotion/ferry/.github/actions/ferry-route@v0.17.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          role: developer
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+
+  run-agent:
+    name: Run Developer agent (script path)
+    needs: [route]
+    if: needs.route.outputs.path == 'script'
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    outputs:
+      input_tokens: ${{ steps.run-developer.outputs.input_tokens }}
+      output_tokens: ${{ steps.run-developer.outputs.output_tokens }}
+      cost_eur: ${{ steps.run-developer.outputs.cost_eur }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install gitleaks
+        shell: bash
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+
+      - name: Run Developer agent
+        id: run-developer
+        uses: big-emotion/ferry/.github/actions/ferry-run-developer@v0.17.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+          ferry_review_transition_id: ${{ secrets.FERRY_REVIEW_TRANSITION_ID }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          google_api_key: ${{ secrets.GOOGLE_API_KEY }}
+          github_token: ${{ github.token }}
+          github_repo: ${{ github.repository }}
+          ferry_dev_model: ${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-4-6' }}
+          ferry_dev_provider: ${{ vars.FERRY_DEV_PROVIDER }}
+          ferry_dev_max_input_tokens: ${{ vars.FERRY_DEV_MAX_INPUT_TOKENS }}
+          ferry_dev_max_tokens: ${{ vars.FERRY_DEV_MAX_TOKENS }}
+          ferry_dev_max_iterations: ${{ vars.FERRY_DEV_MAX_ITERATIONS }}
+          ferry_bash_timeout_max_ms: ${{ vars.FERRY_BASH_TIMEOUT_MAX_MS }}
+          ferry_max_cost_eur_per_run: ${{ vars.FERRY_MAX_COST_EUR_PER_RUN }}
+          ferry_llm_retry_max_attempts: ${{ vars.FERRY_LLM_RETRY_MAX_ATTEMPTS }}
+          ferry_jira_retry_max_attempts: ${{ vars.FERRY_JIRA_RETRY_MAX_ATTEMPTS }}
+          # pre_agent_command: npm ci  # uncomment to install deps before the agent
+          # pre_agent_timeout_minutes: '3'
+          # post_agent_command: ''  # uncomment to run cleanup after the agent
+
+  run-agent-claude-code:
+    name: Run Developer agent (claude-code path)
+    needs: [route]
+    if: needs.route.outputs.path == 'claude-code'
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+      checks: read # PR check-runs / statusCheckRollup
+      actions: read # gh run view --log-failed / actions/runs
+      id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ vars.FERRY_INTEGRATION_BRANCH || 'main' }}
+          fetch-depth: 0
+      # Resolve the system prompt: prompts/dev.claude-code.md from this repo if
+      # present, otherwise Ferry's bundled default. To customise the prompt edit
+      # that file — no need to touch this workflow. See docs/CONFIGURATION.md.
+      - name: Resolve agent prompt
+        id: prompt
+        run: >-
+          npx -y -p @big-emotion/ferry@v0.17.0 ferry-cc-prompt
+          --agent dev
+          --ticket-key "${{ github.event.client_payload.ticket_key }}"
+          --run-id "${{ github.event.client_payload.event_id }}"
+          --review-transition-id "${{ secrets.FERRY_REVIEW_TRANSITION_ID }}"
+      - uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.prompt.outputs.prompt }}
+          claude_args: >-
+            --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@v0.17.0","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
+            --permission-mode acceptEdits
+            --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
+            --model ${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-4-6' }}
+
+  emit-audit:
+    name: Emit audit line
+    needs: [run-agent, run-agent-claude-code]
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Emit audit line
+        uses: big-emotion/ferry/.github/actions/ferry-emit-audit@v0.17.0
+        with:
+          ticket: ${{ github.event.client_payload.ticket_key }}
+          phase: dev
+          run_id: ${{ github.event.client_payload.event_id }}
+          model: ${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-4-6' }}
+          outcome: ${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
+          input_tokens: ${{ needs.run-agent.outputs.input_tokens || '0' }}
+          output_tokens: ${{ needs.run-agent.outputs.output_tokens || '0' }}
+          cost_eur: ${{ needs.run-agent.outputs.cost_eur || '0' }}
+          start_ms: ${{ github.run_id }}
+          audit_issue: ${{ vars.FERRY_AUDIT_ISSUE }}
+          github_token: ${{ github.token }}

--- a/.github/workflows/ferry-iterate.yml
+++ b/.github/workflows/ferry-iterate.yml
@@ -1,0 +1,197 @@
+# Installed from examples/consumer-setup/workflows/ferry-iterate.yml (dogfooding, FER-3).
+# Pinned to @v0.17.0 — bump alongside the release reference map (see .claude/skills/ferry-release).
+# Required secrets: FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN,
+#                   FERRY_REVIEW_TRANSITION_ID
+#                   ANTHROPIC_API_KEY    — required when FERRY_ITER_PROVIDER=anthropic (default)
+#                   OPENAI_API_KEY       — required when FERRY_ITER_PROVIDER=openai
+#                   GOOGLE_API_KEY       — required when FERRY_ITER_PROVIDER=google
+#                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
+#                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path).
+# Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
+# Optional variables: FERRY_ITER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#                     FERRY_ITER_PROVIDER (default: anthropic; also: openai, google)
+#                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
+#
+# Note: MCP server support is not available for non-Anthropic providers in the Iterator agent.
+#                     FERRY_ITER_MAX_INPUT_TOKENS (default: 500000)
+#                     FERRY_DEV_MAX_TOKENS (default: 16384)
+#                     FERRY_DEV_MAX_ITERATIONS (default: 200)
+#                     FERRY_BASH_TIMEOUT_MAX_MS (default: 300000)
+#                     FERRY_MAX_COST_EUR_PER_RUN (default: 10)
+#                     FERRY_LLM_RETRY_MAX_ATTEMPTS (default: 3)
+#                     FERRY_JIRA_RETRY_MAX_ATTEMPTS (default: 3)
+# Action inputs:      pre_agent_command (optional) — shell command to run before the agent (e.g. npm ci)
+#                     pre_agent_timeout_minutes (optional, default: 3)
+#                     post_agent_command (optional) — shell command to run after the agent (always runs)
+# claude-code path:   When execution_path=claude-code the Iterator runs as ONE direct
+#                     anthropics/claude-code-action call. The agent pushes fixes to the existing
+#                     PR with native git/gh tools and does its own Jira work via the ferry-jira-mcp
+#                     MCP server (npx -p @big-emotion/ferry@v0.17.0 ferry-jira-mcp). It never merges,
+#                     closes, or opens PRs. Cost tracking on this path is best-effort — audit
+#                     token/cost are emitted as 0.
+
+name: Ferry — Iterate
+
+on:
+  repository_dispatch:
+    types: [ferry-iterate]
+
+# cancel-in-progress: false — same as dev; writes state.json and branch commits
+concurrency:
+  group: ferry-${{ github.workflow }}-${{ github.event.client_payload.ticket_key || 'ferry-invalid-payload-sinkhole' }}
+  cancel-in-progress: false
+
+jobs:
+  gate-envelope:
+    name: Validate event envelope
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate event envelope
+        uses: big-emotion/ferry/.github/actions/ferry-envelope-validate@v0.17.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+
+  route:
+    name: Resolve execution path
+    needs: [gate-envelope]
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+    outputs:
+      path: ${{ steps.route.outputs.path }}
+      reason: ${{ steps.route.outputs.reason }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve execution path
+        id: route
+        uses: big-emotion/ferry/.github/actions/ferry-route@v0.17.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          role: iterator
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+
+  run-agent:
+    name: Run Iterator agent (script path)
+    needs: [route]
+    if: needs.route.outputs.path == 'script'
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    outputs:
+      input_tokens: ${{ steps.run-iterator.outputs.input_tokens }}
+      output_tokens: ${{ steps.run-iterator.outputs.output_tokens }}
+      cost_eur: ${{ steps.run-iterator.outputs.cost_eur }}
+      model: ${{ steps.run-iterator.outputs.model }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        shell: bash
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz \
+            | tar -xz -C /usr/local/bin gitleaks
+
+      - name: Run Iterator agent
+        id: run-iterator
+        uses: big-emotion/ferry/.github/actions/ferry-run-iterator@v0.17.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+          ferry_review_transition_id: ${{ secrets.FERRY_REVIEW_TRANSITION_ID }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          google_api_key: ${{ secrets.GOOGLE_API_KEY }}
+          github_token: ${{ github.token }}
+          github_repo: ${{ github.repository }}
+          ferry_iter_model: ${{ vars.FERRY_ITER_MODEL || 'claude-sonnet-4-6' }}
+          ferry_iter_provider: ${{ vars.FERRY_ITER_PROVIDER }}
+          ferry_iter_max_input_tokens: ${{ vars.FERRY_ITER_MAX_INPUT_TOKENS || '500000' }}
+          ferry_dev_max_tokens: ${{ vars.FERRY_DEV_MAX_TOKENS }}
+          ferry_dev_max_iterations: ${{ vars.FERRY_DEV_MAX_ITERATIONS }}
+          ferry_bash_timeout_max_ms: ${{ vars.FERRY_BASH_TIMEOUT_MAX_MS }}
+          ferry_max_cost_eur_per_run: ${{ vars.FERRY_MAX_COST_EUR_PER_RUN }}
+          ferry_llm_retry_max_attempts: ${{ vars.FERRY_LLM_RETRY_MAX_ATTEMPTS }}
+          ferry_jira_retry_max_attempts: ${{ vars.FERRY_JIRA_RETRY_MAX_ATTEMPTS }}
+          # pre_agent_command: npm ci  # uncomment to install deps before the agent
+          # pre_agent_timeout_minutes: '3'
+          # post_agent_command: ''  # uncomment to run cleanup after the agent
+
+  run-agent-claude-code:
+    name: Run Iterator agent (claude-code path)
+    needs: [route]
+    if: needs.route.outputs.path == 'claude-code'
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+      checks: read # PR check-runs / statusCheckRollup
+      actions: read # gh run view --log-failed / actions/runs
+      id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ferry/${{ github.event.client_payload.ticket_key }}
+          fetch-depth: 0
+      # Resolve the system prompt: prompts/iterate.claude-code.md from this repo
+      # if present, otherwise Ferry's bundled default. To customise the prompt
+      # edit that file — no need to touch this workflow. See docs/CONFIGURATION.md.
+      - name: Resolve agent prompt
+        id: prompt
+        run: >-
+          npx -y -p @big-emotion/ferry@v0.17.0 ferry-cc-prompt
+          --agent iterate
+          --ticket-key "${{ github.event.client_payload.ticket_key }}"
+          --run-id "${{ github.event.client_payload.event_id }}"
+          --review-transition-id "${{ secrets.FERRY_REVIEW_TRANSITION_ID }}"
+      - uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.prompt.outputs.prompt }}
+          claude_args: >-
+            --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@v0.17.0","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
+            --permission-mode acceptEdits
+            --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
+            --model ${{ vars.FERRY_ITER_MODEL || 'claude-sonnet-4-6' }}
+
+  emit-audit:
+    name: Emit audit line
+    needs: [run-agent, run-agent-claude-code]
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Emit audit line
+        uses: big-emotion/ferry/.github/actions/ferry-emit-audit@v0.17.0
+        with:
+          ticket: ${{ github.event.client_payload.ticket_key }}
+          phase: iterate
+          run_id: ${{ github.event.client_payload.event_id }}
+          model: ${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
+          outcome: ${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
+          input_tokens: ${{ needs.run-agent.outputs.input_tokens || '0' }}
+          output_tokens: ${{ needs.run-agent.outputs.output_tokens || '0' }}
+          cost_eur: ${{ needs.run-agent.outputs.cost_eur || '0' }}
+          start_ms: ${{ github.run_id }}
+          audit_issue: ${{ vars.FERRY_AUDIT_ISSUE }}
+          github_token: ${{ github.token }}

--- a/.github/workflows/ferry-merge.yml
+++ b/.github/workflows/ferry-merge.yml
@@ -1,0 +1,162 @@
+# Installed from examples/consumer-setup/workflows/ferry-merge.yml (dogfooding, FER-3).
+# Pinned to @v0.17.0 — bump alongside the release reference map (see .claude/skills/ferry-release).
+# Required secrets: FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN
+#                   ANTHROPIC_API_KEY    — required when FERRY_MERGER_PROVIDER=anthropic (default)
+#                   OPENAI_API_KEY       — required when FERRY_MERGER_PROVIDER=openai
+#                   GOOGLE_API_KEY       — required when FERRY_MERGER_PROVIDER=google
+#                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
+#                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path).
+# Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
+# Optional variables: FERRY_MERGER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#                     FERRY_MERGER_PROVIDER (default: anthropic; also: openai, google)
+#                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
+# claude-code path:   When execution_path=claude-code the Merger runs as ONE direct
+#                     anthropics/claude-code-action call. The agent does its own Jira work via the
+#                     ferry-jira-mcp MCP server (npx -p @big-emotion/ferry@v0.17.0 ferry-jira-mcp).
+#                     Cost tracking on this path is best-effort — audit token/cost are emitted as 0.
+# Triggered by:       The Reviewer agent dispatches ferry-merge automatically on approve (FR32).
+
+name: Ferry — Merge
+
+on:
+  repository_dispatch:
+    types: [ferry-merge]
+
+# cancel-in-progress: false — merge must complete atomically; cancellation mid-merge = inconsistent PR state
+concurrency:
+  group: ferry-${{ github.workflow }}-${{ github.event.client_payload.ticket_key || 'ferry-invalid-payload-sinkhole' }}
+  cancel-in-progress: false
+
+jobs:
+  gate-envelope:
+    name: Validate event envelope
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate event envelope
+        uses: big-emotion/ferry/.github/actions/ferry-envelope-validate@v0.17.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+
+  route:
+    name: Resolve execution path
+    needs: [gate-envelope]
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+    outputs:
+      path: ${{ steps.route.outputs.path }}
+      reason: ${{ steps.route.outputs.reason }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve execution path
+        id: route
+        uses: big-emotion/ferry/.github/actions/ferry-route@v0.17.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          role: merger
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+
+  run-agent:
+    name: Run Merger agent (script path)
+    needs: [route]
+    if: needs.route.outputs.path == 'script'
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    outputs:
+      input_tokens: ${{ steps.run-merger.outputs.input_tokens }}
+      output_tokens: ${{ steps.run-merger.outputs.output_tokens }}
+      cost_eur: ${{ steps.run-merger.outputs.cost_eur }}
+      model: ${{ steps.run-merger.outputs.model }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Merger agent
+        id: run-merger
+        uses: big-emotion/ferry/.github/actions/ferry-run-merger@v0.17.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          google_api_key: ${{ secrets.GOOGLE_API_KEY }}
+          github_token: ${{ github.token }}
+          github_repo: ${{ github.repository }}
+          ferry_merger_model: ${{ vars.FERRY_MERGER_MODEL || 'claude-sonnet-4-6' }}
+
+  run-agent-claude-code:
+    name: Run Merger agent (claude-code path)
+    needs: [route]
+    if: needs.route.outputs.path == 'claude-code'
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+      checks: read # PR check-runs / statusCheckRollup
+      actions: read # gh run view --log-failed / actions/runs
+      id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ferry/${{ github.event.client_payload.ticket_key }}
+          fetch-depth: 0
+      # Resolve the system prompt: prompts/merge.claude-code.md from this repo
+      # if present, otherwise Ferry's bundled default. To customise the prompt
+      # edit that file — no need to touch this workflow. See docs/CONFIGURATION.md.
+      - name: Resolve agent prompt
+        id: prompt
+        run: >-
+          npx -y -p @big-emotion/ferry@v0.17.0 ferry-cc-prompt
+          --agent merge
+          --ticket-key "${{ github.event.client_payload.ticket_key }}"
+          --run-id "${{ github.event.client_payload.event_id }}"
+      - uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.prompt.outputs.prompt }}
+          claude_args: >-
+            --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@v0.17.0","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
+            --permission-mode bypassPermissions
+            --disallowedTools 'Bash(gh pr close),Bash(gh pr close:*)'
+            --model ${{ vars.FERRY_MERGER_MODEL || 'claude-sonnet-4-6' }}
+
+  emit-audit:
+    name: Emit audit line
+    needs: [run-agent, run-agent-claude-code]
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Emit audit line
+        uses: big-emotion/ferry/.github/actions/ferry-emit-audit@v0.17.0
+        with:
+          ticket: ${{ github.event.client_payload.ticket_key }}
+          phase: merge
+          run_id: ${{ github.event.client_payload.event_id }}
+          model: ${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
+          outcome: ${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
+          input_tokens: ${{ needs.run-agent.outputs.input_tokens || '0' }}
+          output_tokens: ${{ needs.run-agent.outputs.output_tokens || '0' }}
+          cost_eur: ${{ needs.run-agent.outputs.cost_eur || '0' }}
+          start_ms: ${{ github.run_id }}
+          audit_issue: ${{ vars.FERRY_AUDIT_ISSUE }}
+          github_token: ${{ github.token }}

--- a/.github/workflows/ferry-refine.yml
+++ b/.github/workflows/ferry-refine.yml
@@ -1,0 +1,172 @@
+# Installed from examples/consumer-setup/workflows/ferry-refine.yml (dogfooding, FER-3).
+# Pinned to @v0.17.0 — bump alongside the release reference map (see .claude/skills/ferry-release).
+# Required secrets: FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN
+#                   ANTHROPIC_API_KEY    — required when FERRY_REFINER_PROVIDER=anthropic (default)
+#                   OPENAI_API_KEY       — required when FERRY_REFINER_PROVIDER=openai
+#                   GOOGLE_API_KEY       — required when FERRY_REFINER_PROVIDER=google
+#                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
+#                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path).
+# Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
+# Optional variables: FERRY_REFINER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#                     FERRY_REFINER_PROVIDER (default: anthropic; also: openai, google)
+#                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
+#                     FERRY_REFINER_SUBTASK_CAP (default: 12)
+#                     FERRY_MAX_COST_EUR_PER_RUN (default: 10)
+#                     FERRY_LLM_RETRY_MAX_ATTEMPTS (default: 3)
+#                     FERRY_JIRA_RETRY_MAX_ATTEMPTS (default: 3)
+# Action inputs:      pre_agent_command (optional) — shell command to run before the agent (e.g. npm ci)
+#                     pre_agent_timeout_minutes (optional, default: 3)
+#                     post_agent_command (optional) — shell command to run after the agent (always runs)
+# claude-code path:   When execution_path=claude-code the Refiner runs as ONE direct
+#                     anthropics/claude-code-action call. The agent does its own Jira work
+#                     via the ferry-jira-mcp MCP server (npx -p @big-emotion/ferry@v0.17.0 ferry-jira-mcp).
+#                     Cost tracking on this path is best-effort — audit token/cost are emitted as 0.
+
+name: Ferry — Refine
+
+on:
+  repository_dispatch:
+    types: [ferry-refine]
+
+# cancel-in-progress: true — Refiner is pure read + audit comment; latest human edit wins
+concurrency:
+  group: ferry-${{ github.workflow }}-${{ github.event.client_payload.ticket_key || 'ferry-invalid-payload-sinkhole' }}
+  cancel-in-progress: true
+
+jobs:
+  gate-envelope:
+    name: Validate event envelope
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate event envelope
+        uses: big-emotion/ferry/.github/actions/ferry-envelope-validate@v0.17.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+
+  route:
+    name: Resolve execution path
+    needs: [gate-envelope]
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+    outputs:
+      path: ${{ steps.route.outputs.path }}
+      reason: ${{ steps.route.outputs.reason }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve execution path
+        id: route
+        uses: big-emotion/ferry/.github/actions/ferry-route@v0.17.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          role: refiner
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+
+  run-agent:
+    name: Run Refiner agent (script path)
+    needs: [route]
+    if: needs.route.outputs.path == 'script'
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install gitleaks
+        shell: bash
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+
+      - name: Run Refiner agent
+        uses: big-emotion/ferry/.github/actions/ferry-run-refiner@v0.17.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          google_api_key: ${{ secrets.GOOGLE_API_KEY }}
+          github_token: ${{ github.token }}
+          github_repo: ${{ github.repository }}
+          ferry_refiner_model: ${{ vars.FERRY_REFINER_MODEL || 'claude-sonnet-4-6' }}
+          ferry_refiner_provider: ${{ vars.FERRY_REFINER_PROVIDER }}
+          ferry_refiner_subtask_cap: ${{ vars.FERRY_REFINER_SUBTASK_CAP }}
+          ferry_max_cost_eur_per_run: ${{ vars.FERRY_MAX_COST_EUR_PER_RUN }}
+          ferry_llm_retry_max_attempts: ${{ vars.FERRY_LLM_RETRY_MAX_ATTEMPTS }}
+          ferry_jira_retry_max_attempts: ${{ vars.FERRY_JIRA_RETRY_MAX_ATTEMPTS }}
+          # pre_agent_command: npm ci  # uncomment to install deps before the agent
+          # pre_agent_timeout_minutes: '3'
+          # post_agent_command: ''  # uncomment to run cleanup after the agent
+
+  run-agent-claude-code:
+    name: Run Refiner agent (claude-code path)
+    needs: [route]
+    if: needs.route.outputs.path == 'claude-code'
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+      id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ vars.FERRY_INTEGRATION_BRANCH || 'main' }}
+          fetch-depth: 0
+      # Resolve the system prompt: prompts/refiner.claude-code.md from this repo
+      # if present, otherwise Ferry's bundled default. To customise the prompt
+      # edit that file — no need to touch this workflow. See docs/CONFIGURATION.md.
+      - name: Resolve agent prompt
+        id: prompt
+        run: >-
+          npx -y -p @big-emotion/ferry@v0.17.0 ferry-cc-prompt
+          --agent refiner
+          --ticket-key "${{ github.event.client_payload.ticket_key }}"
+          --run-id "${{ github.event.client_payload.event_id }}"
+      - uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.prompt.outputs.prompt }}
+          claude_args: >-
+            --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@v0.17.0","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
+            --permission-mode acceptEdits
+            --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
+            --model ${{ vars.FERRY_REFINER_MODEL || 'claude-sonnet-4-6' }}
+
+  emit-audit:
+    name: Emit audit line
+    needs: [run-agent, run-agent-claude-code]
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped')
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Emit audit line
+        uses: big-emotion/ferry/.github/actions/ferry-emit-audit@v0.17.0
+        with:
+          ticket: ${{ github.event.client_payload.ticket_key }}
+          phase: refine
+          run_id: ${{ github.event.client_payload.event_id }}
+          model: ${{ vars.FERRY_REFINER_MODEL || 'claude-sonnet-4-6' }}
+          outcome: ${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
+          # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
+          input_tokens: '0'
+          output_tokens: '0'
+          cost_eur: '0'
+          start_ms: ${{ github.run_id }}
+          audit_issue: ${{ vars.FERRY_AUDIT_ISSUE }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ferry-review.yml
+++ b/.github/workflows/ferry-review.yml
@@ -1,0 +1,220 @@
+# Installed from examples/consumer-setup/workflows/ferry-review.yml (dogfooding, FER-3).
+# Pinned to @v0.17.0 — bump alongside the release reference map (see .claude/skills/ferry-release).
+# Required secrets: FERRY_JIRA_BASE_URL, FERRY_JIRA_EMAIL, FERRY_JIRA_API_TOKEN,
+#                   FERRY_ITER_TRANSITION_ID
+#                   ANTHROPIC_API_KEY    — required when FERRY_REVIEW_PROVIDER=anthropic (default)
+#                   OPENAI_API_KEY       — required when FERRY_REVIEW_PROVIDER=openai
+#                   GOOGLE_API_KEY       — required when FERRY_REVIEW_PROVIDER=google
+#                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
+#                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path).
+# Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
+# Optional variables: FERRY_REVIEW_MODEL (default: claude-sonnet-4-6)
+#                     FERRY_REVIEW_PROVIDER (default: anthropic; also: openai, google)
+#                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
+#                     FERRY_REVIEWER_MAX_ITERATIONS (default: 40)
+#                     FERRY_REVIEWER_MAX_TOKENS (default: 16384)
+#                     FERRY_MAX_COST_EUR_PER_RUN (default: 10)
+#                     FERRY_LLM_RETRY_MAX_ATTEMPTS (default: 3)
+#                     FERRY_JIRA_RETRY_MAX_ATTEMPTS (default: 3)
+# Action inputs:      pre_agent_command (optional) — shell command to run before the agent (e.g. npm ci)
+#                     pre_agent_timeout_minutes (optional, default: 3)
+#                     post_agent_command (optional) — shell command to run after the agent (always runs)
+# claude-code path:   When execution_path=claude-code the Reviewer runs as ONE direct
+#                     anthropics/claude-code-action call, preceded by a deterministic ci-gate job.
+#                     The ci-gate skips the reviewer silently while CI is pending, and on red CI
+#                     requests changes (FR24) — posts a PR comment + transitions the ticket — without
+#                     spending an LLM call. The agent does its own Jira work via the ferry-jira-mcp
+#                     MCP server (npx -p @big-emotion/ferry@v0.17.0 ferry-jira-mcp). It never merges or closes
+#                     PRs. Cost tracking on this path is best-effort — audit token/cost are emitted as 0.
+#
+# Note: MCP server support is not available for non-Anthropic providers in the Reviewer agent.
+
+name: Ferry — Review
+
+on:
+  repository_dispatch:
+    types: [ferry-review]
+
+# cancel-in-progress: false — writes fingerprints to state.iteration_history[] + PR review body; must complete atomically
+concurrency:
+  group: ferry-${{ github.workflow }}-${{ github.event.client_payload.ticket_key || 'ferry-invalid-payload-sinkhole' }}
+  cancel-in-progress: false
+
+jobs:
+  gate-envelope:
+    name: Validate event envelope
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Validate event envelope
+        uses: big-emotion/ferry/.github/actions/ferry-envelope-validate@v0.17.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+
+  route:
+    name: Resolve execution path
+    needs: [gate-envelope]
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+    outputs:
+      path: ${{ steps.route.outputs.path }}
+      reason: ${{ steps.route.outputs.reason }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve execution path
+        id: route
+        uses: big-emotion/ferry/.github/actions/ferry-route@v0.17.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          role: reviewer
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+
+  run-agent:
+    name: Run Reviewer agent (script path)
+    needs: [route]
+    if: needs.route.outputs.path == 'script'
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: write # required to dispatch ferry-merge (FR32) via POST /repos/.../dispatches on approve
+      pull-requests: write
+      issues: write
+      checks: read
+    outputs:
+      input_tokens: ${{ steps.run-reviewer.outputs.input_tokens }}
+      output_tokens: ${{ steps.run-reviewer.outputs.output_tokens }}
+      cost_eur: ${{ steps.run-reviewer.outputs.cost_eur }}
+      model: ${{ steps.run-reviewer.outputs.model }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install gitleaks
+        shell: bash
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+
+      - name: Run Reviewer agent
+        id: run-reviewer
+        uses: big-emotion/ferry/.github/actions/ferry-run-reviewer@v0.17.0
+        with:
+          payload: ${{ toJson(github.event.client_payload) }}
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+          ferry_iter_transition_id: ${{ secrets.FERRY_ITER_TRANSITION_ID }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          google_api_key: ${{ secrets.GOOGLE_API_KEY }}
+          github_token: ${{ github.token }}
+          github_repo: ${{ github.repository }}
+          ferry_review_model: ${{ vars.FERRY_REVIEW_MODEL || 'claude-sonnet-4-6' }}
+          ferry_review_provider: ${{ vars.FERRY_REVIEW_PROVIDER }}
+          ferry_reviewer_max_iterations: ${{ vars.FERRY_REVIEWER_MAX_ITERATIONS }}
+          ferry_reviewer_max_tokens: ${{ vars.FERRY_REVIEWER_MAX_TOKENS }}
+          ferry_max_cost_eur_per_run: ${{ vars.FERRY_MAX_COST_EUR_PER_RUN }}
+          ferry_llm_retry_max_attempts: ${{ vars.FERRY_LLM_RETRY_MAX_ATTEMPTS }}
+          ferry_jira_retry_max_attempts: ${{ vars.FERRY_JIRA_RETRY_MAX_ATTEMPTS }}
+          # pre_agent_command: npm ci  # uncomment to install deps before the agent
+          # pre_agent_timeout_minutes: '3'
+          # post_agent_command: ''  # uncomment to run cleanup after the agent
+
+  ci-gate:
+    name: Reviewer CI pre-gate
+    needs: [route]
+    if: needs.route.outputs.path == 'claude-code'
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: read
+    outputs:
+      proceed: ${{ steps.ci-gate.outputs.proceed }}
+      outcome: ${{ steps.ci-gate.outputs.outcome }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve reviewer CI pre-gate
+        id: ci-gate
+        uses: big-emotion/ferry/.github/actions/ferry-ci-gate@v0.17.0
+        with:
+          ticket_key: ${{ github.event.client_payload.ticket_key }}
+          run_id: ${{ github.event.client_payload.event_id }}
+          github_token: ${{ github.token }}
+          github_repo: ${{ github.repository }}
+          jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
+          jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
+          jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
+          ferry_iter_transition_id: ${{ secrets.FERRY_ITER_TRANSITION_ID }}
+
+  run-agent-claude-code:
+    name: Run Reviewer agent (claude-code path)
+    needs: [route, ci-gate]
+    if: needs.route.outputs.path == 'claude-code' && needs.ci-gate.outputs.proceed == 'true'
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: write # required to dispatch ferry-merge (FR32) via POST /repos/.../dispatches
+      pull-requests: write
+      issues: read
+      id-token: write # required by anthropics/claude-code-action@v1 OIDC auth
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ferry/${{ github.event.client_payload.ticket_key }}
+          fetch-depth: 0
+      # Resolve the system prompt: prompts/review.claude-code.md from this repo
+      # if present, otherwise Ferry's bundled default. To customise the prompt
+      # edit that file — no need to touch this workflow. See docs/CONFIGURATION.md.
+      - name: Resolve agent prompt
+        id: prompt
+        run: >-
+          npx -y -p @big-emotion/ferry@v0.17.0 ferry-cc-prompt
+          --agent review
+          --ticket-key "${{ github.event.client_payload.ticket_key }}"
+          --run-id "${{ github.event.client_payload.event_id }}"
+          --approve-transition-id "${{ secrets.FERRY_APPROVE_TRANSITION_ID }}"
+          --changes-transition-id "${{ secrets.FERRY_ITER_TRANSITION_ID }}"
+      - uses: anthropics/claude-code-action@1dc994ee7a008f0ecc866d9ac23ef036b7229f84 # v1.0.127
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.prompt.outputs.prompt }}
+          claude_args: >-
+            --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@v0.17.0","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
+            --permission-mode acceptEdits
+            --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
+            --model ${{ vars.FERRY_REVIEW_MODEL || 'claude-sonnet-4-6' }}
+
+  emit-audit:
+    name: Emit audit line
+    needs: [run-agent, run-agent-claude-code, ci-gate]
+    if: always() && (needs.run-agent.result != 'skipped' || needs.run-agent-claude-code.result != 'skipped' || (needs.ci-gate.result != 'skipped' && needs.ci-gate.outputs.outcome == 'ci-red'))
+    runs-on: ${{ fromJSON(vars.FERRY_RUNNER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Emit audit line
+        uses: big-emotion/ferry/.github/actions/ferry-emit-audit@v0.17.0
+        with:
+          ticket: ${{ github.event.client_payload.ticket_key }}
+          phase: review
+          run_id: ${{ github.event.client_payload.event_id }}
+          model: ${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
+          outcome: ${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || (needs.ci-gate.outputs.outcome == 'ci-red' && 'ci-red') || needs.run-agent-claude-code.result }}
+          # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
+          input_tokens: ${{ needs.run-agent.outputs.input_tokens || '0' }}
+          output_tokens: ${{ needs.run-agent.outputs.output_tokens || '0' }}
+          cost_eur: ${{ needs.run-agent.outputs.cost_eur || '0' }}
+          start_ms: ${{ github.run_id }}
+          audit_issue: ${{ vars.FERRY_AUDIT_ISSUE }}
+          github_token: ${{ github.token }}

--- a/ferry.config.json
+++ b/ferry.config.json
@@ -1,0 +1,7 @@
+{
+  "execution_path": "claude-code",
+  "ticket_types": {
+    "refine_allowlist": ["Tâche"],
+    "dev_allowlist": ["Tâche"]
+  }
+}

--- a/prompts/_project.md
+++ b/prompts/_project.md
@@ -1,0 +1,11 @@
+## Project: @big-emotion/ferry (Ferry developing itself)
+
+This repository IS Ferry — the agent pipeline you are running on. Rules that are non-negotiable here:
+
+- **Bundle rule**: any change under `src/` requires `npm run build:ferry` and committing the regenerated `.ferry/` in the same PR. CI (`check:bundle`) fails on drift. Never edit `.ferry/` directly.
+- **Quality gates**: `npm run typecheck && npm run lint && npm run format:check && npm test` must pass before any PR or push.
+- **Strict TS, NodeNext ESM**: local imports use `.js` specifiers; no `any` (lint error).
+- **Agent isolation**: code under `src/agents/**` never imports `@octokit/rest` or Jira modules directly — all IO goes through `src/lib/dispatch/runner/github-actions/`, `src/lib/io/tracker/factory.ts`, `src/lib/llm/`.
+- **FR registry**: behavior carrying an `FRnn` tag must have an entry in `docs/REQUIREMENTS.md` (`npm run check:fr-drift` gates it).
+- **CODEOWNERS**: `.github/**`, `src/schemas/**`, `prompts/*.md` need human codeowner review — say so in the PR body; never expect auto-merge on those paths. Schema changes are migrations (backward compatible unless intentionally breaking).
+- **Prompts contract**: never edit the bundled `prompts/<agent>.md` defaults for repo-specific needs — that is what `prompts/<agent>.extra.md` files (like this one's siblings) are for.

--- a/prompts/dev.extra.md
+++ b/prompts/dev.extra.md
@@ -1,0 +1,7 @@
+## Ferry-repo Developer rules
+
+1. **Rebuild bundles last.** If your diff touches `src/`, your final implementation step — after all code and tests are green — is `npm run build:ferry`, then commit the `.ferry/` diff in the same PR. A PR with `src/` changes and no matching `.ferry/` rebuild fails CI (`check:bundle`).
+2. **Run the four gates before opening the PR**: `npm run typecheck && npm run lint && npm run format:check && npm test`. When your change is FR-tagged, also run `npm run check:fr-drift` and add/update the `docs/REQUIREMENTS.md` entry in the same PR.
+3. **Tests live next to the implementation** (`src/x/y.ts` → `src/x/y.test.ts`), use Vitest, and mock all external IO — tests never hit real GitHub, Jira, or LLM APIs. Fixtures live in `src/__fixtures__/`.
+4. **CODEOWNERS-protected paths** (`.github/**`, `src/schemas/**`, `prompts/*.md`): if the ticket forces you to touch them, state it explicitly in the PR body ("requires codeowner review: <paths>").
+5. **Idempotency**: any new external write (comment, label, transition) must be fingerprinted/repeatable per the `[ferry:<role>:<run-id>]` convention.

--- a/prompts/iterate.extra.md
+++ b/prompts/iterate.extra.md
@@ -1,0 +1,6 @@
+## Ferry-repo Iterator rules
+
+1. **Rebuild bundles last.** If your fixes touch `src/`, finish with `npm run build:ferry` and commit the `.ferry/` diff in the same push. A push with `src/` changes and no matching `.ferry/` rebuild fails CI (`check:bundle`).
+2. **Run the four gates before pushing**: `npm run typecheck && npm run lint && npm run format:check && npm test`. If the reviewer's findings involve FR-tagged behavior, keep `docs/REQUIREMENTS.md` in sync (`npm run check:fr-drift`).
+3. **Tests live next to the implementation**, use Vitest, and mock all external IO. Fix the root cause the review names — do not weaken or delete a failing test to get green.
+4. **CODEOWNERS-protected paths** (`.github/**`, `src/schemas/**`, `prompts/*.md`): if a fix touches them, call it out in your PR comment ("requires codeowner review: <paths>").

--- a/prompts/refiner.extra.md
+++ b/prompts/refiner.extra.md
@@ -1,0 +1,5 @@
+## Ferry-repo Refiner rules
+
+1. **Bundle sub-task ordering.** When the ticket touches `src/`, the **last** sub-task of the breakdown must be: "Rebuild `.ferry/` bundles (`npm run build:ferry`) and commit them in the same PR". Every other implementation sub-task precedes it.
+2. **FR registry sub-task.** When the ticket ships or changes FR-tagged behavior, include a sub-task to add/update the corresponding entry in `docs/REQUIREMENTS.md` (CI gate: `npm run check:fr-drift`).
+3. **Flag protected paths.** When the breakdown involves `.github/**`, `src/schemas/**`, or `prompts/*.md`, note in the sub-task description that the change needs human codeowner review, and for schemas that backward compatibility is required unless the ticket says otherwise.


### PR DESCRIPTION
## Summary
Wire `big-emotion/ferry` as a consumer of its own pipeline (dogfooding epic [FER-1](https://big-emotion.atlassian.net/browse/FER-1)):

- **[FER-3](https://big-emotion.atlassian.net/browse/FER-3)** — the five agent dispatch workflows in `.github/workflows/`, copied verbatim from `examples/consumer-setup/workflows/` and pinned to `@v0.17.0` (only the copy-instruction header lines replaced; `ferry-merge`'s duplicated comment block deduplicated). Verified with `diff`: bodies are byte-identical to the stubs.
- **[FER-4](https://big-emotion.atlassian.net/browse/FER-4)** — `ferry.config.json`: `execution_path: claude-code` + `ticket_types` allowlist `["Tâche"]`. FER is a team-managed Jira project whose only issue types are Tâche/Epic/Sous-tâche — the default `[Story, Bug, Spike]` allowlist would silently skip every dispatch.
- **[FER-7](https://big-emotion.atlassian.net/browse/FER-7)** — `prompts/_project.md` + `{refiner,dev,iterate}.extra.md`: repo-specific agent rules via Ferry's own consumer composition mechanism (bundle rebuild rule, quality gates, agent isolation, FR registry, CODEOWNERS awareness). Bundled `prompts/<agent>.md` defaults untouched.

## Not in this PR (human steps before first run)
- [FER-5](https://big-emotion.atlassian.net/browse/FER-5) — secrets/variables (`FERRY_*`, `FERRY_AUDIT_ISSUE`, transition IDs)
- [FER-6](https://big-emotion.atlassian.net/browse/FER-6) — FER board columns + the 4 Jira Automation dispatch rules

Until those land, the workflows are inert (repository_dispatch only, no trigger source).

## Test plan
- [x] Full gate green via pre-push hook (typecheck, lint, format:check, tests, check:bundle)
- [x] Workflow bodies diff-verified against the stubs
- [x] Prompt extras within the composition size caps (`_project.md` < 2048 B, `*.extra.md` < 4096 B)
- [ ] End-to-end validation deferred to [FER-9](https://big-emotion.atlassian.net/browse/FER-9) once FER-5/FER-6 are done

> `.github/**` is CODEOWNERS-protected — codeowner review required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)