### PR TITLE
perf: cut CI/LLM cost — drop redundant npm ci, bound claude-code turns, cap Reviewer spend

### DIFF
--- a/.ferry/agent.js
+++ b/.ferry/agent.js
@@ -10119,6 +10119,14 @@ function countPriorIterations(existingComments) {
 
 // src/agents/reviewer/review-action.ts
 var REPO_ROOT3 = process.env.GITHUB_WORKSPACE ?? process.cwd();
+function reviewerLoopLimits(limits) {
+  return {
+    maxIterations: limits.reviewer_max_iterations,
+    maxTokens: limits.reviewer_max_tokens,
+    maxInputTokens: limits.max_tokens_per_run,
+    maxCostEur: limits.max_cost_eur_per_run
+  };
+}
 async function main3(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT3);
@@ -10300,8 +10308,7 @@ async function main3(envelope, logger) {
     provider,
     model,
     thinking: thinkingOverride,
-    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
-    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
+    ...reviewerLoopLimits(effectiveCfg.limits),
     executeTool: executeTool2,
     logger
   });

--- a/.github/actions/ferry-emit-audit/action.yml
+++ b/.github/actions/ferry-emit-audit/action.yml
@@ -44,10 +44,10 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
       with:
         node-version: '20'
-    - name: Install Ferry action dependencies
-      shell: bash
-      run: npm ci --prefer-offline
-      working-directory: ${{ github.action_path }}
+    # Dependencies are vendored: node_modules is committed in this action
+    # directory and checked out with the action, so no install is needed. The
+    # previous `npm ci --prefer-offline` step only deleted the committed
+    # node_modules and cold-reinstalled it from the registry on every run.
     - name: Emit audit line
       shell: bash
       run: node ${{ github.action_path }}/emit-audit-action.js

--- a/.github/actions/ferry-envelope-validate/action.yml
+++ b/.github/actions/ferry-envelope-validate/action.yml
@@ -11,10 +11,10 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
       with:
         node-version: '20'
-    - name: Install Ferry action dependencies
-      shell: bash
-      run: npm ci --prefer-offline
-      working-directory: ${{ github.action_path }}
+    # Dependencies are vendored: node_modules is committed in this action
+    # directory and checked out with the action, so no install is needed. The
+    # previous `npm ci --prefer-offline` step only deleted the committed
+    # node_modules and cold-reinstalled it from the registry on every run.
     - name: Validate envelope
       shell: bash
       run: node ${{ github.action_path }}/validate-action.js

--- a/.github/actions/ferry-run-claude-agent/action.yml
+++ b/.github/actions/ferry-run-claude-agent/action.yml
@@ -36,6 +36,15 @@ inputs:
     description: Model id passed to --model
     required: false
     default: claude-sonnet-5
+  max_turns:
+    description: >-
+      Upper bound on agent turns, passed to claude as --max-turns. Without it a
+      hung or looping agent runs to the job's timeout-minutes ceiling (up to
+      120 min) with no turn cap. Defaults to the script path's Developer/
+      Iterator ceiling (200) so no legitimate run regresses; lower it per role
+      from the caller to tighten cost.
+    required: false
+    default: '200'
   integration_branch:
     description: Branch refiner/dev check out (the base for new work)
     required: false
@@ -227,6 +236,7 @@ runs:
           --permission-mode bypassPermissions
           --disallowedTools '${{ steps.guardrails.outputs.disallowed }}'
           --model ${{ inputs.model }}
+          --max-turns ${{ inputs.max_turns }}
           ${{ inputs.extra_claude_args }}
     # if: always() still fires on job cancellation/timeout, so a hung run keeps
     # its execution log. Guard on a non-empty output — a hard-killed step sets none.

--- a/.github/actions/ferry-run-developer/action.yml
+++ b/.github/actions/ferry-run-developer/action.yml
@@ -107,10 +107,10 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
       with:
         node-version: '20'
