### PR TITLE
fix(cc-agent): request actions:read so agents can read CI state

### DIFF
--- a/.github/actions/ferry-run-claude-agent/action.yml
+++ b/.github/actions/ferry-run-claude-agent/action.yml
@@ -211,6 +211,15 @@ runs:
         # make the merger permanently unrunnable. Allow Ferry's own bot only
         # (not '*'); the action lower-cases and strips the [bot] suffix.
         allowed_bots: claude
+        # The App installation token carries no Actions scope by default, so
+        # `gh run list` / `gh run view --log-failed` return 403 for the agent:
+        # the Developer/Iterator cannot read failing CI logs and the Merger
+        # cannot verify the green state it gates the merge on (FR32, ADR-0005).
+        # additional_permissions requests actions:read via OIDC; the calling
+        # job's `permissions:` block must grant the matching `actions: read`
+        # ceiling (ferry-router.yml already does).
+        additional_permissions: |
+          actions: read
         prompt: ${{ steps.prompt.outputs.prompt }}
         claude_args: >-
           --verbose


### PR DESCRIPTION
The claude-code-action App installation token carries no Actions scope, so every `gh run list` / `gh run view --log-failed` call made by an agent returns 403.

Observed on the CHANSUP dry-run (big-emotion/support-agent-chancellerie, ticket CHANSUP-46): the Developer honestly labeled its PR `ci-failing` because CI was unreadable ("gh pr checks 21 returned HTTP 403 — Resource not accessible by integration"), and the Merger cannot verify the green state it gates the merge on (FR32, ADR-0005). The same symptom is visible on big-emotion/website PR #12 (`ci-failing` despite the reviewer approving).

Fix: request `actions: read` via claude-code-action's `additional_permissions` input. The calling job must grant the matching ceiling — `ferry-router.yml`'s `run-agent` job already declares `permissions: actions: read`, so consumers on the router pattern get the fix by bumping the action pin alone.

After merge this needs a tag (v1.0.2) so consumers can bump their `@v1.0.1` pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)