### PR TITLE
fix(claude-code): allow-list Ferry's own bot so the Merger can run

### DIFF
--- a/.github/actions/ferry-run-claude-agent/action.yml
+++ b/.github/actions/ferry-run-claude-agent/action.yml
@@ -204,6 +204,13 @@ runs:
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         show_full_output: ${{ inputs.show_full_output == 'true' }}
+        # The merger is reached only by the ferry-merge event the Reviewer
+        # dispatches on approval (ADR-0005), so its run's actor is Ferry's own
+        # Claude App (claude[bot]) — never a human. claude-code-action's
+        # human-actor gate rejects bot actors unless allow-listed, which would
+        # make the merger permanently unrunnable. Allow Ferry's own bot only
+        # (not '*'); the action lower-cases and strips the [bot] suffix.
+        allowed_bots: claude
         prompt: ${{ steps.prompt.outputs.prompt }}
         claude_args: >-
           --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Ferry uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Merger never ran on the `claude-code` path — `claude-code-action` blocked its own trigger.** By design the Merger is reached only by the `ferry-merge` event the Reviewer dispatches on approval (ADR-0005), so the merge run's actor is Ferry's Claude GitHub App (`claude[bot]`), never a human. `anthropics/claude-code-action`'s human-actor gate rejects any bot actor unless it is in `allowed_bots` (default empty), so `ferry-run-claude-agent` — which never set that input — made the Merger structurally unrunnable (it failed with `Workflow initiated by non-human actor: claude (type: Bot)`). The composite now passes `allowed_bots: claude`, allow-listing Ferry's own bot only. Human-triggered roles (refiner/dev/review/iterate, whose runs carry a human actor) are unaffected — `allowed_bots` is consulted only for bot actors.
+
 ---
 
 ## [1.0.1] — 2026-07-18


### PR DESCRIPTION
## Problem

On the `claude-code` execution path, the **Merger never runs** — every `ferry-merge` run dies immediately with:

```
Workflow initiated by non-human actor: claude (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

### Root cause

By design (ADR-0005), moving a ticket into a merge column does nothing — the Merger is reached **only** by the `ferry-merge` `repository_dispatch` that the **Reviewer dispatches on approval**. The Reviewer runs under `anthropics/claude-code-action`, which authenticates the agent as Ferry's **Claude GitHub App (`claude[bot]`)** — so the `ferry-merge` run's `github.actor` is `claude[bot]`, never a human. (Observed on a consumer repo: run actor = `claude[bot]`, event `repository_dispatch`.)

`claude-code-action` has a human-actor gate that rejects any bot actor unless it is listed in its `allowed_bots` input (default `''` = no bots). `ferry-run-claude-agent` never set that input, so **the Merger is structurally unrunnable** — the one role Ferry's own architecture guarantees is bot-triggered.

All other roles pass only because their runs are triggered by the Jira automation rule under a human PAT (`actor = <human>`), and `allowed_bots` is consulted **only** for bot actors.

## Fix

Pass `allowed_bots: claude` on the `claude-code-action` step in `ferry-run-claude-agent`. This allow-lists Ferry's own bot **only** (not `*`; the action lower-cases the actor and strips the `[bot]` suffix, so `claude` ≡ `claude[bot]`). On the `claude-code` path the triggering bot is always the Claude App, so no input/consumer change is needed — consumers only re-pin to the new tag.

- Human-triggered roles (refiner/dev/review/iterate) are **unaffected** — their runs carry a human actor, for which `allowed_bots` is never consulted.
- `*` deliberately avoided: on the private/consumer repos this runs on, only Ferry's own App can be the bot actor, so a specific allow-list is the least-privilege choice.

## Verification (local, this branch)

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm test` ✅ — **161 files / 2378 tests pass**

(`check:fr-drift` fails identically on unmodified `main` in this local macOS shell — a pre-existing environment artifact, not from this change; it scans `src/prompts/docs` only, neither of the touched files. It passes on the Ubuntu CI runner.)

## Release / follow-up (maintainer)

This PR lands the fix under `CHANGELOG.md [Unreleased]`. To ship it:

1. Merge this PR.
2. Cut **v1.0.2** — `/ferry-release patch` (or `npm version patch` + CHANGELOG `[1.0.2]` + MIGRATIONS `## 1.0.1 → 1.0.2 (none — internal changes only)` + push tag). The tag push triggers `release.yml` (npm publish + GitHub Release + moving `v1`).
3. Bump the consumer pins in `big-emotion/website` `ferry-router.yml` (the 5 `@v1.0.1` action refs + `ferry_version: v1.0.1` → `v1.0.2`). A follow-up PR is prepared for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)