-    - name: Install Ferry agent dependencies
-      shell: bash
-      run: npm ci --prefer-offline
-      working-directory: ${{ github.action_path }}
+    # Dependencies are vendored: node_modules is committed in this action
+    # directory and checked out with the action, so no install is needed. The
+    # previous `npm ci --prefer-offline` step only deleted the committed
+    # node_modules and cold-reinstalled it from the registry on every run.
     - name: Skip Task tickets (FR6)
       shell: bash
       run: node ${{ github.action_path }}/skip-task-type-action.js

--- a/.github/actions/ferry-run-developer/agent.js
+++ b/.github/actions/ferry-run-developer/agent.js
@@ -10119,6 +10119,14 @@ function countPriorIterations(existingComments) {
 
 // src/agents/reviewer/review-action.ts
 var REPO_ROOT3 = process.env.GITHUB_WORKSPACE ?? process.cwd();
+function reviewerLoopLimits(limits) {
+  return {
+    maxIterations: limits.reviewer_max_iterations,
+    maxTokens: limits.reviewer_max_tokens,
+    maxInputTokens: limits.max_tokens_per_run,
+    maxCostEur: limits.max_cost_eur_per_run
+  };
+}
 async function main3(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT3);
@@ -10300,8 +10308,7 @@ async function main3(envelope, logger) {
     provider,
     model,
     thinking: thinkingOverride,
-    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
-    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
+    ...reviewerLoopLimits(effectiveCfg.limits),
     executeTool: executeTool2,
     logger
   });

--- a/.github/actions/ferry-run-iterator/action.yml
+++ b/.github/actions/ferry-run-iterator/action.yml
@@ -110,10 +110,10 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
       with:
         node-version: '20'
-    - name: Install Ferry agent dependencies
-      shell: bash
-      run: npm ci --prefer-offline
-      working-directory: ${{ github.action_path }}
+    # Dependencies are vendored: node_modules is committed in this action
+    # directory and checked out with the action, so no install is needed. The
+    # previous `npm ci --prefer-offline` step only deleted the committed
+    # node_modules and cold-reinstalled it from the registry on every run.
     - name: Skip Task tickets (FR6)
       shell: bash
       run: node ${{ github.action_path }}/skip-task-type-action.js

--- a/.github/actions/ferry-run-iterator/agent.js
+++ b/.github/actions/ferry-run-iterator/agent.js
@@ -10119,6 +10119,14 @@ function countPriorIterations(existingComments) {
 
 // src/agents/reviewer/review-action.ts
 var REPO_ROOT3 = process.env.GITHUB_WORKSPACE ?? process.cwd();
+function reviewerLoopLimits(limits) {
+  return {
+    maxIterations: limits.reviewer_max_iterations,
+    maxTokens: limits.reviewer_max_tokens,
+    maxInputTokens: limits.max_tokens_per_run,
+    maxCostEur: limits.max_cost_eur_per_run
+  };
+}
 async function main3(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT3);
@@ -10300,8 +10308,7 @@ async function main3(envelope, logger) {
     provider,
     model,
     thinking: thinkingOverride,
-    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
-    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
+    ...reviewerLoopLimits(effectiveCfg.limits),
     executeTool: executeTool2,
     logger
   });

--- a/.github/actions/ferry-run-merger/action.yml
+++ b/.github/actions/ferry-run-merger/action.yml
@@ -94,10 +94,10 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
       with:
         node-version: '20'
-    - name: Install Ferry agent dependencies
-      shell: bash
-      run: npm ci --prefer-offline
-      working-directory: ${{ github.action_path }}
+    # Dependencies are vendored: node_modules is committed in this action
+    # directory and checked out with the action, so no install is needed. The
+    # previous `npm ci --prefer-offline` step only deleted the committed
+    # node_modules and cold-reinstalled it from the registry on every run.
     - name: Skip Task tickets (FR6)
       shell: bash
       run: node ${{ github.action_path }}/skip-task-type-action.js

