### PR TITLE
chore(config): per-agent model tiers (Opus 4.8 + Sonnet 5)

### DIFF
--- a/.ferry/agent.js
+++ b/.ferry/agent.js
@@ -373,6 +373,8 @@ import { appendFileSync } from "node:fs";
 // src/lib/llm/pricing.ts
 var EUR_TO_USD = 1 / 0.93;
 var RATES = {
+  "anthropic/claude-opus-4-8": { inputPer1M: 4.65, outputPer1M: 23.25 },
+  "anthropic/claude-sonnet-5": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },
   "anthropic/claude-haiku": { inputPer1M: 0.23, outputPer1M: 1.16 },
@@ -602,10 +604,10 @@ import { createRequire as createRequire2 } from "node:module";
 var _require2 = createRequire2(import.meta.url);
 var DEFAULT_FERRY_CONFIG = {
   models: {
-    refiner: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    dev: { provider: "anthropic", model: "claude-opus-4-5" },
-    review: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    iterate: { provider: "anthropic", model: "claude-sonnet-4-6" }
+    refiner: { provider: "anthropic", model: "claude-opus-4-8" },
+    dev: { provider: "anthropic", model: "claude-sonnet-5" },
+    review: { provider: "anthropic", model: "claude-opus-4-8" },
+    iterate: { provider: "anthropic", model: "claude-sonnet-5" }
   },
   limits: {
     max_iterations: 3,

--- a/.ferry/ci-gate-action.js
+++ b/.ferry/ci-gate-action.js
@@ -3810,10 +3810,10 @@ var FerryError = class extends Error {
 var _require = createRequire(import.meta.url);
 var DEFAULT_FERRY_CONFIG = {
   models: {
-    refiner: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    dev: { provider: "anthropic", model: "claude-opus-4-5" },
-    review: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    iterate: { provider: "anthropic", model: "claude-sonnet-4-6" }
+    refiner: { provider: "anthropic", model: "claude-opus-4-8" },
+    dev: { provider: "anthropic", model: "claude-sonnet-5" },
+    review: { provider: "anthropic", model: "claude-opus-4-8" },
+    iterate: { provider: "anthropic", model: "claude-sonnet-5" }
   },
   limits: {
     max_iterations: 3,

--- a/.ferry/route-action.js
+++ b/.ferry/route-action.js
@@ -181,10 +181,10 @@ import { createRequire as createRequire2 } from "node:module";
 var _require2 = createRequire2(import.meta.url);
 var DEFAULT_FERRY_CONFIG = {
   models: {
-    refiner: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    dev: { provider: "anthropic", model: "claude-opus-4-5" },
-    review: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    iterate: { provider: "anthropic", model: "claude-sonnet-4-6" }
+    refiner: { provider: "anthropic", model: "claude-opus-4-8" },
+    dev: { provider: "anthropic", model: "claude-sonnet-5" },
+    review: { provider: "anthropic", model: "claude-opus-4-8" },
+    iterate: { provider: "anthropic", model: "claude-sonnet-5" }
   },
   limits: {
     max_iterations: 3,

--- a/.github/actions/ferry-ci-gate/ci-gate-action.js
+++ b/.github/actions/ferry-ci-gate/ci-gate-action.js
@@ -3810,10 +3810,10 @@ var FerryError = class extends Error {
 var _require = createRequire(import.meta.url);
 var DEFAULT_FERRY_CONFIG = {
   models: {
-    refiner: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    dev: { provider: "anthropic", model: "claude-opus-4-5" },
-    review: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    iterate: { provider: "anthropic", model: "claude-sonnet-4-6" }
+    refiner: { provider: "anthropic", model: "claude-opus-4-8" },
+    dev: { provider: "anthropic", model: "claude-sonnet-5" },
+    review: { provider: "anthropic", model: "claude-opus-4-8" },
+    iterate: { provider: "anthropic", model: "claude-sonnet-5" }
   },
   limits: {
     max_iterations: 3,

--- a/.github/actions/ferry-route/route-action.js
+++ b/.github/actions/ferry-route/route-action.js
@@ -181,10 +181,10 @@ import { createRequire as createRequire2 } from "node:module";
 var _require2 = createRequire2(import.meta.url);
 var DEFAULT_FERRY_CONFIG = {
   models: {
-    refiner: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    dev: { provider: "anthropic", model: "claude-opus-4-5" },
-    review: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    iterate: { provider: "anthropic", model: "claude-sonnet-4-6" }
+    refiner: { provider: "anthropic", model: "claude-opus-4-8" },
+    dev: { provider: "anthropic", model: "claude-sonnet-5" },
+    review: { provider: "anthropic", model: "claude-opus-4-8" },
+    iterate: { provider: "anthropic", model: "claude-sonnet-5" }
   },
   limits: {
     max_iterations: 3,

--- a/.github/actions/ferry-run-claude-agent/action.yml
+++ b/.github/actions/ferry-run-claude-agent/action.yml
@@ -35,7 +35,7 @@ inputs:
   model:
     description: Model id passed to --model
     required: false
-    default: claude-sonnet-4-6
+    default: claude-sonnet-5
   integration_branch:
     description: Branch refiner/dev check out (the base for new work)
     required: false

--- a/.github/actions/ferry-run-developer/agent.js
+++ b/.github/actions/ferry-run-developer/agent.js
@@ -373,6 +373,8 @@ import { appendFileSync } from "node:fs";
 // src/lib/llm/pricing.ts
 var EUR_TO_USD = 1 / 0.93;
 var RATES = {
+  "anthropic/claude-opus-4-8": { inputPer1M: 4.65, outputPer1M: 23.25 },
+  "anthropic/claude-sonnet-5": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },
   "anthropic/claude-haiku": { inputPer1M: 0.23, outputPer1M: 1.16 },
@@ -602,10 +604,10 @@ import { createRequire as createRequire2 } from "node:module";
 var _require2 = createRequire2(import.meta.url);
 var DEFAULT_FERRY_CONFIG = {
   models: {
-    refiner: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    dev: { provider: "anthropic", model: "claude-opus-4-5" },
-    review: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    iterate: { provider: "anthropic", model: "claude-sonnet-4-6" }
+    refiner: { provider: "anthropic", model: "claude-opus-4-8" },
+    dev: { provider: "anthropic", model: "claude-sonnet-5" },
+    review: { provider: "anthropic", model: "claude-opus-4-8" },
+    iterate: { provider: "anthropic", model: "claude-sonnet-5" }
   },
   limits: {
     max_iterations: 3,

--- a/.github/actions/ferry-run-iterator/agent.js
+++ b/.github/actions/ferry-run-iterator/agent.js
@@ -373,6 +373,8 @@ import { appendFileSync } from "node:fs";
 // src/lib/llm/pricing.ts
 var EUR_TO_USD = 1 / 0.93;
 var RATES = {
+  "anthropic/claude-opus-4-8": { inputPer1M: 4.65, outputPer1M: 23.25 },
+  "anthropic/claude-sonnet-5": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },
   "anthropic/claude-haiku": { inputPer1M: 0.23, outputPer1M: 1.16 },
@@ -602,10 +604,10 @@ import { createRequire as createRequire2 } from "node:module";
 var _require2 = createRequire2(import.meta.url);
 var DEFAULT_FERRY_CONFIG = {
   models: {
-    refiner: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    dev: { provider: "anthropic", model: "claude-opus-4-5" },
-    review: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    iterate: { provider: "anthropic", model: "claude-sonnet-4-6" }
+    refiner: { provider: "anthropic", model: "claude-opus-4-8" },
+    dev: { provider: "anthropic", model: "claude-sonnet-5" },
+    review: { provider: "anthropic", model: "claude-opus-4-8" },
+    iterate: { provider: "anthropic", model: "claude-sonnet-5" }
   },
   limits: {
     max_iterations: 3,

--- a/.github/actions/ferry-run-merger/agent.js
+++ b/.github/actions/ferry-run-merger/agent.js
@@ -373,6 +373,8 @@ import { appendFileSync } from "node:fs";
 // src/lib/llm/pricing.ts
 var EUR_TO_USD = 1 / 0.93;
 var RATES = {
+  "anthropic/claude-opus-4-8": { inputPer1M: 4.65, outputPer1M: 23.25 },
+  "anthropic/claude-sonnet-5": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },
   "anthropic/claude-haiku": { inputPer1M: 0.23, outputPer1M: 1.16 },
@@ -602,10 +604,10 @@ import { createRequire as createRequire2 } from "node:module";
 var _require2 = createRequire2(import.meta.url);
 var DEFAULT_FERRY_CONFIG = {
   models: {
-    refiner: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    dev: { provider: "anthropic", model: "claude-opus-4-5" },
-    review: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    iterate: { provider: "anthropic", model: "claude-sonnet-4-6" }
+    refiner: { provider: "anthropic", model: "claude-opus-4-8" },
+    dev: { provider: "anthropic", model: "claude-sonnet-5" },
+    review: { provider: "anthropic", model: "claude-opus-4-8" },
+    iterate: { provider: "anthropic", model: "claude-sonnet-5" }
   },
   limits: {
     max_iterations: 3,

--- a/.github/actions/ferry-run-refiner/agent.js
+++ b/.github/actions/ferry-run-refiner/agent.js
@@ -373,6 +373,8 @@ import { appendFileSync } from "node:fs";
 // src/lib/llm/pricing.ts
 var EUR_TO_USD = 1 / 0.93;
 var RATES = {
+  "anthropic/claude-opus-4-8": { inputPer1M: 4.65, outputPer1M: 23.25 },
+  "anthropic/claude-sonnet-5": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },
   "anthropic/claude-haiku": { inputPer1M: 0.23, outputPer1M: 1.16 },
@@ -602,10 +604,10 @@ import { createRequire as createRequire2 } from "node:module";
 var _require2 = createRequire2(import.meta.url);
 var DEFAULT_FERRY_CONFIG = {
   models: {
-    refiner: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    dev: { provider: "anthropic", model: "claude-opus-4-5" },
-    review: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    iterate: { provider: "anthropic", model: "claude-sonnet-4-6" }
+    refiner: { provider: "anthropic", model: "claude-opus-4-8" },
+    dev: { provider: "anthropic", model: "claude-sonnet-5" },
+    review: { provider: "anthropic", model: "claude-opus-4-8" },
+    iterate: { provider: "anthropic", model: "claude-sonnet-5" }
   },
   limits: {
     max_iterations: 3,

--- a/.github/actions/ferry-run-reviewer/agent.js
+++ b/.github/actions/ferry-run-reviewer/agent.js
@@ -373,6 +373,8 @@ import { appendFileSync } from "node:fs";
 // src/lib/llm/pricing.ts
 var EUR_TO_USD = 1 / 0.93;
 var RATES = {
+  "anthropic/claude-opus-4-8": { inputPer1M: 4.65, outputPer1M: 23.25 },
+  "anthropic/claude-sonnet-5": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-sonnet-4-6": { inputPer1M: 2.79, outputPer1M: 13.95 },
   "anthropic/claude-opus": { inputPer1M: 13.95, outputPer1M: 69.75 },
   "anthropic/claude-haiku": { inputPer1M: 0.23, outputPer1M: 1.16 },
@@ -602,10 +604,10 @@ import { createRequire as createRequire2 } from "node:module";
 var _require2 = createRequire2(import.meta.url);
 var DEFAULT_FERRY_CONFIG = {
   models: {
-    refiner: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    dev: { provider: "anthropic", model: "claude-opus-4-5" },
-    review: { provider: "anthropic", model: "claude-sonnet-4-6" },
-    iterate: { provider: "anthropic", model: "claude-sonnet-4-6" }
+    refiner: { provider: "anthropic", model: "claude-opus-4-8" },
+    dev: { provider: "anthropic", model: "claude-sonnet-5" },
+    review: { provider: "anthropic", model: "claude-opus-4-8" },
+    iterate: { provider: "anthropic", model: "claude-sonnet-5" }
   },
   limits: {
     max_iterations: 3,

--- a/.github/workflows/ferry-router.yml
+++ b/.github/workflows/ferry-router.yml
@@ -16,7 +16,8 @@
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_INTEGRATION_BRANCH (default: main)
 #                     FERRY_REFINER_MODEL / FERRY_DEV_MODEL / FERRY_REVIEW_MODEL /
-#                     FERRY_ITER_MODEL / FERRY_MERGER_MODEL (default: claude-sonnet-4-6)
+#                     FERRY_ITER_MODEL / FERRY_MERGER_MODEL (defaults: claude-opus-4-8
+#                     for refiner/reviewer/merger, claude-sonnet-5 for developer/iterator)
 #                     FERRY_PRE_AGENT_COMMAND (dependency bootstrap, e.g. "npm ci")
 #                     FERRY_EXTRA_CLAUDE_ARGS (extra claude_args, e.g. more --mcp-config)
 #                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array)
@@ -147,7 +148,7 @@ jobs:
           jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
           jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
           jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
-          model: ${{ vars[needs.route.outputs.model_var] || 'claude-sonnet-4-6' }}
+          model: ${{ vars[needs.route.outputs.model_var] || (contains(fromJSON('["refiner","reviewer","merger"]'), needs.route.outputs.role) && 'claude-opus-4-8' || 'claude-sonnet-5') }}
           integration_branch: ${{ vars.FERRY_INTEGRATION_BRANCH || 'main' }}
           checkout_token: ${{ secrets.FERRY_CHECKOUT_TOKEN }}
           review_transition_id: ${{ secrets.FERRY_REVIEW_TRANSITION_ID }}
@@ -189,7 +190,7 @@ jobs:
           ticket: ${{ github.event.client_payload.ticket_key }}
           phase: ${{ needs.route.outputs.phase }}
           run_id: ${{ github.event.client_payload.event_id }}
-          model: ${{ vars[needs.route.outputs.model_var] || 'claude-sonnet-4-6' }}
+          model: ${{ vars[needs.route.outputs.model_var] || (contains(fromJSON('["refiner","reviewer","merger"]'), needs.route.outputs.role) && 'claude-opus-4-8' || 'claude-sonnet-5') }}
           outcome: ${{ (needs.ci-gate.result != 'skipped' && needs.ci-gate.outputs.outcome == 'ci-red' && 'ci-red') || needs.run-agent.result }}
           # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
           input_tokens: '0'

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -74,19 +74,19 @@ All variables marked **wired** below are read directly by the standard consumer 
 
 #### Model and provider overrides
 
-| Variable                 | Default             | Wired?          | Affects         | Description                                                                                                                                                                |
-| ------------------------ | ------------------- | --------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `FERRY_DEV_MODEL`        | `claude-sonnet-4-6` | yes (`dev`)     | Developer agent | Override the model ID for the Developer. Wired via the `ferry_dev_model` composite action input.                                                                           |
-| `FERRY_DEV_PROVIDER`     | `anthropic`         | yes (`dev`)     | Developer agent | LLM provider override for the Developer (`anthropic` / `openai` / `google`). MCP integration requires `anthropic`.                                                         |
-| `FERRY_REVIEW_MODEL`     | `claude-sonnet-4-6` | yes (`review`)  | Reviewer agent  | Override the model ID for the Reviewer. Wired via the `ferry_review_model` composite action input.                                                                         |
-| `FERRY_REVIEW_PROVIDER`  | `anthropic`         | yes (`review`)  | Reviewer agent  | LLM provider override for the Reviewer (`anthropic` / `openai` / `google`). MCP integration requires `anthropic`.                                                          |
-| `FERRY_ITER_MODEL`       | `claude-sonnet-4-6` | yes (`iterate`) | Iterator agent  | Override the model ID for the Iterator. Wired via the `ferry_iter_model` composite action input.                                                                           |
-| `FERRY_ITER_PROVIDER`    | `anthropic`         | yes (`iterate`) | Iterator agent  | LLM provider override for the Iterator (`anthropic` / `openai` / `google`). MCP integration requires `anthropic`.                                                          |
-| `FERRY_REFINER_MODEL`    | `claude-sonnet-4-6` | yes (`refine`)  | Refiner agent   | Override the model ID for the Refiner. Wired via the `ferry_refiner_model` composite action input.                                                                         |
-| `FERRY_REFINER_PROVIDER` | `anthropic`         | yes (`refine`)  | Refiner agent   | LLM provider override for the Refiner (`anthropic` / `openai` / `google`).                                                                                                 |
-| `FERRY_MERGER_MODEL`     | `claude-sonnet-4-6` | yes (`merge`)   | Merger agent    | Override the model ID used by the Merger when generating a squash commit message. Wired via the `ferry_merger_model` composite action input.                               |
-| `FERRY_MERGER_PROVIDER`  | `anthropic`         | yes (`merge`)   | Merger agent    | LLM provider override for the Merger (`anthropic` / `openai` / `google`).                                                                                                  |
-| `FERRY_MERGE_STRATEGY`   | `squash`            | yes (`merge`)   | Merger agent    | Merge strategy passed to `gh pr merge`. Accepted values: `squash`, `merge`, `rebase`. Default `squash` keeps a linear history and folds sub-task commits into one message. |
+| Variable                 | Default           | Wired?          | Affects         | Description                                                                                                                                                                |
+| ------------------------ | ----------------- | --------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FERRY_DEV_MODEL`        | `claude-sonnet-5` | yes (`dev`)     | Developer agent | Override the model ID for the Developer. Wired via the `ferry_dev_model` composite action input.                                                                           |
+| `FERRY_DEV_PROVIDER`     | `anthropic`       | yes (`dev`)     | Developer agent | LLM provider override for the Developer (`anthropic` / `openai` / `google`). MCP integration requires `anthropic`.                                                         |
+| `FERRY_REVIEW_MODEL`     | `claude-opus-4-8` | yes (`review`)  | Reviewer agent  | Override the model ID for the Reviewer. Wired via the `ferry_review_model` composite action input.                                                                         |
+| `FERRY_REVIEW_PROVIDER`  | `anthropic`       | yes (`review`)  | Reviewer agent  | LLM provider override for the Reviewer (`anthropic` / `openai` / `google`). MCP integration requires `anthropic`.                                                          |
+| `FERRY_ITER_MODEL`       | `claude-sonnet-5` | yes (`iterate`) | Iterator agent  | Override the model ID for the Iterator. Wired via the `ferry_iter_model` composite action input.                                                                           |
+| `FERRY_ITER_PROVIDER`    | `anthropic`       | yes (`iterate`) | Iterator agent  | LLM provider override for the Iterator (`anthropic` / `openai` / `google`). MCP integration requires `anthropic`.                                                          |
+| `FERRY_REFINER_MODEL`    | `claude-opus-4-8` | yes (`refine`)  | Refiner agent   | Override the model ID for the Refiner. Wired via the `ferry_refiner_model` composite action input.                                                                         |
+| `FERRY_REFINER_PROVIDER` | `anthropic`       | yes (`refine`)  | Refiner agent   | LLM provider override for the Refiner (`anthropic` / `openai` / `google`).                                                                                                 |
+| `FERRY_MERGER_MODEL`     | `claude-opus-4-8` | yes (`merge`)   | Merger agent    | Override the model ID used by the Merger when generating a squash commit message. Wired via the `ferry_merger_model` composite action input.                               |
+| `FERRY_MERGER_PROVIDER`  | `anthropic`       | yes (`merge`)   | Merger agent    | LLM provider override for the Merger (`anthropic` / `openai` / `google`).                                                                                                  |
+| `FERRY_MERGE_STRATEGY`   | `squash`          | yes (`merge`)   | Merger agent    | Merge strategy passed to `gh pr merge`. Accepted values: `squash`, `merge`, `rebase`. Default `squash` keeps a linear history and folds sub-task commits into one message. |
 
 #### Token and iteration limits
 
@@ -240,19 +240,19 @@ Ferry reads the config file from `GITHUB_WORKSPACE` (the checked-out repo root) 
   "models": {
     "refiner": {
       "provider": "anthropic",
-      "model": "claude-sonnet-4-6"
+      "model": "claude-opus-4-8"
     },
     "dev": {
       "provider": "anthropic",
-      "model": "claude-sonnet-4-6"
+      "model": "claude-sonnet-5"
     },
     "review": {
       "provider": "anthropic",
-      "model": "claude-sonnet-4-6"
+      "model": "claude-opus-4-8"
     },
     "iterate": {
       "provider": "anthropic",
-      "model": "claude-sonnet-4-6"
+      "model": "claude-sonnet-5"
     }
   },
   "limits": {
@@ -311,15 +311,15 @@ Ferry supports three LLM providers: **`anthropic`**, **`openai`**, and **`google
 | Cache-weighted token budget   | ✅          | ❌ (raw token sum) | ❌ (raw token sum) |
 | Expected cost per long run    | Baseline    | ~2–3× higher       | ~2–3× higher       |
 
-**Expected cost differential (approximate, relative to `claude-sonnet-4-6`):**
+**Expected cost differential (approximate, relative to `claude-sonnet-5`):**
 
-| Provider / model                  | Relative cost | Notes                                                    |
-| --------------------------------- | :-----------: | -------------------------------------------------------- |
-| `anthropic` / `claude-sonnet-4-6` |   baseline    | Recommended; prompt caching reduces repeat costs by ~80% |
-| `openai` / `gpt-4o`               |     ~1–2×     | No caching discount; good for refiner single-turn use    |
-| `openai` / `gpt-4o-mini`          |     ~0.2×     | Cost-effective for light refiner tasks                   |
-| `google` / `gemini-2.5-pro`       |    ~0.5–1×    | Competitive for long-context refiner calls               |
-| `google` / `gemini-2.5-flash`     |    ~0.05×     | Very low cost; good for high-volume refinement           |
+| Provider / model                | Relative cost | Notes                                                    |
+| ------------------------------- | :-----------: | -------------------------------------------------------- |
+| `anthropic` / `claude-sonnet-5` |   baseline    | Recommended; prompt caching reduces repeat costs by ~80% |
+| `openai` / `gpt-4o`             |     ~1–2×     | No caching discount; good for refiner single-turn use    |
+| `openai` / `gpt-4o-mini`        |     ~0.2×     | Cost-effective for light refiner tasks                   |
+| `google` / `gemini-2.5-pro`     |    ~0.5–1×    | Competitive for long-context refiner calls               |
+| `google` / `gemini-2.5-flash`   |    ~0.05×     | Very low cost; good for high-volume refinement           |
 
 > **HTTP MCP:** Anthropic's HTTP MCP beta connector (`type: url` servers in `AGENT_MCP_SERVERS`) is Anthropic-only. Configuring an HTTP MCP server for an OpenAI or Google run raises a hard error at startup. Use stdio MCP servers for cross-provider compatibility.
 >
@@ -329,16 +329,16 @@ Ferry supports three LLM providers: **`anthropic`**, **`openai`**, and **`google
 >
 > **MCP availability:** Even with `provider: anthropic`, only the Developer and Iterator agents load MCP servers from `AGENT_MCP_SERVERS`. The Refiner and Reviewer ignore MCP configuration regardless of provider.
 
-| Field                     | Default               | Description                                                                                                                                      |
-| ------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `models.refiner.provider` | `"anthropic"`         | LLM provider for the Refiner. Accepts `"anthropic"`, `"openai"`, or `"google"`.                                                                  |
-| `models.refiner.model`    | `"claude-sonnet-4-6"` | Model ID for the Refiner (overridden by `FERRY_REFINER_MODEL`). Use a model ID valid for your chosen provider (e.g. `gpt-4o`, `gemini-2.5-pro`). |
-| `models.dev.provider`     | `"anthropic"`         | LLM provider for the Developer. Accepts `"anthropic"`, `"openai"`, or `"google"`. Note: MCP server integration requires `"anthropic"`.           |
-| `models.dev.model`        | `"claude-sonnet-4-6"` | Model ID for the Developer (overridden by `FERRY_DEV_MODEL`). Use a model ID matching your chosen provider.                                      |
-| `models.review.provider`  | `"anthropic"`         | LLM provider for the Reviewer. Accepts `"anthropic"`, `"openai"`, or `"google"`. Note: MCP server integration requires `"anthropic"`.            |
-| `models.review.model`     | `"claude-sonnet-4-6"` | Model ID for the Reviewer (overridden by `FERRY_REVIEW_MODEL`). Use a model ID matching your chosen provider.                                    |
-| `models.iterate.provider` | `"anthropic"`         | LLM provider for the Iterator. Accepts `"anthropic"`, `"openai"`, or `"google"`. Note: MCP server integration requires `"anthropic"`.            |
-| `models.iterate.model`    | `"claude-sonnet-4-6"` | Model ID for the Iterator (overridden by `FERRY_ITER_MODEL`). Use a model ID matching your chosen provider.                                      |
+| Field                     | Default             | Description                                                                                                                                      |
+| ------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `models.refiner.provider` | `"anthropic"`       | LLM provider for the Refiner. Accepts `"anthropic"`, `"openai"`, or `"google"`.                                                                  |
+| `models.refiner.model`    | `"claude-opus-4-8"` | Model ID for the Refiner (overridden by `FERRY_REFINER_MODEL`). Use a model ID valid for your chosen provider (e.g. `gpt-4o`, `gemini-2.5-pro`). |
+| `models.dev.provider`     | `"anthropic"`       | LLM provider for the Developer. Accepts `"anthropic"`, `"openai"`, or `"google"`. Note: MCP server integration requires `"anthropic"`.           |
+| `models.dev.model`        | `"claude-sonnet-5"` | Model ID for the Developer (overridden by `FERRY_DEV_MODEL`). Use a model ID matching your chosen provider.                                      |
+| `models.review.provider`  | `"anthropic"`       | LLM provider for the Reviewer. Accepts `"anthropic"`, `"openai"`, or `"google"`. Note: MCP server integration requires `"anthropic"`.            |
+| `models.review.model`     | `"claude-opus-4-8"` | Model ID for the Reviewer (overridden by `FERRY_REVIEW_MODEL`). Use a model ID matching your chosen provider.                                    |
+| `models.iterate.provider` | `"anthropic"`       | LLM provider for the Iterator. Accepts `"anthropic"`, `"openai"`, or `"google"`. Note: MCP server integration requires `"anthropic"`.            |
+| `models.iterate.model`    | `"claude-sonnet-5"` | Model ID for the Iterator (overridden by `FERRY_ITER_MODEL`). Use a model ID matching your chosen provider.                                      |
 
 #### `limits`
 
@@ -933,7 +933,7 @@ Router workflow settings (all optional):
 | `FERRY_EXTRA_CLAUDE_ARGS`  | variable | _(empty)_          | Extra flags appended verbatim to `claude_args` — e.g. additional `--mcp-config '<json>'` blocks for consumer MCP servers.                                             |
 | `FERRY_CHECKOUT_TOKEN`     | secret   | _(workflow token)_ | PAT or App token used for checkout — and therefore for agent pushes — so pushed commits re-trigger CI: a `github-actions[bot]` push suppresses `pull_request` events. |
 
-Per-role models still come from `FERRY_REFINER_MODEL` / `FERRY_DEV_MODEL` / `FERRY_REVIEW_MODEL` / `FERRY_ITER_MODEL` / `FERRY_MERGER_MODEL` (default `claude-sonnet-4-6`) — the router picks the variable matching the resolved role. The `FERRY_REVIEW_TRANSITION_ID` / `FERRY_ITER_TRANSITION_ID` / `FERRY_APPROVE_TRANSITION_ID` secrets are optional overrides here: the composite auto-resolves those transition ids from the `workflow.agents.*` status names. The merger's post-merge move is the exception — on the claude-code path the agent name-matches a "Done"/"Closed" transition itself (see the Merger section); `auto_transition_done` and `FERRY_MERGE_DONE_TRANSITION_ID` apply to the script path.
+Per-role models still come from `FERRY_REFINER_MODEL` / `FERRY_DEV_MODEL` / `FERRY_REVIEW_MODEL` / `FERRY_ITER_MODEL` / `FERRY_MERGER_MODEL` (defaults: `claude-opus-4-8` for refiner/reviewer/merger, `claude-sonnet-5` for developer/iterator) — the router picks the variable matching the resolved role. The `FERRY_REVIEW_TRANSITION_ID` / `FERRY_ITER_TRANSITION_ID` / `FERRY_APPROVE_TRANSITION_ID` secrets are optional overrides here: the composite auto-resolves those transition ids from the `workflow.agents.*` status names. The merger's post-merge move is the exception — on the claude-code path the agent name-matches a "Done"/"Closed" transition itself (see the Merger section); `auto_transition_done` and `FERRY_MERGE_DONE_TRANSITION_ID` apply to the script path.
 
 ### How the codex-cli path runs
 
@@ -1020,12 +1020,12 @@ Run `ferry-update` to add the workflow stub automatically, or copy `examples/con
 
 ### Configuration
 
-| Setting                                   | Type     | Default             | Description                                                                                                                                                                                                                                                      |
-| ----------------------------------------- | -------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `FERRY_MERGE_STRATEGY` (var)              | variable | `squash`            | Merge strategy: `squash`, `merge`, or `rebase`. Passed directly to `gh pr merge`.                                                                                                                                                                                |
-| `FERRY_MERGER_MODEL` (var)                | variable | `claude-sonnet-4-6` | LLM model used to generate the squash commit message. Ignored when `FERRY_MERGE_STRATEGY` is not `squash`.                                                                                                                                                       |
-| `FERRY_MERGER_PROVIDER` (var)             | variable | `anthropic`         | LLM provider for commit-message generation (`anthropic` / `openai` / `google`). Ignored when `FERRY_MERGE_STRATEGY` is not `squash`.                                                                                                                             |
-| `FERRY_MERGE_DONE_TRANSITION_ID` (secret) | secret   | _(none)_            | **Optional override, script path.** Explicit Jira transition id for the post-merge move. Auto-resolved from `workflow.agents.merger.auto_transition_done` when unset (default `null` — the column is left unchanged post-merge). Unread on the claude-code path. |
+| Setting                                   | Type     | Default           | Description                                                                                                                                                                                                                                                      |
+| ----------------------------------------- | -------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `FERRY_MERGE_STRATEGY` (var)              | variable | `squash`          | Merge strategy: `squash`, `merge`, or `rebase`. Passed directly to `gh pr merge`.                                                                                                                                                                                |
+| `FERRY_MERGER_MODEL` (var)                | variable | `claude-opus-4-8` | LLM model used to generate the squash commit message. Ignored when `FERRY_MERGE_STRATEGY` is not `squash`.                                                                                                                                                       |
+| `FERRY_MERGER_PROVIDER` (var)             | variable | `anthropic`       | LLM provider for commit-message generation (`anthropic` / `openai` / `google`). Ignored when `FERRY_MERGE_STRATEGY` is not `squash`.                                                                                                                             |
+| `FERRY_MERGE_DONE_TRANSITION_ID` (secret) | secret   | _(none)_          | **Optional override, script path.** Explicit Jira transition id for the post-merge move. Auto-resolved from `workflow.agents.merger.auto_transition_done` when unset (default `null` — the column is left unchanged post-merge). Unread on the claude-code path. |
 
 Wiring caveats — only `FERRY_MERGER_MODEL` is wired into the `ferry-merge.yml` stub (passed as the composite's `ferry_merger_model` input):
 

--- a/examples/consumer-setup-gitlab/dev.gitlab-ci.yml
+++ b/examples/consumer-setup-gitlab/dev.gitlab-ci.yml
@@ -8,7 +8,7 @@ ferry-dev:
     - if: '$FERRY_DISPATCH_TYPE == "ferry-dev"'
   variables:
     FERRY_AGENT_ROLE: developer
-    FERRY_DEV_MODEL: ${FERRY_DEV_MODEL:-claude-sonnet-4-6}
+    FERRY_DEV_MODEL: ${FERRY_DEV_MODEL:-claude-sonnet-5}
   script:
     - apk add --no-cache git
     - npm install -g "@big-emotion/ferry@${FERRY_VERSION}"

--- a/examples/consumer-setup-gitlab/iterate.gitlab-ci.yml
+++ b/examples/consumer-setup-gitlab/iterate.gitlab-ci.yml
@@ -8,7 +8,7 @@ ferry-iterate:
     - if: '$FERRY_DISPATCH_TYPE == "ferry-iterate"'
   variables:
     FERRY_AGENT_ROLE: iterator
-    FERRY_ITER_MODEL: ${FERRY_ITER_MODEL:-claude-sonnet-4-6}
+    FERRY_ITER_MODEL: ${FERRY_ITER_MODEL:-claude-sonnet-5}
   script:
     - apk add --no-cache git
     - npm install -g "@big-emotion/ferry@${FERRY_VERSION}"

--- a/examples/consumer-setup-gitlab/refine.gitlab-ci.yml
+++ b/examples/consumer-setup-gitlab/refine.gitlab-ci.yml
@@ -9,7 +9,7 @@ ferry-refine:
     - if: '$FERRY_DISPATCH_TYPE == "ferry-refine"'
   variables:
     FERRY_AGENT_ROLE: refiner
-    FERRY_REFINER_MODEL: ${FERRY_REFINER_MODEL:-claude-sonnet-4-6}
+    FERRY_REFINER_MODEL: ${FERRY_REFINER_MODEL:-claude-opus-4-8}
   script:
     - npm install -g "@big-emotion/ferry@${FERRY_VERSION}"
     - ferry-agent run --role refiner

--- a/examples/consumer-setup-gitlab/review.gitlab-ci.yml
+++ b/examples/consumer-setup-gitlab/review.gitlab-ci.yml
@@ -8,7 +8,7 @@ ferry-review:
     - if: '$FERRY_DISPATCH_TYPE == "ferry-review"'
   variables:
     FERRY_AGENT_ROLE: reviewer
-    FERRY_REVIEW_MODEL: ${FERRY_REVIEW_MODEL:-claude-sonnet-4-6}
+    FERRY_REVIEW_MODEL: ${FERRY_REVIEW_MODEL:-claude-opus-4-8}
   script:
     - npm install -g "@big-emotion/ferry@${FERRY_VERSION}"
     - ferry-agent run --role reviewer

--- a/examples/consumer-setup/workflows/ferry-dev.yml
+++ b/examples/consumer-setup/workflows/ferry-dev.yml
@@ -8,7 +8,7 @@
 #                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
 #                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path).
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
-# Optional variables: FERRY_DEV_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+# Optional variables: FERRY_DEV_MODEL (default: claude-sonnet-5; use model ID matching your provider)
 #                     FERRY_DEV_PROVIDER (default: anthropic; also: openai, google)
 #                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 #
@@ -114,7 +114,7 @@ jobs:
           google_api_key: ${{ secrets.GOOGLE_API_KEY }}
           github_token: ${{ github.token }}
           github_repo: ${{ github.repository }}
-          ferry_dev_model: ${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-4-6' }}
+          ferry_dev_model: ${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-5' }}
           ferry_dev_provider: ${{ vars.FERRY_DEV_PROVIDER }}
           ferry_dev_max_input_tokens: ${{ vars.FERRY_DEV_MAX_INPUT_TOKENS }}
           ferry_dev_max_tokens: ${{ vars.FERRY_DEV_MAX_TOKENS }}
@@ -163,7 +163,7 @@ jobs:
             --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@v1.1.1","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
             --permission-mode acceptEdits
             --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
-            --model ${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-4-6' }}
+            --model ${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-5' }}
 
   emit-audit:
     name: Emit audit line
@@ -182,7 +182,7 @@ jobs:
           ticket: ${{ github.event.client_payload.ticket_key }}
           phase: dev
           run_id: ${{ github.event.client_payload.event_id }}
-          model: ${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-4-6' }}
+          model: ${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-5' }}
           outcome: ${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
           # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
           input_tokens: ${{ needs.run-agent.outputs.input_tokens || '0' }}

--- a/examples/consumer-setup/workflows/ferry-iterate.yml
+++ b/examples/consumer-setup/workflows/ferry-iterate.yml
@@ -8,7 +8,7 @@
 #                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
 #                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path).
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
-# Optional variables: FERRY_ITER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+# Optional variables: FERRY_ITER_MODEL (default: claude-sonnet-5; use model ID matching your provider)
 #                     FERRY_ITER_PROVIDER (default: anthropic; also: openai, google)
 #                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 #
@@ -118,7 +118,7 @@ jobs:
           google_api_key: ${{ secrets.GOOGLE_API_KEY }}
           github_token: ${{ github.token }}
           github_repo: ${{ github.repository }}
-          ferry_iter_model: ${{ vars.FERRY_ITER_MODEL || 'claude-sonnet-4-6' }}
+          ferry_iter_model: ${{ vars.FERRY_ITER_MODEL || 'claude-sonnet-5' }}
           ferry_iter_provider: ${{ vars.FERRY_ITER_PROVIDER }}
           ferry_iter_max_input_tokens: ${{ vars.FERRY_ITER_MAX_INPUT_TOKENS || '500000' }}
           ferry_dev_max_tokens: ${{ vars.FERRY_DEV_MAX_TOKENS }}
@@ -167,7 +167,7 @@ jobs:
             --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@v1.1.1","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
             --permission-mode acceptEdits
             --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
-            --model ${{ vars.FERRY_ITER_MODEL || 'claude-sonnet-4-6' }}
+            --model ${{ vars.FERRY_ITER_MODEL || 'claude-sonnet-5' }}
 
   emit-audit:
     name: Emit audit line
@@ -186,7 +186,7 @@ jobs:
           ticket: ${{ github.event.client_payload.ticket_key }}
           phase: iterate
           run_id: ${{ github.event.client_payload.event_id }}
-          model: ${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
+          model: ${{ needs.run-agent.outputs.model || 'claude-sonnet-5' }}
           outcome: ${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
           # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
           input_tokens: ${{ needs.run-agent.outputs.input_tokens || '0' }}

--- a/examples/consumer-setup/workflows/ferry-merge.yml
+++ b/examples/consumer-setup/workflows/ferry-merge.yml
@@ -7,7 +7,7 @@
 #                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
 #                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path).
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
-# Optional variables: FERRY_MERGER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+# Optional variables: FERRY_MERGER_MODEL (default: claude-opus-4-8; use model ID matching your provider)
 #                     FERRY_MERGER_PROVIDER (default: anthropic; also: openai, google)
 #                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 # claude-code path:   When execution_path=claude-code the Merger runs as ONE direct
@@ -25,7 +25,7 @@
 #                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path)
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_MERGER_PROVIDER (default: anthropic; also: openai, google)
-#                     FERRY_MERGER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#                     FERRY_MERGER_MODEL (default: claude-opus-4-8; use model ID matching your provider)
 #                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 
 name: Ferry — Merge
@@ -107,7 +107,7 @@ jobs:
           google_api_key: ${{ secrets.GOOGLE_API_KEY }}
           github_token: ${{ github.token }}
           github_repo: ${{ github.repository }}
-          ferry_merger_model: ${{ vars.FERRY_MERGER_MODEL || 'claude-sonnet-4-6' }}
+          ferry_merger_model: ${{ vars.FERRY_MERGER_MODEL || 'claude-opus-4-8' }}
 
   run-agent-claude-code:
     name: Run Merger agent (claude-code path)
@@ -144,7 +144,7 @@ jobs:
             --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@v1.1.1","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
             --permission-mode bypassPermissions
             --disallowedTools 'Bash(gh pr close),Bash(gh pr close:*)'
-            --model ${{ vars.FERRY_MERGER_MODEL || 'claude-sonnet-4-6' }}
+            --model ${{ vars.FERRY_MERGER_MODEL || 'claude-opus-4-8' }}
 
   emit-audit:
     name: Emit audit line
@@ -163,7 +163,7 @@ jobs:
           ticket: ${{ github.event.client_payload.ticket_key }}
           phase: merge
           run_id: ${{ github.event.client_payload.event_id }}
-          model: ${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
+          model: ${{ needs.run-agent.outputs.model || 'claude-opus-4-8' }}
           outcome: ${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
           # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
           input_tokens: ${{ needs.run-agent.outputs.input_tokens || '0' }}

--- a/examples/consumer-setup/workflows/ferry-refine.yml
+++ b/examples/consumer-setup/workflows/ferry-refine.yml
@@ -7,7 +7,7 @@
 #                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
 #                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path).
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
-# Optional variables: FERRY_REFINER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+# Optional variables: FERRY_REFINER_MODEL (default: claude-opus-4-8; use model ID matching your provider)
 #                     FERRY_REFINER_PROVIDER (default: anthropic; also: openai, google)
 #                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 #                     FERRY_REFINER_SUBTASK_CAP (default: 12)
@@ -99,7 +99,7 @@ jobs:
           google_api_key: ${{ secrets.GOOGLE_API_KEY }}
           github_token: ${{ github.token }}
           github_repo: ${{ github.repository }}
-          ferry_refiner_model: ${{ vars.FERRY_REFINER_MODEL || 'claude-sonnet-4-6' }}
+          ferry_refiner_model: ${{ vars.FERRY_REFINER_MODEL || 'claude-opus-4-8' }}
           ferry_refiner_provider: ${{ vars.FERRY_REFINER_PROVIDER }}
           ferry_refiner_subtask_cap: ${{ vars.FERRY_REFINER_SUBTASK_CAP }}
           ferry_max_cost_eur_per_run: ${{ vars.FERRY_MAX_COST_EUR_PER_RUN }}
@@ -142,7 +142,7 @@ jobs:
             --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@v1.1.1","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
             --permission-mode acceptEdits
             --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
-            --model ${{ vars.FERRY_REFINER_MODEL || 'claude-sonnet-4-6' }}
+            --model ${{ vars.FERRY_REFINER_MODEL || 'claude-opus-4-8' }}
 
   emit-audit:
     name: Emit audit line
@@ -161,7 +161,7 @@ jobs:
           ticket: ${{ github.event.client_payload.ticket_key }}
           phase: refine
           run_id: ${{ github.event.client_payload.event_id }}
-          model: ${{ vars.FERRY_REFINER_MODEL || 'claude-sonnet-4-6' }}
+          model: ${{ vars.FERRY_REFINER_MODEL || 'claude-opus-4-8' }}
           outcome: ${{ needs.run-agent.result != 'skipped' && needs.run-agent.result || needs.run-agent-claude-code.result }}
           # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
           input_tokens: '0'

--- a/examples/consumer-setup/workflows/ferry-review.yml
+++ b/examples/consumer-setup/workflows/ferry-review.yml
@@ -8,7 +8,7 @@
 #                   CLAUDE_CODE_OAUTH_TOKEN — required only when execution_path=claude-code
 #                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path).
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
-# Optional variables: FERRY_REVIEW_MODEL (default: claude-sonnet-4-6)
+# Optional variables: FERRY_REVIEW_MODEL (default: claude-opus-4-8)
 #                     FERRY_REVIEW_PROVIDER (default: anthropic; also: openai, google)
 #                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 #                     FERRY_REVIEWER_MAX_ITERATIONS (default: 40)
@@ -116,7 +116,7 @@ jobs:
           google_api_key: ${{ secrets.GOOGLE_API_KEY }}
           github_token: ${{ github.token }}
           github_repo: ${{ github.repository }}
-          ferry_review_model: ${{ vars.FERRY_REVIEW_MODEL || 'claude-sonnet-4-6' }}
+          ferry_review_model: ${{ vars.FERRY_REVIEW_MODEL || 'claude-opus-4-8' }}
           ferry_review_provider: ${{ vars.FERRY_REVIEW_PROVIDER }}
           ferry_reviewer_max_iterations: ${{ vars.FERRY_REVIEWER_MAX_ITERATIONS }}
           ferry_reviewer_max_tokens: ${{ vars.FERRY_REVIEWER_MAX_TOKENS }}
@@ -190,7 +190,7 @@ jobs:
             --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@v1.1.1","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
             --permission-mode acceptEdits
             --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
-            --model ${{ vars.FERRY_REVIEW_MODEL || 'claude-sonnet-4-6' }}
+            --model ${{ vars.FERRY_REVIEW_MODEL || 'claude-opus-4-8' }}
 
   emit-audit:
     name: Emit audit line
@@ -209,7 +209,7 @@ jobs:
           ticket: ${{ github.event.client_payload.ticket_key }}
           phase: review
           run_id: ${{ github.event.client_payload.event_id }}
-          model: ${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
+          model: ${{ needs.run-agent.outputs.model || 'claude-opus-4-8' }}
           outcome: ${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || (needs.ci-gate.outputs.outcome == 'ci-red' && 'ci-red') || needs.run-agent-claude-code.result }}
           # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
           input_tokens: ${{ needs.run-agent.outputs.input_tokens || '0' }}

--- a/examples/consumer-setup/workflows/ferry-router.yml
+++ b/examples/consumer-setup/workflows/ferry-router.yml
@@ -16,7 +16,8 @@
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_INTEGRATION_BRANCH (default: main)
 #                     FERRY_REFINER_MODEL / FERRY_DEV_MODEL / FERRY_REVIEW_MODEL /
-#                     FERRY_ITER_MODEL / FERRY_MERGER_MODEL (default: claude-sonnet-4-6)
+#                     FERRY_ITER_MODEL / FERRY_MERGER_MODEL (defaults: claude-opus-4-8
+#                     for refiner/reviewer/merger, claude-sonnet-5 for developer/iterator)
 #                     FERRY_PRE_AGENT_COMMAND (dependency bootstrap, e.g. "npm ci")
 #                     FERRY_EXTRA_CLAUDE_ARGS (extra claude_args, e.g. more --mcp-config)
 #                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array)
@@ -147,7 +148,7 @@ jobs:
           jira_base_url: ${{ secrets.FERRY_JIRA_BASE_URL }}
           jira_email: ${{ secrets.FERRY_JIRA_EMAIL }}
           jira_api_token: ${{ secrets.FERRY_JIRA_API_TOKEN }}
-          model: ${{ vars[needs.route.outputs.model_var] || 'claude-sonnet-4-6' }}
+          model: ${{ vars[needs.route.outputs.model_var] || (contains(fromJSON('["refiner","reviewer","merger"]'), needs.route.outputs.role) && 'claude-opus-4-8' || 'claude-sonnet-5') }}
           integration_branch: ${{ vars.FERRY_INTEGRATION_BRANCH || 'main' }}
           checkout_token: ${{ secrets.FERRY_CHECKOUT_TOKEN }}
           review_transition_id: ${{ secrets.FERRY_REVIEW_TRANSITION_ID }}
@@ -189,7 +190,7 @@ jobs:
           ticket: ${{ github.event.client_payload.ticket_key }}
           phase: ${{ needs.route.outputs.phase }}
           run_id: ${{ github.event.client_payload.event_id }}
-          model: ${{ vars[needs.route.outputs.model_var] || 'claude-sonnet-4-6' }}
+          model: ${{ vars[needs.route.outputs.model_var] || (contains(fromJSON('["refiner","reviewer","merger"]'), needs.route.outputs.role) && 'claude-opus-4-8' || 'claude-sonnet-5') }}
           outcome: ${{ (needs.ci-gate.result != 'skipped' && needs.ci-gate.outputs.outcome == 'ci-red' && 'ci-red') || needs.run-agent.result }}
           # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
           input_tokens: '0'

--- a/src/cli/cost/reconcile.ts
+++ b/src/cli/cost/reconcile.ts
@@ -9,6 +9,8 @@ const EUR_TO_USD = 1 / USD_TO_EUR;
 const ANTHROPIC_MODEL_MAP: Record<string, string> = {
   'Claude Opus 4.5': 'claude-opus-4-5',
   'Claude Opus 4.7': 'claude-opus-4-7',
+  'Claude Opus 4.8': 'claude-opus-4-8',
+  'Claude Sonnet 5': 'claude-sonnet-5',
   'Claude Sonnet 4.5': 'claude-sonnet-4-5',
   'Claude Sonnet 4.6': 'claude-sonnet-4-6',
   'Claude Haiku 4.5': 'claude-haiku-4-5',

--- a/src/cli/init/gitlab/templates.ts
+++ b/src/cli/init/gitlab/templates.ts
@@ -30,7 +30,7 @@ ferry-refine:
     - if: '$FERRY_DISPATCH_TYPE == "ferry-refine"'
   variables:
     FERRY_AGENT_ROLE: refiner
-    FERRY_REFINER_MODEL: \${FERRY_REFINER_MODEL:-claude-sonnet-4-6}
+    FERRY_REFINER_MODEL: \${FERRY_REFINER_MODEL:-claude-opus-4-8}
   script:
     - npm install -g "@big-emotion/ferry@\${FERRY_VERSION}"
     - ferry-agent run --role refiner
@@ -46,7 +46,7 @@ ferry-dev:
     - if: '$FERRY_DISPATCH_TYPE == "ferry-dev"'
   variables:
     FERRY_AGENT_ROLE: developer
-    FERRY_DEV_MODEL: \${FERRY_DEV_MODEL:-claude-sonnet-4-6}
+    FERRY_DEV_MODEL: \${FERRY_DEV_MODEL:-claude-sonnet-5}
   script:
     - apk add --no-cache git
     - npm install -g "@big-emotion/ferry@\${FERRY_VERSION}"
@@ -63,7 +63,7 @@ ferry-review:
     - if: '$FERRY_DISPATCH_TYPE == "ferry-review"'
   variables:
     FERRY_AGENT_ROLE: reviewer
-    FERRY_REVIEW_MODEL: \${FERRY_REVIEW_MODEL:-claude-sonnet-4-6}
+    FERRY_REVIEW_MODEL: \${FERRY_REVIEW_MODEL:-claude-opus-4-8}
   script:
     - npm install -g "@big-emotion/ferry@\${FERRY_VERSION}"
     - ferry-agent run --role reviewer
@@ -79,7 +79,7 @@ ferry-iterate:
     - if: '$FERRY_DISPATCH_TYPE == "ferry-iterate"'
   variables:
     FERRY_AGENT_ROLE: iterator
-    FERRY_ITER_MODEL: \${FERRY_ITER_MODEL:-claude-sonnet-4-6}
+    FERRY_ITER_MODEL: \${FERRY_ITER_MODEL:-claude-sonnet-5}
   script:
     - apk add --no-cache git
     - npm install -g "@big-emotion/ferry@\${FERRY_VERSION}"

--- a/src/cli/init/init.test.ts
+++ b/src/cli/init/init.test.ts
@@ -239,6 +239,6 @@ describe('workflowTemplates', () => {
     expect(dev?.content).toContain('claude_args: >-');
     expect(dev?.content).toContain('ferry-jira-mcp');
     // The model is interpolated from the per-agent variable, not hardcoded.
-    expect(dev?.content).toContain("--model ${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-4-6' }}");
+    expect(dev?.content).toContain("--model ${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-5' }}");
   });
 });

--- a/src/cli/init/templates.test.ts
+++ b/src/cli/init/templates.test.ts
@@ -211,11 +211,11 @@ describe('workflowTemplates — claude-code path single-step shape', () => {
     // A consumer who sets the per-agent FERRY_*_MODEL variable must be honoured
     // on the claude-code path too — the model must never be hardcoded.
     const modelVars: Record<string, string> = {
-      'ferry-refine.yml': "--model ${{ vars.FERRY_REFINER_MODEL || 'claude-sonnet-4-6' }}",
-      'ferry-dev.yml': "--model ${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-4-6' }}",
-      'ferry-review.yml': "--model ${{ vars.FERRY_REVIEW_MODEL || 'claude-sonnet-4-6' }}",
-      'ferry-iterate.yml': "--model ${{ vars.FERRY_ITER_MODEL || 'claude-sonnet-4-6' }}",
-      'ferry-merge.yml': "--model ${{ vars.FERRY_MERGER_MODEL || 'claude-sonnet-4-6' }}",
+      'ferry-refine.yml': "--model ${{ vars.FERRY_REFINER_MODEL || 'claude-opus-4-8' }}",
+      'ferry-dev.yml': "--model ${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-5' }}",
+      'ferry-review.yml': "--model ${{ vars.FERRY_REVIEW_MODEL || 'claude-opus-4-8' }}",
+      'ferry-iterate.yml': "--model ${{ vars.FERRY_ITER_MODEL || 'claude-sonnet-5' }}",
+      'ferry-merge.yml': "--model ${{ vars.FERRY_MERGER_MODEL || 'claude-opus-4-8' }}",
     };
     for (const tmpl of workflowTemplates('v1')) {
       const expected = modelVars[tmpl.filename];
@@ -224,8 +224,9 @@ describe('workflowTemplates — claude-code path single-step shape', () => {
         tmpl.content,
         `${tmpl.filename}: --model not interpolated from the model var`,
       ).toContain(expected);
+      const bareModel = /'([^']+)'/.exec(expected)![1];
       expect(tmpl.content, `${tmpl.filename}: --model is still hardcoded`).not.toContain(
-        '--model claude-sonnet-4-6\n',
+        `--model ${bareModel}\n`,
       );
     }
   });
@@ -714,7 +715,7 @@ describe('routerWorkflowTemplate — thin router (claude-code path)', () => {
 
   it('resolves the model dynamically from the role model_var', () => {
     expect(router.content).toContain(
-      "model: ${{ vars[needs.route.outputs.model_var] || 'claude-sonnet-4-6' }}",
+      'model: ${{ vars[needs.route.outputs.model_var] || (contains(fromJSON(\'["refiner","reviewer","merger"]\'), needs.route.outputs.role) && \'claude-opus-4-8\' || \'claude-sonnet-5\') }}',
     );
   });
 

--- a/src/cli/init/templates.ts
+++ b/src/cli/init/templates.ts
@@ -46,7 +46,7 @@ export function workflowTemplates(
 #                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path)
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_REFINER_PROVIDER (default: anthropic; also: openai, google)
-#                     FERRY_REFINER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#                     FERRY_REFINER_MODEL (default: claude-opus-4-8; use model ID matching your provider)
 #                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 
 name: Ferry — Refine
@@ -126,7 +126,7 @@ jobs:
           google_api_key: \${{ secrets.GOOGLE_API_KEY }}
           github_token: \${{ github.token }}
           github_repo: \${{ github.repository }}
-          ferry_refiner_model: claude-sonnet-4-6
+          ferry_refiner_model: claude-opus-4-8
 
   run-agent-claude-code:
     name: Run Refiner agent (claude-code path)
@@ -161,7 +161,7 @@ jobs:
             --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@${version}","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"\${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"\${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"\${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
             --permission-mode bypassPermissions
             --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
-            --model \${{ vars.FERRY_REFINER_MODEL || 'claude-sonnet-4-6' }}
+            --model \${{ vars.FERRY_REFINER_MODEL || 'claude-opus-4-8' }}
 
   run-agent-codex-cli:
     name: Run Refiner agent (codex-cli path)
@@ -213,7 +213,7 @@ jobs:
           ticket: \${{ github.event.client_payload.ticket_key }}
           phase: refine
           run_id: \${{ github.event.client_payload.event_id }}
-          model: claude-sonnet-4-6
+          model: claude-opus-4-8
           outcome: \${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || needs.run-agent-codex-cli.result }}
           # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
           input_tokens: '0'
@@ -236,7 +236,7 @@ jobs:
 #                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path)
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_DEV_PROVIDER (default: anthropic; also: openai, google)
-#                     FERRY_DEV_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#                     FERRY_DEV_MODEL (default: claude-sonnet-5; use model ID matching your provider)
 #                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 #
 # Note: MCP server support is not available for non-Anthropic providers in the Developer agent.
@@ -326,7 +326,7 @@ jobs:
           google_api_key: \${{ secrets.GOOGLE_API_KEY }}
           github_token: \${{ github.token }}
           github_repo: \${{ github.repository }}
-          ferry_dev_model: claude-sonnet-4-6
+          ferry_dev_model: claude-sonnet-5
 
   run-agent-claude-code:
     name: Run Developer agent (claude-code path)
@@ -364,7 +364,7 @@ jobs:
             --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@${version}","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"\${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"\${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"\${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
             --permission-mode bypassPermissions
             --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
-            --model \${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-4-6' }}
+            --model \${{ vars.FERRY_DEV_MODEL || 'claude-sonnet-5' }}
 
   run-agent-codex-cli:
     name: Run Developer agent (codex-cli path)
@@ -418,7 +418,7 @@ jobs:
           ticket: \${{ github.event.client_payload.ticket_key }}
           phase: dev
           run_id: \${{ github.event.client_payload.event_id }}
-          model: claude-sonnet-4-6
+          model: claude-sonnet-5
           outcome: \${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || needs.run-agent-codex-cli.result }}
           # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
           input_tokens: \${{ needs.run-agent.outputs.input_tokens || '0' }}
@@ -441,7 +441,7 @@ jobs:
 #                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path)
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_REVIEW_PROVIDER (default: anthropic; also: openai, google)
-#                     FERRY_REVIEW_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#                     FERRY_REVIEW_MODEL (default: claude-opus-4-8; use model ID matching your provider)
 #                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 #
 # Note: MCP server support is not available for non-Anthropic providers in the Reviewer agent.
@@ -533,7 +533,7 @@ jobs:
           google_api_key: \${{ secrets.GOOGLE_API_KEY }}
           github_token: \${{ github.token }}
           github_repo: \${{ github.repository }}
-          ferry_review_model: \${{ vars.FERRY_REVIEW_MODEL || 'claude-sonnet-4-6' }}
+          ferry_review_model: \${{ vars.FERRY_REVIEW_MODEL || 'claude-opus-4-8' }}
 
   ci-gate:
     name: Reviewer CI pre-gate
@@ -598,7 +598,7 @@ jobs:
             --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@${version}","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"\${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"\${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"\${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
             --permission-mode bypassPermissions
             --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
-            --model \${{ vars.FERRY_REVIEW_MODEL || 'claude-sonnet-4-6' }}
+            --model \${{ vars.FERRY_REVIEW_MODEL || 'claude-opus-4-8' }}
 
   run-agent-codex-cli:
     name: Run Reviewer agent (codex-cli path)
@@ -654,7 +654,7 @@ jobs:
           ticket: \${{ github.event.client_payload.ticket_key }}
           phase: review
           run_id: \${{ github.event.client_payload.event_id }}
-          model: \${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
+          model: \${{ needs.run-agent.outputs.model || 'claude-opus-4-8' }}
           outcome: \${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || (needs.run-agent-codex-cli.result != 'skipped' && needs.run-agent-codex-cli.result) || (needs.ci-gate.outputs.outcome == 'ci-red' && 'ci-red') || needs.run-agent-codex-cli.result || needs.run-agent-claude-code.result }}
           # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
           input_tokens: \${{ needs.run-agent.outputs.input_tokens || '0' }}
@@ -677,7 +677,7 @@ jobs:
 #                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path)
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_ITER_PROVIDER (default: anthropic; also: openai, google)
-#                     FERRY_ITER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#                     FERRY_ITER_MODEL (default: claude-sonnet-5; use model ID matching your provider)
 #                     FERRY_ITER_MAX_INPUT_TOKENS (default: 500000)
 #                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 #
@@ -771,7 +771,7 @@ jobs:
           google_api_key: \${{ secrets.GOOGLE_API_KEY }}
           github_token: \${{ github.token }}
           github_repo: \${{ github.repository }}
-          ferry_iter_model: \${{ vars.FERRY_ITER_MODEL || 'claude-sonnet-4-6' }}
+          ferry_iter_model: \${{ vars.FERRY_ITER_MODEL || 'claude-sonnet-5' }}
           ferry_iter_max_input_tokens: \${{ vars.FERRY_ITER_MAX_INPUT_TOKENS || '500000' }}
 
   run-agent-claude-code:
@@ -810,7 +810,7 @@ jobs:
             --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@${version}","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"\${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"\${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"\${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
             --permission-mode bypassPermissions
             --disallowedTools 'Bash(gh pr merge),Bash(gh pr merge:*),Bash(gh pr close:*)'
-            --model \${{ vars.FERRY_ITER_MODEL || 'claude-sonnet-4-6' }}
+            --model \${{ vars.FERRY_ITER_MODEL || 'claude-sonnet-5' }}
 
   run-agent-codex-cli:
     name: Run Iterator agent (codex-cli path)
@@ -864,7 +864,7 @@ jobs:
           ticket: \${{ github.event.client_payload.ticket_key }}
           phase: iterate
           run_id: \${{ github.event.client_payload.event_id }}
-          model: \${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
+          model: \${{ needs.run-agent.outputs.model || 'claude-sonnet-5' }}
           outcome: \${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || needs.run-agent-codex-cli.result }}
           # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
           input_tokens: \${{ needs.run-agent.outputs.input_tokens || '0' }}
@@ -886,7 +886,7 @@ jobs:
 #                                             (ADR-0006 §6 — anthropic_api_key is forbidden on this path)
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_MERGER_PROVIDER (default: anthropic; also: openai, google)
-#                     FERRY_MERGER_MODEL (default: claude-sonnet-4-6; use model ID matching your provider)
+#                     FERRY_MERGER_MODEL (default: claude-opus-4-8; use model ID matching your provider)
 #                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array for self-hosted runners, e.g. '["self-hosted","X64"]')
 
 name: Ferry — Merge
@@ -968,7 +968,7 @@ jobs:
           google_api_key: \${{ secrets.GOOGLE_API_KEY }}
           github_token: \${{ github.token }}
           github_repo: \${{ github.repository }}
-          ferry_merger_model: \${{ vars.FERRY_MERGER_MODEL || 'claude-sonnet-4-6' }}
+          ferry_merger_model: \${{ vars.FERRY_MERGER_MODEL || 'claude-opus-4-8' }}
 
   run-agent-claude-code:
     name: Run Merger agent (claude-code path)
@@ -1005,7 +1005,7 @@ jobs:
             --mcp-config '{"mcpServers":{"jira":{"command":"npx","args":["-y","-p","@big-emotion/ferry@${version}","ferry-jira-mcp"],"env":{"FERRY_JIRA_BASE_URL":"\${{ secrets.FERRY_JIRA_BASE_URL }}","FERRY_JIRA_EMAIL":"\${{ secrets.FERRY_JIRA_EMAIL }}","FERRY_JIRA_API_TOKEN":"\${{ secrets.FERRY_JIRA_API_TOKEN }}"}}}}'
             --permission-mode bypassPermissions
             --disallowedTools 'Bash(gh pr close),Bash(gh pr close:*)'
-            --model \${{ vars.FERRY_MERGER_MODEL || 'claude-sonnet-4-6' }}
+            --model \${{ vars.FERRY_MERGER_MODEL || 'claude-opus-4-8' }}
 
   run-agent-codex-cli:
     name: Run Merger agent (codex-cli path)
@@ -1058,7 +1058,7 @@ jobs:
           ticket: \${{ github.event.client_payload.ticket_key }}
           phase: merge
           run_id: \${{ github.event.client_payload.event_id }}
-          model: \${{ needs.run-agent.outputs.model || 'claude-sonnet-4-6' }}
+          model: \${{ needs.run-agent.outputs.model || 'claude-opus-4-8' }}
           outcome: \${{ (needs.run-agent.result != 'skipped' && needs.run-agent.result) || (needs.run-agent-claude-code.result != 'skipped' && needs.run-agent-claude-code.result) || needs.run-agent-codex-cli.result }}
           # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
           input_tokens: \${{ needs.run-agent.outputs.input_tokens || '0' }}
@@ -1095,7 +1095,8 @@ export function routerWorkflowTemplate(version: string): WorkflowEntry {
 # Required variables: FERRY_AUDIT_ISSUE (GitHub Issue number for the audit log)
 # Optional variables: FERRY_INTEGRATION_BRANCH (default: main)
 #                     FERRY_REFINER_MODEL / FERRY_DEV_MODEL / FERRY_REVIEW_MODEL /
-#                     FERRY_ITER_MODEL / FERRY_MERGER_MODEL (default: claude-sonnet-4-6)
+#                     FERRY_ITER_MODEL / FERRY_MERGER_MODEL (defaults: claude-opus-4-8
+#                     for refiner/reviewer/merger, claude-sonnet-5 for developer/iterator)
 #                     FERRY_PRE_AGENT_COMMAND (dependency bootstrap, e.g. "npm ci")
 #                     FERRY_EXTRA_CLAUDE_ARGS (extra claude_args, e.g. more --mcp-config)
 #                     FERRY_RUNNER (default: "ubuntu-latest"; JSON string or array)
@@ -1226,7 +1227,7 @@ jobs:
           jira_base_url: \${{ secrets.FERRY_JIRA_BASE_URL }}
           jira_email: \${{ secrets.FERRY_JIRA_EMAIL }}
           jira_api_token: \${{ secrets.FERRY_JIRA_API_TOKEN }}
-          model: \${{ vars[needs.route.outputs.model_var] || 'claude-sonnet-4-6' }}
+          model: \${{ vars[needs.route.outputs.model_var] || (contains(fromJSON('["refiner","reviewer","merger"]'), needs.route.outputs.role) && 'claude-opus-4-8' || 'claude-sonnet-5') }}
           integration_branch: \${{ vars.FERRY_INTEGRATION_BRANCH || 'main' }}
           checkout_token: \${{ secrets.FERRY_CHECKOUT_TOKEN }}
           review_transition_id: \${{ secrets.FERRY_REVIEW_TRANSITION_ID }}
@@ -1268,7 +1269,7 @@ jobs:
           ticket: \${{ github.event.client_payload.ticket_key }}
           phase: \${{ needs.route.outputs.phase }}
           run_id: \${{ github.event.client_payload.event_id }}
-          model: \${{ vars[needs.route.outputs.model_var] || 'claude-sonnet-4-6' }}
+          model: \${{ vars[needs.route.outputs.model_var] || (contains(fromJSON('["refiner","reviewer","merger"]'), needs.route.outputs.role) && 'claude-opus-4-8' || 'claude-sonnet-5') }}
           outcome: \${{ (needs.ci-gate.result != 'skipped' && needs.ci-gate.outputs.outcome == 'ci-red' && 'ci-red') || needs.run-agent.result }}
           # claude-code path does cost tracking best-effort by design — it emits no token/cost outputs.
           input_tokens: '0'

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -48,10 +48,10 @@ describe('loadFerryConfig', () => {
     it('defaults include all four models', () => {
       mockNoConfigFile();
       const cfg = loadFerryConfig('/repo');
-      expect(cfg.models.refiner.model).toBe('claude-sonnet-4-6');
-      expect(cfg.models.dev.model).toBe('claude-opus-4-5');
-      expect(cfg.models.review.model).toBe('claude-sonnet-4-6');
-      expect(cfg.models.iterate.model).toBe('claude-sonnet-4-6');
+      expect(cfg.models.refiner.model).toBe('claude-opus-4-8');
+      expect(cfg.models.dev.model).toBe('claude-sonnet-5');
+      expect(cfg.models.review.model).toBe('claude-opus-4-8');
+      expect(cfg.models.iterate.model).toBe('claude-sonnet-5');
     });
 
     it('defaults include oscillation cap of 3', () => {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -184,10 +184,10 @@ export interface SafetyConfig {
 
 export const DEFAULT_FERRY_CONFIG: FerryConfig = {
   models: {
-    refiner: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
-    dev: { provider: 'anthropic', model: 'claude-opus-4-5' },
-    review: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
-    iterate: { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+    refiner: { provider: 'anthropic', model: 'claude-opus-4-8' },
+    dev: { provider: 'anthropic', model: 'claude-sonnet-5' },
+    review: { provider: 'anthropic', model: 'claude-opus-4-8' },
+    iterate: { provider: 'anthropic', model: 'claude-sonnet-5' },
   },
   limits: {
     max_iterations: 3,

--- a/src/lib/llm/pricing.ts
+++ b/src/lib/llm/pricing.ts
@@ -10,6 +10,8 @@ export const EUR_TO_USD = 1 / 0.93;
 
 // EUR/USD ≈ 0.93; rates pinned 2025-Q2
 const RATES: Record<string, TokenRates> = {
+  'anthropic/claude-opus-4-8': { inputPer1M: 4.65, outputPer1M: 23.25 },
+  'anthropic/claude-sonnet-5': { inputPer1M: 2.79, outputPer1M: 13.95 },
   'anthropic/claude-sonnet-4-6': { inputPer1M: 2.79, outputPer1M: 13.95 },
   'anthropic/claude-opus': { inputPer1M: 13.95, outputPer1M: 69.75 },
   'anthropic/claude-haiku': { inputPer1M: 0.23, outputPer1M: 1.16 },


### PR DESCRIPTION
## What

Align each agent with its intended model tier:

| Agent | Model |
|---|---|
| Refiner | `claude-opus-4-8` |
| Reviewer | `claude-opus-4-8` |
| Merger | `claude-opus-4-8` |
| Developer | `claude-sonnet-5` |
| Iterator | `claude-sonnet-5` |

## Why

Every agent previously fell back to `claude-sonnet-4-6` (no `FERRY_*_MODEL` variables were set), and the script-path Developer default was the outdated `claude-opus-4-5`. This aligns the defaults with the desired tiers.

## Changes

- **`src/lib/config.ts`** — `DEFAULT_FERRY_CONFIG.models` per-agent defaults.
- **`ferry-init` templates** (GitHub + GitLab), **consumer stubs**, and the **dogfood router** — per-agent fallbacks. The router resolves Opus/Sonnet from the resolved role instead of a single shared fallback.
- **`pricing.ts`** — exact rate rows for `claude-opus-4-8` and `claude-sonnet-5` so cost accounting no longer reuses the legacy Opus fallback rate for Sonnet 5.
- **`reconcile.ts`** — Anthropic invoice-name mappings for both models.
- **`docs/CONFIGURATION.md`** and tests updated; `.ferry/` bundles rebuilt.

Live agents on this repo are already covered by the `FERRY_*_MODEL` GitHub variables (set out-of-band); this PR changes the code defaults that ship to consumers at the next release.

## Note

The `provider-phase-mismatch` cost heuristic (`src/cli/cost/advice.ts`, #142) still recommends switching the Refiner off Opus — it will now fire on every Refiner run and contradict this change. Left untouched; needs a follow-up decision.

## Gates

typecheck ✅ · lint ✅ · format ✅ · 2382 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)