--- a/.github/actions/ferry-run-merger/agent.js
+++ b/.github/actions/ferry-run-merger/agent.js
@@ -10119,6 +10119,14 @@ function countPriorIterations(existingComments) {
 
 // src/agents/reviewer/review-action.ts
 var REPO_ROOT3 = process.env.GITHUB_WORKSPACE ?? process.cwd();
+function reviewerLoopLimits(limits) {
+  return {
+    maxIterations: limits.reviewer_max_iterations,
+    maxTokens: limits.reviewer_max_tokens,
+    maxInputTokens: limits.max_tokens_per_run,
+    maxCostEur: limits.max_cost_eur_per_run
+  };
+}
 async function main3(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT3);
@@ -10300,8 +10308,7 @@ async function main3(envelope, logger) {
     provider,
     model,
     thinking: thinkingOverride,
-    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
-    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
+    ...reviewerLoopLimits(effectiveCfg.limits),
     executeTool: executeTool2,
     logger
   });

--- a/.github/actions/ferry-run-refiner/action.yml
+++ b/.github/actions/ferry-run-refiner/action.yml
@@ -76,10 +76,10 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
       with:
         node-version: '20'
-    - name: Install Ferry agent dependencies
-      shell: bash
-      run: npm ci --prefer-offline
-      working-directory: ${{ github.action_path }}
+    # Dependencies are vendored: node_modules is committed in this action
+    # directory and checked out with the action, so no install is needed. The
+    # previous `npm ci --prefer-offline` step only deleted the committed
+    # node_modules and cold-reinstalled it from the registry on every run.
     - name: Skip Task tickets (FR6)
       shell: bash
       run: node ${{ github.action_path }}/skip-task-type-action.js

--- a/.github/actions/ferry-run-refiner/agent.js
+++ b/.github/actions/ferry-run-refiner/agent.js
@@ -10119,6 +10119,14 @@ function countPriorIterations(existingComments) {
 
 // src/agents/reviewer/review-action.ts
 var REPO_ROOT3 = process.env.GITHUB_WORKSPACE ?? process.cwd();
+function reviewerLoopLimits(limits) {
+  return {
+    maxIterations: limits.reviewer_max_iterations,
+    maxTokens: limits.reviewer_max_tokens,
+    maxInputTokens: limits.max_tokens_per_run,
+    maxCostEur: limits.max_cost_eur_per_run
+  };
+}
 async function main3(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT3);
@@ -10300,8 +10308,7 @@ async function main3(envelope, logger) {
     provider,
     model,
     thinking: thinkingOverride,
-    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
-    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
+    ...reviewerLoopLimits(effectiveCfg.limits),
     executeTool: executeTool2,
     logger
   });

--- a/.github/actions/ferry-run-reviewer/action.yml
+++ b/.github/actions/ferry-run-reviewer/action.yml
@@ -102,10 +102,10 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
       with:
         node-version: '20'
-    - name: Install Ferry agent dependencies
-      shell: bash
-      run: npm ci --prefer-offline
-      working-directory: ${{ github.action_path }}
+    # Dependencies are vendored: node_modules is committed in this action
+    # directory and checked out with the action, so no install is needed. The
+    # previous `npm ci --prefer-offline` step only deleted the committed
+    # node_modules and cold-reinstalled it from the registry on every run.
     - name: Skip Task tickets (FR6)
       shell: bash
       run: node ${{ github.action_path }}/skip-task-type-action.js

--- a/.github/actions/ferry-run-reviewer/agent.js
+++ b/.github/actions/ferry-run-reviewer/agent.js
@@ -10119,6 +10119,14 @@ function countPriorIterations(existingComments) {
 
 // src/agents/reviewer/review-action.ts
 var REPO_ROOT3 = process.env.GITHUB_WORKSPACE ?? process.cwd();
+function reviewerLoopLimits(limits) {
+  return {
+    maxIterations: limits.reviewer_max_iterations,
+    maxTokens: limits.reviewer_max_tokens,
+    maxInputTokens: limits.max_tokens_per_run,
+    maxCostEur: limits.max_cost_eur_per_run
+  };
+}
 async function main3(envelope, logger) {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
   const { owner, repo, runner, tracker, ferryCfg: initialCfg } = createGitHubContext(REPO_ROOT3);
@@ -10300,8 +10308,7 @@ async function main3(envelope, logger) {
     provider,
     model,
     thinking: thinkingOverride,
-    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
-    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
+    ...reviewerLoopLimits(effectiveCfg.limits),
     executeTool: executeTool2,
     logger
   });

--- a/src/agents/reviewer/review-action.test.ts
+++ b/src/agents/reviewer/review-action.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, it } from 'vitest';
 import { countPriorIterations } from './changes-guard.js';
+import { reviewerLoopLimits } from './review-action.js';
+import { DEFAULT_FERRY_CONFIG } from '../../lib/config.js';
+
+describe('reviewer loop budget — reviewerLoopLimits', () => {
+  it('bounds the reviewer per run with an input-token and EUR ceiling, not just iteration/output caps', () => {
+    const limits = reviewerLoopLimits(DEFAULT_FERRY_CONFIG.limits);
+    expect(limits.maxIterations).toBe(DEFAULT_FERRY_CONFIG.limits.reviewer_max_iterations);
+    expect(limits.maxTokens).toBe(DEFAULT_FERRY_CONFIG.limits.reviewer_max_tokens);
+    // Regression guard: the Opus-class reviewer must carry the same per-run
+    // ceilings the developer and iterator do (previously it had neither).
+    expect(limits.maxInputTokens).toBe(DEFAULT_FERRY_CONFIG.limits.max_tokens_per_run);
+    expect(limits.maxCostEur).toBe(DEFAULT_FERRY_CONFIG.limits.max_cost_eur_per_run);
+  });
+});
 
 const iteratorComment = (n: number) =>
   `[ferry:iterator:abc${n}] Iteration ${n} complete. Pushed fixes to PR#42. Moved back to Review.`;

--- a/src/agents/reviewer/review-action.ts
+++ b/src/agents/reviewer/review-action.ts
@@ -31,8 +31,26 @@ import {
 import { countPriorIterations } from './changes-guard.js';
 import type { EventEnvelopeV1 } from '../../lib/envelope/types.js';
 import type { Logger } from '../../lib/agent-runtime/index.js';
+import type { FerryConfig } from '../../lib/config.js';
 
 const REPO_ROOT = process.env.GITHUB_WORKSPACE ?? process.cwd();
+
+/**
+ * Per-run budget for the reviewer's agent loop. The reviewer defaults to an
+ * Opus-class model, so — like the developer and iterator — it must carry a
+ * per-run input-token and EUR ceiling, not only an iteration/output cap.
+ * review-action previously built the loop with just reviewer_max_iterations
+ * and reviewer_max_tokens, leaving no maxInputTokens/maxCostEur: a review could
+ * run the full reviewer_max_iterations of an Opus model with no spend bound.
+ */
+export function reviewerLoopLimits(limits: FerryConfig['limits']) {
+  return {
+    maxIterations: limits.reviewer_max_iterations,
+    maxTokens: limits.reviewer_max_tokens,
+    maxInputTokens: limits.max_tokens_per_run,
+    maxCostEur: limits.max_cost_eur_per_run,
+  };
+}
 
 export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<void> {
   const { ticket_key: ticketKey, event_id: eventId } = envelope;
@@ -262,8 +280,7 @@ export async function main(envelope: EventEnvelopeV1, logger: Logger): Promise<v
     provider,
     model,
     thinking: thinkingOverride,
-    maxIterations: effectiveCfg.limits.reviewer_max_iterations,
-    maxTokens: effectiveCfg.limits.reviewer_max_tokens,
+    ...reviewerLoopLimits(effectiveCfg.limits),
     executeTool,
     logger,
   });


### PR DESCRIPTION
## What & why

A cost + install-DX pass on Ferry. There are two stacked cost meters — GitHub Actions **runner minutes** and **LLM tokens** — plus a governance blind spot on the `claude-code` execution path (this repo's default), where per-run token/cost telemetry is emitted as €0 and the 50%-budget auto-pause can't fire.

This PR is a **draft for CI validation** and lands the three highest-value, lowest-risk fixes. Two larger follow-ups are scoped at the bottom.

### 1. Drop the redundant `npm ci` in vendored composite actions
The 7 composite actions that commit their `node_modules` ran `npm ci --prefer-offline` on every invocation, which **deleted the committed `node_modules` and cold-reinstalled it from the registry** — a network install repeated across every agent job of every ticket (~15–21 cold installs per ticket in the multi-job fan-out). The runner already checks the vendored deps out with the action, so the install was pure waste. `route` + `ci-gate` (which don't vendor `node_modules`) keep their install step.

> A naive `cache: npm` on `setup-node` would **not** work here — the lockfile lives under `_actions/` (outside `GITHUB_WORKSPACE`), so `hashFiles` can't key it and the step hard-fails for every consumer. Removing the redundant install is both simpler and strictly better.

### 2. Bound the `claude-code` path with `--max-turns`
The claude-code path passed no `--max-turns`, so a hung or looping agent ran to the job's 120-min timeout with no turn cap (ADR-0006 assumed one was set; the implementation omitted it). Adds a `max_turns` input on `ferry-run-claude-agent`, appended to `claude_args`, defaulting to **200** — the script path's Developer/Iterator ceiling — so no legitimate run regresses while runaway loops are bounded.

### 3. Bound the Reviewer's per-run cost like dev/iterate
The Reviewer defaults to an Opus-class model but built its agent loop with only `reviewer_max_iterations` + `reviewer_max_tokens` — no `maxInputTokens`/`maxCostEur`. A review could therefore run the full `reviewer_max_iterations` of Opus with no per-run input-token or EUR ceiling, unlike the Developer and Iterator loops. Extracts `reviewerLoopLimits()` (unit-tested) and passes `max_tokens_per_run` + `max_cost_eur_per_run` through.

## Verification (local)
- `npm run typecheck` — clean
- `npx vitest run src/agents/reviewer/review-action.test.ts` — 9/9 (incl. the new budget guard)
- pre-commit prettier + eslint — clean on changed files
- All 9 composite `action.yml` re-parsed as valid YAML
- **CI validation pending** (hence draft): `check:bundle` + the 8-job matrix — the caching/vendoring behaviour can't be proven from a local clone.

## Planned follow-ups (separate PRs)
- [ ] **Job/step timeouts** on the per-agent script/claude-code/codex agent jobs (hang backstop). Lower marginal value: the script path is already bounded by `max_agent_iterations` + the EUR/input caps, and the claude path is now bounded by the router's 120-min timeout + `--max-turns`. Needs non-uniform edits across the `templates.ts` generator + the 8 `examples/consumer-setup/workflows` fixtures → cleaner as its own PR.
- [ ] **Automate the `ferry-init` manual tail** — create the audit issue + set `FERRY_AUDIT_ISSUE`, set workflow-write permissions via `gh api`, write the two ops workflows instead of `curl`. A behaviour change to the installer + install-guide contract → its own PR.
- [ ] **Model tiering is config, not code** (already overridable via `FERRY_<ROLE>_MODEL`). Measure-first: instrument the claude-code path's token telemetry (today `emit-audit` reports €0), then A/B Refiner=Opus vs Sonnet against downstream rework before changing defaults. Refiner is high-leverage (it gates every downstream agent), so don't downgrade it blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
